### PR TITLE
LitData Refactor PR1: Get individual functions for data pipelines

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,6 +15,9 @@ The config file has three main sections:
     - `provider`: (str) Provider class to read the input sleap files. Only "LabelsReader" supported for the training pipeline.
     - `train_labels_path`: (str) Path to training data (`.slp` file)
     - `val_labels_path`: (str) Path to validation data (`.slp` file)
+    - `user_instances_only`: (bool) `True` if only user labeled instances should be used for training. If `False`, both user labeled and predicted instances would be used. *Default*: `True`.
+    - `chunk_size`: (int) Size of each chunk (in MB). *Default*: "100". 
+    #TODO: change in inference ckpts
     - `preprocessing`:
         - `is_rgb`: (bool) True if the image has 3 channels (RGB image). If input has only one
         channel when this is set to `True`, then the images from single-channel
@@ -30,7 +33,6 @@ The config file has three main sections:
         - `min_crop_size`: (int) Minimum crop size to be used if `crop_hw` is `None`.
     - `use_augmentations_train`: (bool) True if the data augmentation should be applied to the training data, else False. 
     - `augmentation_config`: (only if `use_augmentations` is `True`)
-        - `random crop`: (Optional) (Dict[float]) {"random_crop_p": None, "crop_height": None. "crop_width": None}, where *random_crop_p* is the probability of applying random crop and *crop_height* and *crop_width* are the desired output size (out_h, out_w) of the crop. 
         - `intensity`: (Optional)
             - `uniform_noise_min`: (float) Minimum value for uniform noise (uniform_noise_min >=0).
             - `uniform_noise_max`: (float) Maximum value for uniform noise (uniform_noise_max <>=1).
@@ -57,7 +59,9 @@ The config file has three main sections:
             - `mixup_lambda`: (float) min-max value of mixup strength. Default is 0-1. *Default*: `None`.
             - `mixup_p`: (float) Probability of applying random mixup v2. *Default*=0.0
             - `input_key`: (str) Can be `image` or `instance`. The input_key `instance` expects the KorniaAugmenter to follow the InstanceCropper else `image` otherwise for default.
-
+            - `random_crop_p`: (float) Probability of applying random crop.
+            - `random_crop_height`: (int) Desired output height of the random crop.
+            - `random_crop_width`: (int) Desired output height of the random crop.
 - `model_config`: 
     - `init_weight`: (str) model weights initialization method. "default" uses kaiming uniform initialization and "xavier" uses Xavier initialization method.
     - `pre_trained_weights`: (str) Pretrained weights file name supported only for ConvNext and SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights","ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"]. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].

--- a/docs/config_bottomup.yaml
+++ b/docs/config_bottomup.yaml
@@ -2,6 +2,7 @@ data_config:
   provider: LabelsReader
   train_labels_path: minimal_instance.pkg.slp
   val_labels_path: minimal_instance.pkg.slp
+  user_instances_only: True
   preprocessing:
     max_width: null
     max_height: null

--- a/docs/config_centroid.yaml
+++ b/docs/config_centroid.yaml
@@ -2,6 +2,7 @@ data_config:
   provider: LabelsReader
   train_labels_path: minimal_instance.pkg.slp
   val_labels_path: minimal_instance.pkg.slp
+  user_instances_only: True
   preprocessing:
     max_width: 
     max_height: 
@@ -9,10 +10,6 @@ data_config:
     is_rgb: False
   use_augmentations_train: true
   augmentation_config: # sample augmentation_config
-    random_crop:
-      random_crop_p: 0
-      crop_height: 160
-      crop_width: 160
     intensity:
       uniform_noise_min: 0.0
       uniform_noise_max: 0.04
@@ -38,6 +35,9 @@ data_config:
       erase_p: 0
       mixup_lambda: null
       mixup_p: 0
+      random_crop_p: 0
+      crop_height: 160
+      crop_width: 160
 
 model_config:
   init_weights: xavier

--- a/docs/config_topdown_centered_instance.yaml
+++ b/docs/config_topdown_centered_instance.yaml
@@ -2,6 +2,7 @@ data_config:
   provider: LabelsReader
   train_labels_path: minimal_instance.pkg.slp
   val_labels_path: minimal_instance.pkg.slp
+  user_instances_only: True
   preprocessing:
     max_width: 
     max_height: 

--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -33,3 +33,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -32,3 +32,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/sleap_nn/data/augmentation.py
+++ b/sleap_nn/data/augmentation.py
@@ -1,7 +1,6 @@
 """This module implements data pipeline blocks for augmentation operations."""
 
 from typing import Any, Dict, Optional, Tuple, Union, Iterator
-
 import kornia as K
 import torch
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -9,6 +8,227 @@ from kornia.augmentation.container import AugmentationSequential
 from kornia.augmentation.utils.param_validation import _range_bound
 from kornia.core import Tensor
 from torch.utils.data.datapipes.datapipe import IterDataPipe
