### PR TITLE
LitData Refactor PR3: Add custom `StreamingDataset` 

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -57,6 +57,7 @@ The config file has three main sections:
             - `mixup_p`: (float) Probability of applying random mixup v2. *Default*=0.0
             - `input_key`: (str) Can be `image` or `instance`. The input_key `instance` expects the KorniaAugmenter to follow the InstanceCropper else `image` otherwise for default.
             - `random crop`: (Optional) (Dict[float]) {"random_crop_p": None, "crop_height": None. "crop_width": None}, where *random_crop_p* is the probability of applying random crop and *crop_height* and *crop_width* are the desired output size (out_h, out_w) of the crop.
+            # TODO: change doc for random crop
 
 - `model_config`: 
     - `init_weight`: (str) model weights initialization method. "default" uses kaiming uniform initialization and "xavier" uses Xavier initialization method.

--- a/docs/config.md
+++ b/docs/config.md
@@ -29,8 +29,7 @@ The config file has three main sections:
         - `crop_hw`: (Tuple[int]) Crop height and width of each instance (h, w) for centered-instance model. If `None`, this would be automatically computed based on the largest instance in the `sio.Labels` file.
         - `min_crop_size`: (int) Minimum crop size to be used if `crop_hw` is `None`.
     - `use_augmentations_train`: (bool) True if the data augmentation should be applied to the training data, else False. 
-    - `augmentation_config`: (only if `use_augmentations` is `True`)
-        - `random crop`: (Optional) (Dict[float]) {"random_crop_p": None, "crop_height": None. "crop_width": None}, where *random_crop_p* is the probability of applying random crop and *crop_height* and *crop_width* are the desired output size (out_h, out_w) of the crop. 
+    - `augmentation_config`: (only if `use_augmentations` is `True`) 
         - `intensity`: (Optional)
             - `uniform_noise_min`: (float) Minimum value for uniform noise (uniform_noise_min >=0).
             - `uniform_noise_max`: (float) Maximum value for uniform noise (uniform_noise_max <>=1).
@@ -57,6 +56,7 @@ The config file has three main sections:
             - `mixup_lambda`: (float) min-max value of mixup strength. Default is 0-1. *Default*: `None`.
             - `mixup_p`: (float) Probability of applying random mixup v2. *Default*=0.0
             - `input_key`: (str) Can be `image` or `instance`. The input_key `instance` expects the KorniaAugmenter to follow the InstanceCropper else `image` otherwise for default.
+            - `random crop`: (Optional) (Dict[float]) {"random_crop_p": None, "crop_height": None. "crop_width": None}, where *random_crop_p* is the probability of applying random crop and *crop_height* and *crop_width* are the desired output size (out_h, out_w) of the crop.
 
 - `model_config`: 
     - `init_weight`: (str) model weights initialization method. "default" uses kaiming uniform initialization and "xavier" uses Xavier initialization method.

