### PR TITLE
Fix augmentation in TopdownConfmaps pipeline

### DIFF
--- a/sleap_nn/data/pipelines.py
+++ b/sleap_nn/data/pipelines.py
@@ -66,13 +66,21 @@ class TopdownConfmapsPipeline:
             provider=provider,
         )
 
-        if use_augmentations and "intensity" in self.data_config.augmentation_config:
-            datapipe = KorniaAugmenter(
-                datapipe,
-                **dict(self.data_config.augmentation_config.intensity),
-                image_key="image",
-                instance_key="instances",
-            )
+        if use_augmentations:
+            if "intensity" in self.data_config.augmentation_config:
+                datapipe = KorniaAugmenter(
+                    datapipe,
+                    **dict(self.data_config.augmentation_config.intensity),
+                    image_key="image",
+                    instance_key="instances",
+                )
+            if "geometric" in self.data_config.augmentation_config:
+                datapipe = KorniaAugmenter(
+                    datapipe,
+                    **dict(self.data_config.augmentation_config.geometric),
+                    image_key="image",
+                    instance_key="instances",
+                )
 
         datapipe = InstanceCentroidFinder(
             datapipe, anchor_ind=self.confmap_head.anchor_part
@@ -82,14 +90,6 @@ class TopdownConfmapsPipeline:
             datapipe,
             self.data_config.preprocessing.crop_hw,
         )
-
-        if use_augmentations and "geometric" in self.data_config.augmentation_config:
-            datapipe = KorniaAugmenter(
-                datapipe,
-                **dict(self.data_config.augmentation_config.geometric),
-                image_key="instance_image",
-                instance_key="instance",
-            )
 
         datapipe = Resizer(
             datapipe,


### PR DESCRIPTION
This PR addresses the issue in https://github.com/talmolab/sleap-nn/issues/76. Both intensity and geometric augmentations are now applied before cropping in the TopDownConfmaps data pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced augmentation logic for improved image processing, allowing for more effective application of intensity and geometric augmentations based on user configuration.

- **Bug Fixes**
	- Streamlined the process for applying augmentations, reducing redundancy and improving clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->