### PR TITLE
Resume training and automatically compute crop size for TopDownConfmaps pipeline

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -26,7 +26,8 @@ The config file has three main sections:
         - `max_width`: (int) Maximum width the image should be padded to. If not provided, the
         original image size will be retained. Default: None.
         - `scale`: (float or List[float]) Factor to resize the image dimensions by, specified as either a float scalar or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions are resized by the same factor. 
-        - `crop_hw`: (List[int]) Crop height and width of each instance (h, w) for centered-instance model.
+        - `crop_hw`: (Tuple[int]) Crop height and width of each instance (h, w) for centered-instance model. If `None`, this would be automatically computed based on the largest instance in the `sio.Labels` file.
+        - `min_crop_size`: (int) Minimum crop size to be used if `crop_hw` is `None`.
     - `use_augmentations_train`: (bool) True if the data augmentation should be applied to the training data, else False. 
     - `augmentation_config`: (only if `use_augmentations` is `True`)
         - `random crop`: (Optional) (Dict[float]) {"random_crop_p": None, "crop_height": None. "crop_width": None}, where *random_crop_p* is the probability of applying random crop and *crop_height* and *crop_width* are the desired output size (out_h, out_w) of the crop. 
@@ -156,12 +157,14 @@ The config file has three main sections:
     - `use_wandb`: (bool) True to enable wandb logging.
     - `save_ckpt`: (bool) True to enable checkpointing. 
     - `save_ckpt_path`: (str) Directory path to save the training config and checkpoint files. *Default*: "./"
+    - `resume_ckpt_path`: (str) Path to `.ckpt` file from which training is resumed. *Default*: `None`.
     - `wandb`: (Only if `use_wandb` is `True`, else skip this)
         - `entity`: (str) Entity of wandb project.
         - `project`: (str) Project name for the wandb project.
         - `name`: (str) Name of the current run.
         - `api_key`: (str) API key. The API key is masked when saved to config files.
         - `wandb_mode`: (str) "offline" if only local logging is required. Default: "None".
+        - `prv_runid`: (str) Previous run ID if training should be resumed from a previous ckpt. *Default*: `None`.
         - `log_params`: (List[str]) List of config parameters to save it in wandb logs. For example, to save learning rate from trainer config section, use "trainer_config.optimizer.lr" (provide the full path to the specific config parameter).
     - `optimizer_name`: (str) Optimizer to be used. One of ["Adam", "AdamW"].
     - `optimizer`

--- a/docs/config_bottomup.yaml
+++ b/docs/config_bottomup.yaml
@@ -96,6 +96,7 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_bottomup1
+  resume_ckpt_path:
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/docs/config_centroid.yaml
+++ b/docs/config_centroid.yaml
@@ -113,12 +113,13 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: 'min_inst_centroid'
+  resume_ckpt_path:
   wandb: # sample wandb config