--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -33,3 +33,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -32,3 +32,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/sleap_nn/data/streaming_datasets.py
+++ b/sleap_nn/data/streaming_datasets.py
@@ -1,0 +1,112 @@
+"""Custom `litdata.StreamingDataset`s for different models."""
+from kornia.geometry.transform import crop_and_resize
+from omegaconf import DictConfig
+from typing import List, Optional, Tuple
+import litdata as ld
+import torch
+
+from sleap_nn.data.augmentation import apply_geometric_augmentation, apply_intensity_augmentation
+from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
+from sleap_nn.data.edge_maps import generate_pafs
+from sleap_nn.data.instance_cropping import make_centered_bboxes
+
+class BottomUpStreamingDataset(ld.StreamingDataset):
+    def __init__(self, augmentation_config: DictConfig,
+                 confmap_head: DictConfig,
+                 pafs_head: DictConfig,
+                 edge_inds: list,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.aug_config = augmentation_config
+        self.confmap_head = confmap_head
+        self.pafs_head = pafs_head
+        self.edge_inds = edge_inds
+
+    def __getitem__(self, index):
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if "intensity" in self.aug_config:
+            ex["image"], ex["instances"] = apply_intensity_augmentation(ex["image"],
+                                                                        ex["instances"],
+                                                                        **self.aug_config.intensity)
+
+        if "geometric" in self.aug_config:
+            ex["image"], ex["instances"] = apply_geometric_augmentation(ex["image"],
+                                                                        ex["instances"],
+                                                                        **self.aug_config.geometric)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(ex["instances"],
+                                                 img_hw=img_hw,
+                                                 num_instances=ex["num_instances"],
+                                                 sigma=self.confmap_head.sigma,
+                                                 output_stride=self.confmap_head.output_stride,
+                                                 is_centroids=False)
+
+        # pafs
+        pafs = generate_pafs(ex["instances"],
+                             img_hw=img_hw,
+                             sigma=self.pafs_head.sigma,
+                             output_stride=self.pafs_head.output_stride,
+                             edge_inds=torch.Tensor(self.edge_inds),
+                             flatten_channels=True,
+                             )
+
+        sample = ex
+        del sample["instances"]
+        sample["confidence_maps"] = confidence_maps
+        sample["part_affinity_fields"] = pafs
+
+        return sample
+    
+class CenteredInstanceStreamingDataset(ld.StreamingDataset):
+    def __init__(self, augmentation_config: DictConfig,
+                 confmap_head: DictConfig,
+                 crop_hw: Tuple[int],
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.aug_config = augmentation_config
+        self.confmap_head = confmap_head
+        self.crop_hw = crop_hw
+
+    def __getitem__(self, index):
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if "intensity" in self.aug_config:
+            ex["image"], ex["instances"] = apply_intensity_augmentation(ex["image"],
+                                                                        ex["instances"],
+                                                                        **self.aug_config.intensity)
+
+        if "geometric" in self.aug_config:
+            ex["image"], ex["instances"] = apply_geometric_augmentation(ex["image"],
+                                                                        ex["instances"],
+                                                                        **self.aug_config.geometric)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Re-crop to original crop size
+        ex["instance"] = ex["instance"].squeeze(dim=0) # n_samples
+        ex["instance_bbox"] = torch.unsqueeze(
+            make_centered_bboxes(ex["centroid"], self.crop_hw[0], self.crop_hw[1]), 0
+        )
+        ex["instance_image"] = crop_and_resize(
+            ex["instance_image"],
+            boxes=ex["instance_bbox"],
+            size=self.crop_hw
+        )
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(ex["instances"],
+                                                 img_hw=img_hw,
+                                                 sigma=self.confmap_head.sigma,
+                                                 output_stride=self.confmap_head.output_stride,)
+
+        sample = ex
+        del sample["instances"]
+        sample["confidence_maps"] = confidence_maps
+
+        return sample

--- a/sleap_nn/data/streaming_datasets.py
+++ b/sleap_nn/data/streaming_datasets.py
@@ -1,6 +1,7 @@
 """Custom `litdata.StreamingDataset`s for different models."""
 
 from kornia.geometry.transform import crop_and_resize
+from litdata.streaming.sampler import ChunkedIndex
 from omegaconf import DictConfig
 from typing import List, Optional, Tuple
 import litdata as ld
@@ -49,6 +50,7 @@ class BottomUpStreamingDataset(ld.StreamingDataset):
         *args,
         **kwargs,
     ):
+        """Constructs a BottomUpStreamingDataset."""
         super().__init__(*args, **kwargs)
         self.aug_config = augmentation_config
         self.confmap_head = confmap_head
@@ -58,6 +60,7 @@ class BottomUpStreamingDataset(ld.StreamingDataset):
         self.scale = scale
 
     def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
         ex = super().__getitem__(index)
 
         # Augmentation
@@ -140,6 +143,7 @@ class CenteredInstanceStreamingDataset(ld.StreamingDataset):
         *args,
         **kwargs,
     ):
+        """Construct a CenteredInstanceStreamingDataset."""
         super().__init__(*args, **kwargs)
         self.aug_config = augmentation_config
         self.confmap_head = confmap_head
