### PR TITLE
LitData Refactor PR2: Implement a function to get the data chunks for all model types

### DIFF
--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -1,0 +1,124 @@
+"""Handles generating data chunks for training."""
+
+import numpy as np
+import torch
+
+from sleap_nn.data.instance_centroids import generate_centroids
+from sleap_nn.data.instance_cropping import generate_crops
+from sleap_nn.data.normalization import apply_normalization, convert_to_grayscale, convert_to_rgb
+from sleap_nn.data.providers import process_lf
+from sleap_nn.data.resizing import apply_pad_to_stride, apply_resizer, apply_sizematcher
+
+def bottomup_data_chunks(lf):
+
+    image, instances_n, frame_idx, video_idx = lf
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+    sample["image"] = convert_to_grayscale(sample["image"]) # TODO: how to set config params
+    sample["image"] = convert_to_rgb(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(sample["image"], max_height, max_width)
+
+    # resize the image
+    sample["image"], sample["instances"] = apply_resizer(sample["image"], sample["instances"],
+                                                         scale=scale)
+    
+    # Pad the image (if needed) according max stride
+    sample["image"] = apply_pad_to_stride(sample["image"], max_stride)
+
+    return sample
+
+def centered_data_chunks(lf):
+
+    image, instances_n, frame_idx, video_idx = lf
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+    sample["image"] = convert_to_grayscale(sample["image"]) # TODO: how to set config params
+    sample["image"] = convert_to_rgb(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(sample["image"], max_height, max_width)
+
+    # resize the image
+    sample["image"], sample["instances"] = apply_resizer(sample["image"], sample["instances"],
+                                                         scale=scale)
+    
+    # Pad the image (if needed) according max stride
+    sample["image"] = apply_pad_to_stride(sample["image"], max_stride)
+
+    # get the centroids based on the anchor idx
+    centroids = generate_centroids(sample["instances"], anchor_ind = anchor_ind)
+
+    crop_size = np.array(crop_size) * np.sqrt(2) # crop extra
+    crop_size = crop_size.astype(np.int32).tolist()
+
+    for cnt, (instance, centroid) in enumerate(zip(sample["instances"], sample["centroids"])):
+        if cnt==sample["num_instances"]:
+            break
+
+        res = generate_crops(sample["image"], instance, centroid, crop_size)
+
+        res["frame_idx"] = sample["frame_idx"]
+        res["video_idx"] = sample["video_idx"]
+        res["num_instances"] = sample["num_instances"]
+        res["orig_size"] = sample["orig_size"]
+
+        yield res
+
+def centroid_data_chunks(lf):
+
+    image, instances_n, frame_idx, video_idx = lf
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+    sample["image"] = convert_to_grayscale(sample["image"]) # TODO: how to set config params
+    sample["image"] = convert_to_rgb(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(sample["image"], max_height, max_width)
+
+    # resize the image
+    sample["image"], sample["instances"] = apply_resizer(sample["image"], sample["instances"],
+                                                         scale=scale)
+    
+    # Pad the image (if needed) according max stride
+    sample["image"] = apply_pad_to_stride(sample["image"], max_stride)
+
+    # get the centroids based on the anchor idx
+    centroids = generate_centroids(sample["instances"], anchor_ind = anchor_ind)
+
+    sample["centroids"] = centroids
+
+    return sample
+
+def single_instance_data_chunks(lf):
+
+    image, instances_n, frame_idx, video_idx = lf
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+    sample["image"] = convert_to_grayscale(sample["image"]) # TODO: how to set config params
+    sample["image"] = convert_to_rgb(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(sample["image"], max_height, max_width)
+
+    # resize the image
+    sample["image"], sample["instances"] = apply_resizer(sample["image"], sample["instances"],
+                                                         scale=scale)
+    
+    # Pad the image (if needed) according max stride
+    sample["image"] = apply_pad_to_stride(sample["image"], max_stride)
+
+    return sample

--- a/sleap_nn/data/streaming_datasets.py
+++ b/sleap_nn/data/streaming_datasets.py
@@ -1,0 +1,46 @@
+"""Custom `litdata.StreamingDataset`s for different models."""
+from omegaconf import DictConfig
+import litdata as ld
+import torch
+
+from sleap_nn.data.augmentation import apply_geometric_augmentation, apply_intensity_augmentation
+from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
+from sleap_nn.data.edge_maps import generate_pafs
+
+class BottomUpStreamingDataset(ld.StreamingDataset):
+    def __init__(self, config: DictConfig, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.config = config
+    
+    def __getitem__(self, index):
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        ex["image"], ex["instances"] = apply_intensity_augmentation(ex["image"],
+                                                                    ex["instances"],)
+                                                                    # TODO)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(ex["instances"],
+                                                 img_hw=img_hw,
+                                                 num_instances=ex["num_instances"],
+                                                 sigma=sigma,
+                                                 output_stride=output_stride)
+
+        # pafs
+        pafs = generate_pafs(ex["instances"],
+                             img_hw=img_hw,
+                             sigma=sigma,
+                             output_stride=output_stride,
+                             edge_inds=edge_inds,
+                             flatten_channels=True,
+                             )
+
+        sample = ex
+        del sample["instances"]
+        sample["confidence_maps"] = confidence_maps
+        sample["part_affinity_fields"] = pafs
+
+        return sample


### PR DESCRIPTION
This is the second PR for #80. Here,  we implement the get_chunks() method for each model pipeline. This method handles all the data preprocessing functions (except augmentation and confidence map (or pafs) generation) to extract dictionaries from .slp file and save them as .bin files.