-    entity: 
     project: 'test_centroid_centered'
     name: 'fly_unet_centered'
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/docs/config_topdown_centered_instance.yaml
+++ b/docs/config_topdown_centered_instance.yaml
@@ -94,6 +94,7 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: 'min_inst_centered'
+  resume_ckpt_path:
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/sleap_nn/data/instance_cropping.py
+++ b/sleap_nn/data/instance_cropping.py
@@ -20,6 +20,7 @@ def find_instance_crop_size(
     min_crop_size: Optional[int] = None,
 ) -> int:
     """Compute the size of the largest instance bounding box from labels.
+
     Args:
         labels: A `sio.Labels` containing user-labeled instances.
         padding: Integer number of pixels to add to the bounds as margin padding.
@@ -29,6 +30,7 @@ def find_instance_crop_size(
         input_scaling: Float factor indicating the scale of the input images if any
             scaling will be done before cropping.
         min_crop_size: The crop size set by the user.
+
     Returns:
         An integer crop size denoting the length of the side of the bounding boxes that
         will contain the instances when cropped. The returned crop size will be larger

--- a/sleap_nn/data/instance_cropping.py
+++ b/sleap_nn/data/instance_cropping.py
@@ -1,11 +1,64 @@
 """Handle cropping of instances."""
 
-from typing import Iterator, Tuple, Dict
+from typing import Iterator, Tuple, Dict, Optional
+
+import math
+import numpy as np
+import sleap_io as sio
 
 import torch
 from kornia.geometry.transform import crop_and_resize
 from torch.utils.data.datapipes.datapipe import IterDataPipe
 from sleap_nn.data.resizing import find_padding_for_stride
+
+
+def find_instance_crop_size(
+    labels: sio.Labels,
+    padding: int = 0,
+    maximum_stride: int = 2,
+    input_scaling: float = 1.0,
+    min_crop_size: Optional[int] = None,
+) -> int:
+    """Compute the size of the largest instance bounding box from labels.
+    Args:
+        labels: A `sio.Labels` containing user-labeled instances.
+        padding: Integer number of pixels to add to the bounds as margin padding.
+        maximum_stride: Ensure that the returned crop size is divisible by this value.
+            Useful for ensuring that the crop size will not be truncated in a given
+            architecture.
+        input_scaling: Float factor indicating the scale of the input images if any
+            scaling will be done before cropping.
+        min_crop_size: The crop size set by the user.
+    Returns:
+        An integer crop size denoting the length of the side of the bounding boxes that
+        will contain the instances when cropped. The returned crop size will be larger
+        or equal to the input `min_crop_size`.
+        This accounts for stride, padding and scaling when ensuring divisibility.
+    """
+    # Check if user-specified crop size is divisible by max stride
+    min_crop_size = 0 if min_crop_size is None else min_crop_size
+    if (min_crop_size > 0) and (min_crop_size % maximum_stride == 0):
+        return min_crop_size
+
+    # Calculate crop size
+    min_crop_size_no_pad = min_crop_size - padding
+    max_length = 0.0
+    for lf in labels:
+        for inst in lf.instances:
+            pts = inst.numpy()
+            pts *= input_scaling
+            max_length = np.maximum(
+                max_length, np.nanmax(pts[:, 0]) - np.nanmin(pts[:, 0])
+            )
+            max_length = np.maximum(
+                max_length, np.nanmax(pts[:, 1]) - np.nanmin(pts[:, 1])
+            )
+            max_length = np.maximum(max_length, min_crop_size_no_pad)
+
+    max_length += float(padding)
+    crop_size = math.ceil(max_length / float(maximum_stride)) * maximum_stride
+
+    return int(crop_size)
 
 
 def make_centered_bboxes(
@@ -60,7 +113,7 @@ class InstanceCropper(IterDataPipe):
 
     Attributes:
         source_dp: The previous `IterDataPipe` with samples that contain an `instances` key.
-        crop_hw: Minimum height and width of the crop in pixels.
+        crop_hw: Height and width of the crop in pixels.
 
     """
 

--- a/sleap_nn/data/pipelines.py
+++ b/sleap_nn/data/pipelines.py
@@ -4,8 +4,10 @@ This allows for convenient ways to configure individual variants of common pipel
 well as to define training vs inference versions based on the same configurations.
 """
 
+from typing import Optional, Tuple
 from omegaconf.omegaconf import DictConfig
 import torch
+from torch.utils.data.datapipes.datapipe import IterDataPipe
 from sleap_nn.data.augmentation import KorniaAugmenter
 from sleap_nn.data.instance_centroids import InstanceCentroidFinder
 from sleap_nn.data.instance_cropping import InstanceCropper
@@ -17,7 +19,6 @@ from sleap_nn.data.confidence_maps import (
     MultiConfidenceMapGenerator,
 )
 from sleap_nn.data.general import KeyFilter
-from torch.utils.data.datapipes.datapipe import IterDataPipe
 
 
 class TopdownConfmapsPipeline:
@@ -29,6 +30,7 @@ class TopdownConfmapsPipeline:
             divisible by.
         confmap_head: DictConfig object with all the keys in the `head_config` section.
         (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        crop_hw: Height and width of the crop in pixels.
 
     Note: If scale is provided for centered-instance model, the images are cropped out
     of original image according to given crop height and width and then the cropped
@@ -36,12 +38,17 @@ class TopdownConfmapsPipeline:
     """
 
     def __init__(
-        self, data_config: DictConfig, max_stride: int, confmap_head: DictConfig
+        self,
+        data_config: DictConfig,
+        max_stride: int,
+        confmap_head: DictConfig,
+        crop_hw: Tuple[int],
     ) -> None:
         """Initialize the data config."""
         self.data_config = data_config
         self.max_stride = max_stride
         self.confmap_head = confmap_head