@@ -148,6 +152,7 @@ class CenteredInstanceStreamingDataset(ld.StreamingDataset):
         self.max_stride = max_stride
 
     def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
         ex = super().__getitem__(index)
 
         # Augmentation
@@ -229,6 +234,7 @@ class CentroidStreamingDataset(ld.StreamingDataset):
         *args,
         **kwargs,
     ):
+        """Construct a CentroidStreamingDataset."""
         super().__init__(*args, **kwargs)
         self.aug_config = augmentation_config
         self.confmap_head = confmap_head
@@ -236,6 +242,7 @@ class CentroidStreamingDataset(ld.StreamingDataset):
         self.scale = scale
 
     def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
         ex = super().__getitem__(index)
 
         # Augmentation
@@ -304,6 +311,7 @@ class SingleInstanceStreamingDataset(ld.StreamingDataset):
         *args,
         **kwargs,
     ):
+        """Construct a SingleInstanceStreamingDataset."""
         super().__init__(*args, **kwargs)
         self.aug_config = augmentation_config
         self.confmap_head = confmap_head
@@ -311,6 +319,7 @@ class SingleInstanceStreamingDataset(ld.StreamingDataset):
         self.scale = scale
 
     def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
         ex = super().__getitem__(index)
 
         # Augmentation

--- a/sleap_nn/data/streaming_datasets.py
+++ b/sleap_nn/data/streaming_datasets.py
@@ -1,112 +1,350 @@
 """Custom `litdata.StreamingDataset`s for different models."""
+
 from kornia.geometry.transform import crop_and_resize
 from omegaconf import DictConfig
 from typing import List, Optional, Tuple
 import litdata as ld
 import torch
 
-from sleap_nn.data.augmentation import apply_geometric_augmentation, apply_intensity_augmentation
+from sleap_nn.data.augmentation import (
+    apply_geometric_augmentation,
+    apply_intensity_augmentation,
+)
 from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
 from sleap_nn.data.edge_maps import generate_pafs
 from sleap_nn.data.instance_cropping import make_centered_bboxes
+from sleap_nn.data.resizing import apply_pad_to_stride, apply_resizer
+
 
 class BottomUpStreamingDataset(ld.StreamingDataset):
