### PR TITLE
Add option to Filter to user instances

### DIFF
--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -5,7 +5,6 @@ import numpy as np
 import sleap_io as sio
 import torch
 from torch.utils.data.datapipes.datapipe import IterDataPipe
-import copy
 
 
 class LabelsReader(IterDataPipe):
@@ -22,7 +21,7 @@ class LabelsReader(IterDataPipe):
 
     def __init__(self, labels: sio.Labels, user_instances_only: bool = True):
         """Initialize labels attribute of the class."""
-        self.labels = copy.deepcopy(labels)
+        self.labels = labels
 
         # Filter to user instances
         if user_instances_only:

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -14,17 +14,26 @@ class LabelsReader(IterDataPipe):
     Attributes:
         labels: sleap_io.Labels object that contains LabeledFrames that will be
             accessed through a torchdata DataPipe
+        user_instances: True if filter labels only to user instances else False. Default value True
     """
 
-    def __init__(self, labels: sio.Labels):
+    def __init__(self, labels: sio.Labels, user_instances: bool):
         """Initialize labels attribute of the class."""
         self.labels = labels
 
+        # Filter to user instances
+        if user_instances:
+            for lf in self.labels:
+                lf.instances = lf.user_instances
+            self.labels.labeled_frames = [
+                lf for lf in self.labels.labeled_frames if len(lf) > 0
+            ]
+
     @classmethod
-    def from_filename(cls, filename: str):
+    def from_filename(cls, filename: str, user_instances: bool = True):
         """Create LabelsReader from a .slp filename."""
         labels = sio.load_slp(filename)
-        return cls(labels)
+        return cls(labels, user_instances)
 
     def __iter__(self):
         """Return an example dictionary containing the following elements.

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterator
 import numpy as np
 import sleap_io as sio
 import torch
+import copy
 from torch.utils.data.datapipes.datapipe import IterDataPipe
 
 
@@ -21,13 +22,13 @@ class LabelsReader(IterDataPipe):
 
     def __init__(self, labels: sio.Labels, user_instances_only: bool = True):
         """Initialize labels attribute of the class."""
-        self.labels = labels
+        self.labels = copy.deepcopy(labels)
 
         # Filter to user instances
         if user_instances_only:
             filtered_lfs = []
             for lf in self.labels:
-                if len(lf.user_instances) > 0:
+                if lf.user_instances is not None and len(lf.user_instances) > 0:
                     lf.instances = lf.user_instances
                     filtered_lfs.append(lf)
             self.labels = sio.Labels(

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -14,26 +14,25 @@ class LabelsReader(IterDataPipe):
     Attributes:
         labels: sleap_io.Labels object that contains LabeledFrames that will be
             accessed through a torchdata DataPipe
-        user_instances: True if filter labels only to user instances else False. Default value True
+        user_instances_only: True if filter labels only to user instances else False. Default value True
     """
 
-    def __init__(self, labels: sio.Labels, user_instances: bool):
+    def __init__(self, labels: sio.Labels, user_instances_only: bool = True):
         """Initialize labels attribute of the class."""
         self.labels = labels
 
         # Filter to user instances
-        if user_instances:
-            for lf in self.labels:
-                lf.instances = lf.user_instances
-            self.labels.labeled_frames = [
-                lf for lf in self.labels.labeled_frames if len(lf) > 0
+        if user_instances_only:
+            filtered_lfs = [
+                lf for lf in self.labels.labeled_frames if len(lf.user_instances) > 0
             ]
+            self.labels = sio.Labels(filtered_lfs)
 
     @classmethod
-    def from_filename(cls, filename: str, user_instances: bool = True):
+    def from_filename(cls, filename: str, user_instances_only: bool = True):
         """Create LabelsReader from a .slp filename."""
         labels = sio.load_slp(filename)
-        return cls(labels, user_instances)
+        return cls(labels, user_instances_only)
 
     def __iter__(self):
         """Return an example dictionary containing the following elements.

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -63,5 +63,9 @@ def test_providers(minimal_instance):
     # Check user instance filtering
     assert len(list(l)) == 1
 
+    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
+    labels = sio.Labels(
+        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
+    )
     l = LabelsReader(labels, user_instances=False)
     assert len(list(l)) == 2

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -54,7 +54,9 @@ def test_filter_user_instances(minimal_instance):
     )
 
     # Create labeled frame.
-    user_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+    user_lf = sio.LabeledFrame(
+        video=video, frame_idx=0, instances=[user_inst, pred_inst]
+    )
     pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
 
     # Create labels.
@@ -63,13 +65,18 @@ def test_filter_user_instances(minimal_instance):
     )
 
     l = LabelsReader(labels, user_instances_only=True)
-    # Check user instance filtering
+
+    # Check user instance filtering.
     assert len(list(l)) == 1
+    lf = next(iter(l))
+    assert len(torch.squeeze(lf["instances"], dim=0)) == 1
 
     l = LabelsReader(labels, user_instances_only=False)
     assert len(list(l)) == 2
+    lf = next(iter(l))
+    assert len(torch.squeeze(lf["instances"], dim=0)) == 2
 
-    # Test with only Predicted instance
+    # Test with only Predicted instance.
     labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[pred_lf])
     l = LabelsReader(labels, user_instances_only=True)
     assert len(list(l)) == 0

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -70,12 +70,22 @@ def test_filter_user_instances(minimal_instance):
     lf = next(iter(l))
     assert len(torch.squeeze(lf["instances"], dim=0)) == 1
 