+
+
+def apply_intensity_augmentation(
+    image: torch.Tensor,
+    instances: torch.Tensor,
+    uniform_noise_min: Optional[float] = 0.0,
+    uniform_noise_max: Optional[float] = 0.04,
+    uniform_noise_p: float = 0.0,
+    gaussian_noise_mean: Optional[float] = 0.02,
+    gaussian_noise_std: Optional[float] = 0.004,
+    gaussian_noise_p: float = 0.0,
+    contrast_min: Optional[float] = 0.5,
+    contrast_max: Optional[float] = 2.0,
+    contrast_p: float = 0.0,
+    brightness: Optional[float] = 0.0,
+    brightness_p: float = 0.0,
+) -> Tuple[torch.Tensor]:
+    """Apply kornia intensity augmentation on image and instances.
+
+    Args:
+        image: Input image. Shape: (n_samples, C, H, W)
+        instances: Input keypoints. (n_samples, n_instances, n_nodes, 2) or (n_samples, n_nodes, 2)
+        uniform_noise_min: Minimum value for uniform noise (uniform_noise_min >=0).
+        uniform_noise_max: Maximum value for uniform noise (uniform_noise_max <=1).
+        uniform_noise_p: Probability of applying random uniform noise.
+        gaussian_noise_mean: The mean of the gaussian distribution.
+        gaussian_noise_std: The standard deviation of the gaussian distribution.
+        gaussian_noise_p: Probability of applying random gaussian noise.
+        contrast_min: Minimum contrast factor to apply. Default: 0.5.
+        contrast_max: Maximum contrast factor to apply. Default: 2.0.
+        contrast_p: Probability of applying random contrast.
+        brightness: The brightness factor to apply Default: 0.0.
+        brightness_p: Probability of applying random brightness.
+
+    Returns:
+        Returns tuple: (image, instances) with augmentation applied.
+    """
+    aug_stack = []
+    if uniform_noise_p > 0:
+        aug_stack.append(
+            RandomUniformNoise(
+                noise=(uniform_noise_min, uniform_noise_max),
+                p=uniform_noise_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if gaussian_noise_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomGaussianNoise(
+                mean=gaussian_noise_mean,
+                std=gaussian_noise_std,
+                p=gaussian_noise_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if contrast_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomContrast(
+                contrast=(contrast_min, contrast_max),
+                p=contrast_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if brightness_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomBrightness(
+                brightness=brightness,
+                p=brightness_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+
+    augmenter = AugmentationSequential(
+        *aug_stack,
+        data_keys=["input", "keypoints"],
+        keepdim=True,
+        same_on_batch=True,
+    )
+
+    inst_shape = instances.shape
+    # Before (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # Before (cropped image): (B=1, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    instances = instances.reshape(inst_shape[0], -1, 2)
+    # (n_samples, C, H, W), (n_samples, n_instances * n_nodes, 2) OR (n_samples, n_nodes, 2)
+
+    aug_image, aug_instances = augmenter(image, instances)
+
+    # After (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # After (cropped image): (n_samples, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    return aug_image, aug_instances.reshape(*inst_shape)
+
+
+def apply_geometric_augmentation(
+    image: torch.Tensor,
+    instances: torch.Tensor,
+    rotation: Optional[float] = 15.0,
+    scale: Union[
+        Optional[float], Tuple[float, float], Tuple[float, float, float, float]
+    ] = None,
+    translate_width: Optional[float] = 0.02,
+    translate_height: Optional[float] = 0.02,
+    affine_p: float = 0.0,
+    erase_scale_min: Optional[float] = 0.0001,
+    erase_scale_max: Optional[float] = 0.01,
+    erase_ratio_min: Optional[float] = 1,
+    erase_ratio_max: Optional[float] = 1,
+    erase_p: float = 0.0,
+    mixup_lambda: Union[Optional[float], Tuple[float, float], None] = None,
+    mixup_p: float = 0.0,
+    random_crop_height: int = 0,
+    random_crop_width: int = 0,
+    random_crop_p: float = 0.0,
+) -> Tuple[torch.Tensor]:
+    """Apply kornia geometric augmentation on image and instances.
+
+    Args:
+        image: Input image. Shape: (n_samples, C, H, W)
+        instances: Input keypoints. (n_samples, n_instances, n_nodes, 2) or (n_samples, n_nodes, 2)
+        rotation: Angles in degrees as a scalar float of the amount of rotation. A
+            random angle in `(-rotation, rotation)` will be sampled and applied to both
+            images and keypoints. Set to 0 to disable rotation augmentation.
+        scale: scaling factor interval. If (a, b) represents isotropic scaling, the scale
+            is randomly sampled from the range a <= scale <= b. If (a, b, c, d), the scale
+            is randomly sampled from the range a <= scale_x <= b, c <= scale_y <= d.
+            Default: None.
+        translate_width: Maximum absolute fraction for horizontal translation. For example,
+            if translate_width=a, then horizontal shift is randomly sampled in the range
+            -img_width * a < dx < img_width * a. Will not translate by default.
+        translate_height: Maximum absolute fraction for vertical translation. For example,
+            if translate_height=a, then vertical shift is randomly sampled in the range
+            -img_height * a < dy < img_height * a. Will not translate by default.
+        affine_p: Probability of applying random affine transformations.
+        erase_scale_min: Minimum value of range of proportion of erased area against input image. Default: 0.0001.
+        erase_scale_max: Maximum value of range of proportion of erased area against input image. Default: 0.01.
+        erase_ratio_min: Minimum value of range of aspect ratio of erased area. Default: 1.
+        erase_ratio_max: Maximum value of range of aspect ratio of erased area. Default: 1.
+        erase_p: Probability of applying random erase.
+        mixup_lambda: min-max value of mixup strength. Default is 0-1. Default: `None`.
+        mixup_p: Probability of applying random mixup v2.
+        random_crop_height: Desired output height of the crop. Must be int.
+        random_crop_width: Desired output width of the crop. Must be int.
+        random_crop_p: Probability of applying random crop.
+
+
+    Returns:
+        Returns tuple: (image, instances) with augmentation applied.
+    """
+    if isinstance(scale, float):
+        scale = (scale, scale)
+    aug_stack = []
+    if affine_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomAffine(
+                degrees=rotation,
+                translate=(translate_width, translate_height),
+                scale=scale,
+                p=affine_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+
+    if erase_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomErasing(
+                scale=(erase_scale_min, erase_scale_max),
+                ratio=(erase_ratio_min, erase_ratio_max),
+                p=erase_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if mixup_p > 0:
+        aug_stack.append(
+            K.augmentation.RandomMixUpV2(
+                lambda_val=mixup_lambda,
+                p=mixup_p,
+                keepdim=True,
+                same_on_batch=True,
+            )
+        )
+    if random_crop_p > 0:
+        if random_crop_height > 0 and random_crop_width > 0:
+            aug_stack.append(
+                K.augmentation.RandomCrop(
+                    size=(random_crop_height, random_crop_width),
+                    pad_if_needed=True,
+                    p=random_crop_p,
+                    keepdim=True,
+                    same_on_batch=True,
+                )
+            )
+        else:
+            raise ValueError(f"random_crop_hw height and width must be greater than 0.")
+
+    augmenter = AugmentationSequential(
+        *aug_stack,
+        data_keys=["input", "keypoints"],
+        keepdim=True,
+        same_on_batch=True,
+    )
+
+    inst_shape = instances.shape
+    # Before (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # Before (cropped image): (B=1, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    instances = instances.reshape(inst_shape[0], -1, 2)
+    # (n_samples, C, H, W), (n_samples, n_instances * n_nodes, 2) OR (n_samples, n_nodes, 2)
+
+    aug_image, aug_instances = augmenter(image, instances)
+
+    # After (full image): (n_samples, C, H, W), (n_samples, n_instances, n_nodes, 2)
+    # or
+    # After (cropped image): (n_samples, C, crop_H, crop_W), (n_samples, n_nodes, 2)
+    return aug_image, aug_instances.reshape(*inst_shape)
 
 
 class RandomUniformNoise(IntensityAugmentationBase2D):

--- a/sleap_nn/data/confidence_maps.py
+++ b/sleap_nn/data/confidence_maps.py
@@ -1,11 +1,97 @@
 """Generate confidence maps."""
 
-from typing import Dict, Iterator
+from typing import Dict, Iterator, Tuple
 
 import torch
 from torch.utils.data.datapipes.datapipe import IterDataPipe
 
 from sleap_nn.data.utils import make_grid_vectors
+
+
+def generate_confmaps(
+    instance: torch.Tensor,
+    img_hw: Tuple[int],
+    sigma: float = 1.5,
+    output_stride: int = 2,
+) -> torch.Tensor:
+    """Generate Confidence maps.
+
+    Args:
+        instance: Input keypoints. (n_samples, n_instances, n_nodes, 2) or
+            (n_samples, n_nodes, 2).
+        img_hw: Image size as tuple (height, width).
+        sigma: The standard deviation of the Gaussian distribution that is used to
+            generate confidence maps. Default: 1.5.
+        output_stride: The relative stride to use when generating confidence maps.
+            A larger stride will generate smaller confidence maps. Default: 2.
+
+    Returns:
+        Confidence maps for the input keypoints.
+    """
+    if instance.ndim != 3:
+        instance = instance.view(instance.shape[0], -1, 2)
+        # instances: (n_samples, n_nodes, 2)
+
+    height, width = img_hw
+
+    xv, yv = make_grid_vectors(height, width, output_stride)
+
+    confidence_maps = make_confmaps(
+        instance,
+        xv,
+        yv,
+        sigma * output_stride,
+    )  # (n_samples, n_nodes, height/ output_stride, width/ output_stride)
+
+    return confidence_maps
+
+
+def generate_multiconfmaps(
+    instances: torch.Tensor,
+    img_hw: Tuple[int],
+    num_instances: int,
+    sigma: float = 1.5,
+    output_stride: int = 2,
+    is_centroids: bool = False,
+) -> torch.Tensor:
+    """Generate multi-instance confidence maps.
+
+    Args:
+        instances: Input keypoints. (n_samples, n_instances, n_nodes, 2) or
+            for centroids - (n_samples, n_instances, 2)
+        img_hw: Image size as tuple (height, width).
+        num_instances: Original number of instances in the frame.
+        sigma: The standard deviation of the Gaussian distribution that is used to
+            generate confidence maps. Default: 1.5.
+        output_stride: The relative stride to use when generating confidence maps.
+            A larger stride will generate smaller confidence maps. Default: 2.
+        is_centroids: True if confidence maps should be generates for centroids else False.
+            Default: False.
+
+    Returns:
+        Confidence maps for the input keypoints.
+    """
+    if is_centroids:
+        points = instances[:, :num_instances, :].unsqueeze(dim=-2)
+        # (n_samples, n_instances, 1, 2)
+    else:
+        points = instances[
+            :, :num_instances, :, :
+        ]  # (n_samples, n_instances, n_nodes, 2)
+
+    height, width = img_hw
+
+    xv, yv = make_grid_vectors(height, width, output_stride)
+
+    confidence_maps = make_multi_confmaps(
+        points,
+        xv,
+        yv,
+        sigma * output_stride,
+    )  # (n_samples, n_nodes, height/ output_stride, width/ output_stride).
+    # If `is_centroids`, (n_samples, 1, height/ output_stride, width/ output_stride).
+
+    return confidence_maps
 
 
 def make_confmaps(

--- a/sleap_nn/data/edge_maps.py
+++ b/sleap_nn/data/edge_maps.py
@@ -247,6 +247,82 @@ def get_edge_points(
     return edge_sources, edge_destinations
 
 
+def generate_pafs(
+    instances: torch.Tensor,
+    img_hw: Tuple[int],
+    sigma: float = 1.5,
+    output_stride=2,
+    edge_inds: Optional[torch.Tensor] = attrs.field(
+        default=None, converter=attrs.converters.optional(ensure_list)
+    ),
+    flatten_channels: bool = False,
+) -> torch.Tensor:
+    """Generate part-affinity fields.
+
+    Args:
+        instances: Input instances. (n_samples, n_instances, n_nodes, 2)
+        img_hw: Image size as tuple (height, width).
+        sigma: The standard deviation of the Gaussian distribution that is used to
+            generate confidence maps. Default: 1.5.
+        output_stride: The relative stride to use when generating confidence maps.
+            A larger stride will generate smaller confidence maps. Default: 2.
+        edge_inds: `torch.Tensor` to use for looking up the index of the
+            edges.
+        flatten_channels: If False, the generated tensors are of shape
+            [height, width, n_edges, 2]. If True, generated tensors are of shape
+            [height, width, n_edges * 2] by flattening the last 2 axes.
+
+    Returns:
+        The "part_affinity_fields" key will be a tensor of shape
+        (grid_height, grid_width, n_edges, 2) containing the combined part affinity
+        fields of all instances in the frame.
+
+        If the `flatten_channels` attribute is set to True, the last 2 axes of the
+        "part_affinity_fields" are flattened to produce a tensor of shape
+        (grid_height, grid_width, n_edges * 2). This is a convenient form when
+        training models as a rank-4 (batched) tensor will generally be expected.
+    """
+    image_height, image_width = img_hw
+
+    # Generate sampling grid vectors.
+    xv, yv = make_grid_vectors(
+        image_height=image_height,
+        image_width=image_width,
+        output_stride=output_stride,
+    )
+    grid_height = len(yv)
+    grid_width = len(xv)
+    n_edges = len(edge_inds)
+
+    instances = instances[0]  # n_samples=1
+    in_img = (instances > 0) & (instances < torch.stack([xv[-1], yv[-1]]).view(1, 1, 2))
+    in_img = in_img.all(dim=-1).any(dim=1)
+    assert len(in_img.shape) == 1
+    instances = instances[in_img]
+
+    edge_sources, edge_destinations = get_edge_points(instances, edge_inds)
+    assert len(edge_sources.shape) == 3
+    assert edge_sources.shape[1:] == (n_edges, 2)
+
+    assert len(edge_destinations.shape) == 3
+    assert edge_destinations.shape[1:] == (n_edges, 2)
+
+    pafs = make_multi_pafs(
+        xv=xv,
+        yv=yv,
+        edge_sources=edge_sources,
+        edge_destinations=edge_destinations,
+        sigma=sigma,
+    )
+    assert pafs.shape == (grid_height, grid_width, n_edges, 2)
+
+    if flatten_channels:
+        pafs = pafs.reshape(grid_height, grid_width, n_edges * 2)
+        assert pafs.shape == (grid_height, grid_width, n_edges * 2)
+
+    return pafs
+
+
 class PartAffinityFieldsGenerator(IterDataPipe):
     """Transformer to generate part affinity fields.
 

--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -1,6 +1,6 @@
 """Handles generating data chunks for training."""
 
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Iterator, Optional, Tuple
 from omegaconf import DictConfig
 import numpy as np
 import torch
@@ -18,7 +18,7 @@ from sleap_nn.data.resizing import apply_sizematcher
 
 
 def bottomup_data_chunks(
-    x: Tuple[Union[sio.LabeledFrame, int]],
+    x: Tuple[sio.LabeledFrame, int],
     data_config: DictConfig,
     max_instances: int,
     user_instances_only: bool = True,
@@ -66,13 +66,13 @@ def bottomup_data_chunks(
 
 
 def centered_instance_data_chunks(
-    x: Tuple[Union[sio.LabeledFrame, int]],
+    x: Tuple[sio.LabeledFrame, int],
     data_config: DictConfig,
     max_instances: int,
     crop_size: Tuple[int],
     anchor_ind: Optional[int],
     user_instances_only: bool = True,
-) -> Dict[str, torch.Tensor]:
+) -> Iterator[Dict[str, torch.Tensor]]:
     """Generate dict from `sio.LabeledFrame`.
 
     This function processes the input `sio.LabeledFrame`, applies data pre-processing
@@ -139,7 +139,7 @@ def centered_instance_data_chunks(
 
 
 def centroid_data_chunks(
-    x: Tuple[Union[sio.LabeledFrame, int]],
+    x: Tuple[sio.LabeledFrame, int],
     data_config: DictConfig,
     max_instances: int,
     anchor_ind: Optional[int],
@@ -196,7 +196,7 @@ def centroid_data_chunks(
 
 
 def single_instance_data_chunks(
-    x: Tuple[Union[sio.LabeledFrame, int]],
+    x: Tuple[sio.LabeledFrame, int],
     data_config: DictConfig,
     user_instances_only: bool = True,
 ) -> Dict[str, torch.Tensor]:

--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -1,0 +1,243 @@
+"""Handles generating data chunks for training."""
+
+from typing import Dict, Optional, Tuple, Union
+from omegaconf import DictConfig
+import numpy as np
+import torch
+
+import sleap_io as sio
+from sleap_nn.data.instance_centroids import generate_centroids
+from sleap_nn.data.instance_cropping import generate_crops
+from sleap_nn.data.normalization import (
+    apply_normalization,
+    convert_to_grayscale,
+    convert_to_rgb,
+)
+from sleap_nn.data.providers import process_lf
+from sleap_nn.data.resizing import apply_sizematcher
+
+
+def bottomup_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    max_instances: int,
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    return sample
+
+
+def centered_instance_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    max_instances: int,
+    crop_size: Tuple[int],
+    anchor_ind: Optional[int],
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        crop_size: Height and width of the crop in pixels.
+        anchor_ind: The index of the node to use as the anchor for the centroid. If not
+            provided or if not present in the instance, the midpoint of the bounding box
+            is used instead.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    # get the centroids based on the anchor idx
+    centroids = generate_centroids(sample["instances"], anchor_ind=anchor_ind)
+
+    crop_size = np.array(crop_size) * np.sqrt(2)  # crop extra
+    crop_size = crop_size.astype(np.int32).tolist()
+
+    sample["instances"], centroids = sample["instances"][0], centroids[0]  # n_samples=1
+
+    for cnt, (instance, centroid) in enumerate(zip(sample["instances"], centroids)):
+        if cnt == sample["num_instances"]:
+            break
+
+        res = generate_crops(sample["image"], instance, centroid, crop_size)
+
+        res["frame_idx"] = sample["frame_idx"]
+        res["video_idx"] = sample["video_idx"]
+        res["num_instances"] = sample["num_instances"]
+        res["orig_size"] = sample["orig_size"]
+
+        yield res
+
+
+def centroid_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    max_instances: int,
+    anchor_ind: Optional[int],
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        anchor_ind: The index of the node to use as the anchor for the centroid. If not
+            provided or if not present in the instance, the midpoint of the bounding box
+            is used instead.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    # get the centroids based on the anchor idx
+    centroids = generate_centroids(sample["instances"], anchor_ind=anchor_ind)
+
+    sample["centroids"] = centroids
+
+    return sample
+
+
+def single_instance_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(
+        lf, video_idx, user_instances_only=user_instances_only, max_instances=1
+    )
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    return sample

--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -35,13 +35,13 @@ def find_points_bbox_midpoint(points: torch.Tensor) -> torch.Tensor:
     return (pts_max + pts_min) * 0.5
 
 
-def find_centroids(
+def generate_centroids(
     points: torch.Tensor, anchor_ind: Optional[int] = None
 ) -> torch.Tensor:
     """Return centroids, falling back to bounding box midpoints.
 
     Args:
-        points: A torch.Tensor of dtype torch.float32 and of shape (..., n_points, 2),
+        points: A torch.Tensor of dtype torch.float32 and of shape (..., n_nodes, 2),
             i.e., rank >= 2.
         anchor_ind: The index of the node to use as the anchor for the centroid. If not
             provided or if not present in the instance, the midpoint of the bounding box
@@ -60,7 +60,7 @@ def find_centroids(
     if missing_anchors.any():
         centroids[missing_anchors] = find_points_bbox_midpoint(points[missing_anchors])
 
-    return centroids
+    return centroids  # (..., n_instances, 2)
 
 
 class InstanceCentroidFinder(IterDataPipe):
@@ -88,7 +88,7 @@ class InstanceCentroidFinder(IterDataPipe):
     def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
         """Add `"centroids"` key to example."""
         for ex in self.source_dp:
-            ex["centroids"] = find_centroids(
+            ex["centroids"] = generate_centroids(
                 ex["instances"], anchor_ind=self.anchor_ind
             )  # (n_samples, n_instances, 2)
             yield ex

--- a/sleap_nn/data/normalization.py
+++ b/sleap_nn/data/normalization.py
@@ -41,6 +41,13 @@ def convert_to_rgb(image: torch.Tensor):
     return image
 
 
+def apply_normalization(image: torch.Tensor):
+    """Normalize image tensor."""
+    if not torch.is_floating_point(image):
+        image = image.to(torch.float32) / 255.0
+    return image
+
+
 class Normalizer(IterDataPipe):
     """IterDataPipe for applying normalization.
 

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -67,20 +67,22 @@ def process_lf(
         instances, axis=0
     )  # (n_samples=1, num_instances, num_nodes, 2)
 
-    image = torch.from_numpy(image.astype("float32"))
     instances = torch.from_numpy(instances.astype("float32"))
 
     num_instances, nodes = instances.shape[1:3]
     img_height, img_width = image.shape[-2:]
 
     # append with nans for broadcasting
-    nans = torch.full((1, np.abs(max_instances - num_instances), nodes, 2), torch.nan)
-    instances = torch.cat(
-        [instances, nans], dim=1
-    )  # (n_samples, max_instances, num_nodes, 2)
+    if max_instances != 1:
+        nans = torch.full(
+            (1, np.abs(max_instances - num_instances), nodes, 2), torch.nan
+        )
+        instances = torch.cat(
+            [instances, nans], dim=1
+        )  # (n_samples, max_instances, num_nodes, 2)
 
     ex = {
-        "image": image,
+        "image": torch.from_numpy(image),
         "instances": instances,
         "video_idx": torch.tensor(video_idx, dtype=torch.int32),
         "frame_idx": torch.tensor(lf.frame_idx, dtype=torch.int32),

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -1,6 +1,6 @@
 """This module implements pipeline blocks for reading input data such as labels."""
 
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import numpy as np
 import sleap_io as sio
@@ -26,6 +26,69 @@ def get_max_instances(labels: sio.Labels):
         if num_inst > max_instances:
             max_instances = num_inst
     return max_instances
+
+
+def process_lf(
+    lf: sio.LabeledFrame,
+    video_idx: int,
+    max_instances: int,
+    user_instances_only: bool = True,
+) -> Dict[str, Any]:
+    """Get sample dict from `sio.LabeledFrame`.
+
+    Args:
+        lf: Input `sio.LabeledFrame`.
+        video_idx: Video index of the given lf.
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instancs, frame index, video index, original image size and
+        number of instances.
+
+    """
+    # Filter to user instances
+    if user_instances_only:
+        if lf.user_instances is not None and len(lf.user_instances) > 0:
+            lf.instances = lf.user_instances
+
+    image = np.transpose(lf.image, (2, 0, 1))  # HWC -> CHW
+
+    instances = []
+    for inst in lf:
+        if not inst.is_empty:
+            instances.append(inst.numpy())
+    instances = np.stack(instances, axis=0)
+
+    # Add singleton time dimension for single frames.
+    image = np.expand_dims(image, axis=0)  # (n_samples=1, C, H, W)
+    instances = np.expand_dims(
+        instances, axis=0
+    )  # (n_samples=1, num_instances, num_nodes, 2)
+
+    image = torch.from_numpy(image.astype("float32"))
+    instances = torch.from_numpy(instances.astype("float32"))
+
+    num_instances, nodes = instances.shape[1:3]
+    img_height, img_width = image.shape[-2:]
+
+    # append with nans for broadcasting
+    nans = torch.full((1, np.abs(max_instances - num_instances), nodes, 2), torch.nan)
+    instances = torch.cat(
+        [instances, nans], dim=1
+    )  # (n_samples, max_instances, num_nodes, 2)
+
+    ex = {
+        "image": image,
+        "instances": instances,
+        "video_idx": torch.tensor(video_idx, dtype=torch.int32),
+        "frame_idx": torch.tensor(lf.frame_idx, dtype=torch.int32),
+        "orig_size": torch.Tensor([img_height, img_width]),
+        "num_instances": num_instances,
+    }
+
+    return ex
 
 
 class LabelsReader(IterDataPipe):

--- a/sleap_nn/data/resizing.py
+++ b/sleap_nn/data/resizing.py
@@ -33,7 +33,7 @@ def find_padding_for_stride(
     return pad_height, pad_width
 
 
-def pad_to_stride(image: torch.Tensor, max_stride: int) -> torch.Tensor:
+def apply_pad_to_stride(image: torch.Tensor, max_stride: int) -> torch.Tensor:
     """Pad an image to meet a max stride constraint.
 
     This is useful for ensuring there is no size mismatch between an image and the
@@ -51,19 +51,20 @@ def pad_to_stride(image: torch.Tensor, max_stride: int) -> torch.Tensor:
         The input image with 0-padding applied to the bottom and/or right such that the
         new shape's height and width are both divisible by `max_stride`.
     """
-    image_height, image_width = image.shape[-2:]
-    pad_height, pad_width = find_padding_for_stride(
-        image_height=image_height,
-        image_width=image_width,
-        max_stride=max_stride,
-    )
+    if max_stride > 1:
+        image_height, image_width = image.shape[-2:]
+        pad_height, pad_width = find_padding_for_stride(
+            image_height=image_height,
+            image_width=image_width,
+            max_stride=max_stride,
+        )
 
-    if pad_height > 0 or pad_width > 0:
-        image = F.pad(
-            image,
-            (0, pad_width, 0, pad_height),
-            mode="constant",
-        ).to(torch.float32)
+        if pad_height > 0 or pad_width > 0:
+            image = F.pad(
+                image,
+                (0, pad_width, 0, pad_height),
+                mode="constant",
+            ).to(torch.float32)
     return image
 
 
@@ -81,6 +82,55 @@ def resize_image(image: torch.Tensor, scale: float):
     img_height, img_width = image.shape[-2:]
     new_size = [int(img_height * scale), int(img_width * scale)]
     image = tvf.resize(image, size=new_size)
+    return image
+
+
+def apply_resizer(image: torch.Tensor, instances: torch.Tensor, scale: float = 1.0):
+    """Rescale image and keypoints by a scale factor.
+
+    Args:
+        image: Image tensor of shape (..., channels, height, width)
+        instances: Keypoints tensor.
+        scale: Factor to resize the image dimensions by, specified as a float
+            scalar. Default: 1.0.
+
+    Returns:
+        Tuple with resized image and corresponding keypoints.
+    """
+    if scale != 1.0:
+        image = resize_image(image, scale)
+        instances = instances * scale
+    return image, instances
+
+
+def apply_sizematcher(
+    image: torch.Tensor,
+    max_height: Optional[int] = None,
+    max_width: Optional[int] = None,
+):
+    """Apply padding to smaller image to (max_height, max_width) shape."""
+    img_height, img_width = image.shape[-2:]
+    # pad images to max_height and max_width
+    if max_height is None:
+        max_height = img_height
+    if max_width is None:
+        max_width = img_width
+    pad_height = max_height - img_height
+    pad_width = max_width - img_width
+    if pad_height < 0:
+        raise ValueError(
+            f"Max height {max_height} should be greater than the current image height: {img_height}"
+        )
+    if pad_width < 0:
+        raise ValueError(
+            f"Max width {max_width} should be greater than the current image width: {img_width}"
+        )
+    image = F.pad(
+        image,
+        (0, pad_width, 0, pad_height),
+        mode="constant",
+    ).to(torch.float32)
+
     return image
 
 
@@ -156,8 +206,9 @@ class PadToStride(IterDataPipe):
     def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
         """Return an example dictionary with the resized image and `orig_size` key to represent the original shape of the source image."""
         for ex in self.source_datapipe:
-            if self.max_stride > 1:
-                ex[self.image_key] = pad_to_stride(ex[self.image_key], self.max_stride)
+            ex[self.image_key] = apply_pad_to_stride(
+                ex[self.image_key], self.max_stride
+            )
             yield ex
 
 

--- a/sleap_nn/data/streaming_datasets.py
+++ b/sleap_nn/data/streaming_datasets.py
@@ -1,0 +1,380 @@
+"""Custom `litdata.StreamingDataset`s for different models."""
+
+from kornia.geometry.transform import crop_and_resize
+from omegaconf import DictConfig
+from typing import List, Optional, Tuple
+import litdata as ld
+import torch
+
+from sleap_nn.data.augmentation import (
+    apply_geometric_augmentation,
+    apply_intensity_augmentation,
+)
+from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
+from sleap_nn.data.edge_maps import generate_pafs
+from sleap_nn.data.instance_cropping import make_centered_bboxes
+from sleap_nn.data.resizing import apply_pad_to_stride, apply_resizer
+
+
+class BottomUpStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for BottomUp pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps and part affinity fields for every
+    data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        pafs_head: DictConfig object with all the keys in the `head_config` section
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type )
+            for PAFs.
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        pafs_head: DictConfig,
+        edge_inds: list,
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Constructs a BottomUpStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.pafs_head = pafs_head
+        self.edge_inds = edge_inds
+        self.max_stride = max_stride
+        self.scale = scale
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["image"], ex["instances"] = apply_intensity_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["image"], ex["instances"] = apply_geometric_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.geometric
+                )
+
+        # resize the image
+        ex["image"], ex["instances"] = apply_resizer(
+            ex["image"],
+            ex["instances"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(
+            ex["instances"],
+            img_hw=img_hw,
+            num_instances=ex["num_instances"],
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+            is_centroids=False,
+        )
+
+        # pafs
+        pafs = generate_pafs(
+            ex["instances"],
+            img_hw=img_hw,
+            sigma=self.pafs_head.sigma,
+            output_stride=self.pafs_head.output_stride,
+            edge_inds=torch.Tensor(self.edge_inds),
+            flatten_channels=True,
+        )
+
+        ex["confidence_maps"] = confidence_maps
+        ex["part_affinity_fields"] = pafs
+
+        return ex
+
+
+class CenteredInstanceStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for CeneteredInstance pipeline.
+
+    The `__getitem__()` applies augmentation, re-crops `instance_image` to original crop size,
+    resizes and pads image (if needed for the given max_stride), and generates confidence maps
+    for every data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        crop_hw: Height and width of the crop in pixels.
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        crop_hw: Tuple[int],
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Construct a CenteredInstanceStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.crop_hw = crop_hw
+        self.scale = scale
+        self.max_stride = max_stride
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["instance_image"], ex["instance"] = apply_intensity_augmentation(
+                    ex["instance_image"], ex["instance"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["instance_image"], ex["instance"] = apply_geometric_augmentation(
+                    ex["instance_image"], ex["instance"], **self.aug_config.geometric
+                )
+
+        # Re-crop to original crop size
+        self.crop_hw = list(self.crop_hw)
+        ex["instance_bbox"] = torch.unsqueeze(
+            make_centered_bboxes(ex["centroid"][0], self.crop_hw[0], self.crop_hw[1]), 0
+        )
+        ex["instance_image"] = crop_and_resize(
+            ex["instance_image"], boxes=ex["instance_bbox"], size=self.crop_hw
+        )
+        point = ex["instance_bbox"][0][0]
+        center_instance = ex["instance"] - point
+        centered_centroid = ex["centroid"] - point
+
+        ex["instance"] = center_instance.unsqueeze(0)  # (n_samples=1, n_nodes, 2)
+        ex["centroid"] = centered_centroid.unsqueeze(0)  # (n_samples=1, 2)
+
+        # resize the image
+        ex["instance_image"], ex["instance"] = apply_resizer(
+            ex["instance_image"],
+            ex["instance"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["instance_image"] = apply_pad_to_stride(
+            ex["instance_image"], max_stride=self.max_stride
+        )
+
+        img_hw = ex["instance_image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(
+            ex["instance"],
+            img_hw=img_hw,
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+        )
+
+        ex["confidence_maps"] = confidence_maps
+
+        return ex
+
+
+class CentroidStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for Centroid pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps for every data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Construct a CentroidStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.max_stride = max_stride
+        self.scale = scale
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["image"], ex["centroids"] = apply_intensity_augmentation(
+                    ex["image"], ex["centroids"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["image"], ex["centroids"] = apply_geometric_augmentation(
+                    ex["image"], ex["centroids"], **self.aug_config.geometric
+                )
+
+        # resize the image
+        ex["image"], ex["centroids"] = apply_resizer(
+            ex["image"],
+            ex["centroids"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(
+            ex["centroids"],
+            img_hw=img_hw,
+            num_instances=ex["num_instances"],
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+            is_centroids=True,
+        )
+
+        ex["centroids_confidence_maps"] = confidence_maps
+
+        return ex
+
+
+class SingleInstanceStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for SingleInstance pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps for every data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Construct a SingleInstanceStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.max_stride = max_stride
+        self.scale = scale
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["image"], ex["instances"] = apply_intensity_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["image"], ex["instances"] = apply_geometric_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.geometric
+                )
+
+        # resize the image
+        ex["image"], ex["instances"] = apply_resizer(
+            ex["image"],
+            ex["instances"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(
+            ex["instances"],
+            img_hw=img_hw,
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+        )
+
+        ex["confidence_maps"] = confidence_maps
+
+        return ex

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -18,7 +18,7 @@ from sleap_nn.data.resizing import (
     Resizer,
     PadToStride,
     resize_image,
-    pad_to_stride,
+    apply_pad_to_stride,
 )
 from sleap_nn.data.normalization import Normalizer, convert_to_grayscale, convert_to_rgb
 from sleap_nn.data.instance_centroids import InstanceCentroidFinder
@@ -51,7 +51,7 @@ class Predictor(ABC):
 
     Attributes:
         preprocess: Only for VideoReader provider. True if preprocessing (reszizing and
-            pad_to_stride) should be applied on the frames read in the video reader.
+            apply_pad_to_stride) should be applied on the frames read in the video reader.
             Default: True.
         video_preprocess_config: Preprocessing config for VideoReader with keys: [`batch_size`,
             `scale`, `is_rgb`, `max_stride`]. Default: {"batch_size": 4, "scale": 1.0,
@@ -277,7 +277,7 @@ class Predictor(ABC):
                         scale = self.video_preprocess_config["scale"]
                         if scale != 1.0:
                             ex["image"] = resize_image(ex["image"], scale)
-                        ex["image"] = pad_to_stride(
+                        ex["image"] = apply_pad_to_stride(
                             ex["image"], self.video_preprocess_config["max_stride"]
                         )
                     outputs_list = self.inference_model(ex)

--- a/sleap_nn/inference/topdown.py
+++ b/sleap_nn/inference/topdown.py
@@ -6,7 +6,7 @@ import lightning as L
 import numpy as np
 from sleap_nn.data.resizing import (
     resize_image,
-    pad_to_stride,
+    apply_pad_to_stride,
 )
 from sleap_nn.inference.peak_finding import crop_bboxes
 from sleap_nn.data.instance_cropping import make_centered_bboxes
@@ -156,7 +156,7 @@ class CentroidCrop(L.LightningModule):
         orig_image = inputs["image"]
         scaled_image = resize_image(orig_image, self.input_scale)
         if self.max_stride != 1:
-            scaled_image = pad_to_stride(scaled_image, self.max_stride)
+            scaled_image = apply_pad_to_stride(scaled_image, self.max_stride)
 
         cms = self.torch_model(scaled_image)
 
@@ -395,7 +395,7 @@ class FindInstancePeaks(L.LightningModule):
         orig_image = inputs["instance_image"]
         scaled_image = resize_image(orig_image, self.input_scale)
         if self.max_stride != 1:
-            scaled_image = pad_to_stride(scaled_image, self.max_stride)
+            scaled_image = apply_pad_to_stride(scaled_image, self.max_stride)
 
         cms = self.torch_model(scaled_image)
 

--- a/tests/data/test_augmentation.py
+++ b/tests/data/test_augmentation.py
@@ -1,8 +1,14 @@
 import pytest
 import torch
 from torch.utils.data import DataLoader
-
+import sleap_io as sio
 from sleap_nn.data.augmentation import KorniaAugmenter, RandomUniformNoise
+from sleap_nn.data.augmentation import (
+    apply_intensity_augmentation,
+    apply_geometric_augmentation,
+)
+from sleap_nn.data.normalization import apply_normalization
+from sleap_nn.data.providers import process_lf
 from sleap_nn.data.normalization import Normalizer
 from sleap_nn.data.providers import LabelsReader
 
@@ -33,6 +39,62 @@ def test_uniform_noise(minimal_instance):
     aug_img = aug(img)
     assert torch.is_tensor(aug_img)
     assert aug_img.shape == (1, 1, 384, 384)
+
+
+def test_apply_intensity_augmentation(minimal_instance):
+    """Test `apply_intensity_augmentation` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+    ex["image"] = apply_normalization(ex["image"])
+
+    img, pts = apply_intensity_augmentation(
+        ex["image"],
+        ex["instances"],
+        uniform_noise_p=1.0,
+        contrast_p=1.0,
+        brightness_p=1.0,
+        gaussian_noise_p=1.0,
+    )
+    # Test all augmentations.
+    assert torch.is_tensor(img)
+    assert torch.is_tensor(pts)
+    assert not torch.equal(img, ex["image"])
+    assert img.shape == (1, 1, 384, 384)
+    assert pts.shape == (1, 2, 2, 2)
+
+
+def test_apply_geometric_augmentation(minimal_instance):
+    """Test `apply_geometric_augmentation` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+    ex["image"] = apply_normalization(ex["image"])
+
+    img, pts = apply_geometric_augmentation(
+        ex["image"],
+        ex["instances"],
+        scale=0.5,
+        affine_p=1.0,
+        random_crop_height=100,
+        random_crop_width=100,
+        random_crop_p=1.0,
+        erase_p=1.0,
+        mixup_p=1.0,
+    )
+    # Test all augmentations.
+    assert torch.is_tensor(img)
+    assert torch.is_tensor(pts)
+    assert not torch.equal(img, ex["image"])
+    assert img.shape == (1, 1, 100, 100)
+    assert pts.shape == (1, 2, 2, 2)
+
+    with pytest.raises(
+        ValueError, match="crop_hw height and width must be greater than 0."
+    ):
+        img, pts = apply_geometric_augmentation(
+            ex["image"], ex["instances"], random_crop_p=1.0, random_crop_height=0
+        )
 
 
 def test_kornia_augmentation(minimal_instance):

--- a/tests/data/test_edge_maps.py
+++ b/tests/data/test_edge_maps.py
@@ -1,13 +1,15 @@
 import numpy as np
 import torch
+import sleap_io as sio
 from sleap_nn.data.utils import make_grid_vectors
-from sleap_nn.data.providers import LabelsReader
+from sleap_nn.data.providers import LabelsReader, process_lf
 from sleap_nn.data.edge_maps import (
     distance_to_edge,
     make_edge_maps,
     make_pafs,
     make_multi_pafs,
     get_edge_points,
+    generate_pafs,
     PartAffinityFieldsGenerator,
 )
 
@@ -171,6 +173,20 @@ def test_get_edge_points():
             [[20, 21], [22, 23], [22, 23]],
         ],
     )
+
+
+def test_generate_pafs(minimal_instance):
+    """Test `generate_pafs` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    pafs = generate_pafs(
+        ex["instances"],
+        img_hw=(384, 384),
+        edge_inds=torch.Tensor(labels.skeletons[0].edge_inds),
+    )
+    assert pafs.shape == (192, 192, 1, 2)
 
 
 def test_part_affinity_fields_generator(minimal_instance):

--- a/tests/data/test_get_data_chunks.py
+++ b/tests/data/test_get_data_chunks.py
@@ -1,0 +1,239 @@
+import sleap_io as sio
+
+from sleap_nn.data.get_data_chunks import (
+    bottomup_data_chunks,
+    centered_instance_data_chunks,
+    centroid_data_chunks,
+    single_instance_data_chunks,
+)
+
+
+def test_bottomup_data_chunks(minimal_instance, config):
+    """Test `bottomup_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            bottomup_data_chunks(
+                (lf, idx), data_config=config.data_config, max_instances=4
+            )
+        )
+
+    assert len(samples) == 1
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 1, 384, 384)
+    assert samples[0]["instances"].shape == (1, 4, 2, 2)
+
+    # test `is_rgb`
+    config.data_config.preprocessing.is_rgb = True
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            bottomup_data_chunks(
+                (lf, idx),
+                data_config=config.data_config,
+                max_instances=2,
+            )
+        )
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 3, 384, 384)
+    assert samples[0]["instances"].shape == (1, 2, 2, 2)
+
+
+def test_centered_instance_data_chunks(minimal_instance, config):
+    """Test `centered_instance_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    samples = []
+    for idx, lf in enumerate(labels):
+        res = centered_instance_data_chunks(
+            (lf, idx),
+            data_config=config.data_config,
+            anchor_ind=0,
+            crop_size=(160, 160),
+            max_instances=4,
+        )
+        samples.extend(res)
+
+    assert len(samples) == 2
+
+    gt_keys = [
+        "instance_image",
+        "instance",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "instance_bbox",
+        "centroid",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["instance_image"].shape == (1, 1, 226, 226)
+    assert samples[0]["instance"].shape == (1, 2, 2)
+
+    # test `is_rgb`
+    config.data_config.preprocessing.scale = 1.0
+    config.data_config.preprocessing.is_rgb = True
+    samples = []
+    for idx, lf in enumerate(labels):
+        res = centered_instance_data_chunks(
+            (lf, idx),
+            data_config=config.data_config,
+            anchor_ind=0,
+            crop_size=(160, 160),
+            max_instances=2,
+        )
+        samples.extend(res)
+
+    gt_keys = [
+        "instance_image",
+        "instance",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "instance_bbox",
+        "centroid",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["instance_image"].shape == (1, 3, 226, 226)
+    assert samples[0]["instance"].shape == (1, 2, 2)
+
+
+def test_centroid_data_chunks(minimal_instance, config):
+    """Test `centroid_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            centroid_data_chunks(
+                (lf, idx),
+                data_config=config.data_config,
+                max_instances=4,
+                anchor_ind=0,
+            )
+        )
+
+    assert len(samples) == 1
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "centroids",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 1, 384, 384)
+    assert samples[0]["instances"].shape == (1, 4, 2, 2)
+    assert samples[0]["centroids"].shape == (1, 4, 2)
+
+    # test  `is_rgb`
+    samples = []
+    config.data_config.preprocessing.is_rgb = True
+    for idx, lf in enumerate(labels):
+        samples.append(
+            centroid_data_chunks(
+                (lf, idx),
+                data_config=config.data_config,
+                max_instances=2,
+                anchor_ind=0,
+            )
+        )
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "centroids",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 3, 384, 384)
+    assert samples[0]["instances"].shape == (1, 2, 2, 2)
+    assert samples[0]["centroids"].shape == (1, 2, 2)
+
+
+def test_single_instance_data_chunks(minimal_instance, config):
+    """Test `single_instance_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    # Making our minimal 2-instance example into a single instance example.
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            single_instance_data_chunks((lf, idx), data_config=config.data_config)
+        )
+
+    assert len(samples) == 1
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 1, 384, 384)
+    assert samples[0]["instances"].shape == (1, 1, 2, 2)
+
+    # test `is_rgb`
+    config.data_config.preprocessing.is_rgb = True
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            single_instance_data_chunks((lf, idx), data_config=config.data_config)
+        )
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 3, 384, 384)
+    assert samples[0]["instances"].shape == (1, 1, 2, 2)

--- a/tests/data/test_instance_centroids.py
+++ b/tests/data/test_instance_centroids.py
@@ -1,14 +1,42 @@
 import torch
-
+import sleap_io as sio
 from sleap_nn.data.instance_centroids import (
     InstanceCentroidFinder,
-    find_centroids,
+    generate_centroids,
 )
-from sleap_nn.data.providers import LabelsReader
+from sleap_nn.data.providers import LabelsReader, process_lf
+
+
+def test_generate_centroids(minimal_instance):
+    """Test `generate_centroids` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    centroids = generate_centroids(ex["instances"], 1).int()
+    gt = torch.Tensor([[[152, 158], [278, 203]]]).int()
+    assert torch.equal(centroids, gt)
+
+    partial_instance = torch.Tensor(
+        [
+            [
+                [[92.6522, 202.7260], [152.3419, 158.4236], [97.2618, 53.5834]],
+                [[205.9301, 187.8896], [torch.nan, torch.nan], [201.4264, 75.2373]],
+                [
+                    [torch.nan, torch.nan],
+                    [torch.nan, torch.nan],
+                    [torch.nan, torch.nan],
+                ],
+            ]
+        ]
+    )
+    centroids = generate_centroids(partial_instance, 1).int()
+    gt = torch.Tensor([[[152, 158], [203, 131], [torch.nan, torch.nan]]]).int()
+    assert torch.equal(centroids, gt)
 
 
 def test_instance_centroids(minimal_instance):
-    """Test InstanceCentroidFinder and find_centroids functions."""
+    """Test InstanceCentroidFinder and generate_centroids functions."""
     # Undefined anchor_ind.
     datapipe = LabelsReader.from_filename(minimal_instance)
     datapipe = InstanceCentroidFinder(datapipe)
@@ -20,7 +48,7 @@ def test_instance_centroids(minimal_instance):
     assert torch.equal(centroids, gt)
 
     # Defined anchor_ind.
-    centroids = find_centroids(instances, 1).int()
+    centroids = generate_centroids(instances, 1).int()
     gt = torch.Tensor([[[152, 158], [278, 203]]]).int()
     assert torch.equal(centroids, gt)
 
@@ -38,6 +66,6 @@ def test_instance_centroids(minimal_instance):
             ]
         ]
     )
-    centroids = find_centroids(partial_instance, 1).int()
+    centroids = generate_centroids(partial_instance, 1).int()
     gt = torch.Tensor([[[152, 158], [203, 131], [torch.nan, torch.nan]]]).int()
     assert torch.equal(centroids, gt)

--- a/tests/data/test_instance_cropping.py
+++ b/tests/data/test_instance_cropping.py
@@ -8,7 +8,7 @@ from sleap_nn.data.instance_cropping import (
     generate_crops,
     make_centered_bboxes,
 )
-from sleap_nn.data.normalization import Normalizer
+from sleap_nn.data.normalization import Normalizer, apply_normalization
 from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
 from sleap_nn.data.providers import LabelsReader, process_lf
 
@@ -91,6 +91,7 @@ def test_generate_crops(minimal_instance):
     labels = sio.load_slp(minimal_instance)
     lf = labels[0]
     ex = process_lf(lf, 0, 2)
+    ex["image"] = apply_normalization(ex["image"])
 
     centroids = generate_centroids(ex["instances"], 0)
     cropped_ex = generate_crops(

--- a/tests/data/test_instance_cropping.py
+++ b/tests/data/test_instance_cropping.py
@@ -1,15 +1,16 @@
 import sleap_io as sio
 import torch
 
-from sleap_nn.data.instance_centroids import InstanceCentroidFinder
+from sleap_nn.data.instance_centroids import InstanceCentroidFinder, generate_centroids
 from sleap_nn.data.instance_cropping import (
     InstanceCropper,
     find_instance_crop_size,
+    generate_crops,
     make_centered_bboxes,
 )
 from sleap_nn.data.normalization import Normalizer
 from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
-from sleap_nn.data.providers import LabelsReader
+from sleap_nn.data.providers import LabelsReader, process_lf
 
 
 def test_find_instance_crop_size(minimal_instance):
@@ -83,3 +84,20 @@ def test_instance_cropper(minimal_instance):
     )
     centered_instance = sample["instance"]
     assert torch.equal(centered_instance, gt.unsqueeze(0))
+
+
+def test_generate_crops(minimal_instance):
+    """Test `generate_crops` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    centroids = generate_centroids(ex["instances"], 0)
+    cropped_ex = generate_crops(
+        ex["image"], ex["instances"][0, 0], centroids[0, 0], crop_size=(100, 100)
+    )
+
+    assert cropped_ex["instance"].shape == (1, 2, 2)
+    assert cropped_ex["centroid"].shape == (1, 2)
+    assert cropped_ex["instance_image"].shape == (1, 1, 100, 100)
+    assert cropped_ex["instance_bbox"].shape == (1, 4, 2)

--- a/tests/data/test_normalization.py
+++ b/tests/data/test_normalization.py
@@ -1,7 +1,11 @@
 import torch
 import numpy as np
 
-from sleap_nn.data.normalization import Normalizer, convert_to_grayscale
+from sleap_nn.data.normalization import (
+    Normalizer,
+    convert_to_grayscale,
+    apply_normalization,
+)
 from sleap_nn.data.providers import LabelsReader
 
 
@@ -28,3 +32,11 @@ def test_convert_to_grayscale():
     img = torch.randint(0, 255, (3, 200, 200))
     res = convert_to_grayscale(img)
     assert res.shape[0] == 1
+
+
+def test_apply_normalization():
+    """Test `apply_normalization` function."""
+    img = torch.randint(0, 255, (3, 200, 200))
+    res = apply_normalization(img)
+    assert torch.max(res) <= 1.0 and torch.min(res) == 0.0
+    assert res.dtype == torch.float32

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -101,3 +101,4 @@ def test_process_lf(minimal_instance):
     assert ex["image"].shape == torch.Size([1, 1, 384, 384])
     assert ex["instances"].shape == torch.Size([1, 4, 2, 2])
     assert torch.isnan(ex["instances"][:, 2:, :, :]).all()
+    assert not torch.is_floating_point(ex["image"])

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -1,6 +1,6 @@
 import torch
 
-from sleap_nn.data.providers import LabelsReader, VideoReader
+from sleap_nn.data.providers import LabelsReader, VideoReader, process_lf
 from queue import Queue
 import sleap_io as sio
 import numpy as np
@@ -91,3 +91,13 @@ def test_videoreader_provider(centered_instance_video):
     finally:
         reader.join()
     assert reader.total_len() == 6
+
+
+def test_process_lf(minimal_instance):
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 4)
+
+    assert ex["image"].shape == torch.Size([1, 1, 384, 384])
+    assert ex["instances"].shape == torch.Size([1, 4, 2, 2])
+    assert torch.isnan(ex["instances"][:, 2:, :, :]).all()

--- a/tests/data/test_resizing.py
+++ b/tests/data/test_resizing.py
@@ -1,7 +1,14 @@
 import torch
 
-from sleap_nn.data.providers import LabelsReader
-from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
+from sleap_nn.data.providers import LabelsReader, process_lf
+from sleap_nn.data.resizing import (
+    SizeMatcher,
+    Resizer,
+    PadToStride,
+    apply_resizer,
+    apply_pad_to_stride,
+    apply_sizematcher,
+)
 import numpy as np
 import sleap_io as sio
 import pytest
@@ -69,12 +76,56 @@ def test_padtostride(minimal_instance):
     image = sample["image"]
     assert image.shape == torch.Size([1, 1, 384, 384])
 
-    pipe = PadToStride(l, max_stride=2)
-    sample = next(iter(pipe))
-    image = sample["image"]
-    assert image.shape == torch.Size([1, 1, 384, 384])
-
     pipe = PadToStride(l, max_stride=500)
     sample = next(iter(pipe))
     image = sample["image"]
     assert image.shape == torch.Size([1, 1, 500, 500])
+
+
+def test_apply_resizer(minimal_instance):
+    """Test `apply_resizer` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    image, instances = apply_resizer(ex["image"], ex["instances"], scale=2.0)
+    assert image.shape == torch.Size([1, 1, 768, 768])
+    assert torch.all(instances == ex["instances"] * 2.0)
+
+
+def test_apply_pad_to_stride(minimal_instance):
+    """Test `apply_pad_to_stride` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    image = apply_pad_to_stride(ex["image"], max_stride=2)
+    assert image.shape == torch.Size([1, 1, 384, 384])
+
+    image = apply_pad_to_stride(ex["image"], max_stride=200)
+    assert image.shape == torch.Size([1, 1, 400, 400])
+
+
+def test_apply_sizematcher(minimal_instance):
+    """Test `apply_sizematcher` function."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(lf, 0, 2)
+
+    image = apply_sizematcher(ex["image"], 500, 500)
+    assert image.shape == torch.Size([1, 1, 500, 500])
+
+    image = apply_sizematcher(ex["image"])
+    assert image.shape == torch.Size([1, 1, 384, 384])
+
+    with pytest.raises(
+        Exception,
+        match=f"Max height {100} should be greater than the current image height: {384}",
+    ):
+        image = apply_sizematcher(ex["image"], max_height=100, max_width=500)
+
+    with pytest.raises(
+        Exception,
+        match=f"Max width {100} should be greater than the current image width: {384}",
+    ):
+        image = apply_sizematcher(ex["image"], max_height=500, max_width=100)

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -1,0 +1,246 @@
+from pathlib import Path
+from omegaconf import DictConfig
+import functools
+import litdata as ld
+import shutil
+import sleap_io as sio
+from sleap_nn.data.get_data_chunks import (
+    bottomup_data_chunks,
+    centered_instance_data_chunks,
+    centroid_data_chunks,
+    single_instance_data_chunks,
+)
+from sleap_nn.data.streaming_datasets import (
+    BottomUpStreamingDataset,
+    CenteredInstanceStreamingDataset,
+    CentroidStreamingDataset,
+    SingleInstanceStreamingDataset,
+)
+
+
+def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test BottomUpStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+    edge_inds = labels.skeletons[0].edge_inds
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        bottomup_data_chunks, data_config=config.data_config, max_instances=2
+    )
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+        pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+
+        dataset = BottomUpStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            pafs_head=pafs_head,
+            edge_inds=edge_inds,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+        assert samples[0]["part_affinity_fields"].shape == (50, 50, 2)
+
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = BottomUpStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            pafs_head=pafs_head,
+            edge_inds=edge_inds,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+            apply_aug=True,
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+        assert samples[0]["part_affinity_fields"].shape == (75, 75, 2)
+
+    finally:
+        shutil.rmtree(dir_path)
+
+
+def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test CenteredInstanceStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        centered_instance_data_chunks,
+        data_config=config.data_config,
+        max_instances=2,
+        crop_size=(160, 160),
+        anchor_ind=0,
+    )
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+        dataset = CenteredInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            crop_hw=(160, 160),
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 2
+
+        assert samples[0]["instance_image"].shape == (1, 1, 100, 100)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 50, 50)
+
+    finally:
+        shutil.rmtree(dir_path)
+
+
+def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test CentroidStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        centroid_data_chunks,
+        data_config=config.data_config,
+        max_instances=2,
+        anchor_ind=0,
+    )
+
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+        dataset = CentroidStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["centroids_confidence_maps"].shape == (1, 1, 100, 100)
+
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = CentroidStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+            apply_aug=True,
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["centroids_confidence_maps"].shape == (1, 1, 150, 150)
+
+    finally:
+        shutil.rmtree(dir_path)
+
+
+def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test SingleInstanceStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        single_instance_data_chunks,
+        data_config=config.data_config,
+    )
+
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+        dataset = SingleInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = SingleInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            apply_aug=True,
+            confmap_head=confmap_head,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+
+    finally:
+        shutil.rmtree(dir_path)

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -60,6 +60,9 @@ def config(sleap_data_dir):
                 },
                 "use_augmentations_train": True,
                 "augmentation_config": {
+                    "intensity": {
+                        "contrast_p": 1.0,
+                    },
                     "geometric": {
                         "rotation": 180.0,
                         "scale": None,


### PR DESCRIPTION
This is the first PR for https://github.com/talmolab/sleap-nn/issues/80. Here, we breakdown the operations in __iter__() of all data processing modules into individual functions that would be useful for implementing the get_chunks() (second PR for https://github.com/talmolab/sleap-nn/issues/80 ).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced configuration options for data processing, including `user_instances_only`, `chunk_size`, and additional parameters for data augmentation.
  - Introduced new functions for generating data chunks from labeled frames, improving data handling for training.
  - Added custom streaming datasets for various model pipelines, optimizing data retrieval processes.
  - New dependency `litdata` added to environment configuration files.

- **Bug Fixes**
  - Corrected the indentation for dependencies in environment configuration files.

- **Tests**
  - Implemented unit tests for new data chunking functions and streaming dataset classes, ensuring reliability and performance.
  - Added tests for the `process_lf` function and updated existing tests to enhance coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->