-    def __init__(self, augmentation_config: DictConfig,
-                 confmap_head: DictConfig,
-                 pafs_head: DictConfig,
-                 edge_inds: list,
-                 *args, **kwargs):
+    """StreamingDataset for BottomUp pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps and part affinity fields for every
+    data sample stored in `.bin` files.
+
+    Args:
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        pafs_head: DictConfig object with all the keys in the `head_config` section
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type )
+            for PAFs.
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+    """
+
+    def __init__(
+        self,
+        augmentation_config: DictConfig,
+        confmap_head: DictConfig,
+        pafs_head: DictConfig,
+        edge_inds: list,
+        max_stride: int,
+        scale: float = 1.0,
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.aug_config = augmentation_config
         self.confmap_head = confmap_head
         self.pafs_head = pafs_head
         self.edge_inds = edge_inds
+        self.max_stride = max_stride
+        self.scale = scale
 
     def __getitem__(self, index):
         ex = super().__getitem__(index)
 
         # Augmentation
         if "intensity" in self.aug_config:
-            ex["image"], ex["instances"] = apply_intensity_augmentation(ex["image"],
-                                                                        ex["instances"],
-                                                                        **self.aug_config.intensity)
+            ex["image"], ex["instances"] = apply_intensity_augmentation(
+                ex["image"], ex["instances"], **self.aug_config.intensity
+            )
 
         if "geometric" in self.aug_config:
-            ex["image"], ex["instances"] = apply_geometric_augmentation(ex["image"],
-                                                                        ex["instances"],
-                                                                        **self.aug_config.geometric)
+            ex["image"], ex["instances"] = apply_geometric_augmentation(
+                ex["image"], ex["instances"], **self.aug_config.geometric
+            )
+
+        # resize the image
+        ex["image"], ex["instances"] = apply_resizer(
+            ex["image"],
+            ex["instances"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
 
         img_hw = ex["image"].shape[-2:]
 
         # Generate confidence maps
-        confidence_maps = generate_multiconfmaps(ex["instances"],
-                                                 img_hw=img_hw,
-                                                 num_instances=ex["num_instances"],
-                                                 sigma=self.confmap_head.sigma,
-                                                 output_stride=self.confmap_head.output_stride,
-                                                 is_centroids=False)
+        confidence_maps = generate_multiconfmaps(
+            ex["instances"],
+            img_hw=img_hw,
+            num_instances=ex["num_instances"],
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+            is_centroids=False,
+        )
 
         # pafs
-        pafs = generate_pafs(ex["instances"],
-                             img_hw=img_hw,
-                             sigma=self.pafs_head.sigma,
-                             output_stride=self.pafs_head.output_stride,
-                             edge_inds=torch.Tensor(self.edge_inds),
-                             flatten_channels=True,
-                             )
+        pafs = generate_pafs(
+            ex["instances"],
+            img_hw=img_hw,
+            sigma=self.pafs_head.sigma,
+            output_stride=self.pafs_head.output_stride,
+            edge_inds=torch.Tensor(self.edge_inds),
+            flatten_channels=True,
+        )
 
-        sample = ex
-        del sample["instances"]
-        sample["confidence_maps"] = confidence_maps
-        sample["part_affinity_fields"] = pafs
+        del ex["instances"]
+        ex["confidence_maps"] = confidence_maps
+        ex["part_affinity_fields"] = pafs
 
-        return sample
-    
+        return ex
+
+
 class CenteredInstanceStreamingDataset(ld.StreamingDataset):
-    def __init__(self, augmentation_config: DictConfig,
-                 confmap_head: DictConfig,
-                 crop_hw: Tuple[int],
-                 *args, **kwargs):
+    """StreamingDataset for CeneteredInstance pipeline.
+
+    The `__getitem__()` applies augmentation, re-crops `instance_image` to original crop size,
+    resizes and pads image (if needed for the given max_stride), and generates confidence maps
+    for every data sample stored in `.bin` files.
+
+    Args:
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        crop_hw: Height and width of the crop in pixels.
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+    """
+
+    def __init__(
+        self,
+        augmentation_config: DictConfig,
+        confmap_head: DictConfig,
+        crop_hw: Tuple[int],
+        max_stride: int,
+        scale: float = 1.0,
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.aug_config = augmentation_config
         self.confmap_head = confmap_head
         self.crop_hw = crop_hw
+        self.scale = scale
+        self.max_stride = max_stride
 
     def __getitem__(self, index):
         ex = super().__getitem__(index)
 
         # Augmentation
         if "intensity" in self.aug_config:
-            ex["image"], ex["instances"] = apply_intensity_augmentation(ex["image"],
-                                                                        ex["instances"],
-                                                                        **self.aug_config.intensity)
+            ex["instance_image"], ex["instance"] = apply_intensity_augmentation(
+                ex["instance_image"], ex["instance"], **self.aug_config.intensity
+            )
 
         if "geometric" in self.aug_config:
-            ex["image"], ex["instances"] = apply_geometric_augmentation(ex["image"],
-                                                                        ex["instances"],
-                                                                        **self.aug_config.geometric)
+            ex["instance_image"], ex["instance"] = apply_geometric_augmentation(
+                ex["instance_image"], ex["instance"], **self.aug_config.geometric
+            )
+
+        # Re-crop to original crop size
+        ex["instance_bbox"] = torch.unsqueeze(
+            make_centered_bboxes(ex["centroid"][0], self.crop_hw[0], self.crop_hw[1]), 0
+        )
+        ex["instance_image"] = crop_and_resize(
+            ex["instance_image"], boxes=ex["instance_bbox"], size=self.crop_hw
+        )
+        point = ex["instance_bbox"][0][0]
+        center_instance = ex["instance"] - point
+        centered_centroid = ex["centroid"] - point
+
+        ex["instance"] = center_instance.unsqueeze(0)  # (n_samples=1, n_nodes, 2)
+        ex["centroid"] = centered_centroid.unsqueeze(0)  # (n_samples=1, 2)
+
+        # resize the image
+        ex["instance_image"], ex["instance"] = apply_resizer(
+            ex["instance_image"],
+            ex["instance"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["instance_image"] = apply_pad_to_stride(
+            ex["instance_image"], max_stride=self.max_stride
+        )
+
+        img_hw = ex["instance_image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(
+            ex["instance"],
+            img_hw=img_hw,
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+        )
+
+        ex["confidence_maps"] = confidence_maps
+
+        return ex
+
+
+class CentroidStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for Centroid pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps for every data sample stored in `.bin` files.
+
+    Args:
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+    """
+
+    def __init__(
+        self,
+        augmentation_config: DictConfig,
+        confmap_head: DictConfig,
+        max_stride: int,
+        scale: float = 1.0,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.aug_config = augmentation_config
+        self.confmap_head = confmap_head
+        self.max_stride = max_stride
+        self.scale = scale
+
+    def __getitem__(self, index):
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if "intensity" in self.aug_config:
+            ex["image"], ex["centroids"] = apply_intensity_augmentation(
+                ex["image"], ex["centroids"], **self.aug_config.intensity
+            )
+
+        if "geometric" in self.aug_config:
+            ex["image"], ex["centroids"] = apply_geometric_augmentation(
+                ex["image"], ex["centroids"], **self.aug_config.geometric
+            )
+
+        # resize the image
+        ex["image"], ex["centroids"] = apply_resizer(
+            ex["image"],
+            ex["centroids"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
 
         img_hw = ex["image"].shape[-2:]
 
-        # Re-crop to original crop size
-        ex["instance"] = ex["instance"].squeeze(dim=0) # n_samples
-        ex["instance_bbox"] = torch.unsqueeze(
-            make_centered_bboxes(ex["centroid"], self.crop_hw[0], self.crop_hw[1]), 0
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(
+            ex["centroids"],
+            img_hw=img_hw,
+            num_instances=ex["num_instances"],
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+            is_centroids=True,
         )
-        ex["instance_image"] = crop_and_resize(
-            ex["instance_image"],
-            boxes=ex["instance_bbox"],
-            size=self.crop_hw
+
+        del ex["centroids"]
+        ex["confidence_maps"] = confidence_maps
+
+        return ex
+
+
+class SingleInstanceStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for SingleInstance pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps for every data sample stored in `.bin` files.
+
+    Args:
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+    """
+
+    def __init__(
+        self,
+        augmentation_config: DictConfig,
+        confmap_head: DictConfig,
+        max_stride: int,
+        scale: float = 1.0,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.aug_config = augmentation_config
+        self.confmap_head = confmap_head
+        self.max_stride = max_stride
+        self.scale = scale
+
+    def __getitem__(self, index):
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if "intensity" in self.aug_config:
+            ex["image"], ex["instances"] = apply_intensity_augmentation(
+                ex["image"], ex["instances"], **self.aug_config.intensity
+            )
+
+        if "geometric" in self.aug_config:
+            ex["image"], ex["instances"] = apply_geometric_augmentation(
+                ex["image"], ex["instances"], **self.aug_config.geometric
+            )
+
+        # resize the image
+        ex["image"], ex["instances"] = apply_resizer(
+            ex["image"],
+            ex["instances"],
+            scale=self.scale,
         )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
+
+        img_hw = ex["image"].shape[-2:]
 
         # Generate confidence maps
-        confidence_maps = generate_confmaps(ex["instances"],
-                                                 img_hw=img_hw,
-                                                 sigma=self.confmap_head.sigma,
-                                                 output_stride=self.confmap_head.output_stride,)
+        confidence_maps = generate_confmaps(
+            ex["instances"],
+            img_hw=img_hw,
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+        )
 
-        sample = ex
-        del sample["instances"]
-        sample["confidence_maps"] = confidence_maps
+        del ex["instances"]
+        ex["confidence_maps"] = confidence_maps
 
-        return sample
+        return ex

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -1,0 +1,237 @@
+from pathlib import Path
+from omegaconf import DictConfig
+import functools
+import litdata as ld
+import shutil
+import sleap_io as sio
+from sleap_nn.data.get_data_chunks import (
+    bottomup_data_chunks,
+    centered_instance_data_chunks,
+    centroid_data_chunks,
+    single_instance_data_chunks,
+)
+from sleap_nn.data.streaming_datasets import (
+    BottomUpStreamingDataset,
+    CenteredInstanceStreamingDataset,
+    CentroidStreamingDataset,
+    SingleInstanceStreamingDataset,
+)
+
+
+def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test BottomUpStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+    edge_inds = labels.skeletons[0].edge_inds
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        bottomup_data_chunks, data_config=config.data_config, max_instances=2
+    )
+    shutil.rmtree(dir_path)
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+
+    dataset = BottomUpStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        pafs_head=pafs_head,
+        edge_inds=edge_inds,
+        max_stride=100,
+        scale=0.5,
+        input_dir=str(dir_path),
+    )
+
+    samples = list(iter(dataset))
+    assert len(samples) == 1
+
+    assert samples[0]["image"].shape == (1, 1, 200, 200)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+    assert samples[0]["part_affinity_fields"].shape == (50, 50, 2)
+
+    # test with random crop
+    config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+    config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+    config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+    dataset = BottomUpStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        pafs_head=pafs_head,
+        edge_inds=edge_inds,
+        max_stride=2,
+        scale=1.0,
+        input_dir=str(dir_path),
+    )
+
+    samples = list(iter(dataset))
+    assert len(samples) == 1
+    print(samples)
+
+    assert samples[0]["image"].shape == (1, 1, 300, 300)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+    assert samples[0]["part_affinity_fields"].shape == (75, 75, 2)
+
+    shutil.rmtree(dir_path)
+
+
+def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test CenteredInstanceStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        centered_instance_data_chunks,
+        data_config=config.data_config,
+        max_instances=2,
+        crop_size=(160, 160),
+        anchor_ind=0,
+    )
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+    dataset = CenteredInstanceStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        crop_hw=(160, 160),
+        max_stride=100,
+        scale=0.5,
+        input_dir=str(dir_path),
+    )
+
+    samples = list(iter(dataset))
+    assert len(samples) == 2
+
+    assert samples[0]["instance_image"].shape == (1, 1, 100, 100)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 50, 50)
+
+    shutil.rmtree(dir_path)
+
+
+def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test CentroidStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        centroid_data_chunks,
+        data_config=config.data_config,
+        max_instances=2,
+        anchor_ind=0,
+    )
+    # shutil.rmtree(dir_path)
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+    dataset = CentroidStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        max_stride=100,
+        scale=0.5,
+        input_dir=str(dir_path),
+    )
+
+    samples = list(iter(dataset))
+    assert len(samples) == 1
+
+    assert samples[0]["image"].shape == (1, 1, 200, 200)
+    assert samples[0]["confidence_maps"].shape == (1, 1, 100, 100)
+
+    # test with random crop
+    config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+    config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+    config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+    dataset = CentroidStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        max_stride=2,
+        scale=1.0,
+        input_dir=str(dir_path),
+    )
+
+    samples = list(iter(dataset))
+    assert len(samples) == 1
+    print(samples)
+
+    assert samples[0]["image"].shape == (1, 1, 300, 300)
+    assert samples[0]["confidence_maps"].shape == (1, 1, 150, 150)
+
+    shutil.rmtree(dir_path)
+
+
+def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test SingleInstanceStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        single_instance_data_chunks,
+        data_config=config.data_config,
+    )
+    # shutil.rmtree(dir_path)
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+    dataset = SingleInstanceStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        max_stride=100,
+        scale=0.5,
+        input_dir=str(dir_path),
+    )
+
+    samples = list(iter(dataset))
+    assert len(samples) == 1
+
+    assert samples[0]["image"].shape == (1, 1, 200, 200)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+
+    # test with random crop
+    config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+    config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+    config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+    dataset = SingleInstanceStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        max_stride=2,
+        scale=1.0,
+        input_dir=str(dir_path),
+    )
+
+    samples = list(iter(dataset))
+    assert len(samples) == 1
+    print(samples)
+
+    assert samples[0]["image"].shape == (1, 1, 300, 300)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+
+    shutil.rmtree(dir_path)

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -28,7 +28,6 @@ def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
     partial_func = functools.partial(
         bottomup_data_chunks, data_config=config.data_config, max_instances=2
     )