+    # Create labeled frame.
+    user_lf = sio.LabeledFrame(
+        video=video, frame_idx=0, instances=[user_inst, pred_inst]
+    )
+    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
+    # Create labels.
+    labels = sio.Labels(
+        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
+    )
     l = LabelsReader(labels, user_instances_only=False)
     assert len(list(l)) == 2
     lf = next(iter(l))
     assert len(torch.squeeze(lf["instances"], dim=0)) == 2
 
     # Test with only Predicted instance.
+    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
     labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[pred_lf])
     l = LabelsReader(labels, user_instances_only=True)
     assert len(list(l)) == 0

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -1,6 +1,8 @@
 import torch
 
 from sleap_nn.data.providers import LabelsReader
+import sleap_io as sio
+import numpy as np
 
 
 def test_providers(minimal_instance):
@@ -9,3 +11,57 @@ def test_providers(minimal_instance):
     instances, image = sample["instances"], sample["image"]
     assert image.shape == torch.Size([1, 1, 384, 384])
     assert instances.shape == torch.Size([1, 2, 2, 2])
+
+    # Create sample Labels object.
+
+    # Create skeleton.
+    skeleton = sio.Skeleton(
+        nodes=["head", "thorax", "abdomen"],
+        edges=[("head", "thorax"), ("thorax", "abdomen")],
+    )
+
+    # Get video.
+    min_labels = sio.load_slp(minimal_instance)
+    video = min_labels.videos[0]
+
+    # Create user labelled instance.
+    user_inst = sio.Instance.from_numpy(
+        points=np.array(
+            [
+                [11.4, 13.4],
+                [13.6, 15.1],
+                [0.3, 9.3],
+            ]
+        ),
+        skeleton=skeleton,
+    )
+
+    # Create Predicted Instance.
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points=np.array(
+            [
+                [10.2, 20.4],
+                [5.8, 15.1],
+                [0.3, 10.6],
+            ]
+        ),
+        skeleton=skeleton,
+        point_scores=np.array([0.5, 0.6, 0.8]),
+        instance_score=0.6,
+    )
+
+    # Create labeled frame.
+    user_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
+
+    # Create labels.
+    labels = sio.Labels(
+        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
+    )
+
+    l = LabelsReader(labels, user_instances=True)
+    # Check user instance filtering
+    assert len(list(l)) == 1
+
+    l = LabelsReader(labels, user_instances=False)
+    assert len(list(l)) == 2

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -14,7 +14,6 @@ def test_providers(minimal_instance):
 
 
 def test_filter_user_instances(minimal_instance):
-
     # Create sample Labels object.
 
     # Create skeleton.
@@ -61,7 +60,8 @@ def test_filter_user_instances(minimal_instance):
 
     # Create labels.
     labels = sio.Labels(
-        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf])
+        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
+    )
 
     l = LabelsReader(labels, user_instances_only=True)
 

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -61,8 +61,7 @@ def test_filter_user_instances(minimal_instance):
 
     # Create labels.
     labels = sio.Labels(
-        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
-    )
+        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf])
 
     l = LabelsReader(labels, user_instances_only=True)
 

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -12,6 +12,9 @@ def test_providers(minimal_instance):
     assert image.shape == torch.Size([1, 1, 384, 384])
     assert instances.shape == torch.Size([1, 2, 2, 2])
 
+
+def test_filter_user_instances(minimal_instance):
+
     # Create sample Labels object.
 
     # Create skeleton.
@@ -59,13 +62,14 @@ def test_providers(minimal_instance):
         videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
     )
 
-    l = LabelsReader(labels, user_instances=True)
+    l = LabelsReader(labels, user_instances_only=True)
     # Check user instance filtering
     assert len(list(l)) == 1
 
-    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
-    labels = sio.Labels(
-        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
-    )
-    l = LabelsReader(labels, user_instances=False)
+    l = LabelsReader(labels, user_instances_only=False)
     assert len(list(l)) == 2
+
+    # Test with only Predicted instance
+    labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[pred_lf])
+    l = LabelsReader(labels, user_instances_only=True)
+    assert len(list(l)) == 0

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -70,22 +70,12 @@ def test_filter_user_instances(minimal_instance):
     lf = next(iter(l))
     assert len(torch.squeeze(lf["instances"], dim=0)) == 1
 
-    # Create labeled frame.
-    user_lf = sio.LabeledFrame(
-        video=video, frame_idx=0, instances=[user_inst, pred_inst]
-    )
-    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
-    # Create labels.
-    labels = sio.Labels(
-        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf, pred_lf]
-    )
     l = LabelsReader(labels, user_instances_only=False)
     assert len(list(l)) == 2
     lf = next(iter(l))
     assert len(torch.squeeze(lf["instances"], dim=0)) == 2
 
     # Test with only Predicted instance.
-    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
     labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[pred_lf])
     l = LabelsReader(labels, user_instances_only=True)
     assert len(list(l)) == 0


### PR DESCRIPTION
Add option to filter only the user instances from the .slp file.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Added a new option to the `LabelsReader` class that allows users to filter and include only user instances in the labels. This provides more flexibility in reading and processing labeled frames.
- Test: Introduced new test cases to verify the functionality of the `LabelsReader` class, specifically the new user instance filtering feature. This ensures the reliability and correctness of the new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->