+        self.crop_hw = crop_hw
 
     def make_training_pipeline(
         self, data_provider: IterDataPipe, use_augmentations: bool = False
@@ -88,7 +95,7 @@ class TopdownConfmapsPipeline:
 
         datapipe = InstanceCropper(
             datapipe,
-            self.data_config.preprocessing.crop_hw,
+            self.crop_hw,
         )
 
         datapipe = Resizer(

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -219,7 +219,7 @@ def compute_oks(
 
     # Compute the OKS.
     n_visible_gt = np.sum(
-        (~missing_gt).astype("float64"), axis=-1, keepdims=True
+        (~missing_gt).astype("float32"), axis=-1, keepdims=True
     )  # (n_gt, 1)
     oks = np.sum(ks, axis=-1) / n_visible_gt
     assert oks.shape == (n_gt, n_pr)

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -22,6 +22,7 @@ from lightning.pytorch.loggers import WandbLogger, CSVLogger
 from sleap_nn.architectures.model import Model
 from lightning.pytorch.callbacks import ModelCheckpoint, EarlyStopping
 from sleap_nn.data.cycler import CyclerIterDataPipe as Cycler
+from sleap_nn.data.instance_cropping import find_instance_crop_size
 from torchvision.models.swin_transformer import (
     Swin_T_Weights,
     Swin_S_Weights,
@@ -89,31 +90,55 @@ class ModelTrainer:
                 self.model_type = k
                 break
 
+        train_labels = sio.load_slp(self.config.data_config.train_labels_path)
+        self.skeletons = train_labels.skeletons
+        max_stride = self.config.model_config.backbone_config.max_stride
+
         if self.model_type == "single_instance":
+
             data_pipeline = SingleInstanceConfmapsPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.single_instance.confmaps,
             )
 
         elif self.model_type == "centered_instance":
+            # compute crop size
+            crop_hw = self.config.data_config.preprocessing.crop_hw
+            if crop_hw is None:
+
+                min_crop_size = (
+                    self.config.data_config.preprocessing.min_crop_size
+                    if "min_crop_size" in self.config.data_config.preprocessing
+                    else None
+                )
+                crop_size = find_instance_crop_size(
+                    train_labels,
+                    maximum_stride=max_stride,
+                    input_scaling=self.config.data_config.preprocessing.scale,
+                    min_crop_size=min_crop_size,
+                )
+                crop_hw = (crop_size, crop_size)
+            self.config.data_config.preprocessing.crop_hw = crop_hw
+
             data_pipeline = TopdownConfmapsPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.centered_instance.confmaps,
+                crop_hw=crop_hw,
             )
 
         elif self.model_type == "centroid":
             data_pipeline = CentroidConfmapsPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.centroid.confmaps,
             )
 
         elif self.model_type == "bottomup":
             data_pipeline = BottomUpPipeline(
                 data_config=self.config.data_config,
-                max_stride=self.config.model_config.backbone_config.max_stride,
+                max_stride=max_stride,
                 confmap_head=self.config.model_config.head_configs.bottomup.confmaps,
                 pafs_head=self.config.model_config.head_configs.bottomup.pafs,
             )
@@ -124,9 +149,6 @@ class ModelTrainer:
             )
 
         # train