-    shutil.rmtree(dir_path)
     ld.optimize(
         fn=partial_func,
         inputs=[(x, labels.videos.index(x.video)) for x in labels],
@@ -36,49 +35,50 @@ def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
         chunk_size=4,
     )
 
-    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
-    pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+    try:
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+        pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
 
-    dataset = BottomUpStreamingDataset(
-        augmentation_config=config.data_config.augmentation_config,
-        confmap_head=confmap_head,
-        pafs_head=pafs_head,
-        edge_inds=edge_inds,
-        max_stride=100,
-        scale=0.5,
-        input_dir=str(dir_path),
-    )
+        dataset = BottomUpStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            pafs_head=pafs_head,
+            edge_inds=edge_inds,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
 
-    samples = list(iter(dataset))
-    assert len(samples) == 1
+        samples = list(iter(dataset))
+        assert len(samples) == 1
 
-    assert samples[0]["image"].shape == (1, 1, 200, 200)
-    assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
-    assert samples[0]["part_affinity_fields"].shape == (50, 50, 2)
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+        assert samples[0]["part_affinity_fields"].shape == (50, 50, 2)
 
-    # test with random crop
-    config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
-    config.data_config.augmentation_config.geometric["random_crop_height"] = 300
-    config.data_config.augmentation_config.geometric["random_crop_width"] = 300
-    dataset = BottomUpStreamingDataset(
-        augmentation_config=config.data_config.augmentation_config,
-        confmap_head=confmap_head,
-        pafs_head=pafs_head,
-        edge_inds=edge_inds,
-        max_stride=2,
-        scale=1.0,
-        input_dir=str(dir_path),
-    )
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = BottomUpStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            pafs_head=pafs_head,
+            edge_inds=edge_inds,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+        )
 
