### PR TITLE
Fix augmentation in TopdownConfmaps pipeline

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -26,7 +26,8 @@ The config file has three main sections:
         - `max_width`: (int) Maximum width the image should be padded to. If not provided, the
         original image size will be retained. Default: None.
         - `scale`: (float or List[float]) Factor to resize the image dimensions by, specified as either a float scalar or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions are resized by the same factor. 
-        - `crop_hw`: (List[int]) Crop height and width of each instance (h, w) for centered-instance model.
+        - `crop_hw`: (Tuple[int]) Crop height and width of each instance (h, w) for centered-instance model. If `None`, this would be automatically computed based on the largest instance in the `sio.Labels` file.
+        - `min_crop_size`: (int) Minimum crop size to be used if `crop_hw` is `None`.
     - `use_augmentations_train`: (bool) True if the data augmentation should be applied to the training data, else False. 
     - `augmentation_config`: (only if `use_augmentations` is `True`)
         - `random crop`: (Optional) (Dict[float]) {"random_crop_p": None, "crop_height": None. "crop_width": None}, where *random_crop_p* is the probability of applying random crop and *crop_height* and *crop_width* are the desired output size (out_h, out_w) of the crop. 
@@ -156,12 +157,13 @@ The config file has three main sections:
     - `use_wandb`: (bool) True to enable wandb logging.
     - `save_ckpt`: (bool) True to enable checkpointing. 
     - `save_ckpt_path`: (str) Directory path to save the training config and checkpoint files. *Default*: "./"
+    - `resume_ckpt_path`: (str) Path to `.ckpt` file from which training is resumed. *Default*: `None`.
     - `wandb`: (Only if `use_wandb` is `True`, else skip this)
-        - `entity`: (str) Entity of wandb project.
         - `project`: (str) Project name for the wandb project.
         - `name`: (str) Name of the current run.
         - `api_key`: (str) API key. The API key is masked when saved to config files.
         - `wandb_mode`: (str) "offline" if only local logging is required. Default: "None".
+        - `prv_runid`: (str) Previous run ID if training should be resumed from a previous ckpt. *Default*: `None`.
         - `log_params`: (List[str]) List of config parameters to save it in wandb logs. For example, to save learning rate from trainer config section, use "trainer_config.optimizer.lr" (provide the full path to the specific config parameter).
     - `optimizer_name`: (str) Optimizer to be used. One of ["Adam", "AdamW"].
     - `optimizer`

--- a/docs/config_bottomup.yaml
+++ b/docs/config_bottomup.yaml
@@ -96,6 +96,7 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_bottomup1
+  resume_ckpt_path:
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/docs/config_centroid.yaml
+++ b/docs/config_centroid.yaml
@@ -113,12 +113,13 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: 'min_inst_centroid'
+  resume_ckpt_path:
   wandb: # sample wandb config
-    entity: 
     project: 'test_centroid_centered'
     name: 'fly_unet_centered'
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/docs/config_topdown_centered_instance.yaml
+++ b/docs/config_topdown_centered_instance.yaml
@@ -94,6 +94,7 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: 'min_inst_centered'
+  resume_ckpt_path:
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/sleap_nn/data/augmentation.py
+++ b/sleap_nn/data/augmentation.py
@@ -1,7 +1,6 @@
 """This module implements data pipeline blocks for augmentation operations."""
 
 from typing import Any, Dict, Optional, Tuple, Union, Iterator
-
 import kornia as K
 import torch
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -9,6 +8,227 @@ from kornia.augmentation.container import AugmentationSequential
 from kornia.augmentation.utils.param_validation import _range_bound
 from kornia.core import Tensor
 from torch.utils.data.datapipes.datapipe import IterDataPipe