-        train_labels = sio.load_slp(self.config.data_config.train_labels_path)
-        self.skeletons = train_labels.skeletons
-
         train_labels_reader = self.provider(train_labels)
 
         train_datapipe = data_pipeline.make_training_pipeline(
@@ -233,7 +255,10 @@ class ModelTrainer:
             else:
                 self._set_wandb()
             wandb_logger = WandbLogger(
-                project=wandb_config.project, name=wandb_config.name, save_dir=dir_path
+                project=wandb_config.project,
+                name=wandb_config.name,
+                save_dir=dir_path,
+                id=self.config.trainer_config.wandb.prv_runid,
             )
             logger.append(wandb_logger)
 
@@ -249,13 +274,15 @@ class ModelTrainer:
                 symm = [list(s.nodes) for s in skl.symmetries]
             else:
                 symm = None
-            self.config["data_config"]["skeletons"][skl.name] = {
+            skl_name = skl.name if skl.name is not None else "skeleton-0"
+            self.config["data_config"]["skeletons"][skl_name] = {
                 "nodes": skl.nodes,
                 "edges": skl.edges,
                 "symmetries": symm,
             }
 
         self._initialize_model()
+        total_params = self._get_param_count()
 
         trainer = L.Trainer(
             callbacks=callbacks,
@@ -268,25 +295,34 @@ class ModelTrainer:
             limit_train_batches=self.steps_per_epoch,
         )
 
-        trainer.fit(self.model, self.train_data_loader, self.val_data_loader)
+        try:
+            trainer.fit(
+                self.model,
+                self.train_data_loader,
+                self.val_data_loader,
+                ckpt_path=self.config.trainer_config.resume_ckpt_path,
+            )
 
-        total_params = self._get_param_count()
+            if self.config.trainer_config.use_wandb:
+                for m in self.config.trainer_config.wandb.log_params:
+                    list_keys = m.split(".")
+                    key = list_keys[-1]
+                    value = self.config[list_keys[0]]
+                    for l in list_keys[1:]:
+                        value = value[l]
+                    wandb_logger.experiment.config.update({key: value})
+                wandb_logger.experiment.config.update({"model_params": total_params})
 
-        if self.config.trainer_config.use_wandb:
-            self.config.trainer_config.wandb.run_id = wandb.run.id
-            self.config.model_config.total_params = total_params
-            for m in self.config.trainer_config.wandb.log_params:
-                list_keys = m.split(".")
-                key = list_keys[-1]
-                value = self.config[list_keys[0]]
-                for l in list_keys[1:]:
-                    value = value[l]
-                wandb_logger.experiment.config.update({key: value})
-            wandb_logger.experiment.config.update({"model_params": total_params})
-            wandb.finish()
+        except Exception:
+            print("Stopping training...")
 
-        # save the configs as yaml in the checkpoint dir
-        OmegaConf.save(config=self.config, f=f"{dir_path}/training_config.yaml")
+        finally:
+            if self.config.trainer_config.use_wandb:
+                self.config.trainer_config.wandb.run_id = wandb.run.id
+                self.config.model_config.total_params = total_params
+                wandb.finish(exit_code=255)
+            # save the configs as yaml in the checkpoint dir
+            OmegaConf.save(config=self.config, f=f"{dir_path}/training_config.yaml")
 
 
 class TrainingModel(L.LightningModule):

--- a/tests/assets/minimal_instance/initial_config.yaml
+++ b/tests/assets/minimal_instance/initial_config.yaml
@@ -63,12 +63,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centered
+  resume_ckpt_path: null
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance/training_config.yaml
+++ b/tests/assets/minimal_instance/training_config.yaml
@@ -76,12 +76,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centered
+  resume_ckpt_path: null
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/initial_config.yaml
@@ -65,12 +65,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_bottomup
+  resume_ckpt_path:
   wandb:
     entity: team-ucsd
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/training_config.yaml
@@ -80,12 +80,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_bottomup
+  resume_ckpt_path:
   wandb:
     entity: team-ucsd
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/minimal_instance_centroid/initial_config.yaml
@@ -59,12 +59,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centroid
+  resume_ckpt_path:
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/assets/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/minimal_instance_centroid/training_config.yaml
@@ -70,12 +70,14 @@ trainer_config:
   use_wandb: false
   save_ckpt: true
   save_ckpt_path: min_inst_centroid
+  resume_ckpt_path:
   wandb:
     entity: null
     project: test_centroid_centered
     name: fly_unet_centered
     wandb_mode: ''
     api_key: ''
+    prv_runid:
     log_params:
     - trainer_config.optimizer_name
     - trainer_config.optimizer.amsgrad

--- a/tests/data/test_instance_cropping.py
+++ b/tests/data/test_instance_cropping.py
@@ -12,6 +12,19 @@ from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
 from sleap_nn.data.providers import LabelsReader
 
 
+def test_find_instance_crop_size(minimal_instance):
+    """Test `find_instance_crop_size` function."""
+    labels = sio.load_slp(minimal_instance)
+    crop_size = find_instance_crop_size(labels)
+    assert crop_size == 74
+
+    crop_size = find_instance_crop_size(labels, min_crop_size=100)
+    assert crop_size == 100
+
+    crop_size = find_instance_crop_size(labels, padding=10)
+    assert crop_size == 84
+
+
 def test_make_centered_bboxes():
     # Test bounding box calculation.
     gt = torch.Tensor(

--- a/tests/data/test_instance_cropping.py
+++ b/tests/data/test_instance_cropping.py
@@ -1,7 +1,12 @@
+import sleap_io as sio
 import torch
 
 from sleap_nn.data.instance_centroids import InstanceCentroidFinder
-from sleap_nn.data.instance_cropping import InstanceCropper, make_centered_bboxes
+from sleap_nn.data.instance_cropping import (
+    InstanceCropper,
+    find_instance_crop_size,
+    make_centered_bboxes,
+)
 from sleap_nn.data.normalization import Normalizer
 from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
 from sleap_nn.data.providers import LabelsReader

--- a/tests/data/test_pipelines.py
+++ b/tests/data/test_pipelines.py
@@ -92,6 +92,7 @@ def test_key_filter(minimal_instance):
 
 def test_topdownconfmapspipeline(minimal_instance):
     """Test the TopdownConfmapsPipeline."""
+    crop_hw = (160, 160)
     base_topdown_data_config = OmegaConf.create(
         {
             "preprocessing": {
@@ -99,7 +100,6 @@ def test_topdownconfmapspipeline(minimal_instance):
                 "max_width": None,
                 "scale": 1.0,
                 "is_rgb": False,
-                "crop_hw": (160, 160),
             },
             "use_augmentations_train": False,
         },
@@ -108,7 +108,10 @@ def test_topdownconfmapspipeline(minimal_instance):
     confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": 0})
 
     pipeline = TopdownConfmapsPipeline(
-        data_config=base_topdown_data_config, max_stride=16, confmap_head=confmap_head
+        data_config=base_topdown_data_config,
+        max_stride=16,
+        confmap_head=confmap_head,
+        crop_hw=crop_hw,
     )
     data_provider = LabelsReader(labels=sio.load_slp(minimal_instance))
 
@@ -143,7 +146,6 @@ def test_topdownconfmapspipeline(minimal_instance):
                 "max_width": None,
                 "scale": 1.0,
                 "is_rgb": False,
-                "crop_hw": (100, 100),
             },
             "use_augmentations_train": True,
             "augmentation_config": {
@@ -184,7 +186,10 @@ def test_topdownconfmapspipeline(minimal_instance):
     )
 
     pipeline = TopdownConfmapsPipeline(
-        data_config=base_topdown_data_config, max_stride=8, confmap_head=confmap_head
+        data_config=base_topdown_data_config,
+        max_stride=8,
+        confmap_head=confmap_head,
+        crop_hw=(100, 100),
     )
 
     data_provider = LabelsReader(labels=sio.load_slp(minimal_instance))
@@ -221,7 +226,6 @@ def test_topdownconfmapspipeline(minimal_instance):
                 "max_width": None,
                 "scale": 2.0,
                 "is_rgb": False,
-                "crop_hw": (100, 100),
             },
             "use_augmentations_train": True,
             "augmentation_config": {
@@ -262,7 +266,10 @@ def test_topdownconfmapspipeline(minimal_instance):
     )
 
     pipeline = TopdownConfmapsPipeline(
-        data_config=base_topdown_data_config, max_stride=16, confmap_head=confmap_head
+        data_config=base_topdown_data_config,
+        max_stride=16,
+        confmap_head=confmap_head,
+        crop_hw=(100, 100),
     )
 
     data_provider = LabelsReader(labels=sio.load_slp(minimal_instance))

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -130,12 +130,14 @@ def config(sleap_data_dir):
                 "use_wandb": False,
                 "save_ckpt": False,
                 "save_ckpt_path": "",
+                "resume_ckpt_path": None,
                 "wandb": {
                     "entity": "team-ucsd",
                     "project": "test",
                     "name": "test_run",
                     "wandb_mode": "offline",
                     "api_key": "",
+                    "prv_runid": None,
                     "log_params": [
                         "trainer_config.optimizer_name",
                         "trainer_config.optimizer.amsgrad",


### PR DESCRIPTION
This PR adds the following features:

- Function to automatically compute crop size with the size of the largest instance bounding box from the labels file.
- Add default name (`"Skeleton-0"`) is assigned to `sio.Skeleton` object if `name` is `None`.
- Resumable training option (with resumable logging in wandb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced parameters for resuming training from checkpoints and specifying minimum crop sizes.
	- Added tracking functionality to prediction classes, enhancing instance management across frames.
	- Implemented new candidate generation strategies for tracking, improving flexibility in managing tracks.
  
- **Bug Fixes**
	- Enhanced error handling during training to ensure configurations are saved even if training fails.

- **Documentation**
	- Updated configuration documentation to reflect new parameters and their usage.

- **Tests**
	- Added unit tests for new tracking functionalities and configurations to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->