-    samples = list(iter(dataset))
-    assert len(samples) == 1
-    print(samples)
+        samples = list(iter(dataset))
+        assert len(samples) == 1
 
-    assert samples[0]["image"].shape == (1, 1, 300, 300)
-    assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
-    assert samples[0]["part_affinity_fields"].shape == (75, 75, 2)
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+        assert samples[0]["part_affinity_fields"].shape == (75, 75, 2)
 
-    shutil.rmtree(dir_path)
+    finally:
+        shutil.rmtree(dir_path)
 
 
 def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
@@ -101,24 +101,26 @@ def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, c
         chunk_size=4,
     )
 
-    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    try:
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
 
-    dataset = CenteredInstanceStreamingDataset(
-        augmentation_config=config.data_config.augmentation_config,
-        confmap_head=confmap_head,
-        crop_hw=(160, 160),
-        max_stride=100,
-        scale=0.5,
-        input_dir=str(dir_path),
-    )
+        dataset = CenteredInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            crop_hw=(160, 160),
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
 
-    samples = list(iter(dataset))
-    assert len(samples) == 2
+        samples = list(iter(dataset))
+        assert len(samples) == 2
 
-    assert samples[0]["instance_image"].shape == (1, 1, 100, 100)
-    assert samples[0]["confidence_maps"].shape == (1, 2, 50, 50)
+        assert samples[0]["instance_image"].shape == (1, 1, 100, 100)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 50, 50)
 