+
+
+def apply_intensity_augmentation(
+    image: torch.Tensor,
+    instances: torch.Tensor,
+    uniform_noise_min: Optional[float] = 0.0,
+    uniform_noise_max: Optional[float] = 0.04,
+    uniform_noise_p: float = 0.0,
+    gaussian_noise_mean: Optional[float] = 0.02,
+    gaussian_noise_std: Optional[float] = 0.004,
+    gaussian_noise_p: float = 0.0,
+    contrast_min: Optional[float] = 0.5,
+    contrast_max: Optional[float] = 2.0,
+    contrast_p: float = 0.0,
+    brightness: Optional[float] = 0.0,
+    brightness_p: float = 0.0,
+) -> Tuple[torch.Tensor]:
+    """Apply kornia intensity augmentation on image and instances.
+
+    Args:
+        image: Input image. Shape: (n_samples, C, H, W)
+        instances: Input keypoints. (n_samples, n_instances, n_nodes, 2) or (n_samples, n_nodes, 2)
+        uniform_noise_min: Minimum value for uniform noise (uniform_noise_min >=0).
+        uniform_noise_max: Maximum value for uniform noise (uniform_noise_max <=1).
+        uniform_noise_p: Probability of applying random uniform noise.
+        gaussian_noise_mean: The mean of the gaussian distribution.
+        gaussian_noise_std: The standard deviation of the gaussian distribution.
+        gaussian_noise_p: Probability of applying random gaussian noise.
+        contrast_min: Minimum contrast factor to apply. Default: 0.5.
+        contrast_max: Maximum contrast factor to apply. Default: 2.0.
+        contrast_p: Probability of applying random contrast.
+        brightness: The brightness factor to apply Default: 0.0.
+        brightness_p: Probability of applying random brightness.
+
+    Returns:
+        Returns tuple: (image, instances) with augmentation applied.
+    """
+    aug_stack = []
+    if uniform_noise_p > 0:
+        aug_stack.append(
+            RandomUniformNoise(
+                noise=(uniform_noise_min, uniform_noise_max),
+                p=uniform_noise_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if gaussian_noise_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomGaussianNoise(
+                mean=gaussian_noise_mean,
+                std=gaussian_noise_std,
+                p=gaussian_noise_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if contrast_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomContrast(
+                contrast=(contrast_min, contrast_max),
+                p=contrast_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if brightness_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomBrightness(
+                brightness=brightness,
+                p=brightness_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+
+    augmenter = AugmentationSequential(
+        *aug_stack,
+        data_keys=["input", "keypoints"],
+        keepdim=True,
+        same_on_batch=True,
+    )
+
+    inst_shape = instances.shape
+    # Before (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # Before (cropped image): (B=1, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    instances = instances.reshape(inst_shape[0], -1, 2)
+    # (n_samples, C, H, W), (n_samples, n_instances * n_nodes, 2) OR (n_samples, n_nodes, 2)
+
+    aug_image, aug_instances = augmenter(image, instances)
+
+    # After (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # After (cropped image): (n_samples, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    return aug_image, aug_instances.reshape(*inst_shape)
+
+
+def apply_geometric_augmentation(
+    image: torch.Tensor,
+    instances: torch.Tensor,
+    rotation: Optional[float] = 15.0,
+    scale: Union[
+        Optional[float], Tuple[float, float], Tuple[float, float, float, float]
+    ] = None,
+    translate_width: Optional[float] = 0.02,
+    translate_height: Optional[float] = 0.02,
+    affine_p: float = 0.0,
+    erase_scale_min: Optional[float] = 0.0001,
+    erase_scale_max: Optional[float] = 0.01,
+    erase_ratio_min: Optional[float] = 1,
+    erase_ratio_max: Optional[float] = 1,
+    erase_p: float = 0.0,
+    mixup_lambda: Union[Optional[float], Tuple[float, float], None] = None,
+    mixup_p: float = 0.0,
+    random_crop_height: int = 0,
+    random_crop_width: int = 0,
+    random_crop_p: float = 0.0,
+) -> Tuple[torch.Tensor]:
+    """Apply kornia geometric augmentation on image and instances.
+
+    Args:
+        image: Input image. Shape: (n_samples, C, H, W)
+        instances: Input keypoints. (n_samples, n_instances, n_nodes, 2) or (n_samples, n_nodes, 2)
+        rotation: Angles in degrees as a scalar float of the amount of rotation. A
+            random angle in `(-rotation, rotation)` will be sampled and applied to both
+            images and keypoints. Set to 0 to disable rotation augmentation.
+        scale: scaling factor interval. If (a, b) represents isotropic scaling, the scale
+            is randomly sampled from the range a <= scale <= b. If (a, b, c, d), the scale
+            is randomly sampled from the range a <= scale_x <= b, c <= scale_y <= d.
+            Default: None.
+        translate_width: Maximum absolute fraction for horizontal translation. For example,
+            if translate_width=a, then horizontal shift is randomly sampled in the range
+            -img_width * a < dx < img_width * a. Will not translate by default.
+        translate_height: Maximum absolute fraction for vertical translation. For example,
+            if translate_height=a, then vertical shift is randomly sampled in the range
+            -img_height * a < dy < img_height * a. Will not translate by default.
+        affine_p: Probability of applying random affine transformations.
+        erase_scale_min: Minimum value of range of proportion of erased area against input image. Default: 0.0001.
+        erase_scale_max: Maximum value of range of proportion of erased area against input image. Default: 0.01.
+        erase_ratio_min: Minimum value of range of aspect ratio of erased area. Default: 1.
+        erase_ratio_max: Maximum value of range of aspect ratio of erased area. Default: 1.
+        erase_p: Probability of applying random erase.
+        mixup_lambda: min-max value of mixup strength. Default is 0-1. Default: `None`.
+        mixup_p: Probability of applying random mixup v2.
+        random_crop_height: Desired output height of the crop. Must be int.
+        random_crop_width: Desired output width of the crop. Must be int.
+        random_crop_p: Probability of applying random crop.
+
+
+    Returns:
+        Returns tuple: (image, instances) with augmentation applied.
+    """
+    if isinstance(scale, float):
+        scale = (scale, scale)
+    aug_stack = []
+    if affine_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomAffine(
+                degrees=rotation,
+                translate=(translate_width, translate_height),
+                scale=scale,
+                p=affine_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+
+    if erase_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomErasing(
+                scale=(erase_scale_min, erase_scale_max),
+                ratio=(erase_ratio_min, erase_ratio_max),
+                p=erase_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if mixup_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomMixUpV2(
+                lambda_val=mixup_lambda,
+                p=mixup_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if random_crop_p > 0:
+        if random_crop_height > 0 and random_crop_width > 0:
+            aug_stack.append(
+                K.augmentation.RandomCrop(
+                    size=(random_crop_height, random_crop_width),
+                    pad_if_needed=True,
+                    p=random_crop_p,
+                    keepdim=True,
+                    same_on_batch=True,
+                )
+            )
+        else:
+            raise ValueError(f"random_crop_hw height and width must be greater than 0.")
+
+    augmenter = AugmentationSequential(
+        *aug_stack,
+        data_keys=["input", "keypoints"],
+        keepdim=True,
+        same_on_batch=True,
+    )
+
+    inst_shape = instances.shape
+    # Before (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # Before (cropped image): (B=1, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    instances = instances.reshape(inst_shape[0], -1, 2)
+    # (n_samples, C, H, W), (n_samples, n_instances * n_nodes, 2) OR (n_samples, n_nodes, 2)
+
+    aug_image, aug_instances = augmenter(image, instances)
+
+    # After (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # After (cropped image): (n_samples, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    return aug_image, aug_instances.reshape(*inst_shape)
 
 
 class RandomUniformNoise(IntensityAugmentationBase2D):

--- a/sleap_nn/data/confidence_maps.py
+++ b/sleap_nn/data/confidence_maps.py
@@ -1,11 +1,97 @@
 """Generate confidence maps."""
 
-from typing import Dict, Iterator
+from typing import Dict, Iterator, Tuple
 
 import torch
 from torch.utils.data.datapipes.datapipe import IterDataPipe
 
 from sleap_nn.data.utils import make_grid_vectors
+
+
+def generate_confmaps(
+    instance: torch.Tensor,
+    img_hw: Tuple[int],
+    sigma: float = 1.5,
+    output_stride: int = 2,
+) -> torch.Tensor:
+    """Generate Confidence maps.
+
+    Args:
+        instance: Input keypoints. (n_samples, n_instances, n_nodes, 2) or
+            (n_samples, n_nodes, 2).
+        img_hw: Image size as tuple (height, width).
+        sigma: The standard deviation of the Gaussian distribution that is used to
+            generate confidence maps. Default: 1.5.
+        output_stride: The relative stride to use when generating confidence maps.
+            A larger stride will generate smaller confidence maps. Default: 2.
+
+    Returns:
+        Confidence maps for the input keypoints.
+    """
+    if instance.ndim != 3:
+        instance = instance.view(instance.shape[0], -1, 2)
+        # instances: (n_samples, n_nodes, 2)
+
+    height, width = img_hw
+
+    xv, yv = make_grid_vectors(height, width, output_stride)
+
+    confidence_maps = make_confmaps(
+        instance,
+        xv,
+        yv,
+        sigma * output_stride,
+    )  # (n_samples, n_nodes, height/ output_stride, width/ output_stride)
+
+    return confidence_maps
+
+
+def generate_multiconfmaps(
+    instances: torch.Tensor,
+    img_hw: Tuple[int],
+    num_instances: int,
+    sigma: float = 1.5,
+    output_stride: int = 2,
+    is_centroids: bool = False,
+) -> torch.Tensor:
+    """Generate multi-instance confidence maps.
+
+    Args:
+        instances: Input keypoints. (n_samples, n_instances, n_nodes, 2) or
+            for centroids - (n_samples, n_instances, 2)
+        img_hw: Image size as tuple (height, width).
+        num_instances: Original number of instances in the frame.
+        sigma: The standard deviation of the Gaussian distribution that is used to
+            generate confidence maps. Default: 1.5.
+        output_stride: The relative stride to use when generating confidence maps.
+            A larger stride will generate smaller confidence maps. Default: 2.
+        is_centroids: True if confidence maps should be generates for centroids else False.
+            Default: False.
+
+    Returns:
+        Confidence maps for the input keypoints.
+    """
+    if is_centroids:
+        points = instances[:, :num_instances, :].unsqueeze(dim=-2)
+        # (n_samples, n_instances, 1, 2)
+    else:
+        points = instances[
+            :, :num_instances, :, :
+        ]  # (n_samples, n_instances, n_nodes, 2)
+
+    height, width = img_hw
+
+    xv, yv = make_grid_vectors(height, width, output_stride)
+
+    confidence_maps = make_multi_confmaps(
+        points,
+        xv,
+        yv,
+        sigma * output_stride,
+    )  # (n_samples, n_nodes, height/ output_stride, width/ output_stride).
+    # If `is_centroids`, (n_samples, 1, height/ output_stride, width/ output_stride).
+
+    return confidence_maps
 
 
 def make_confmaps(

--- a/sleap_nn/data/edge_maps.py
+++ b/sleap_nn/data/edge_maps.py
@@ -247,6 +247,82 @@ def get_edge_points(
     return edge_sources, edge_destinations
 
 
+def generate_pafs(
+    instances: torch.Tensor,
+    img_hw: Tuple[int],
+    sigma: float = 1.5,
+    output_stride=2,
+    edge_inds: Optional[torch.Tensor] = attrs.field(
+        default=None, converter=attrs.converters.optional(ensure_list)
+    ),
+    flatten_channels: bool = False,
+) -> torch.Tensor:
+    """Generate part-affinity fields.
+
+    Args:
+        instances: Input instances. (n_samples, n_instances, n_nodes, 2)
+        img_hw: Image size as tuple (height, width).
+        sigma: The standard deviation of the Gaussian distribution that is used to
+            generate confidence maps. Default: 1.5.
+        output_stride: The relative stride to use when generating confidence maps.
+            A larger stride will generate smaller confidence maps. Default: 2.
+        edge_inds: `torch.Tensor` to use for looking up the index of the
+            edges.
+        flatten_channels: If False, the generated tensors are of shape
+            [height, width, n_edges, 2]. If True, generated tensors are of shape
+            [height, width, n_edges * 2] by flattening the last 2 axes.
+
+    Returns:
+        The "part_affinity_fields" key will be a tensor of shape
+        (grid_height, grid_width, n_edges, 2) containing the combined part affinity
+        fields of all instances in the frame.
+
+        If the `flatten_channels` attribute is set to True, the last 2 axes of the
+        "part_affinity_fields" are flattened to produce a tensor of shape
+        (grid_height, grid_width, n_edges * 2). This is a convenient form when
+        training models as a rank-4 (batched) tensor will generally be expected.
+    """
+    image_height, image_width = img_hw
+
+    # Generate sampling grid vectors.
+    xv, yv = make_grid_vectors(
+        image_height=image_height,
+        image_width=image_width,
+        output_stride=output_stride,
+    )
+    grid_height = len(yv)
+    grid_width = len(xv)
+    n_edges = len(edge_inds)
+
+    instances = instances[0]  # n_samples=1
+    in_img = (instances > 0) & (instances < torch.stack([xv[-1], yv[-1]]).view(1, 1, 2))
+    in_img = in_img.all(dim=-1).any(dim=1)
+    assert len(in_img.shape) == 1
+    instances = instances[in_img]
+
+    edge_sources, edge_destinations = get_edge_points(instances, edge_inds)
+    assert len(edge_sources.shape) == 3
+    assert edge_sources.shape[1:] == (n_edges, 2)
+
+    assert len(edge_destinations.shape) == 3
+    assert edge_destinations.shape[1:] == (n_edges, 2)
+
+    pafs = make_multi_pafs(
+        xv=xv,
+        yv=yv,
+        edge_sources=edge_sources,
+        edge_destinations=edge_destinations,
+        sigma=sigma,
+    )
+    assert pafs.shape == (grid_height, grid_width, n_edges, 2)
+
+    if flatten_channels:
+        pafs = pafs.reshape(grid_height, grid_width, n_edges * 2)
+        assert pafs.shape == (grid_height, grid_width, n_edges * 2)
+
+    return pafs
+
+
 class PartAffinityFieldsGenerator(IterDataPipe):
     """Transformer to generate part affinity fields.
 

--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -35,13 +35,13 @@ def find_points_bbox_midpoint(points: torch.Tensor) -> torch.Tensor:
     return (pts_max + pts_min) * 0.5
 
 
-def find_centroids(
+def generate_centroids(
     points: torch.Tensor, anchor_ind: Optional[int] = None
 ) -> torch.Tensor:
     """Return centroids, falling back to bounding box midpoints.
 
     Args:
-        points: A torch.Tensor of dtype torch.float32 and of shape (..., n_points, 2),
+        points: A torch.Tensor of dtype torch.float32 and of shape (..., n_nodes, 2),
             i.e., rank >= 2.
         anchor_ind: The index of the node to use as the anchor for the centroid. If not
             provided or if not present in the instance, the midpoint of the bounding box
@@ -60,7 +60,7 @@ def find_centroids(
     if missing_anchors.any():
         centroids[missing_anchors] = find_points_bbox_midpoint(points[missing_anchors])
 
-    return centroids
+    return centroids  # (..., n_instances, 2)
 
 
 class InstanceCentroidFinder(IterDataPipe):
@@ -88,7 +88,7 @@ class InstanceCentroidFinder(IterDataPipe):
     def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
         """Add `"centroids"` key to example."""
         for ex in self.source_dp:
-            ex["centroids"] = find_centroids(
+            ex["centroids"] = generate_centroids(
                 ex["instances"], anchor_ind=self.anchor_ind
             )  # (n_samples, n_instances, 2)
             yield ex

--- a/sleap_nn/data/instance_cropping.py
+++ b/sleap_nn/data/instance_cropping.py
@@ -1,11 +1,64 @@
 """Handle cropping of instances."""
 
-from typing import Iterator, Tuple, Dict
-
+from typing import Iterator, Tuple, Dict, Optional
+import math
+import numpy as np
+import sleap_io as sio
 import torch
 from kornia.geometry.transform import crop_and_resize
 from torch.utils.data.datapipes.datapipe import IterDataPipe
-from sleap_nn.data.resizing import find_padding_for_stride
+
+
+def find_instance_crop_size(
+    labels: sio.Labels,
+    padding: int = 0,
+    maximum_stride: int = 2,
+    input_scaling: float = 1.0,
+    min_crop_size: Optional[int] = None,
+) -> int:
+    """Compute the size of the largest instance bounding box from labels.
+
+    Args:
+        labels: A `sio.Labels` containing user-labeled instances.
+        padding: Integer number of pixels to add to the bounds as margin padding.
+        maximum_stride: Ensure that the returned crop size is divisible by this value.
+            Useful for ensuring that the crop size will not be truncated in a given
+            architecture.
+        input_scaling: Float factor indicating the scale of the input images if any
+            scaling will be done before cropping.
+        min_crop_size: The crop size set by the user.
+
+    Returns:
+        An integer crop size denoting the length of the side of the bounding boxes that
+        will contain the instances when cropped. The returned crop size will be larger
+        or equal to the input `min_crop_size`.
+
+        This accounts for stride, padding and scaling when ensuring divisibility.
+    """
+    # Check if user-specified crop size is divisible by max stride
+    min_crop_size = 0 if min_crop_size is None else min_crop_size
+    if (min_crop_size > 0) and (min_crop_size % maximum_stride == 0):
+        return min_crop_size
+
+    # Calculate crop size
+    min_crop_size_no_pad = min_crop_size - padding
+    max_length = 0.0
+    for lf in labels:
+        for inst in lf.instances:
+            pts = inst.numpy()
+            pts *= input_scaling
+            max_length = np.maximum(
+                max_length, np.nanmax(pts[:, 0]) - np.nanmin(pts[:, 0])
+            )
+            max_length = np.maximum(
+                max_length, np.nanmax(pts[:, 1]) - np.nanmin(pts[:, 1])
+            )
+            max_length = np.maximum(max_length, min_crop_size_no_pad)
+
+    max_length += float(padding)
+    crop_size = math.ceil(max_length / float(maximum_stride)) * maximum_stride
+
+    return int(crop_size)
 
 
 def make_centered_bboxes(
@@ -53,6 +106,54 @@ def make_centered_bboxes(
     return corners + offset
 
 
+def generate_crops(
+    image: torch.Tensor,
+    instance: torch.Tensor,
+    centroid: torch.Tensor,
+    crop_size: Tuple[int],
+) -> Dict[str, torch.Tensor]:
+    """Generate cropped image for the given centroid.
+
+    Args:
+        image: Input source image. (n_samples, C, H, W)
+        instance: Keypoints for the instance to be cropped. (n_nodes, 2)
+        centroid: Centroid of the instance to be cropped. (2)
+        crop_size: (height, width) of the crop to be generated.
+
+    Returns:
+        A dictionary with cropped images, bounding box for the cropped instance, keypoints and
+        centroids adjusted to the crop.
+    """
+    box_size = crop_size
+
+    # Generate bounding boxes from centroid.
+    instance_bbox = torch.unsqueeze(
+        make_centered_bboxes(centroid, box_size[0], box_size[1]), 0
+    )  # (n_samples=1, 4, 2)
+
+    # Generate cropped image of shape (n_samples, C, crop_H, crop_W)
+    instance_image = crop_and_resize(
+        image,
+        boxes=instance_bbox,
+        size=box_size,
+    )
+
+    # Access top left point (x,y) of bounding box and subtract this offset from
+    # position of nodes.
+    point = instance_bbox[0][0]
+    center_instance = (instance - point).unsqueeze(0)  # (n_samples=1, n_nodes, 2)
+    centered_centroid = (centroid - point).unsqueeze(0)  # (n_samples=1, 2)
+
+    cropped_sample = {
+        "instance_image": instance_image,
+        "instance_bbox": instance_bbox,
+        "instance": center_instance,
+        "centroid": centered_centroid,
+    }
+
+    return cropped_sample
+
+
 class InstanceCropper(IterDataPipe):
     """IterDataPipe for cropping instances.
 
@@ -60,7 +161,7 @@ class InstanceCropper(IterDataPipe):
 
     Attributes:
         source_dp: The previous `IterDataPipe` with samples that contain an `instances` key.
-        crop_hw: Minimum height and width of the crop in pixels.
+        crop_hw: Height and width of the crop in pixels.
 
     """
 

--- a/sleap_nn/data/normalization.py
+++ b/sleap_nn/data/normalization.py
@@ -41,6 +41,13 @@ def convert_to_rgb(image: torch.Tensor):
     return image
 
 
+def apply_normalization(image: torch.Tensor):
+    """Normalize image tensor."""
+    if not torch.is_floating_point(image):
+        image = image.to(torch.float32) / 255.0
+    return image
+
+
 class Normalizer(IterDataPipe):
     """IterDataPipe for applying normalization.
 

--- a/sleap_nn/data/pipelines.py
+++ b/sleap_nn/data/pipelines.py
@@ -66,13 +66,21 @@ class TopdownConfmapsPipeline:
             provider=provider,
         )
 
-        if use_augmentations and "intensity" in self.data_config.augmentation_config:
-            datapipe = KorniaAugmenter(
-                datapipe,
-                **dict(self.data_config.augmentation_config.intensity),
-                image_key="image",
-                instance_key="instances",
-            )
+        if use_augmentations:
+            if "intensity" in self.data_config.augmentation_config:
+                datapipe = KorniaAugmenter(
+                    datapipe,
+                    **dict(self.data_config.augmentation_config.intensity),
+                    image_key="image",
+                    instance_key="instances",
+                )
+            if "geometric" in self.data_config.augmentation_config:
+                datapipe = KorniaAugmenter(
+                    datapipe,
+                    **dict(self.data_config.augmentation_config.geometric),
+                    image_key="image",
+                    instance_key="instances",
+                )
 
         datapipe = InstanceCentroidFinder(
             datapipe, anchor_ind=self.confmap_head.anchor_part
@@ -82,14 +90,6 @@ class TopdownConfmapsPipeline:
             datapipe,
             self.data_config.preprocessing.crop_hw,
         )
-
-        if use_augmentations and "geometric" in self.data_config.augmentation_config:
-            datapipe = KorniaAugmenter(
-                datapipe,
-                **dict(self.data_config.augmentation_config.geometric),
-                image_key="instance_image",
-                instance_key="instance",
-            )
 
         datapipe = Resizer(
             datapipe,

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -1,6 +1,6 @@
 """This module implements pipeline blocks for reading input data such as labels."""
 
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import numpy as np
 import sleap_io as sio
@@ -26,6 +26,69 @@ def get_max_instances(labels: sio.Labels):
         if num_inst > max_instances:
             max_instances = num_inst
     return max_instances
+
+
+def process_lf(
+    lf: sio.LabeledFrame,
+    video_idx: int,
+    max_instances: int,
+    user_instances_only: bool = True,
+) -> Dict[str, Any]:
+    """Get sample dict from `sio.LabeledFrame`.
+
+    Args:
+        lf: Input `sio.LabeledFrame`.
+        video_idx: Video index of the given lf.
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instancs, frame index, video index, original image size and
+        number of instances.
+
+    """
+    # Filter to user instances
+    if user_instances_only:
+        if lf.user_instances is not None and len(lf.user_instances) > 0:
+            lf.instances = lf.user_instances
+
+    image = np.transpose(lf.image, (2, 0, 1))  # HWC -> CHW
+
+    instances = []
+    for inst in lf:
+        if not inst.is_empty:
+            instances.append(inst.numpy())
+    instances = np.stack(instances, axis=0)
+
+    # Add singleton time dimension for single frames.
+    image = np.expand_dims(image, axis=0)  # (n_samples=1, C, H, W)
+    instances = np.expand_dims(
+        instances, axis=0
+    )  # (n_samples=1, num_instances, num_nodes, 2)
+
+    image = torch.from_numpy(image.astype("float32"))
+    instances = torch.from_numpy(instances.astype("float32"))
+
+    num_instances, nodes = instances.shape[1:3]
+    img_height, img_width = image.shape[-2:]
+
+    # append with nans for broadcasting
+    nans = torch.full((1, np.abs(max_instances - num_instances), nodes, 2), torch.nan)
+    instances = torch.cat(
+        [instances, nans], dim=1
+    )  # (n_samples, max_instances, num_nodes, 2)
+
+    ex = {
+        "image": image,
+        "instances": instances,
+        "video_idx": torch.tensor(video_idx, dtype=torch.int32),
+        "frame_idx": torch.tensor(lf.frame_idx, dtype=torch.int32),
+        "orig_size": torch.Tensor([img_height, img_width]),
+        "num_instances": num_instances,
+    }
+
+    return ex
 
 
 class LabelsReader(IterDataPipe):

--- a/sleap_nn/data/resizing.py
+++ b/sleap_nn/data/resizing.py
@@ -33,7 +33,7 @@ def find_padding_for_stride(
     return pad_height, pad_width
 
 
-def pad_to_stride(image: torch.Tensor, max_stride: int) -> torch.Tensor:
+def apply_pad_to_stride(image: torch.Tensor, max_stride: int) -> torch.Tensor:
     """Pad an image to meet a max stride constraint.
 
     This is useful for ensuring there is no size mismatch between an image and the
@@ -51,19 +51,20 @@ def pad_to_stride(image: torch.Tensor, max_stride: int) -> torch.Tensor:
         The input image with 0-padding applied to the bottom and/or right such that the
         new shape's height and width are both divisible by `max_stride`.
     """
-    image_height, image_width = image.shape[-2:]
-    pad_height, pad_width = find_padding_for_stride(
-        image_height=image_height,
-        image_width=image_width,
-        max_stride=max_stride,
-    )
+    if max_stride > 1:
+        image_height, image_width = image.shape[-2:]
+        pad_height, pad_width = find_padding_for_stride(
+            image_height=image_height,
+            image_width=image_width,
+            max_stride=max_stride,
+        )
 
-    if pad_height > 0 or pad_width > 0:
-        image = F.pad(
-            image,
-            (0, pad_width, 0, pad_height),
-            mode="constant",
-        ).to(torch.float32)
+        if pad_height > 0 or pad_width > 0:
+            image = F.pad(
+                image,
+                (0, pad_width, 0, pad_height),
+                mode="constant",
+            ).to(torch.float32)
     return image
 
 
@@ -81,6 +82,55 @@ def resize_image(image: torch.Tensor, scale: float):
     img_height, img_width = image.shape[-2:]
     new_size = [int(img_height * scale), int(img_width * scale)]
     image = tvf.resize(image, size=new_size)
+    return image
+
+
+def apply_resizer(image: torch.Tensor, instances: torch.Tensor, scale: float = 1.0):
+    """Rescale image and keypoints by a scale factor.
+
+    Args:
+        image: Image tensor of shape (..., channels, height, width)
+        instances: Keypoints tensor.
+        scale: Factor to resize the image dimensions by, specified as a float
+            scalar. Default: 1.0.
+
+    Returns:
+        Tuple with resized image and corresponding keypoints.
+    """
+    if scale != 1.0:
+        image = resize_image(image, scale)
+        instances = instances * scale
+    return image, instances
+
+
+def apply_sizematcher(
+    image: torch.Tensor,
+    max_height: Optional[int] = None,
+    max_width: Optional[int] = None,
+):
+    """Apply padding to smaller image to (max_height, max_width) shape."""
+    img_height, img_width = image.shape[-2:]
+    # pad images to max_height and max_width
+    if max_height is None:
+        max_height = img_height
+    if max_width is None:
+        max_width = img_width
+    pad_height = max_height - img_height
+    pad_width = max_width - img_width
+    if pad_height < 0:
+        raise ValueError(
+            f"Max height {max_height} should be greater than the current image height: {img_height}"
+        )
+    if pad_width < 0:
+        raise ValueError(
+            f"Max width {max_width} should be greater than the current image width: {img_width}"
+        )
+    image = F.pad(
+        image,
+        (0, pad_width, 0, pad_height),
+        mode="constant",
+    ).to(torch.float32)
+
     return image
 
 
@@ -156,8 +206,9 @@ class PadToStride(IterDataPipe):
     def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
         """Return an example dictionary with the resized image and `orig_size` key to represent the original shape of the source image."""
         for ex in self.source_datapipe:
-            if self.max_stride > 1:
-                ex[self.image_key] = pad_to_stride(ex[self.image_key], self.max_stride)
+            ex[self.image_key] = apply_pad_to_stride(
+                ex[self.image_key], self.max_stride
+            )
             yield ex
 
 

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -219,7 +219,7 @@ def compute_oks(
 
     # Compute the OKS.
     n_visible_gt = np.sum(
-        (~missing_gt).astype("float64"), axis=-1, keepdims=True
+        (~missing_gt).astype("float32"), axis=-1, keepdims=True
     )  # (n_gt, 1)
     oks = np.sum(ks, axis=-1) / n_visible_gt
     assert oks.shape == (n_gt, n_pr)

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -18,7 +18,7 @@ from sleap_nn.data.resizing import (
     Resizer,
     PadToStride,
     resize_image,
-    pad_to_stride,
+    apply_pad_to_stride,
 )
 from sleap_nn.data.normalization import Normalizer, convert_to_grayscale, convert_to_rgb
 from sleap_nn.data.instance_centroids import InstanceCentroidFinder
@@ -40,6 +40,7 @@ from sleap_nn.inference.topdown import (
     TopDownInferenceModel,
 )
 from sleap_nn.inference.utils import get_skeleton_from_config
+from sleap_nn.tracking.tracker import Tracker
 
 
 @attrs.define
@@ -50,7 +51,7 @@ class Predictor(ABC):
 
     Attributes:
         preprocess: Only for VideoReader provider. True if preprocessing (reszizing and
-            pad_to_stride) should be applied on the frames read in the video reader.
+            apply_pad_to_stride) should be applied on the frames read in the video reader.
             Default: True.
         video_preprocess_config: Preprocessing config for VideoReader with keys: [`batch_size`,
             `scale`, `is_rgb`, `max_stride`]. Default: {"batch_size": 4, "scale": 1.0,
@@ -88,8 +89,6 @@ class Predictor(ABC):
         integral_patch_size: int = 5,
         batch_size: int = 4,
         max_instances: Optional[int] = None,
-        output_stride: int = 2,
-        pafs_output_stride: int = 4,
         return_confmaps: bool = False,
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
@@ -111,14 +110,6 @@ class Predictor(ABC):
                 integer scalar. Default: 5.
             batch_size: (int) Number of samples per batch. Default: 4.
             max_instances: (int) Max number of instances to consider from the predictions.
-            output_stride: (int) Stride of the output confidence maps relative to the input
-                image. This is the reciprocal of the resolution, e.g., an output stride
-                of 2 results in confidence maps that are 0.5x the size of the input.
-                Increasing this value can considerably speed up model performance and
-                decrease memory requirements, at the cost of decreased spatial resolution.
-                Default: 2
-            pafs_output_stride: (int) Stride of the output part affinity fields relative
-                to the input image. Default: 4.
             return_confmaps: (bool) If `True`, predicted confidence maps will be returned
                 along with the predicted peak values and points. Default: False.
             device: (str) Device on which torch.Tensor will be allocated. One of the
@@ -151,7 +142,6 @@ class Predictor(ABC):
                 integral_refinement=integral_refinement,
                 integral_patch_size=integral_patch_size,
                 batch_size=batch_size,
-                output_stride=output_stride,
                 return_confmaps=return_confmaps,
                 device=device,
                 preprocess_config=preprocess_config,
@@ -174,7 +164,6 @@ class Predictor(ABC):
                 integral_patch_size=integral_patch_size,
                 batch_size=batch_size,
                 max_instances=max_instances,
-                output_stride=output_stride,
                 return_confmaps=return_confmaps,
                 device=device,
                 preprocess_config=preprocess_config,
@@ -189,8 +178,6 @@ class Predictor(ABC):
                 integral_patch_size=integral_patch_size,
                 batch_size=batch_size,
                 max_instances=max_instances,
-                output_stride=output_stride,
-                pafs_output_stride=pafs_output_stride,
                 return_confmaps=return_confmaps,
                 device=device,
                 preprocess_config=preprocess_config,
@@ -290,7 +277,7 @@ class Predictor(ABC):
                         scale = self.video_preprocess_config["scale"]
                         if scale != 1.0:
                             ex["image"] = resize_image(ex["image"], scale)
-                        ex["image"] = pad_to_stride(
+                        ex["image"] = apply_pad_to_stride(
                             ex["image"], self.video_preprocess_config["max_stride"]
                         )
                     outputs_list = self.inference_model(ex)
@@ -373,12 +360,6 @@ class TopDownPredictor(Predictor):
             integer scalar. Default: 5.
         batch_size: (int) Number of samples per batch. Default: 4.
         max_instances: (int) Max number of instances to consider from the predictions.
-        output_stride: (int) Stride of the output confidence maps relative to the input
-            image. This is the reciprocal of the resolution, e.g., an output stride
-            of 2 results in confidence maps that are 0.5x the size of the input.
-            Increasing this value can considerably speed up model performance and
-            decrease memory requirements, at the cost of decreased spatial resolution.
-            Default: 2
         return_confmaps: (bool) If `True`, predicted confidence maps will be returned
             along with the predicted peak values and points. Default: False.
         device: (str) Device on which torch.Tensor will be allocated. One of the
@@ -386,25 +367,27 @@ class TopDownPredictor(Predictor):
             Default: "cpu"
         preprocess_config: (OmegaConf) OmegaConf object with keys as the parameters
             in the `data_config.preprocessing` section.
-
+        tracker: A `sleap_nn.tracking.Tracker` that will be called to associate
+            detections over time. Predicted instances will not be assigned to tracks if
+            if this is `None`.
 
     """
 
-    centroid_config: Optional[OmegaConf] = attrs.field(default=None)
-    confmap_config: Optional[OmegaConf] = attrs.field(default=None)
-    centroid_model: Optional[L.LightningModule] = attrs.field(default=None)
-    confmap_model: Optional[L.LightningModule] = attrs.field(default=None)
-    videos: Optional[List[sio.Video]] = attrs.field(default=None)
-    skeletons: Optional[List[sio.Skeleton]] = attrs.field(default=None)
+    centroid_config: Optional[OmegaConf] = None
+    confmap_config: Optional[OmegaConf] = None
+    centroid_model: Optional[L.LightningModule] = None
+    confmap_model: Optional[L.LightningModule] = None
+    videos: Optional[List[sio.Video]] = None
+    skeletons: Optional[List[sio.Skeleton]] = None
     peak_threshold: Union[float, List[float]] = 0.2
     integral_refinement: str = None
     integral_patch_size: int = 5
     batch_size: int = 4
     max_instances: Optional[int] = None
-    output_stride: int = 2
     return_confmaps: bool = False
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
+    tracker: Optional[Tracker] = None
 
     def _initialize_inference_model(self):
         """Initialize the inference model from the trained models and configuration."""
@@ -430,7 +413,7 @@ class TopDownPredictor(Predictor):
             centroid_crop_layer = CentroidCrop(
                 torch_model=self.centroid_model,
                 peak_threshold=centroid_peak_threshold,
-                output_stride=self.output_stride,
+                output_stride=self.centroid_config.model_config.head_configs.centroid.confmaps.output_stride,
                 refinement=self.integral_refinement,
                 integral_patch_size=self.integral_patch_size,
                 return_confmaps=self.return_confmaps,
@@ -450,7 +433,7 @@ class TopDownPredictor(Predictor):
             instance_peaks_layer = FindInstancePeaks(
                 torch_model=self.confmap_model,
                 peak_threshold=centered_instance_peak_threshold,
-                output_stride=self.output_stride,
+                output_stride=self.confmap_config.model_config.head_configs.centered_instance.confmaps.output_stride,
                 refinement=self.integral_refinement,
                 integral_patch_size=self.integral_patch_size,
                 return_confmaps=self.return_confmaps,
@@ -484,7 +467,6 @@ class TopDownPredictor(Predictor):
         integral_patch_size: int = 5,
         batch_size: int = 4,
         max_instances: Optional[int] = None,
-        output_stride: int = 2,
         return_confmaps: bool = False,
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
@@ -503,12 +485,6 @@ class TopDownPredictor(Predictor):
                 integer scalar. Default: 5.
             batch_size: (int) Number of samples per batch. Default: 4.
             max_instances: (int) Max number of instances to consider from the predictions.
-            output_stride: (int) Stride of the output confidence maps relative to the input
-                image. This is the reciprocal of the resolution, e.g., an output stride
-                of 2 results in confidence maps that are 0.5x the size of the input.
-                Increasing this value can considerably speed up model performance and
-                decrease memory requirements, at the cost of decreased spatial resolution.
-                Default: 2.
             return_confmaps: (bool) If `True`, predicted confidence maps will be returned
                 along with the predicted peak values and points. Default: False.
             device: (str) Device on which torch.Tensor will be allocated. One of the
@@ -531,7 +507,7 @@ class TopDownPredictor(Predictor):
             )
             skeletons = get_skeleton_from_config(centroid_config.data_config.skeletons)
             centroid_model = CentroidModel.load_from_checkpoint(
-                f"{centroid_ckpt_path}/best.ckpt",
+                checkpoint_path=f"{centroid_ckpt_path}/best.ckpt",
                 config=centroid_config,
                 skeletons=skeletons,
                 model_type="centroid",
@@ -547,7 +523,7 @@ class TopDownPredictor(Predictor):
             confmap_config = OmegaConf.load(f"{confmap_ckpt_path}/training_config.yaml")
             skeletons = get_skeleton_from_config(confmap_config.data_config.skeletons)
             confmap_model = TopDownCenteredInstanceModel.load_from_checkpoint(
-                f"{confmap_ckpt_path}/best.ckpt",
+                checkpoint_path=f"{confmap_ckpt_path}/best.ckpt",
                 config=confmap_config,
                 skeletons=skeletons,
                 model_type="centered_instance",
@@ -570,7 +546,6 @@ class TopDownPredictor(Predictor):
             integral_patch_size=integral_patch_size,
             batch_size=batch_size,
             max_instances=max_instances,
-            output_stride=output_stride,
             return_confmaps=return_confmaps,
             device=device,
             preprocess_config=preprocess_config,
@@ -701,7 +676,8 @@ class TopDownPredictor(Predictor):
     ) -> sio.Labels:
         """Create labeled frames from a generator that yields inference results.
 
-        This method converts pure arrays into SLEAP-specific data structures.
+        This method converts pure arrays into SLEAP-specific data structures and assigns
+        tracks to the predicted instances if tracker is specified.
 
         Args:
             generator: A generator that returns dictionaries with inference results.
@@ -749,13 +725,18 @@ class TopDownPredictor(Predictor):
         for key, inst in preds.items():
             # Create list of LabeledFrames.
             video_idx, frame_idx = key
-            predicted_frames.append(
-                sio.LabeledFrame(
-                    video=self.videos[video_idx],
-                    frame_idx=frame_idx,
-                    instances=inst,
-                )
+            lf = sio.LabeledFrame(
+                video=self.videos[video_idx],
+                frame_idx=frame_idx,
+                instances=inst,
             )
+
+            if self.tracker:
+                lf.instances = self.tracker.track(
+                    untracked_instances=inst, frame_idx=frame_idx, image=lf.image
+                )
+
+            predicted_frames.append(lf)
 
         pred_labels = sio.Labels(
             videos=self.videos,
@@ -791,12 +772,6 @@ class SingleInstancePredictor(Predictor):
         integral_patch_size: (int) Size of patches to crop around each rough peak as an
             integer scalar. Default: 5.
         batch_size: (int) Number of samples per batch. Default: 4.
-        output_stride: (int) Stride of the output confidence maps relative to the input
-            image. This is the reciprocal of the resolution, e.g., an output stride
-            of 2 results in confidence maps that are 0.5x the size of the input.
-            Increasing this value can considerably speed up model performance and
-            decrease memory requirements, at the cost of decreased spatial resolution.
-            Default: 2
         return_confmaps: (bool) If `True`, predicted confidence maps will be returned
             along with the predicted peak values and points. Default: False.
         device: (str) Device on which torch.Tensor will be allocated. One of the
@@ -815,7 +790,6 @@ class SingleInstancePredictor(Predictor):
     integral_refinement: str = None
     integral_patch_size: int = 5
     batch_size: int = 4
-    output_stride: int = 2
     return_confmaps: bool = False
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
@@ -825,7 +799,7 @@ class SingleInstancePredictor(Predictor):
         self.inference_model = SingleInstanceInferenceModel(
             torch_model=self.confmap_model,
             peak_threshold=self.peak_threshold,
-            output_stride=self.output_stride,
+            output_stride=self.confmap_config.model_config.head_configs.single_instance.confmaps.output_stride,
             refinement=self.integral_refinement,
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
@@ -848,7 +822,6 @@ class SingleInstancePredictor(Predictor):
         integral_refinement: str = None,
         integral_patch_size: int = 5,
         batch_size: int = 4,
-        output_stride: int = 2,
         return_confmaps: bool = False,
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
@@ -865,12 +838,6 @@ class SingleInstancePredictor(Predictor):
             integral_patch_size: (int) Size of patches to crop around each rough peak as an
                 integer scalar. Default: 5.
             batch_size: (int) Number of samples per batch. Default: 4.
-            output_stride: (int) Stride of the output confidence maps relative to the input
-                image. This is the reciprocal of the resolution, e.g., an output stride
-                of 2 results in confidence maps that are 0.5x the size of the input.
-                Increasing this value can considerably speed up model performance and
-                decrease memory requirements, at the cost of decreased spatial resolution.
-                Default: 2
             return_confmaps: (bool) If `True`, predicted confidence maps will be returned
                 along with the predicted peak values and points. Default: False.
             device: (str) Device on which torch.Tensor will be allocated. One of the
@@ -886,7 +853,7 @@ class SingleInstancePredictor(Predictor):
         confmap_config = OmegaConf.load(f"{confmap_ckpt_path}/training_config.yaml")
         skeletons = get_skeleton_from_config(confmap_config.data_config.skeletons)
         confmap_model = SingleInstanceModel.load_from_checkpoint(
-            f"{confmap_ckpt_path}/best.ckpt",
+            checkpoint_path=f"{confmap_ckpt_path}/best.ckpt",
             config=confmap_config,
             skeletons=skeletons,
             model_type="single_instance",
@@ -902,7 +869,6 @@ class SingleInstancePredictor(Predictor):
             integral_refinement=integral_refinement,
             integral_patch_size=integral_patch_size,
             batch_size=batch_size,
-            output_stride=output_stride,
             return_confmaps=return_confmaps,
             device=device,
             preprocess_config=preprocess_config,
@@ -1088,14 +1054,6 @@ class BottomUpPredictor(Predictor):
             integer scalar. Default: 5.
         batch_size: (int) Number of samples per batch. Default: 4.
         max_instances: (int) Max number of instances to consider from the predictions.
-        output_stride: (int) Stride of the output confidence maps relative to the input
-            image. This is the reciprocal of the resolution, e.g., an output stride
-            of 2 results in confidence maps that are 0.5x the size of the input.
-            Increasing this value can considerably speed up model performance and
-            decrease memory requirements, at the cost of decreased spatial resolution.
-            Default: 2
-        pafs_output_stride: (int) Stride of the output part affinity fields relative
-            to the input image. Default: 4.
         return_confmaps: (bool) If `True`, predicted confidence maps will be returned
             along with the predicted peak values and points. Default: False.
         device: (str) Device on which torch.Tensor will be allocated. One of the
@@ -1103,6 +1061,9 @@ class BottomUpPredictor(Predictor):
             Default: "cpu".
         preprocess_config: (OmegaConf) OmegaConf object with keys as the parameters
                 in the `data_config.preprocessing` section.
+        tracker: A `sleap.nn.tracking.Tracker` that will be called to associate
+            detections over time. Predicted instances will not be assigned to tracks if
+            if this is `None`.
 
     """
 
@@ -1120,11 +1081,10 @@ class BottomUpPredictor(Predictor):
     integral_patch_size: int = 5
     batch_size: int = 4
     max_instances: Optional[int] = None
-    output_stride: int = 2
-    pafs_output_stride: int = 4
     return_confmaps: bool = False
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
+    tracker: Optional[Tracker] = None
 
     def _initialize_inference_model(self):
         """Initialize the inference model from the trained models and configuration."""
@@ -1152,8 +1112,8 @@ class BottomUpPredictor(Predictor):
             torch_model=self.bottomup_model,
             paf_scorer=paf_scorer,
             peak_threshold=self.peak_threshold,
-            cms_output_stride=self.output_stride,
-            pafs_output_stride=self.pafs_output_stride,
+            cms_output_stride=self.bottomup_config.model_config.head_configs.bottomup.confmaps.output_stride,
+            pafs_output_stride=self.bottomup_config.model_config.head_configs.bottomup.pafs.output_stride,
             refinement=self.integral_refinement,
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
@@ -1177,8 +1137,6 @@ class BottomUpPredictor(Predictor):
         integral_patch_size: int = 5,
         batch_size: int = 4,
         max_instances: Optional[int] = None,
-        output_stride: int = 2,
-        pafs_output_stride: int = 4,
         return_confmaps: bool = False,
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
@@ -1196,14 +1154,6 @@ class BottomUpPredictor(Predictor):
                 integer scalar. Default: 5.
             batch_size: (int) Number of samples per batch. Default: 4.
             max_instances: (int) Max number of instances to consider from the predictions.
-            output_stride: (int) Stride of the output confidence maps relative to the input
-                image. This is the reciprocal of the resolution, e.g., an output stride
-                of 2 results in confidence maps that are 0.5x the size of the input.
-                Increasing this value can considerably speed up model performance and
-                decrease memory requirements, at the cost of decreased spatial resolution.
-                Default: 2
-            pafs_output_stride: (int) Stride of the output part affinity fields relative
-                to the input image. Default: 4.
             return_confmaps: (bool) If `True`, predicted confidence maps will be returned
                 along with the predicted peak values and points. Default: False.
             device: (str) Device on which torch.Tensor will be allocated. One of the
@@ -1236,8 +1186,6 @@ class BottomUpPredictor(Predictor):
             integral_patch_size=integral_patch_size,
             batch_size=batch_size,
             max_instances=max_instances,
-            output_stride=output_stride,
-            pafs_output_stride=pafs_output_stride,
             return_confmaps=return_confmaps,
             preprocess_config=preprocess_config,
         )
@@ -1327,7 +1275,8 @@ class BottomUpPredictor(Predictor):
     ) -> sio.Labels:
         """Create labeled frames from a generator that yields inference results.
 
-        This method converts pure arrays into SLEAP-specific data structures.
+        This method converts pure arrays into SLEAP-specific data structures and assigns
+        tracks to the predicted instances if tracker is specified.
 
         Args:
             generator: A generator that returns dictionaries with inference results.
@@ -1388,13 +1337,20 @@ class BottomUpPredictor(Predictor):
                         : min(max_instances, len(predicted_instances))
                     ]
 
-                predicted_frames.append(
-                    sio.LabeledFrame(
-                        video=self.videos[video_idx],
-                        frame_idx=frame_idx,
-                        instances=predicted_instances,
-                    )
+                lf = sio.LabeledFrame(
+                    video=self.videos[video_idx],
+                    frame_idx=frame_idx,
+                    instances=predicted_instances,
                 )
+
+                if self.tracker:
+                    lf.instances = self.tracker.track(
+                        untracked_instances=predicted_instances,
+                        frame_idx=frame_idx,
+                        image=lf.image,
+                    )
+
+                predicted_frames.append(lf)
 
         pred_labels = sio.Labels(
             videos=self.videos,
@@ -1418,8 +1374,6 @@ def main(
     videoreader_start_idx: int = 0,
     videoreader_end_idx: int = 100,
     crop_hw: List[int] = (160, 160),
-    output_stride: int = 2,
-    pafs_output_stride: int = 4,
     peak_threshold: Union[float, List[float]] = 0.2,
     integral_refinement: str = None,
     integral_patch_size: int = 5,
@@ -1434,6 +1388,19 @@ def main(
     make_labels: bool = True,
     save_path: str = "",
     device: str = "cpu",
+    tracking: bool = False,
+    tracking_window_size: int = 5,
+    tracking_instance_score_threshold: float = 0.0,
+    candidates_method: str = "fixed_window",
+    features: str = "keypoints",
+    scoring_method: str = "oks",
+    scoring_reduction: str = "mean",
+    track_matching_method: str = "hungarian",
+    max_tracks: Optional[int] = None,
+    use_flow: bool = False,
+    of_img_scale: float = 1.0,
+    of_window_size: int = 21,
+    of_max_levels: int = 3,
 ):
     """Entry point to run inference on trained SLEAP-NN models.
 
@@ -1460,14 +1427,6 @@ def main(
         videoreader_start_idx: (int) Start index of the frames to read. Default: 0.
         videoreader_end_idx: (int) End index of the frames to read. Default: 100.
         crop_hw: List[int] Minimum height and width of the crop in pixels. Default: (160, 160).
-        output_stride: (int) Stride of the output confidence maps relative to the input
-                image. This is the reciprocal of the resolution, e.g., an output stride
-                of 2 results in confidence maps that are 0.5x the size of the input.
-                Increasing this value can considerably speed up model performance and
-                decrease memory requirements, at the cost of decreased spatial resolution.
-                Default: 2
-        pafs_output_stride: (int) Stride of the output part affinity fields relative
-                to the input image. Default: 4.
         peak_threshold: (float) Minimum confidence threshold. Peaks with values below
                 this will be ignored. Default: 0.2. This can also be `List[float]` for topdown
                 centroid and centered-instance model, where the first element corresponds
@@ -1511,6 +1470,38 @@ def main(
         device: (str) Device on which torch.Tensor will be allocated. One of the
                 ("cpu", "cuda", "mkldnn", "opengl", "opencl", "ideep", "hip", "msnpu").
                 Default: "cpu".
+        tracking: (bool) If True, runs tracking on the predicted instances.
+        tracking_window_size: Number of frames to look for in the candidate instances to match
+                with the current detections. Default: 5.
+        tracking_instance_score_threshold: Instance score threshold for creating new tracks.
+            Default: 0.0.
+        candidates_method: Either of `fixed_window` or `local_queues`. In fixed window
+            method, candidates from the last `window_size` frames. In local queues,
+            last `window_size` instances for each track ID is considered for matching
+            against the current detection. Default: `fixed_window`.
+        features: Feature representation for the candidates to update current detections.
+            One of [`keypoints`, `centroids`, `bboxes`, `image`]. Default: `keypoints`.
+        scoring_method: Method to compute association score between features from the
+            current frame and the previous tracks. One of [`oks`, `cosine_sim`, `iou`,
+            `euclidean_dist`]. Default: `oks`.
+        scoring_reduction: Method to aggregate and reduce multiple scores if there are
+            several detections associated with the same track. One of [`mean`, `max`,
+            `weighted`]. Default: `mean`.
+        track_matching_method: Track matching algorithm. One of `hungarian`, `greedy.
+            Default: `hungarian`.
+        max_tracks: Meaximum number of new tracks to be created to avoid redundant tracks.
+            (only for local queues candidate) Default: None.
+        use_flow: If True, `FlowShiftTracker` is used, where the poses are matched using
+        optical flow shifts. Default: `False`.
+        of_img_scale: Factor to scale the images by when computing optical flow. Decrease
+            this to increase performance at the cost of finer accuracy. Sometimes
+            decreasing the image scale can improve performance with fast movements.
+            Default: 1.0. (only if `use_flow` is True)
+        of_window_size: Optical flow window size to consider at each pyramid scale
+            level. Default: 21. (only if `use_flow` is True)
+        of_max_levels: Number of pyramid scale levels to consider. This is different
+            from the scale parameter, which determines the initial image scaling.
+            Default: 3. (only if `use_flow` is True)
 
     Returns:
         Returns `sio.Labels` object if `make_labels` is True. Else this function returns
@@ -1537,12 +1528,26 @@ def main(
         integral_patch_size=integral_patch_size,
         batch_size=batch_size,
         max_instances=max_instances,
-        output_stride=output_stride,
-        pafs_output_stride=pafs_output_stride,
         return_confmaps=return_confmaps,
         device=device,
         preprocess_config=OmegaConf.create(preprocess_config),
     )
+
+    if tracking:
+        predictor.tracker = Tracker.from_config(
+            candidates_method=candidates_method,
+            window_size=tracking_window_size,
+            instance_score_threshold=tracking_instance_score_threshold,
+            features=features,
+            scoring_method=scoring_method,
+            scoring_reduction=scoring_reduction,
+            track_matching_method=track_matching_method,
+            max_tracks=max_tracks,
+            use_flow=use_flow,
+            of_img_scale=of_img_scale,
+            of_window_size=of_window_size,
+            of_max_levels=of_max_levels,
+        )
 
     if isinstance(predictor, BottomUpPredictor):
         predictor.inference_model.paf_scorer.max_edge_length_ratio = (

--- a/sleap_nn/inference/topdown.py
+++ b/sleap_nn/inference/topdown.py
@@ -6,7 +6,7 @@ import lightning as L
 import numpy as np
 from sleap_nn.data.resizing import (
     resize_image,
-    pad_to_stride,
+    apply_pad_to_stride,
 )
 from sleap_nn.inference.peak_finding import crop_bboxes
 from sleap_nn.data.instance_cropping import make_centered_bboxes
@@ -156,7 +156,7 @@ class CentroidCrop(L.LightningModule):
         orig_image = inputs["image"]
         scaled_image = resize_image(orig_image, self.input_scale)
         if self.max_stride != 1:
-            scaled_image = pad_to_stride(scaled_image, self.max_stride)
+            scaled_image = apply_pad_to_stride(scaled_image, self.max_stride)
 
         cms = self.torch_model(scaled_image)
 
@@ -395,7 +395,7 @@ class FindInstancePeaks(L.LightningModule):
         orig_image = inputs["instance_image"]
         scaled_image = resize_image(orig_image, self.input_scale)
         if self.max_stride != 1:
-            scaled_image = pad_to_stride(scaled_image, self.max_stride)
+            scaled_image = apply_pad_to_stride(scaled_image, self.max_stride)
 
         cms = self.torch_model(scaled_image)
 

--- a/sleap_nn/tracking/__init__.py
+++ b/sleap_nn/tracking/__init__.py
@@ -1,0 +1,1 @@
+"""Tracker related modules."""

--- a/sleap_nn/tracking/candidates/fixed_window.py
+++ b/sleap_nn/tracking/candidates/fixed_window.py
@@ -1,0 +1,143 @@
+"""Module to generate Fixed window candidates."""
+
+from typing import Optional, List, Deque, Union
+from sleap_nn.tracking.track_instance import TrackInstances, TrackedInstanceFeature
+import sleap_io as sio
+from collections import deque
+import numpy as np
+
+
+class FixedWindowCandidates:
+    """Fixed-window method for candidate generation.
+
+    This module handles `tracker_queue` using the fixed window method, where track assignments
+    are determined based on the last `window_size` frames.
+
+    Attributes:
+        window_size: Number of previous frames to compare the current predicted instance with.
+            Default: 5.
+        instance_score_threshold: Instance score threshold for creating new tracks.
+            Default: 0.0.
+        tracker_queue: Deque object that stores the past `window_size` tracked instances.
+        current_tracks: List of track IDs that are being tracked.
+    """
+
+    def __init__(self, window_size: int = 5, instance_score_threshold: float = 0.0):
+        """Initialize class variables."""
+        self.window_size = window_size
+        self.instance_score_threshold = instance_score_threshold
+        self.tracker_queue = deque(maxlen=self.window_size)
+        self.current_tracks = []
+
+    def get_track_instances(
+        self,
+        feature_list: List[Union[np.array]],
+        untracked_instances: List[sio.PredictedInstance],
+        frame_idx: int,
+        image: np.array,
+    ) -> TrackInstances:
+        """Return an instance of `TrackInstances` object for the `untracked_instances`."""
+        track_instance = TrackInstances(
+            src_instances=untracked_instances,
+            track_ids=[None] * len(untracked_instances),
+            tracking_scores=[None] * len(untracked_instances),
+            features=feature_list,
+            instance_scores=[instance.score for instance in untracked_instances],
+            frame_idx=frame_idx,
+            image=image,
+        )
+        return track_instance
+
+    def get_features_from_track_id(
+        self, track_id: int, candidates_list: Optional[Deque] = None
+    ) -> List[TrackedInstanceFeature]:
+        """Return list of `TrackedInstanceFeature` objects for instances in tracker queue with the given `track_id`.
+
+        Note: If `candidates_list` is `None`, then features of all the instances in the
+            tracker queue are returned by default. Else, only the features from the given
+            candidates_list are returned.
+        """
+        output = []
+        tracked_candidates = (
+            candidates_list if candidates_list is not None else self.tracker_queue
+        )
+        for t in tracked_candidates:
+            if track_id in t.track_ids:
+                track_idx = t.track_ids.index(track_id)
+                tracked_instance_feature = TrackedInstanceFeature(
+                    feature=t.features[track_idx],
+                    src_predicted_instance=t.src_instances[track_idx],
+                    frame_idx=t.frame_idx,
+                    tracking_score=t.tracking_scores[track_idx],
+                    instance_score=t.instance_scores[track_idx],
+                    shifted_keypoints=None,
+                )
+                output.append(tracked_instance_feature)
+        return output
+
+    def get_new_track_id(self) -> int:
+        """Return a new track_id."""
+        if not self.current_tracks:
+            new_track_id = 0
+        else:
+            new_track_id = max(self.current_tracks) + 1
+        return new_track_id
+
+    def add_new_tracks(
+        self, current_instances: TrackInstances, add_to_queue: bool = True
+    ) -> TrackInstances:
+        """Add new track IDs to the `TrackInstances` object and to the tracker queue."""
+        is_new_track = False
+        for i, score in enumerate(current_instances.instance_scores):
+            if (
+                score > self.instance_score_threshold
+                and current_instances.track_ids[i] is None
+            ):
+                is_new_track = True
+                new_tracks_id = self.get_new_track_id()
+                current_instances.track_ids[i] = new_tracks_id
+                current_instances.tracking_scores[i] = 1.0
+                self.current_tracks.append(new_tracks_id)
+
+        if add_to_queue and is_new_track:
+            self.tracker_queue.append(current_instances)
+
+        return current_instances
+
+    def update_tracks(
+        self,
+        current_instances: TrackInstances,
+        row_inds: np.array,
+        col_inds: np.array,
+        tracking_scores: List[float],
+    ) -> TrackInstances:
+        """Assign tracks to `TrackInstances` based on the output of track matching algorithm.
+
+        Args:
+            current_instances: `TrackInstances` instance with features and unassigned tracks.
+            row_inds: List of indices for the  `current_instances` object that has an assigned
+                track.
+            col_inds: List of track IDs that have been assigned a new instance.
+            tracking_scores: List of tracking scores from the cost matrix.
+
+        """
+        add_to_queue = True
+        if np.any(row_inds) and np.any(col_inds):
+
+            for idx, (row, col) in enumerate(zip(row_inds, col_inds)):
+                current_instances.track_ids[row] = col
+                current_instances.tracking_scores[row] = tracking_scores[idx]
+
+            # update tracks to queue
+            self.tracker_queue.append(current_instances)
+            add_to_queue = False
+
+            # Create new tracks for instances with unassigned tracks from track matching
+            new_current_instances_inds = [
+                x for x in range(len(current_instances.features)) if x not in row_inds
+            ]
+            if new_current_instances_inds:
+                current_instances = self.add_new_tracks(
+                    current_instances, add_to_queue=add_to_queue
+                )
+        return current_instances

--- a/sleap_nn/tracking/candidates/local_queues.py
+++ b/sleap_nn/tracking/candidates/local_queues.py
@@ -1,0 +1,164 @@
+"""Module to generate Tracking local queue candidates."""
+
+from typing import Dict, Optional, List, Deque, DefaultDict, Union
+import numpy as np
+import sleap_io as sio
+from sleap_nn.tracking.track_instance import (
+    TrackInstanceLocalQueue,
+    TrackedInstanceFeature,
+)
+from collections import defaultdict, deque
+
+
+class LocalQueueCandidates:
+    """Track local queues method for candidate generation.
+
+    This module handles `tracker_queue` using the local queues method, where track assignments
+    are determined based on the last `window_size` instances for each track.
+
+    Attributes:
+        window_size: Number of previous frames to compare the current predicted instance with.
+            Default: 5.
+        max_tracks: Maximum number of new tracks that can be created. Default: None.
+        instance_score_threshold: Instance score threshold for creating new tracks.
+            Default: 0.0.
+        tracker_queue: Dictionary that stores the past frames of all the tracks identified
+            so far as `deque`.
+        current_tracks: List of track IDs that are being tracked.
+    """
+
+    def __init__(
+        self,
+        window_size: int = 5,
+        max_tracks: Optional[int] = None,
+        instance_score_threshold: float = 0.0,
+    ):
+        """Initialize class variables."""
+        self.window_size = window_size
+        self.max_tracks = max_tracks
+        self.instance_score_threshold = instance_score_threshold
+        self.tracker_queue = defaultdict(Deque)
+        self.current_tracks = []
+
+    def get_track_instances(
+        self,
+        feature_list: List[Union[np.array]],
+        untracked_instances: List[sio.PredictedInstance],
+        frame_idx: int,
+        image: np.array,
+    ) -> List[TrackInstanceLocalQueue]:
+        """Return a list of `TrackInstanceLocalQueue` instances for the `untracked_instances`."""
+        track_instances = []
+        for ind, (feat, instance) in enumerate(zip(feature_list, untracked_instances)):
+            track_instance = TrackInstanceLocalQueue(
+                src_instance=instance,
+                src_instance_idx=ind,
+                track_id=None,
+                feature=feat,
+                instance_score=instance.score,
+                frame_idx=frame_idx,
+                image=image,
+            )
+            track_instances.append(track_instance)
+        return track_instances
+
+    def get_features_from_track_id(
+        self, track_id: int, candidates_list: Optional[DefaultDict[int, Deque]] = None
+    ) -> List[TrackedInstanceFeature]:
+        """Return list of `TrackedInstanceFeature` objects for instances in tracker queue with the given `track_id`.
+
+        Note: If `candidates_list` is `None`, then features of all the instances in the
+            tracker queue are returned by default. Else, only the features from the given
+            candidates_list are returned.
+        """
+        tracked_instances = (
+            candidates_list if candidates_list is not None else self.tracker_queue
+        )
+        output = []
+        for t in tracked_instances[track_id]:
+            tracked_instance_feature = TrackedInstanceFeature(
+                feature=t.feature,
+                src_predicted_instance=t.src_instance,
+                frame_idx=t.frame_idx,
+                tracking_score=t.tracking_score,
+                instance_score=t.instance_score,
+                shifted_keypoints=None,
+            )
+            output.append(tracked_instance_feature)
+        return output
+
+    def get_new_track_id(self) -> int:
+        """Return a new track_id."""
+        if not self.current_tracks:
+            new_track_id = 0
+        else:
+            new_track_id = max(self.current_tracks) + 1
+            if self.max_tracks is not None and new_track_id > self.max_tracks:  # TODO
+                raise Exception("Exceeding max tracks")
+        self.tracker_queue[new_track_id] = deque(maxlen=self.window_size)
+        return new_track_id
+
+    def add_new_tracks(
+        self, current_instances: List[TrackInstanceLocalQueue]
+    ) -> List[TrackInstanceLocalQueue]:
+        """Add new track IDs to the `TrackInstanceLocalQueue` objects and to the tracker queue."""
+        track_instances = []
+        for t in current_instances:
+            if t.instance_score > self.instance_score_threshold:
+                new_track_id = self.get_new_track_id()
+                t.track_id = new_track_id
+                t.tracking_score = 1.0
+                self.current_tracks.append(new_track_id)
+                self.tracker_queue[new_track_id].append(t)
+            track_instances.append(t)
+
+        return track_instances
+
+    def update_tracks(
+        self,
+        current_instances: List[TrackInstanceLocalQueue],
+        row_inds: np.array,
+        col_inds: np.array,
+        tracking_scores: List[float],
+    ) -> List[TrackInstanceLocalQueue]:
+        """Assign tracks to `TrackInstanceLocalQueue` objects based on the output of track matching algorithm.
+
+        Args:
+            current_instances: List of TrackInstanceLocalQueue objects with features and unassigned tracks.
+            row_inds: List of indices for the  `current_instances` object that has an assigned
+                track.
+            col_inds: List of track IDs that have been assigned a new instance.
+            tracking_scores: List of tracking scores from the cost matrix.
+
+        """
+        if np.any(row_inds) and np.any(col_inds):
+            for idx, (row, col) in enumerate(zip(row_inds, col_inds)):
+                current_instances[row].track_id = col
+                current_instances[row].tracking_score = tracking_scores[idx]
+
+            for track_instance in current_instances:
+                if track_instance.track_id is not None:
+                    self.tracker_queue[track_instance.track_id].append(track_instance)
+
+            # Create new tracks for instances with unassigned tracks from track matching
+            new_current_instances_inds = [
+                x for x in range(len(current_instances)) if x not in row_inds
+            ]
+            if new_current_instances_inds:
+                for ind in new_current_instances_inds:
+                    self.add_new_tracks(current_instances[ind])
+
+        return current_instances
+
+    def get_instances_groupby_frame_idx(
+        self, candidates_list: Optional[DefaultDict[int, Deque]]
+    ) -> Dict[int, List[TrackInstanceLocalQueue]]:
+        """Return dictionary with list of `TrackInstanceLocalQueue` objects grouped by frame index."""
+        instances_dict = defaultdict(list)
+        tracked_instances = (
+            candidates_list if candidates_list is not None else self.tracker_queue
+        )
+        for _, instances in tracked_instances.items():
+            for instance in instances:
+                instances_dict[instance.frame_idx].append(instance)
+        return instances_dict

--- a/sleap_nn/tracking/track_instance.py
+++ b/sleap_nn/tracking/track_instance.py
@@ -1,0 +1,50 @@
+"""TrackInstance Data structure for Tracker queue."""
+
+from typing import List, Optional
+import attrs
+import numpy as np
+import sleap_io as sio
+
+
+@attrs.define
+class TrackInstances:
+    """Data structure for instances in tracker queue for fixed window method."""
+
+    src_instances: List[sio.PredictedInstance]
+    features: List[np.array]
+    instance_scores: List[float] = None
+    track_ids: Optional[List[int]] = None
+    tracking_scores: Optional[List[float]] = None
+    frame_idx: Optional[float] = None
+    image: Optional[np.array] = None
+
+
+@attrs.define
+class TrackInstanceLocalQueue:
+    """Data structure for instances in tracker queue for Local Queue method."""
+
+    src_instance: sio.PredictedInstance
+    src_instance_idx: int
+    feature: np.array
+    instance_score: float = None
+    track_id: Optional[int] = None
+    tracking_score: Optional[float] = None
+    frame_idx: Optional[float] = None
+    image: Optional[np.array] = None
+
+
+@attrs.define
+class TrackedInstanceFeature:
+    """Data structure for tracked instances.
+
+    This data structure is used for updating the previous tracked instances and get the
+    features of the tracked instances. `shifted_keypoints` is used only for the `FlowShiftTracker`
+    to store the optical flow shifted instances.
+    """
+
+    feature: np.ndarray
+    src_predicted_instance: sio.PredictedInstance
+    frame_idx: int
+    tracking_score: float
+    instance_score: float
+    shifted_keypoints: np.ndarray = None

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -1,0 +1,604 @@
+"""Module for tracking."""
+
+from typing import Any, Dict, List, Union, Deque, DefaultDict, Optional
+from collections import defaultdict
+import attrs
+import cv2
+import numpy as np
+
+import sleap_io as sio
+from sleap_nn.evaluation import compute_oks
+from sleap_nn.tracking.candidates.fixed_window import FixedWindowCandidates
+from sleap_nn.tracking.candidates.local_queues import LocalQueueCandidates
+from sleap_nn.tracking.track_instance import (
+    TrackedInstanceFeature,
+    TrackInstances,
+    TrackInstanceLocalQueue,
+)
+from sleap_nn.tracking.utils import (
+    hungarian_matching,
+    greedy_matching,
+    get_bbox,
+    get_centroid,
+    get_keypoints,
+    compute_euclidean_distance,
+    compute_iou,
+    compute_cosine_sim,
+)
+
+
+@attrs.define
+class Tracker:
+    """Simple Pose Tracker.
+
+    This is the base class for all Trackers. This module handles tracking instances
+    across frames by creating new track IDs (or) assigning track IDs to each predicted
+    instance when the `.track()` is called. This class is initialized in the `Predictor`
+    classes.
+
+    Attributes:
+        candidate: Instance of either `FixedWindowCandidates` or `LocalQueueCandidates`.
+        features: Feature representation for the candidates to update current detections.
+            One of [`keypoints`, `centroids`, `bboxes`, `image`]. Default: `keypoints`.
+        scoring_method: Method to compute association score between features from the
+            current frame and the previous tracks. One of [`oks`, `cosine_sim`, `iou`,
+            `euclidean_dist`]. Default: `oks`.
+        scoring_reduction: Method to aggregate and reduce multiple scores if there are
+            several detections associated with the same track. One of [`mean`, `max`,
+            `weighted`]. Default: `mean`.
+        track_matching_method: Track matching algorithm. One of `hungarian`, `greedy.
+                Default: `hungarian`.
+        use_flow: If True, `FlowShiftTracker` is used, where the poses are matched using
+            optical flow shifts. Default: `False`.
+        is_local_queue: `True` if `LocalQueueCandidates` is used else `False`.
+
+    """
+
+    candidate: Union[FixedWindowCandidates, LocalQueueCandidates] = (
+        FixedWindowCandidates()
+    )
+    features: str = "keypoints"
+    scoring_method: str = "oks"
+    scoring_reduction: str = "mean"
+    track_matching_method: str = "hungarian"
+    use_flow: bool = False
+    is_local_queue: bool = False
+    _scoring_functions: Dict[str, Any] = {
+        "oks": compute_oks,
+        "iou": compute_iou,
+        "cosine_sim": compute_cosine_sim,
+        "euclidean_dist": compute_euclidean_distance,
+    }
+    _scoring_reduction_methods: Dict[str, Any] = {"mean": np.nanmean, "max": np.nanmax}
+    _feature_methods: Dict[str, Any] = {
+        "keypoints": get_keypoints,
+        "centroids": get_centroid,
+        "bboxes": get_bbox,
+    }
+    _track_matching_methods: Dict[str, Any] = {
+        "hungarian": hungarian_matching,
+        "greedy": greedy_matching,
+    }
+    _track_objects: Dict[int, sio.Track] = {}
+
+    @classmethod
+    def from_config(
+        cls,
+        window_size: int = 5,
+        instance_score_threshold: float = 0.0,
+        candidates_method: str = "fixed_window",
+        features: str = "keypoints",
+        scoring_method: str = "oks",
+        scoring_reduction: str = "mean",
+        track_matching_method: str = "hungarian",
+        max_tracks: Optional[int] = None,
+        use_flow: bool = False,
+        of_img_scale: float = 1.0,
+        of_window_size: int = 21,
+        of_max_levels: int = 3,
+    ):
+        """Create `Tracker` from config.
+
+        Args:
+            window_size: Number of frames to look for in the candidate instances to match
+                with the current detections. Default: 5.
+            instance_score_threshold: Instance score threshold for creating new tracks.
+                Default: 0.0.
+            candidates_method: Either of `fixed_window` or `local_queues`. In fixed window
+                method, candidates from the last `window_size` frames. In local queues,
+                last `window_size` instances for each track ID is considered for matching
+                against the current detection. Default: `fixed_window`.
+            features: Feature representation for the candidates to update current detections.
+                One of [`keypoints`, `centroids`, `bboxes`, `image`]. Default: `keypoints`.
+            scoring_method: Method to compute association score between features from the
+                current frame and the previous tracks. One of [`oks`, `cosine_sim`, `iou`,
+                `euclidean_dist`]. Default: `oks`.
+            scoring_reduction: Method to aggregate and reduce multiple scores if there are
+                several detections associated with the same track. One of [`mean`, `max`,
+                `weighted`]. Default: `mean`.
+            track_matching_method: Track matching algorithm. One of `hungarian`, `greedy.
+                Default: `hungarian`.
+            max_tracks: Meaximum number of new tracks to be created to avoid redundant tracks.
+                (only for local queues candidate) Default: None.
+            use_flow: If True, `FlowShiftTracker` is used, where the poses are matched using
+            optical flow shifts. Default: `False`.
+            of_img_scale: Factor to scale the images by when computing optical flow. Decrease
+                this to increase performance at the cost of finer accuracy. Sometimes
+                decreasing the image scale can improve performance with fast movements.
+                Default: 1.0. (only if `use_flow` is True)
+            of_window_size: Optical flow window size to consider at each pyramid scale
+                level. Default: 21. (only if `use_flow` is True)
+            of_max_levels: Number of pyramid scale levels to consider. This is different
+                from the scale parameter, which determines the initial image scaling.
+                Default: 3. (only if `use_flow` is True)
+
+        """
+        if candidates_method == "fixed_window":
+            candidate = FixedWindowCandidates(
+                window_size=window_size,
+                instance_score_threshold=instance_score_threshold,
+            )
+            is_local_queue = False
+
+        elif candidates_method == "local_queues":
+            candidate = LocalQueueCandidates(
+                window_size=window_size,
+                max_tracks=max_tracks,
+                instance_score_threshold=instance_score_threshold,
+            )
+            is_local_queue = True
+
+        else:
+            raise ValueError(
+                f"{candidates_method} is not a valid method. Please choose one of [`fixed_window`, `local_queues`]"
+            )
+
+        if use_flow:
+            return FlowShiftTracker(
+                candidate=candidate,
+                features=features,
+                scoring_method=scoring_method,
+                scoring_reduction=scoring_reduction,
+                track_matching_method=track_matching_method,
+                img_scale=of_img_scale,
+                of_window_size=of_window_size,
+                of_max_levels=of_max_levels,
+                is_local_queue=is_local_queue,
+            )
+
+        tracker = cls(
+            candidate=candidate,
+            features=features,
+            scoring_method=scoring_method,
+            scoring_reduction=scoring_reduction,
+            track_matching_method=track_matching_method,
+            use_flow=use_flow,
+            is_local_queue=is_local_queue,
+        )
+        return tracker
+
+    def track(
+        self,
+        untracked_instances: List[sio.PredictedInstance],
+        frame_idx: int,
+        image: np.ndarray = None,
+    ) -> List[sio.PredictedInstance]:
+        """Assign track IDs to the untracked list of `sio.PredictedInstance` objects.
+
+        Args:
+            untracked_instances: List of untracked `sio.PredictedInstance` objects.
+            frame_idx: Frame index of the predicted instances.
+            image: Source image if visual features are to be used (also when using flow).
+
+        Returns:
+            List of `sio.PredictedInstance` objects, each having an assigned track.
+        """
+        # get features for the untracked instances.
+        current_instances = self.get_features(untracked_instances, frame_idx, image)
+
+        candidates_list = (
+            self.generate_candidates()
+        )  # either Deque/ DefaultDict for FixedWindow/ LocalQueue candidate.
+
+        if candidates_list:
+            # if track queue is not empty
+
+            # update candidates if needed and get the features from previous tracked instances.
+            candidates_feature_dict = self.update_candidates(candidates_list, image)
+
+            # scoring function
+            scores = self.get_scores(current_instances, candidates_feature_dict)
+            cost_matrix = self.scores_to_cost_matrix(scores)
+
+            # track assignment
+            current_tracked_instances = self.assign_tracks(
+                current_instances, cost_matrix
+            )
+
+        else:
+            # Initialize the tracker queue if empty.
+            current_tracked_instances = self.candidate.add_new_tracks(current_instances)
+
+        # convert the `current_instances` back to `List[sio.PredictedInstance]` objects.
+        if self.is_local_queue:
+            new_pred_instances = []
+            for instance in current_tracked_instances:
+                if instance.track_id is not None:
+                    if instance.track_id not in self._track_objects:
+                        self._track_objects[instance.track_id] = sio.Track(
+                            instance.track_id
+                        )
+                    instance.src_instance.track = self._track_objects[instance.track_id]
+                    instance.src_instance.tracking_score = instance.tracking_score
+                new_pred_instances.append(instance.src_instance)
+
+        else:
+            new_pred_instances = []
+            for idx, inst in enumerate(current_tracked_instances.src_instances):
+                track_id = current_tracked_instances.track_ids[idx]
+                if track_id is not None:
+                    if track_id not in self._track_objects:
+                        self._track_objects[track_id] = sio.Track(track_id)
+                    inst.track = self._track_objects[track_id]
+                    inst.tracking_score = current_tracked_instances.tracking_scores[idx]
+                    new_pred_instances.append(inst)
+
+        return new_pred_instances
+
+    def get_features(
+        self,
+        untracked_instances: List[sio.PredictedInstance],
+        frame_idx: int,
+        image: np.ndarray = None,
+    ) -> Union[TrackInstances, List[TrackInstanceLocalQueue]]:
+        """Get features for the current untracked instances.
+
+        The feature can either be an embedding of cropped image around each instance (visual feature),
+        the bounding box coordinates, or centroids, or the poses as a feature.
+
+        Args:
+            untracked_instances: List of untracked `sio.PredictedInstance` objects.
+            frame_idx: Frame index of the current untracked instances.
+            image: Image of the current frame if visual features are to be used.
+
+        Returns:
+            `TrackInstances` object or `List[TrackInstanceLocalQueue]` with the features
+            assigned for the untracked instances and track_id set as `None`.
+        """
+        if self.features not in self._feature_methods:
+            raise ValueError(
+                "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes` and `image`"
+            )
+
+        feature_method = self._feature_methods[self.features]
+        feature_list = []
+        for pred_instance in untracked_instances:
+            feature_list.append(feature_method(pred_instance))
+
+        current_instances = self.candidate.get_track_instances(
+            feature_list, untracked_instances, frame_idx=frame_idx, image=image
+        )
+
+        return current_instances
+
+    def generate_candidates(self):
+        """Get the tracked instances from tracker queue."""
+        return self.candidate.tracker_queue
+
+    def update_candidates(
+        self, candidates_list: Union[Deque, DefaultDict[int, Deque]], image: np.ndarray
+    ) -> Dict[int, TrackedInstanceFeature]:
+        """Return dictionary with the features of tracked instances.
+
+        Args:
+            candidates_list: List of tracked instances from tracker queue to consider.
+            image: Image of the current untracked frame. (used for flow shift tracker)
+
+        Returns:
+            Dictionary with keys as track IDs and values as the list of `TrackedInstanceFeature`.
+        """
+        candidates_feature_dict = defaultdict(list)
+        for track_id in self.candidate.current_tracks:
+            candidates_feature_dict[track_id].extend(
+                self.candidate.get_features_from_track_id(track_id, candidates_list)
+            )
+        return candidates_feature_dict
+
+    def get_scores(
+        self,
+        current_instances: Union[TrackInstances, List[TrackInstanceLocalQueue]],
+        candidates_feature_dict: Dict[int, TrackedInstanceFeature],
+    ):
+        """Compute association score between untracked and tracked instances.
+
+        For visual feature vectors, this can be `cosine_sim`, for bounding boxes
+        it could be `iou`, for centroids it could be `euclidean_dist`, and for poses it
+        could be `oks`.
+
+        Args:
+            current_instances: `TrackInstances` object or `List[TrackInstanceLocalQueue]`
+                with features and unassigned tracks.
+            candidates_feature_dict: Dictionary with keys as track IDs and values as the
+                list of `TrackedInstanceFeature`.
+
+        Returns:
+            scores: Score matrix of shape (num_new_instances, num_existing_tracks)
+        """
+        if self.scoring_method not in self._scoring_functions:
+            raise ValueError(
+                "Invalid `scoring_method` argument. Please provide one of `oks`, `cosine_sim`, `iou`, and `euclidean_dist`."
+            )
+
+        if self.scoring_reduction not in self._scoring_reduction_methods:
+            raise ValueError(
+                "Invalid `scoring_reduction` argument. Please provide one of `mean`, `max`, and `weighted`."
+            )
+
+        scoring_method = self._scoring_functions[self.scoring_method]
+        scoring_reduction = self._scoring_reduction_methods[self.scoring_reduction]
+
+        # Get list of features for the `current_instances`.
+        if self.is_local_queue:
+            current_instances_features = [x.feature for x in current_instances]
+        else:
+            current_instances_features = [x for x in current_instances.features]
+
+        scores = np.zeros(
+            (len(current_instances_features), len(self.candidate.current_tracks))
+        )
+
+        for f_idx, f in enumerate(current_instances_features):
+            for track_id in self.candidate.current_tracks:
+                oks = [
+                    scoring_method(f, x.feature)
+                    for x in candidates_feature_dict[track_id]
+                ]
+                oks = scoring_reduction(oks)  # scoring reduction
+                scores[f_idx][track_id] = oks
+
+        return scores
+
+    def scores_to_cost_matrix(self, scores: np.ndarray):
+        """Converts `scores` matrix to cost matrix for track assignments."""
+        cost_matrix = -scores
+        cost_matrix[np.isnan(cost_matrix)] = np.inf
+        return cost_matrix
+
+    def assign_tracks(
+        self,
+        current_instances: Union[TrackInstances, List[TrackInstanceLocalQueue]],
+        cost_matrix: np.ndarray,
+    ) -> Union[TrackInstances, List[TrackInstanceLocalQueue]]:
+        """Assign track IDs using Hungarian method.
+
+        Args:
+            current_instances: `TrackInstances` object or `List[TrackInstanceLocalQueue]`
+                with features and unassigned tracks.
+            cost_matrix: Cost matrix of shape (num_new_instances, num_existing_tracks).
+
+        Returns:
+            `TrackInstances` object or `List[TrackInstanceLocalQueue]`objects with
+                track IDs assigned.
+        """
+        if self.track_matching_method not in self._track_matching_methods:
+            raise ValueError(
+                "Invalid `track_matching_method` argument. Please provide one of `hungarian`, and `greedy`."
+            )
+
+        matching_method = self._track_matching_methods[self.track_matching_method]
+
+        row_inds, col_inds = matching_method(cost_matrix)
+        tracking_scores = [
+            -cost_matrix[row, col] for row, col in zip(row_inds, col_inds)
+        ]
+
+        # update the candidates tracker queue with the newly tracked instances and assign
+        # track IDs to `current_instances`.
+        current_tracked_instances = self.candidate.update_tracks(
+            current_instances, row_inds, col_inds, tracking_scores
+        )
+
+        return current_tracked_instances
+
+
+@attrs.define
+class FlowShiftTracker(Tracker):
+    """Module for tracking using optical flow shift matching.
+
+    This module handles tracking instances across frames by creating new track IDs (or)
+    assigning track IDs to each instance when the `.track()` is called using optical flow
+    based track matching. This is a sub-class of the `Tracker` module, which configures
+    the `update_candidates()` method specific to optical flow shift matching. This class is
+    initialized in the `Tracker.from_config()` method.
+
+    Attributes:
+        candidates: Either `FixedWindowCandidates` or `LocalQueueCandidates` object.
+        features: One of [`keypoints`, `centroids`, `bboxes`, `image`].
+            Default: `keypoints`.
+        scoring_method: Method to compute association score between features from the
+            current frame and the previous tracks. One of [`oks`, `cosine_sim`, `iou`,
+            `euclidean_dist`]. Default: `oks`.
+        scoring_reduction: Method to aggregate and reduce multiple scores if there are
+            several detections associated with the same track. One of [`mean`, `max`,
+            `weighted`]. Default: `mean`.
+        track_matching_method: track matching algorithm. One of `hungarian`, `greedy.
+                Default: `hungarian`.
+        use_flow: If True, `FlowShiftTracker` is used, where the poses are matched using
+            optical flow. Default: `False`.
+        is_local_queue: `True` if `LocalQueueCandidates` is used else `False`.
+        img_scale: Factor to scale the images by when computing optical flow. Decrease
+            this to increase performance at the cost of finer accuracy. Sometimes
+            decreasing the image scale can improve performance with fast movements.
+            Default: 1.0.
+        of_window_size: Optical flow window size to consider at each pyramid scale
+            level. Default: 21.
+        of_max_levels: Number of pyramid scale levels to consider. This is different
+            from the scale parameter, which determines the initial image scaling.
+            Default: 3
+
+    """
+
+    img_scale: float = 1.0
+    of_window_size: int = 21
+    of_max_levels: int = 3
+
+    def _compute_optical_flow(
+        self, ref_pts: np.ndarray, ref_img: np.ndarray, new_img: np.ndarray
+    ):
+        """Compute instances on new frame using optical flow displacements."""
+        ref_img, new_img = self._preprocess_imgs(ref_img, new_img)
+        shifted_pts, status, errs = cv2.calcOpticalFlowPyrLK(
+            ref_img,
+            new_img,
+            (np.concatenate(ref_pts, axis=0)).astype("float32") * self.img_scale,
+            None,
+            winSize=(self.of_window_size, self.of_window_size),
+            maxLevel=self.of_max_levels,
+            criteria=(cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 30, 0.01),
+        )
+        shifted_pts /= self.img_scale
+        return shifted_pts, status, errs
+
+    def _preprocess_imgs(self, ref_img: np.ndarray, new_img: np.ndarray):
+        """Pre-process images for optical flow."""
+        # Convert to uint8 for cv2.calcOpticalFlowPyrLK
+        if np.issubdtype(ref_img.dtype, np.floating):
+            ref_img = ref_img.astype("uint8")
+        if np.issubdtype(new_img.dtype, np.floating):
+            new_img = new_img.astype("uint8")
+
+        # Ensure images are rank 2 in case there is a singleton channel dimension.
+        if ref_img.ndim > 3:
+            ref_img = np.squeeze(ref_img)
+            new_img = np.squeeze(new_img)
+
+        # Convert RGB to grayscale.
+        if ref_img.ndim > 2 and ref_img.shape[0] == 3:
+            ref_img = cv2.cvtColor(ref_img, cv2.COLOR_BGR2GRAY)
+            new_img = cv2.cvtColor(new_img, cv2.COLOR_BGR2GRAY)
+
+        # Input image scaling.
+        if self.img_scale != 1:
+            ref_img = cv2.resize(ref_img, None, None, self.img_scale, self.img_scale)
+            new_img = cv2.resize(new_img, None, None, self.img_scale, self.img_scale)
+
+        return ref_img, new_img
+
+    def get_shifted_instances_from_prv_frames(
+        self,
+        candidates_list: Union[Deque, DefaultDict[int, Deque]],
+        new_img: np.ndarray,
+        feature_method,
+    ) -> Dict[int, List[TrackedInstanceFeature]]:
+        """Generate shifted instances onto the new frame by applying optical flow."""
+        shifted_instances_prv_frames = defaultdict(list)
+
+        if self.is_local_queue:
+            # for local queue
+            ref_candidates = self.candidate.get_instances_groupby_frame_idx(
+                candidates_list
+            )
+            for fidx, ref_candidate_list in ref_candidates.items():
+                ref_pts = [x.src_instance.numpy() for x in ref_candidate_list]
+                shifted_pts, status, errs = self._compute_optical_flow(
+                    ref_pts=ref_pts,
+                    ref_img=ref_candidate_list[0].image,
+                    new_img=new_img,
+                )
+
+                sections = np.cumsum([len(x) for x in ref_pts])[:-1]
+                shifted_pts = np.split(shifted_pts, sections, axis=0)
+                status = np.split(status, sections, axis=0)
+                errs = np.split(errs, sections, axis=0)
+
+                # Create shifted instances.
+                for idx, (ref_candidate, pts, found) in enumerate(
+                    zip(ref_candidate_list, shifted_pts, status)
+                ):
+                    # Exclude points that weren't found by optical flow.
+                    found = found.squeeze().astype(bool)
+                    pts[~found] = np.nan
+
+                    # Create a shifted instance.
+                    shifted_instances_prv_frames[ref_candidate.track_id].append(
+                        TrackedInstanceFeature(
+                            feature=feature_method(pts),
+                            src_predicted_instance=ref_candidate.src_instance,
+                            frame_idx=fidx,
+                            tracking_score=ref_candidate.tracking_score,
+                            instance_score=ref_candidate.instance_score,
+                            shifted_keypoints=pts,
+                        )
+                    )
+
+        else:
+            # for fixed window
+            candidates_list = (
+                candidates_list
+                if candidates_list is not None
+                else self.candidate.tracker_queue
+            )
+            for ref_candidate in candidates_list:
+                ref_pts = [x.numpy() for x in ref_candidate.src_instances]
+                shifted_pts, status, errs = self._compute_optical_flow(
+                    ref_pts=ref_pts, ref_img=ref_candidate.image, new_img=new_img
+                )
+
+                sections = np.cumsum([len(x) for x in ref_pts])[:-1]
+                shifted_pts = np.split(shifted_pts, sections, axis=0)
+                status = np.split(status, sections, axis=0)
+                errs = np.split(errs, sections, axis=0)
+
+                # Create shifted instances.
+                for idx, (pts, found) in enumerate(zip(shifted_pts, status)):
+                    # Exclude points that weren't found by optical flow.
+                    found = found.squeeze().astype(bool)
+                    pts[~found] = np.nan
+
+                    # Create a shifted instance.
+                    shifted_instances_prv_frames[ref_candidate.track_ids[idx]].append(
+                        TrackedInstanceFeature(
+                            feature=feature_method(pts),
+                            src_predicted_instance=ref_candidate.src_instances[idx],
+                            frame_idx=ref_candidate.frame_idx,
+                            tracking_score=ref_candidate.tracking_scores[idx],
+                            instance_score=ref_candidate.instance_scores[idx],
+                            shifted_keypoints=pts,
+                        )
+                    )
+
+        return shifted_instances_prv_frames
+
+    def update_candidates(
+        self,
+        candidates_list: Union[Deque, DefaultDict[int, Deque]],
+        image: np.ndarray,
+    ) -> Dict[int, TrackedInstanceFeature]:
+        """Return dictionary with the features of tracked instances.
+
+        In this method, the tracked instances in the tracker queue are shifted on to the
+        current frame using optical flow. The features are then computed from the shifted
+        instances.
+
+        Args:
+            candidates_list: Tracker queue from the candidate class.
+            image: Image of the current untracked frame. (used for flow shift tracker)
+
+        Returns:
+            Dictionary with keys as track IDs and values as the list of `TrackedInstanceFeature`.
+        """
+        # get feature method for the shifted instances
+        if self.features not in self._feature_methods:
+            raise ValueError(
+                "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes` and `image`"
+            )
+        feature_method = self._feature_methods[self.features]
+
+        # get shifted instances from optical flow
+        shifted_instances_prv_frames = self.get_shifted_instances_from_prv_frames(
+            candidates_list=candidates_list,
+            new_img=image,
+            feature_method=feature_method,
+        )
+
+        return shifted_instances_prv_frames

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -1,0 +1,100 @@
+"""Helper functions for Tracker module."""
+
+from typing import List, Tuple, Union
+from scipy.optimize import linear_sum_assignment
+
+import numpy as np
+import sleap_io as sio
+
+
+def hungarian_matching(cost_matrix: np.ndarray) -> List[Tuple[int, int]]:
+    """Match new instances to existing tracks using Hungarian matching."""
+    row_ids, col_ids = linear_sum_assignment(cost_matrix)
+    return row_ids, col_ids
+
+
+def greedy_matching(cost_matrix: np.ndarray) -> List[Tuple[int, int]]:
+    """Match new instances to existing tracks using greedy bipartite matching."""
+    # Sort edges by ascending cost.
+    rows, cols = np.unravel_index(np.argsort(cost_matrix, axis=None), cost_matrix.shape)
+    unassigned_edges = list(zip(rows, cols))
+
+    # Greedily assign edges.
+    row_inds, col_inds = [], []
+    while len(unassigned_edges) > 0:
+        # Assign the lowest cost edge.
+        row_ind, col_ind = unassigned_edges.pop(0)
+        row_inds.append(row_ind)
+        col_inds.append(col_ind)
+
+        # Remove all other edges that contain either node (in reverse order).
+        for i in range(len(unassigned_edges) - 1, -1, -1):
+            if unassigned_edges[i][0] == row_ind or unassigned_edges[i][1] == col_ind:
+                del unassigned_edges[i]
+
+    return row_inds, col_inds
+
+
+def get_keypoints(pred_instance: Union[sio.PredictedInstance, np.ndarray]):
+    """Return keypoints as np.array from the `PredictedInstance` object."""
+    if isinstance(pred_instance, np.ndarray):
+        return pred_instance
+    return pred_instance.numpy()
+
+
+def get_centroid(pred_instance: Union[sio.PredictedInstance, np.ndarray]):
+    """Return the centroid of the `PredictedInstance` object."""
+    pts = pred_instance
+    if not isinstance(pred_instance, np.ndarray):
+        pts = pred_instance.numpy()
+    centroid = np.nanmedian(pts, axis=0)
+    return centroid
+
+
+def get_bbox(pred_instance: Union[sio.PredictedInstance, np.ndarray]):
+    """Return the bounding box coordinates for the `PredictedInstance` object."""
+    points = (
+        pred_instance.numpy()
+        if not isinstance(pred_instance, np.ndarray)
+        else pred_instance
+    )
+    bbox = np.concatenate(
+        [
+            np.nanmin(points, axis=0),
+            np.nanmax(points, axis=0),
+        ]  # [xmin, ymin, xmax, ymax]
+    )
+    return bbox
+
+
+def compute_euclidean_distance(a, b):
+    """Return the negative euclidean distance between a and b points."""
+    return -np.linalg.norm(a - b)
+
+
+def compute_iou(a, b):
+    """Return the intersection over union for given a and b bounding boxes [xmin, ymin, xmax, ymax]."""
+    (xmin1, ymin1, xmax1, ymax1), (xmin2, ymin2, xmax2, ymax2) = a, b
+
+    xmin_intersection = max(xmin1, xmin2)
+    ymin_intersection = max(ymin1, ymin2)
+    xmax_intersection = min(xmax1, xmax2)
+    ymax_intersection = min(ymax1, ymax2)
+
+    intersection_area = max(0, xmax_intersection - xmin_intersection + 1) * max(
+        0, ymax_intersection - ymin_intersection + 1
+    )
+    bbox1_area = (xmax1 - xmin1 + 1) * (ymax1 - ymin1 + 1)
+    bbox2_area = (xmax2 - xmin2 + 1) * (ymax2 - ymin2 + 1)
+    union_area = bbox1_area + bbox2_area - intersection_area
+
+    iou = intersection_area / union_area
+    return iou
+
+
+def compute_cosine_sim(a, b):
+    """Return cosine simalirity between a and b vectors."""
+    numer = np.dot(a, b)
+    denom = np.linalg.norm(a) * np.linalg.norm(b)
+    cosine_sim = numer / denom
+    return cosine_sim

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -22,6 +22,7 @@ from lightning.pytorch.loggers import WandbLogger, CSVLogger
 from sleap_nn.architectures.model import Model
 from lightning.pytorch.callbacks import ModelCheckpoint, EarlyStopping
 from sleap_nn.data.cycler import CyclerIterDataPipe as Cycler
+from sleap_nn.data.instance_cropping import find_instance_crop_size
 from torchvision.models.swin_transformer import (
     Swin_T_Weights,
     Swin_S_Weights,
@@ -89,31 +90,55 @@ class ModelTrainer:
                 self.model_type = k
                 break
 
+        train_labels = sio.load_slp(self.config.data_config.train_labels_path)
+        self.skeletons = train_labels.skeletons
+        max_stride = self.config.model_config.backbone_config.max_stride
+
         if self.model_type == "single_instance":
+
             data_pipeline = SingleInstanceConfmapsPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.single_instance.confmaps,
             )
 
         elif self.model_type == "centered_instance":
+            # compute crop size
+            crop_hw = self.config.data_config.preprocessing.crop_hw
+            if crop_hw is None:
+
+                min_crop_size = (
+                    self.config.data_config.preprocessing.min_crop_size
+                    if "min_crop_size" in self.config.data_config.preprocessing
+                    else None
+                )
+                crop_size = find_instance_crop_size(
+                    train_labels,
+                    maximum_stride=max_stride,
+                    input_scaling=self.config.data_config.preprocessing.scale,
+                    min_crop_size=min_crop_size,
+                )
+                crop_hw = (crop_size, crop_size)
+            self.config.data_config.preprocessing.crop_hw = crop_hw
+
             data_pipeline = TopdownConfmapsPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.centered_instance.confmaps,
+                crop_hw=crop_hw,
             )
 
         elif self.model_type == "centroid":
             data_pipeline = CentroidConfmapsPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.centroid.confmaps,
             )
 
         elif self.model_type == "bottomup":
             data_pipeline = BottomUpPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.bottomup.confmaps,
                 pafs_head=self.config.model_config.head_configs.bottomup.pafs,
             )
@@ -124,9 +149,6 @@ class ModelTrainer:
             )
 
         # train
-        train_labels = sio.load_slp(self.config.data_config.train_labels_path)
-        self.skeletons = train_labels.skeletons
-
         train_labels_reader = self.provider(train_labels)
 
         train_datapipe = data_pipeline.make_training_pipeline(
@@ -233,7 +255,10 @@ class ModelTrainer:
             else:
                 self._set_wandb()
             wandb_logger = WandbLogger(
-                project=wandb_config.project, name=wandb_config.name, save_dir=dir_path
+                project=wandb_config.project,
+                name=wandb_config.name,
+                save_dir=dir_path,
+                id=self.config.trainer_config.wandb.prv_runid,
             )
             logger.append(wandb_logger)
 
@@ -249,13 +274,15 @@ class ModelTrainer:
                 symm = [list(s.nodes) for s in skl.symmetries]
             else:
                 symm = None
-            self.config["data_config"]["skeletons"][skl.name] = {
+            skl_name = skl.name if skl.name is not None else "skeleton-0"
+            self.config["data_config"]["skeletons"][skl_name] = {
                 "nodes": skl.nodes,
                 "edges": skl.edges,
                 "symmetries": symm,
             }
 
         self._initialize_model()
+        total_params = self._get_param_count()
 
         trainer = L.Trainer(
             callbacks=callbacks,
@@ -268,25 +295,34 @@ class ModelTrainer:
             limit_train_batches=self.steps_per_epoch,
         )
 
-        trainer.fit(self.model, self.train_data_loader, self.val_data_loader)
+        try:
+            trainer.fit(
+                self.model,
+                self.train_data_loader,
+                self.val_data_loader,
+                ckpt_path=self.config.trainer_config.resume_ckpt_path,
+            )
 
-        total_params = self._get_param_count()
+            if self.config.trainer_config.use_wandb:
+                for m in self.config.trainer_config.wandb.log_params:
+                    list_keys = m.split(".")
+                    key = list_keys[-1]
+                    value = self.config[list_keys[0]]
+                    for l in list_keys[1:]:
+                        value = value[l]
+                    wandb_logger.experiment.config.update({key: value})
+                wandb_logger.experiment.config.update({"model_params": total_params})
 
-        if self.config.trainer_config.use_wandb:
-            self.config.trainer_config.wandb.run_id = wandb.run.id
-            self.config.model_config.total_params = total_params
-            for m in self.config.trainer_config.wandb.log_params:
-                list_keys = m.split(".")
-                key = list_keys[-1]
-                value = self.config[list_keys[0]]
-                for l in list_keys[1:]:
-                    value = value[l]
-                wandb_logger.experiment.config.update({key: value})
-            wandb_logger.experiment.config.update({"model_params": total_params})
-            wandb.finish()
+        except Exception:
+            print("Stopping training...")
 
-        # save the configs as yaml in the checkpoint dir
-        OmegaConf.save(config=self.config, f=f"{dir_path}/training_config.yaml")
+        finally:
+            if self.config.trainer_config.use_wandb:
+                self.config.trainer_config.wandb.run_id = wandb.run.id
+                self.config.model_config.total_params = total_params
+                wandb.finish(exit_code=255)
+            # save the configs as yaml in the checkpoint dir
+            OmegaConf.save(config=self.config, f=f"{dir_path}/training_config.yaml")
 
 
 class TrainingModel(L.LightningModule):

--- a/tests/assets/minimal_instance/initial_config.yaml
+++ b/tests/assets/minimal_instance/initial_config.yaml
@@ -63,12 +63,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centered
+  resume_ckpt_path: null
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance/training_config.yaml
+++ b/tests/assets/minimal_instance/training_config.yaml
@@ -76,12 +76,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centered
+  resume_ckpt_path: null
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/initial_config.yaml
@@ -65,12 +65,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_bottomup
+  resume_ckpt_path:
   wandb:
     entity: team-ucsd
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/training_config.yaml
@@ -80,12 +80,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_bottomup
+  resume_ckpt_path:
   wandb:
     entity: team-ucsd
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/minimal_instance_centroid/initial_config.yaml
@@ -59,12 +59,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centroid
+  resume_ckpt_path:
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/minimal_instance_centroid/training_config.yaml
@@ -70,12 +70,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centroid
+  resume_ckpt_path:
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/data/test_augmentation.py
+++ b/tests/data/test_augmentation.py
@@ -1,8 +1,14 @@
 import pytest
 import torch
 from torch.utils.data import DataLoader
-
+import sleap_io as sio
 from sleap_nn.data.augmentation import KorniaAugmenter, RandomUniformNoise
+from sleap_nn.data.augmentation import (
+    apply_intensity_augmentation,
+    apply_geometric_augmentation,
+)
+from sleap_nn.data.normalization import apply_normalization
+from sleap_nn.data.providers import process_lf
 from sleap_nn.data.normalization import Normalizer
 from sleap_nn.data.providers import LabelsReader
 
@@ -33,6 +39,62 @@ def test_uniform_noise(minimal_instance):
     aug_img = aug(img)
     assert torch.is_tensor(aug_img)
     assert aug_img.shape == (1, 1, 384, 384)
+
+
+def test_apply_intensity_augmentation(minimal_instance):
+    """Test `apply_intensity_augmentation` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+    ex["image"] = apply_normalization(ex["image"])
+
+    img, pts = apply_intensity_augmentation(
+        ex["image"],
+        ex["instances"],
+        uniform_noise_p=1.0,
+        contrast_p=1.0,
+        brightness_p=1.0,
+        gaussian_noise_p=1.0,
+    )
+    # Test all augmentations.
+    assert torch.is_tensor(img)
+    assert torch.is_tensor(pts)
+    assert not torch.equal(img, ex["image"])
+    assert img.shape == (1, 1, 384, 384)
+    assert pts.shape == (1, 2, 2, 2)
+
+
+def test_apply_geometric_augmentation(minimal_instance):
+    """Test `apply_geometric_augmentation` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+    ex["image"] = apply_normalization(ex["image"])
+
+    img, pts = apply_geometric_augmentation(
+        ex["image"],
+        ex["instances"],
+        scale=0.5,
+        affine_p=1.0,
+        random_crop_height=100,
+        random_crop_width=100,
+        random_crop_p=1.0,
+        erase_p=1.0,
+        mixup_p=1.0,
+    )
+    # Test all augmentations.
+    assert torch.is_tensor(img)
+    assert torch.is_tensor(pts)
+    assert not torch.equal(img, ex["image"])
+    assert img.shape == (1, 1, 100, 100)
+    assert pts.shape == (1, 2, 2, 2)
+
+    with pytest.raises(
+        ValueError, match="crop_hw height and width must be greater than 0."
+    ):
+        img, pts = apply_geometric_augmentation(
+            ex["image"], ex["instances"], random_crop_p=1.0, random_crop_height=0
+        )
 
 
 def test_kornia_augmentation(minimal_instance):

--- a/tests/data/test_edge_maps.py
+++ b/tests/data/test_edge_maps.py
@@ -1,13 +1,15 @@
 import numpy as np
 import torch
+import sleap_io as sio
 from sleap_nn.data.utils import make_grid_vectors
-from sleap_nn.data.providers import LabelsReader
+from sleap_nn.data.providers import LabelsReader, process_lf
 from sleap_nn.data.edge_maps import (
     distance_to_edge,
     make_edge_maps,
     make_pafs,
     make_multi_pafs,
     get_edge_points,
+    generate_pafs,
     PartAffinityFieldsGenerator,
 )
 
@@ -171,6 +173,20 @@ def test_get_edge_points():
             [[20, 21], [22, 23], [22, 23]],
         ],
     )
+
+
+def test_generate_pafs(minimal_instance):
+    """Test `generate_pafs` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    pafs = generate_pafs(
+        ex["instances"],
+        img_hw=(384, 384),
+        edge_inds=torch.Tensor(labels.skeletons[0].edge_inds),
+    )
+    assert pafs.shape == (192, 192, 1, 2)
 
 
 def test_part_affinity_fields_generator(minimal_instance):

--- a/tests/data/test_instance_centroids.py
+++ b/tests/data/test_instance_centroids.py
@@ -1,14 +1,42 @@
 import torch
-
+import sleap_io as sio
 from sleap_nn.data.instance_centroids import (
     InstanceCentroidFinder,
-    find_centroids,
+    generate_centroids,
 )
-from sleap_nn.data.providers import LabelsReader
+from sleap_nn.data.providers import LabelsReader, process_lf
+
+
+def test_generate_centroids(minimal_instance):
+    """Test `generate_centroids` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    centroids = generate_centroids(ex["instances"], 1).int()
+    gt = torch.Tensor([[[152, 158], [278, 203]]]).int()
+    assert torch.equal(centroids, gt)
+
+    partial_instance = torch.Tensor(
+        [
+            [
+                [[92.6522, 202.7260], [152.3419, 158.4236], [97.2618, 53.5834]],
+                [[205.9301, 187.8896], [torch.nan, torch.nan], [201.4264, 75.2373]],
+                [
+                    [torch.nan, torch.nan],
+                    [torch.nan, torch.nan],
+                    [torch.nan, torch.nan],
+                ],
+            ]
+        ]
+    )
+    centroids = generate_centroids(partial_instance, 1).int()
+    gt = torch.Tensor([[[152, 158], [203, 131], [torch.nan, torch.nan]]]).int()
+    assert torch.equal(centroids, gt)
 
 
 def test_instance_centroids(minimal_instance):
-    """Test InstanceCentroidFinder and find_centroids functions."""
+    """Test InstanceCentroidFinder and generate_centroids functions."""
     # Undefined anchor_ind.
     datapipe = LabelsReader.from_filename(minimal_instance)
     datapipe = InstanceCentroidFinder(datapipe)
@@ -20,7 +48,7 @@ def test_instance_centroids(minimal_instance):
     assert torch.equal(centroids, gt)
 
     # Defined anchor_ind.
-    centroids = find_centroids(instances, 1).int()
+    centroids = generate_centroids(instances, 1).int()
     gt = torch.Tensor([[[152, 158], [278, 203]]]).int()
     assert torch.equal(centroids, gt)
 
@@ -38,6 +66,6 @@ def test_instance_centroids(minimal_instance):
             ]
         ]
     )
-    centroids = find_centroids(partial_instance, 1).int()
+    centroids = generate_centroids(partial_instance, 1).int()
     gt = torch.Tensor([[[152, 158], [203, 131], [torch.nan, torch.nan]]]).int()
     assert torch.equal(centroids, gt)

--- a/tests/data/test_instance_cropping.py
+++ b/tests/data/test_instance_cropping.py
@@ -1,10 +1,29 @@
+import sleap_io as sio
 import torch
 
-from sleap_nn.data.instance_centroids import InstanceCentroidFinder
-from sleap_nn.data.instance_cropping import InstanceCropper, make_centered_bboxes
+from sleap_nn.data.instance_centroids import InstanceCentroidFinder, generate_centroids
+from sleap_nn.data.instance_cropping import (
+    InstanceCropper,
+    find_instance_crop_size,
+    generate_crops,
+    make_centered_bboxes,
+)
 from sleap_nn.data.normalization import Normalizer
 from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
-from sleap_nn.data.providers import LabelsReader
+from sleap_nn.data.providers import LabelsReader, process_lf
+
+
+def test_find_instance_crop_size(minimal_instance):
+    """Test `find_instance_crop_size` function."""
+    labels = sio.load_slp(minimal_instance)
+    crop_size = find_instance_crop_size(labels)
+    assert crop_size == 74
+
+    crop_size = find_instance_crop_size(labels, min_crop_size=100)
+    assert crop_size == 100
+
+    crop_size = find_instance_crop_size(labels, padding=10)
+    assert crop_size == 84
 
 
 def test_make_centered_bboxes():
@@ -65,3 +84,20 @@ def test_instance_cropper(minimal_instance):
     )
     centered_instance = sample["instance"]
     assert torch.equal(centered_instance, gt.unsqueeze(0))
+
+
+def test_generate_crops(minimal_instance):
+    """Test `generate_crops` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    centroids = generate_centroids(ex["instances"], 0)
+    cropped_ex = generate_crops(
+        ex["image"], ex["instances"][0, 0], centroids[0, 0], crop_size=(100, 100)
+    )
+
+    assert cropped_ex["instance"].shape == (1, 2, 2)
+    assert cropped_ex["centroid"].shape == (1, 2)
+    assert cropped_ex["instance_image"].shape == (1, 1, 100, 100)
+    assert cropped_ex["instance_bbox"].shape == (1, 4, 2)

--- a/tests/data/test_normalization.py
+++ b/tests/data/test_normalization.py
@@ -1,7 +1,11 @@
 import torch
 import numpy as np
 
-from sleap_nn.data.normalization import Normalizer, convert_to_grayscale
+from sleap_nn.data.normalization import (
+    Normalizer,
+    convert_to_grayscale,
+    apply_normalization,
+)
 from sleap_nn.data.providers import LabelsReader
 
 
@@ -28,3 +32,11 @@ def test_convert_to_grayscale():
     img = torch.randint(0, 255, (3, 200, 200))
     res = convert_to_grayscale(img)
     assert res.shape[0] == 1
+
+
+def test_apply_normalization():
+    """Test `apply_normalization` function."""
+    img = torch.randint(0, 255, (3, 200, 200))
+    res = apply_normalization(img)
+    assert torch.max(res) <= 1.0 and torch.min(res) == 0.0
+    assert res.dtype == torch.float32

--- a/tests/data/test_pipelines.py
+++ b/tests/data/test_pipelines.py
@@ -92,6 +92,7 @@ def test_key_filter(minimal_instance):
 
 def test_topdownconfmapspipeline(minimal_instance):
     """Test the TopdownConfmapsPipeline."""
+    crop_hw = (160, 160)
     base_topdown_data_config = OmegaConf.create(
         {
             "preprocessing": {
@@ -99,7 +100,6 @@ def test_topdownconfmapspipeline(minimal_instance):
                 "max_width": None,
                 "scale": 1.0,
                 "is_rgb": False,
-                "crop_hw": (160, 160),
             },
             "use_augmentations_train": False,
         },
@@ -108,7 +108,10 @@ def test_topdownconfmapspipeline(minimal_instance):
     confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": 0})
 
     pipeline = TopdownConfmapsPipeline(
-        data_config=base_topdown_data_config, max_stride=16, confmap_head=confmap_head
+        data_config=base_topdown_data_config,
+        max_stride=16,
+        confmap_head=confmap_head,
+        crop_hw=crop_hw,
     )
     data_provider = LabelsReader(labels=sio.load_slp(minimal_instance))
 
@@ -143,7 +146,6 @@ def test_topdownconfmapspipeline(minimal_instance):
                 "max_width": None,
                 "scale": 1.0,
                 "is_rgb": False,
-                "crop_hw": (100, 100),
             },
             "use_augmentations_train": True,
             "augmentation_config": {
@@ -184,7 +186,10 @@ def test_topdownconfmapspipeline(minimal_instance):
     )
 
     pipeline = TopdownConfmapsPipeline(
-        data_config=base_topdown_data_config, max_stride=8, confmap_head=confmap_head
+        data_config=base_topdown_data_config,
+        max_stride=8,
+        confmap_head=confmap_head,
+        crop_hw=(100, 100),
     )
 
     data_provider = LabelsReader(labels=sio.load_slp(minimal_instance))
@@ -221,7 +226,6 @@ def test_topdownconfmapspipeline(minimal_instance):
                 "max_width": None,
                 "scale": 2.0,
                 "is_rgb": False,
-                "crop_hw": (100, 100),
             },
             "use_augmentations_train": True,
             "augmentation_config": {
@@ -262,7 +266,10 @@ def test_topdownconfmapspipeline(minimal_instance):
     )
 
     pipeline = TopdownConfmapsPipeline(
-        data_config=base_topdown_data_config, max_stride=16, confmap_head=confmap_head
+        data_config=base_topdown_data_config,
+        max_stride=16,
+        confmap_head=confmap_head,
+        crop_hw=(100, 100),
     )
 
     data_provider = LabelsReader(labels=sio.load_slp(minimal_instance))

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -1,6 +1,6 @@
 import torch
 
-from sleap_nn.data.providers import LabelsReader, VideoReader
+from sleap_nn.data.providers import LabelsReader, VideoReader, process_lf
 from queue import Queue
 import sleap_io as sio
 import numpy as np
@@ -91,3 +91,13 @@ def test_videoreader_provider(centered_instance_video):
     finally:
         reader.join()
     assert reader.total_len() == 6
+
+
+def test_process_lf(minimal_instance):
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 4)
+
+    assert ex["image"].shape == torch.Size([1, 1, 384, 384])
+    assert ex["instances"].shape == torch.Size([1, 4, 2, 2])
+    assert torch.isnan(ex["instances"][:, 2:, :, :]).all()

--- a/tests/data/test_resizing.py
+++ b/tests/data/test_resizing.py
@@ -1,7 +1,14 @@
 import torch
 
-from sleap_nn.data.providers import LabelsReader
-from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
+from sleap_nn.data.providers import LabelsReader, process_lf
+from sleap_nn.data.resizing import (
+    SizeMatcher,
+    Resizer,
+    PadToStride,
+    apply_resizer,
+    apply_pad_to_stride,
+    apply_sizematcher,
+)
 import numpy as np
 import sleap_io as sio
 import pytest
@@ -69,12 +76,56 @@ def test_padtostride(minimal_instance):
     image = sample["image"]
     assert image.shape == torch.Size([1, 1, 384, 384])
 
-    pipe = PadToStride(l, max_stride=2)
-    sample = next(iter(pipe))
-    image = sample["image"]
-    assert image.shape == torch.Size([1, 1, 384, 384])
-
     pipe = PadToStride(l, max_stride=500)
     sample = next(iter(pipe))
     image = sample["image"]
     assert image.shape == torch.Size([1, 1, 500, 500])
+
+
+def test_apply_resizer(minimal_instance):
+    """Test `apply_resizer` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    image, instances = apply_resizer(ex["image"], ex["instances"], scale=2.0)
+    assert image.shape == torch.Size([1, 1, 768, 768])
+    assert torch.all(instances == ex["instances"] * 2.0)
+
+
+def test_apply_pad_to_stride(minimal_instance):
+    """Test `apply_pad_to_stride` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    image = apply_pad_to_stride(ex["image"], max_stride=2)
+    assert image.shape == torch.Size([1, 1, 384, 384])
+
+    image = apply_pad_to_stride(ex["image"], max_stride=200)
+    assert image.shape == torch.Size([1, 1, 400, 400])
+
+
+def test_apply_sizematcher(minimal_instance):
+    """Test `apply_sizematcher` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    image = apply_sizematcher(ex["image"], 500, 500)
+    assert image.shape == torch.Size([1, 1, 500, 500])
+
+    image = apply_sizematcher(ex["image"])
+    assert image.shape == torch.Size([1, 1, 384, 384])
+
+    with pytest.raises(
+        Exception,
+        match=f"Max height {100} should be greater than the current image height: {384}",
+    ):
+        image = apply_sizematcher(ex["image"], max_height=100, max_width=500)
+
+    with pytest.raises(
+        Exception,
+        match=f"Max width {100} should be greater than the current image width: {384}",
+    ):
+        image = apply_sizematcher(ex["image"], max_height=500, max_width=100)

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -130,12 +130,14 @@ def config(sleap_data_dir):
                 "use_wandb": False,
                 "save_ckpt": False,
                 "save_ckpt_path": "",
+                "resume_ckpt_path": None,
                 "wandb": {
                     "entity": "team-ucsd",
                     "project": "test",
                     "name": "test_run",
                     "wandb_mode": "offline",
                     "api_key": "",
+                    "prv_runid": None,
                     "log_params": [
                         "trainer_config.optimizer_name",
                         "trainer_config.optimizer.amsgrad",

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -156,6 +156,26 @@ def test_topdown_predictor(
             peak_threshold=0.1,
         )
 
+    # test with tracking
+    pred_labels = main(
+        model_paths=[minimal_instance_centroid_ckpt, minimal_instance_ckpt],
+        data_path="./tests/assets/centered_pair_small.mp4",
+        provider="VideoReader",
+        make_labels=True,
+        max_instances=2,
+        peak_threshold=0.1,
+        videoreader_start_idx=0,
+        videoreader_end_idx=20,
+        tracking=True,
+    )
+
+    assert len(pred_labels.tracks) <= 2  # should be less than max tracks
+
+    for lf in pred_labels:
+        for instance in lf.instances:
+            assert instance.track is not None
+            assert instance.tracking_score == 1
+
 
 def test_single_instance_predictor(minimal_instance, minimal_instance_ckpt):
     """Test SingleInstancePredictor module."""
@@ -404,3 +424,21 @@ def test_bottomup_predictor(minimal_instance, minimal_instance_bottomup_ckpt):
             max_instances=6,
             peak_threshold=0.03,
         )
+
+    # test with tracking
+    pred_labels = main(
+        model_paths=[minimal_instance_bottomup_ckpt],
+        data_path="./tests/assets/minimal_instance.pkg.slp",
+        provider="LabelsReader",
+        make_labels=True,
+        max_instances=6,
+        peak_threshold=0.03,
+        tracking=True,
+    )
+
+    for lf in pred_labels:
+        for instance in lf.instances:
+            assert instance.track is not None
+            assert instance.tracking_score == 1
+
+    assert len(pred_labels.tracks) <= 6  # should be less than max tracks

--- a/tests/tracking/candidates/test_fixed_window.py
+++ b/tests/tracking/candidates/test_fixed_window.py
@@ -1,0 +1,52 @@
+from typing import DefaultDict, Deque, List
+import numpy as np
+from sleap_nn.inference.predictors import main
+from sleap_nn.tracking.track_instance import TrackedInstanceFeature
+from sleap_nn.tracking.candidates.fixed_window import FixedWindowCandidates
+from sleap_nn.tracking.tracker import Tracker
+
+
+def get_pred_instances(minimal_instance_ckpt, n=10):
+    result_labels = main(
+        model_paths=[minimal_instance_ckpt],
+        data_path="./tests/assets/minimal_instance.pkg.slp",
+        provider="LabelsReader",
+        make_labels=True,
+        max_instances=6,
+        peak_threshold=0.0,
+        integral_refinement="integral",
+    )
+    pred_instances = []
+    for idx, lf in enumerate(result_labels):
+        pred_instances.extend(lf.instances)
+        if idx == n:
+            break
+    return pred_instances
+
+
+def test_fixed_window_candidates(minimal_instance_ckpt):
+
+    pred_instances = get_pred_instances(minimal_instance_ckpt, 2)
+    tracker = Tracker.from_config()
+    track_instances = tracker.get_features(pred_instances, 0)
+
+    fixed_window_candidates = FixedWindowCandidates(3)
+    assert isinstance(fixed_window_candidates.tracker_queue, Deque)
+    fixed_window_candidates.update_tracks(track_instances, None, None, None)
+    # (tracks are assigned only if row/ col ids exists)
+    assert not fixed_window_candidates.tracker_queue
+
+    track_instances = fixed_window_candidates.add_new_tracks(track_instances)
+    assert len(fixed_window_candidates.tracker_queue) == 1
+
+    new_track_id = fixed_window_candidates.get_new_track_id()
+    assert new_track_id == 2
+
+    track_instances = tracker.get_features(pred_instances, 0)
+    tracked_instances = fixed_window_candidates.add_new_tracks(track_instances)
+    assert tracked_instances.track_ids == [2, 3]
+    assert tracked_instances.tracking_scores == [1.0, 1.0]
+
+    features_track_id = fixed_window_candidates.get_features_from_track_id(0)
+    assert isinstance(features_track_id, list)
+    assert len(features_track_id) == 1

--- a/tests/tracking/candidates/test_local_queues.py
+++ b/tests/tracking/candidates/test_local_queues.py
@@ -1,0 +1,55 @@
+from typing import DefaultDict, Deque
+import numpy as np
+
+from sleap_nn.inference.predictors import main
+from sleap_nn.tracking.candidates.local_queues import LocalQueueCandidates
+from sleap_nn.tracking.tracker import Tracker
+
+
+def get_pred_instances(minimal_instance_ckpt, n=10):
+    result_labels = main(
+        model_paths=[minimal_instance_ckpt],
+        data_path="./tests/assets/minimal_instance.pkg.slp",
+        provider="LabelsReader",
+        make_labels=True,
+        max_instances=6,
+        peak_threshold=0.0,
+        integral_refinement="integral",
+    )
+    pred_instances = []
+    for idx, lf in enumerate(result_labels):
+        pred_instances.extend(lf.instances)
+        if idx == n:
+            break
+    return pred_instances
+
+
+def test_local_queues_candidates(minimal_instance_ckpt):
+
+    pred_instances = get_pred_instances(minimal_instance_ckpt, 2)
+    tracker = Tracker.from_config(candidates_method="local_queues")
+    track_instances = tracker.get_features(pred_instances, 0)
+
+    local_queues_candidates = LocalQueueCandidates(3, 20)
+    assert isinstance(local_queues_candidates.tracker_queue, DefaultDict)
+    assert isinstance(local_queues_candidates.tracker_queue[0], Deque)
+    local_queues_candidates.update_tracks(track_instances, None, None, None)
+    # (tracks are assigned only if row/ col ids exists)
+    assert not local_queues_candidates.tracker_queue[0]
+
+    track_instances = local_queues_candidates.add_new_tracks(track_instances)
+    assert len(local_queues_candidates.tracker_queue) == 2
+    assert len(local_queues_candidates.tracker_queue[0]) == 1
+    assert len(local_queues_candidates.tracker_queue[1]) == 1
+
+    new_track_id = local_queues_candidates.get_new_track_id()
+    assert new_track_id == 2
+
+    track_instances = tracker.get_features(pred_instances, 0)
+    tracked_instances = local_queues_candidates.add_new_tracks(track_instances)
+    assert tracked_instances[0].track_id == 2
+    assert tracked_instances[1].track_id == 3
+
+    features_track_id = local_queues_candidates.get_features_from_track_id(0)
+    assert isinstance(features_track_id, list)
+    assert len(features_track_id) == 1

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -1,0 +1,306 @@
+import pytest
+import numpy as np
+from sleap_nn.inference.predictors import main
+from sleap_nn.tracking.tracker import Tracker, FlowShiftTracker
+from sleap_nn.tracking.track_instance import (
+    TrackedInstanceFeature,
+    TrackInstanceLocalQueue,
+    TrackInstances,
+)
+import math
+
+
+def get_pred_instances(minimal_instance_ckpt):
+    """Get `sio.PredictedInstance` objects from Predictor class."""
+    result_labels = main(
+        model_paths=[minimal_instance_ckpt],
+        data_path="./tests/assets/minimal_instance.pkg.slp",
+        provider="LabelsReader",
+        make_labels=True,
+        max_instances=6,
+        peak_threshold=0.0,
+        integral_refinement="integral",
+    )
+    pred_instances = []
+    imgs = []
+    for lf in result_labels:
+        pred_instances.extend(lf.instances)
+        imgs.append(lf.image)
+    return pred_instances, imgs
+
+
+def test_tracker(minimal_instance_ckpt):
+    """Test `Tracker` module."""
+    # Test for the first two instances (high instance threshold)
+    # no new tracks should be created
+    pred_instances, _ = get_pred_instances(minimal_instance_ckpt)
+    tracker = Tracker.from_config(instance_score_threshold=1.0)
+    assert isinstance(tracker, Tracker)
+    assert not isinstance(tracker, FlowShiftTracker)
+    for p in pred_instances:
+        assert p.track is None
+    tracked_instances = tracker.track(pred_instances, 0)
+    for t in tracked_instances:
+        assert t.track is None
+    assert len(tracker.candidate.current_tracks) == 0
+
+    # Test Fixed-window method
+    # pose as feature, oks scoring method, avg score reduction, hungarian matching
+    # Test for the first two instances (tracks assigned to each of the new instances)
+    pred_instances, _ = get_pred_instances(minimal_instance_ckpt)
+    tracker = Tracker.from_config(
+        instance_score_threshold=0.0, candidates_method="fixed_window"
+    )
+    for p in pred_instances:
+        assert p.track is None
+    tracked_instances = tracker.track(pred_instances, 0)  # 2 tracks are created
+    for t in tracked_instances:
+        assert t.track is not None
+    assert tracked_instances[0].track.name == 0 and tracked_instances[1].track.name == 1
+    assert len(tracker.candidate.tracker_queue) == 1
+    assert tracker.candidate.current_tracks == [0, 1]
+    assert tracker.candidate.tracker_queue[0].track_ids == [0, 1]
+
+    # Test local queue method
+    # pose as feature, oks scoring method, max score reduction, hungarian matching
+    # Test for the first two instances (tracks assigned to each of the new instances)
+    pred_instances, _ = get_pred_instances(minimal_instance_ckpt)
+    tracker = Tracker.from_config(
+        instance_score_threshold=0.0, candidates_method="local_queues"
+    )
+    for p in pred_instances:
+        assert p.track is None
+    tracked_instances = tracker.track(pred_instances, 0)  # 2 tracks are created
+    for t in tracked_instances:
+        assert t.track is not None
+    assert len(tracker.candidate.tracker_queue) == 2
+    assert tracker.candidate.current_tracks == [0, 1]
+    assert tracked_instances[0].track.name == 0 and tracked_instances[1].track.name == 1
+
+    # Test indv. functions for fixed window
+    # with 2 existing tracks in the queue
+    pred_instances, _ = get_pred_instances(minimal_instance_ckpt)
+    tracker = Tracker.from_config(
+        instance_score_threshold=0.0,
+        candidates_method="fixed_window",
+        scoring_reduction="max",
+        track_matching_method="greedy",
+    )
+    _ = tracker.track(pred_instances, 0)
+
+    pred_instances, _ = get_pred_instances(minimal_instance_ckpt)
+    # Test points as feature
+    track_instances = tracker.get_features(pred_instances, 0, None)
+    assert isinstance(track_instances, TrackInstances)
+    for p, t in zip(pred_instances, track_instances.features):
+        assert np.all(p.numpy() == t)
+
+    # Test get_scores(), oks as scoring
+    candidates_list = tracker.generate_candidates()
+    candidate_feature_dict = tracker.update_candidates(candidates_list, None)
+    scores = tracker.get_scores(track_instances, candidate_feature_dict)
+    assert np.all(scores == np.array([[1.0, 0], [0, 1.0]]))
+
+    # Test assign_tracks()
+    cost = tracker.scores_to_cost_matrix(scores)
+    track_instances = tracker.assign_tracks(track_instances, cost)
+    assert track_instances.track_ids[0] == 0 and track_instances.track_ids[1] == 1
+    assert np.all(track_instances.features[0] == pred_instances[0].numpy())
+    assert len(tracker.candidate.current_tracks) == 2
+    assert len(tracker.candidate.tracker_queue) == 2
+    assert track_instances.tracking_scores == [1.0, 1.0]
+
+    tracked_instances = tracker.track(pred_instances, 0)
+    assert len(tracker.candidate.tracker_queue) == 3
+    assert len(tracker.candidate.current_tracks) == 2
+    assert np.all(
+        tracker.candidate.tracker_queue[0].features[0]
+        == tracker.candidate.tracker_queue[2].features[0]
+    )
+    assert (
+        tracker.candidate.tracker_queue[0].track_ids[1]
+        == tracker.candidate.tracker_queue[2].track_ids[1]
+    )
+
+    # Test with NaNs
+    tracker.candidate.tracker_queue[0].features[0] = np.full(
+        tracker.candidate.tracker_queue[0].features[0].shape, np.NaN
+    )
+    tracked_instances = tracker.track(pred_instances, 0)
+    assert len(tracker.candidate.current_tracks) == 2
+    assert tracked_instances[0].track.name == 0 and tracked_instances[1].track.name == 1
+
+    # Test local queue tracker
+    # with existing tracks
+    pred_instances, _ = get_pred_instances(minimal_instance_ckpt)
+    tracker = Tracker.from_config(
+        instance_score_threshold=0.0,
+        candidates_method="local_queues",
+    )
+    _ = tracker.track(pred_instances, 0)
+
+    tracked_instances = tracker.track(pred_instances, 0)
+    assert len(tracker.candidate.tracker_queue) == 2
+    assert (
+        len(tracker.candidate.tracker_queue[0]) == 2
+        and len(tracker.candidate.tracker_queue[1]) == 2
+    )
+    assert np.all(
+        tracker.candidate.tracker_queue[0][0].feature
+        == tracker.candidate.tracker_queue[0][1].feature
+    )
+
+    # test features - centroids + euclidean scoring
+    tracker = Tracker.from_config(
+        features="centroids", scoring_reduction="max", scoring_method="euclidean_dist"
+    )
+    tracked_instances = tracker.track(pred_instances, 0)  # add instances to queue
+    track_instances = tracker.get_features(pred_instances, 0, None)
+    for p, t in zip(pred_instances, track_instances.features):
+        pts = p.numpy()
+        centroid = np.nanmean(pts[:, 0]), np.nanmean(pts[:, 1])
+        assert np.all(centroid == t)
+    candidates_list = tracker.generate_candidates()
+    candidate_feature_dict = tracker.update_candidates(candidates_list, None)
+    scores = tracker.get_scores(track_instances, candidate_feature_dict)
+    assert scores[0, 0] == 0 and scores[1, 1] == 0
+    assert scores[1, 0] == scores[0, 1]
+    assert math.isclose(scores[0, 1], -108.20057, rel_tol=1e-4)
+
+    # test features - bboxes + iou scoring
+    tracker = Tracker.from_config(features="bboxes", scoring_method="iou")
+    tracked_instances = tracker.track(pred_instances, 0)  # add instances to queue
+    track_instances = tracker.get_features(pred_instances, 0, None)
+    for p, t in zip(pred_instances, track_instances.features):
+        pts = p.numpy()
+        bbox = (
+            np.nanmin(pts[:, 0]),
+            np.nanmin(pts[:, 1]),
+            np.nanmax(pts[:, 0]),
+            np.nanmax(pts[:, 1]),
+        )
+        assert np.all(bbox == t)
+    candidates_list = tracker.generate_candidates()
+    candidate_feature_dict = tracker.update_candidates(candidates_list, None)
+    assert isinstance(candidate_feature_dict[0][0], TrackedInstanceFeature)
+    assert candidate_feature_dict[0][0].shifted_keypoints is None
+    scores = tracker.get_scores(track_instances, candidate_feature_dict)
+    assert scores[0, 0] == 1 and scores[1, 1] == 1
+    assert scores[1, 0] == scores[0, 1] == 0
+
+    # Test for invalid argumnets
+    # candidate method
+    with pytest.raises(ValueError):
+        tracker = Tracker.from_config(
+            max_tracks=30, window_size=10, candidates_method="tracking"
+        )
+
+    with pytest.raises(ValueError):
+        tracker = Tracker.from_config(features="centered")
+        track_instances = tracker.track(pred_instances, 0)
+
+    with pytest.raises(ValueError):
+        tracker = Tracker.from_config(scoring_method="dist")
+        track_instances = tracker.track(pred_instances, 0)
+
+        track_instances = tracker.track(pred_instances, 0)
+
+    with pytest.raises(ValueError):
+        tracker = Tracker.from_config(scoring_reduction="min")
+        track_instances = tracker.track(pred_instances, 0)
+
+        track_instances = tracker.track(pred_instances, 0)
+
+    with pytest.raises(ValueError):
+        tracker = Tracker.from_config(track_matching_method="min")
+        track_instances = tracker.track(pred_instances, 0)
+
+        track_instances = tracker.track(pred_instances, 0)
+
+
+def test_flowshifttracker(minimal_instance_ckpt):
+    """Tests for `FlowShiftTracker` class."""
+    # Test Fixed-window method: pose as feature, oks scoring method
+    # Test for the first two instances (tracks assigned to each of the new instances)
+    pred_instances, imgs = get_pred_instances(minimal_instance_ckpt)
+    tracker = Tracker.from_config(
+        instance_score_threshold=0.0,
+        candidates_method="fixed_window",
+        use_flow=True,
+        track_matching_method="greedy",
+    )
+    assert isinstance(tracker, FlowShiftTracker)
+    for p in pred_instances:
+        assert p.track is None
+    tracked_instances = tracker.track(
+        pred_instances, 0, imgs[0]
+    )  # 2 tracks are created
+    for t in tracked_instances:
+        assert t.track is not None
+    assert len(tracker.candidate.tracker_queue) == 1
+    assert len(tracker.candidate.current_tracks) == 2
+
+    # Test track() with track_queue not empty
+    tracked_instances = tracker.track(pred_instances, 0, imgs[0])
+    assert len(tracker.candidate.tracker_queue) == 2
+    assert len(tracker.candidate.current_tracks) == 2
+    assert np.all(
+        tracker.candidate.tracker_queue[0].features[0]
+        == tracker.candidate.tracker_queue[1].features[0]
+    )
+    assert (
+        tracker.candidate.tracker_queue[0].track_ids[1]
+        == tracker.candidate.tracker_queue[1].track_ids[1]
+    )
+
+    # Test Local queue method: pose as feature, oks scoring method
+    # Test for the first two instances (tracks assigned to each of the new instances)
+    pred_instances, imgs = get_pred_instances(minimal_instance_ckpt)
+    tracker = Tracker.from_config(
+        instance_score_threshold=0.0,
+        candidates_method="local_queues",
+        use_flow=True,
+        of_img_scale=0.5,
+    )
+    assert isinstance(tracker, FlowShiftTracker)
+    for p in pred_instances:
+        assert p.track is None
+    tracked_instances = tracker.track(
+        pred_instances, 0, imgs[0]
+    )  # 2 tracks are created
+    for t in tracked_instances:
+        assert t.track is not None
+    assert len(tracker.candidate.tracker_queue[0]) == 1
+    assert len(tracker.candidate.current_tracks) == 2
+
+    # Test track() with track_queue not empty
+    tracked_instances = tracker.track(pred_instances, 0, imgs[0].astype("float32"))
+    assert len(tracker.candidate.tracker_queue[0]) == 2
+    assert len(tracker.candidate.current_tracks) == 2
+    assert np.all(
+        tracker.candidate.tracker_queue[0][0].feature
+        == tracker.candidate.tracker_queue[0][1].feature
+    )
+    assert np.any(
+        tracker.candidate.tracker_queue[0][0].feature
+        != tracker.candidate.tracker_queue[1][1].feature
+    )
+
+    # Test update_candidates()
+    candidates_list = tracker.generate_candidates()
+    candidate_feature_dict = tracker.update_candidates(candidates_list, imgs[0])
+    assert isinstance(candidate_feature_dict[0][0], TrackedInstanceFeature)
+    assert candidate_feature_dict[0][0].shifted_keypoints is not None
+    assert np.any(
+        candidate_feature_dict[0][0].src_predicted_instance.numpy()
+        == candidate_feature_dict[0][0].shifted_keypoints
+    )
+
+    # Test `_preprocess_imgs`
+    ref, new = tracker._preprocess_imgs(
+        imgs[0].astype("float32"), imgs[0].astype("float32")
+    )
+    assert np.issubdtype(ref.dtype, np.integer)
+    assert np.issubdtype(new.dtype, np.integer)
+    assert imgs[0].shape == (384, 384, 1)
+    assert ref.shape == (192, 192) and new.shape == (192, 192)


### PR DESCRIPTION
This PR addresses the issue in #76. Both intensity and geometric augmentations are now applied before cropping in the TopDownConfmaps data pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data augmentation logic for improved flexibility in applying augmentations.
	- New `interp1d` function added for linear interpolation of PyTorch tensors.
  
- **Bug Fixes**
	- Improved coordinate handling in PAF processing to prevent out-of-bounds errors.

- **Configuration Changes**
	- Adjusted multiple configuration parameters for the model, including `filters_rate`, `max_stride`, and `up_interpolate` settings.
  
- **Tests**
	- Added tests for the new `interp1d` function.
	- Updated assertions in existing test cases to accommodate flexible instance counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->