-    shutil.rmtree(dir_path)
+    finally:
+        shutil.rmtree(dir_path)
 
 
 def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
@@ -133,7 +135,7 @@ def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
         max_instances=2,
         anchor_ind=0,
     )
-    # shutil.rmtree(dir_path)
+
     ld.optimize(
         fn=partial_func,
         inputs=[(x, labels.videos.index(x.video)) for x in labels],
@@ -141,42 +143,44 @@ def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
         chunk_size=4,
     )
 
-    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    try:
 
-    dataset = CentroidStreamingDataset(
-        augmentation_config=config.data_config.augmentation_config,
-        confmap_head=confmap_head,
-        max_stride=100,
-        scale=0.5,
-        input_dir=str(dir_path),
-    )
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
 
-    samples = list(iter(dataset))
-    assert len(samples) == 1
+        dataset = CentroidStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
 
-    assert samples[0]["image"].shape == (1, 1, 200, 200)
-    assert samples[0]["confidence_maps"].shape == (1, 1, 100, 100)
+        samples = list(iter(dataset))
+        assert len(samples) == 1
 
-    # test with random crop
-    config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
-    config.data_config.augmentation_config.geometric["random_crop_height"] = 300
-    config.data_config.augmentation_config.geometric["random_crop_width"] = 300
-    dataset = CentroidStreamingDataset(
-        augmentation_config=config.data_config.augmentation_config,
-        confmap_head=confmap_head,
-        max_stride=2,
-        scale=1.0,
-        input_dir=str(dir_path),
-    )
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["confidence_maps"].shape == (1, 1, 100, 100)
 
-    samples = list(iter(dataset))
-    assert len(samples) == 1
-    print(samples)
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = CentroidStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+        )
 
-    assert samples[0]["image"].shape == (1, 1, 300, 300)
-    assert samples[0]["confidence_maps"].shape == (1, 1, 150, 150)
+        samples = list(iter(dataset))
+        assert len(samples) == 1
 
-    shutil.rmtree(dir_path)
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["confidence_maps"].shape == (1, 1, 150, 150)
+
+    finally:
+        shutil.rmtree(dir_path)
 
 
 def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
@@ -189,7 +193,7 @@ def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, con
         single_instance_data_chunks,
         data_config=config.data_config,
     )
-    # shutil.rmtree(dir_path)
+
     for lf in labels:
         lf.instances = lf.instances[:1]
     ld.optimize(
@@ -199,39 +203,41 @@ def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, con
         chunk_size=4,
     )
 
-    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    try:
 
-    dataset = SingleInstanceStreamingDataset(
-        augmentation_config=config.data_config.augmentation_config,
-        confmap_head=confmap_head,
-        max_stride=100,
-        scale=0.5,
-        input_dir=str(dir_path),
-    )
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
 
-    samples = list(iter(dataset))
-    assert len(samples) == 1
+        dataset = SingleInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
 
-    assert samples[0]["image"].shape == (1, 1, 200, 200)
-    assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+        samples = list(iter(dataset))
+        assert len(samples) == 1
 
-    # test with random crop
-    config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
-    config.data_config.augmentation_config.geometric["random_crop_height"] = 300
-    config.data_config.augmentation_config.geometric["random_crop_width"] = 300
-    dataset = SingleInstanceStreamingDataset(
-        augmentation_config=config.data_config.augmentation_config,
-        confmap_head=confmap_head,
-        max_stride=2,
-        scale=1.0,
-        input_dir=str(dir_path),
-    )
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
 
-    samples = list(iter(dataset))
-    assert len(samples) == 1
-    print(samples)
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = SingleInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+        )
 
-    assert samples[0]["image"].shape == (1, 1, 300, 300)
-    assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+        samples = list(iter(dataset))
+        assert len(samples) == 1
 
-    shutil.rmtree(dir_path)
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+
+    finally:
+        shutil.rmtree(dir_path)


### PR DESCRIPTION
This is the third PR for https://github.com/talmolab/sleap-nn/issues/80. Here, we implement a custom `litdata.StreamingDataset` class for each model type. In the `litdata.StreamingDataset.__getitem__()` method, we apply augmentation, resizer, pad_to_stride and generate confidence maps (and part affinity fields for bottom-up model) .