### PR TITLE
LitData Refactor PR2: Implement a function to get the data chunks for all model types

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,6 +15,9 @@ The config file has three main sections:
     - `provider`: (str) Provider class to read the input sleap files. Only "LabelsReader" supported for the training pipeline.
     - `train_labels_path`: (str) Path to training data (`.slp` file)
     - `val_labels_path`: (str) Path to validation data (`.slp` file)
+    - `user_instances_only`: (bool) `True` if only user labeled instances should be used for training. If `False`, both user labeled and predicted instances would be used. *Default*: `True`.
+    - `chunk_size`: (int) Size of each chunk (in MB). *Default*: "100". 
+    #TODO: change in inference ckpts
     - `preprocessing`:
         - `is_rgb`: (bool) True if the image has 3 channels (RGB image). If input has only one
         channel when this is set to `True`, then the images from single-channel
@@ -30,7 +33,6 @@ The config file has three main sections:
         - `min_crop_size`: (int) Minimum crop size to be used if `crop_hw` is `None`.
     - `use_augmentations_train`: (bool) True if the data augmentation should be applied to the training data, else False. 
     - `augmentation_config`: (only if `use_augmentations` is `True`)
-        - `random crop`: (Optional) (Dict[float]) {"random_crop_p": None, "crop_height": None. "crop_width": None}, where *random_crop_p* is the probability of applying random crop and *crop_height* and *crop_width* are the desired output size (out_h, out_w) of the crop. 
         - `intensity`: (Optional)
             - `uniform_noise_min`: (float) Minimum value for uniform noise (uniform_noise_min >=0).
             - `uniform_noise_max`: (float) Maximum value for uniform noise (uniform_noise_max <>=1).
@@ -57,7 +59,9 @@ The config file has three main sections:
             - `mixup_lambda`: (float) min-max value of mixup strength. Default is 0-1. *Default*: `None`.
             - `mixup_p`: (float) Probability of applying random mixup v2. *Default*=0.0
             - `input_key`: (str) Can be `image` or `instance`. The input_key `instance` expects the KorniaAugmenter to follow the InstanceCropper else `image` otherwise for default.
-
+            - `random_crop_p`: (float) Probability of applying random crop.
+            - `random_crop_height`: (int) Desired output height of the random crop.
+            - `random_crop_width`: (int) Desired output height of the random crop.
 - `model_config`: 
     - `init_weight`: (str) model weights initialization method. "default" uses kaiming uniform initialization and "xavier" uses Xavier initialization method.
     - `pre_trained_weights`: (str) Pretrained weights file name supported only for ConvNext and SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights","ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"]. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].

--- a/docs/config_bottomup.yaml
+++ b/docs/config_bottomup.yaml
@@ -2,6 +2,7 @@ data_config:
   provider: LabelsReader
   train_labels_path: minimal_instance.pkg.slp
   val_labels_path: minimal_instance.pkg.slp
+  user_instances_only: True
   preprocessing:
     max_width: null
     max_height: null

--- a/docs/config_centroid.yaml
+++ b/docs/config_centroid.yaml
@@ -2,6 +2,7 @@ data_config:
   provider: LabelsReader
   train_labels_path: minimal_instance.pkg.slp
   val_labels_path: minimal_instance.pkg.slp
+  user_instances_only: True
   preprocessing:
     max_width: 
     max_height: 
@@ -9,10 +10,6 @@ data_config:
     is_rgb: False
   use_augmentations_train: true
   augmentation_config: # sample augmentation_config
-    random_crop:
-      random_crop_p: 0
-      crop_height: 160
-      crop_width: 160
     intensity:
       uniform_noise_min: 0.0
       uniform_noise_max: 0.04
@@ -38,6 +35,9 @@ data_config:
       erase_p: 0
       mixup_lambda: null
       mixup_p: 0
+      random_crop_p: 0
+      crop_height: 160
+      crop_width: 160
 
 model_config:
   init_weights: xavier

--- a/docs/config_topdown_centered_instance.yaml
+++ b/docs/config_topdown_centered_instance.yaml
@@ -2,6 +2,7 @@ data_config:
   provider: LabelsReader
   train_labels_path: minimal_instance.pkg.slp
   val_labels_path: minimal_instance.pkg.slp
+  user_instances_only: True
   preprocessing:
     max_width: 
     max_height: 

--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -33,3 +33,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -32,3 +32,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - litdata

--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -1,0 +1,243 @@
+"""Handles generating data chunks for training."""
+
+from typing import Dict, Optional, Tuple, Union
+from omegaconf import DictConfig
+import numpy as np
+import torch
+
+import sleap_io as sio
+from sleap_nn.data.instance_centroids import generate_centroids
+from sleap_nn.data.instance_cropping import generate_crops
+from sleap_nn.data.normalization import (
+    apply_normalization,
+    convert_to_grayscale,
+    convert_to_rgb,
+)
+from sleap_nn.data.providers import process_lf
+from sleap_nn.data.resizing import apply_sizematcher
+
+
+def bottomup_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    max_instances: int,
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    return sample
+
+
+def centered_instance_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    max_instances: int,
+    crop_size: Tuple[int],
+    anchor_ind: Optional[int],
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        crop_size: Height and width of the crop in pixels.
+        anchor_ind: The index of the node to use as the anchor for the centroid. If not
+            provided or if not present in the instance, the midpoint of the bounding box
+            is used instead.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    # get the centroids based on the anchor idx
+    centroids = generate_centroids(sample["instances"], anchor_ind=anchor_ind)
+
+    crop_size = np.array(crop_size) * np.sqrt(2)  # crop extra
+    crop_size = crop_size.astype(np.int32).tolist()
+
+    sample["instances"], centroids = sample["instances"][0], centroids[0]  # n_samples=1
+
+    for cnt, (instance, centroid) in enumerate(zip(sample["instances"], centroids)):
+        if cnt == sample["num_instances"]:
+            break
+
+        res = generate_crops(sample["image"], instance, centroid, crop_size)
+
+        res["frame_idx"] = sample["frame_idx"]
+        res["video_idx"] = sample["video_idx"]
+        res["num_instances"] = sample["num_instances"]
+        res["orig_size"] = sample["orig_size"]
+
+        yield res
+
+
+def centroid_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    max_instances: int,
+    anchor_ind: Optional[int],
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        anchor_ind: The index of the node to use as the anchor for the centroid. If not
+            provided or if not present in the instance, the midpoint of the bounding box
+            is used instead.
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    # get the centroids based on the anchor idx
+    centroids = generate_centroids(sample["instances"], anchor_ind=anchor_ind)
+
+    sample["centroids"] = centroids
+
+    return sample
+
+
+def single_instance_data_chunks(
+    x: Tuple[Union[sio.LabeledFrame, int]],
+    data_config: DictConfig,
+    user_instances_only: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Generate dict from `sio.LabeledFrame`.
+
+    This function processes the input `sio.LabeledFrame`, applies data pre-processing
+    operations (except augmentation and confmaps generation). This function is passed
+    to `litdata.optimize()` which applies this function on all the `sio.LabeledFrame`s
+    in the training `.slp` file and saves these dictionaries as `.bin` files.
+
+    Args:
+        x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
+            index of lf.video in the source sio.labels.videos.
+        data_config: Data-related configuration. (`data_config` section in the config file)
+        user_instances_only: True if filter labels only to user instances else False.
+            Default: True.
+
+    Returns:
+        Dict with image, instances, frame index, video index, original image size and
+        number of instances.
+
+    """
+    lf, video_idx = x
+
+    sample = process_lf(
+        lf, video_idx, user_instances_only=user_instances_only, max_instances=1
+    )
+
+    # Normalize image
+    sample["image"] = apply_normalization(sample["image"])
+
+    if data_config.preprocessing.is_rgb:
+        sample["image"] = convert_to_rgb(sample["image"])
+    else:
+        sample["image"] = convert_to_grayscale(sample["image"])
+
+    # size matcher
+    sample["image"] = apply_sizematcher(
+        sample["image"],
+        max_height=data_config.preprocessing.max_height,
+        max_width=data_config.preprocessing.max_width,
+    )
+
+    return sample

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -74,10 +74,13 @@ def process_lf(
     img_height, img_width = image.shape[-2:]
 
     # append with nans for broadcasting
-    nans = torch.full((1, np.abs(max_instances - num_instances), nodes, 2), torch.nan)
-    instances = torch.cat(
-        [instances, nans], dim=1
-    )  # (n_samples, max_instances, num_nodes, 2)
+    if max_instances != 1:
+        nans = torch.full(
+            (1, np.abs(max_instances - num_instances), nodes, 2), torch.nan
+        )
+        instances = torch.cat(
+            [instances, nans], dim=1
+        )  # (n_samples, max_instances, num_nodes, 2)
 
     ex = {
         "image": image,

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -67,7 +67,6 @@ def process_lf(
         instances, axis=0
     )  # (n_samples=1, num_instances, num_nodes, 2)
 
-    image = torch.from_numpy(image.astype("float32"))
     instances = torch.from_numpy(instances.astype("float32"))
 
     num_instances, nodes = instances.shape[1:3]
@@ -83,7 +82,7 @@ def process_lf(
         )  # (n_samples, max_instances, num_nodes, 2)
 
     ex = {
-        "image": image,
+        "image": torch.from_numpy(image),
         "instances": instances,
         "video_idx": torch.tensor(video_idx, dtype=torch.int32),
         "frame_idx": torch.tensor(lf.frame_idx, dtype=torch.int32),

--- a/sleap_nn/data/streaming_datasets.py
+++ b/sleap_nn/data/streaming_datasets.py
@@ -1,0 +1,380 @@
+"""Custom `litdata.StreamingDataset`s for different models."""
+
+from kornia.geometry.transform import crop_and_resize
+from omegaconf import DictConfig
+from typing import List, Optional, Tuple
+import litdata as ld
+import torch
+
+from sleap_nn.data.augmentation import (
+    apply_geometric_augmentation,
+    apply_intensity_augmentation,
+)
+from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
+from sleap_nn.data.edge_maps import generate_pafs
+from sleap_nn.data.instance_cropping import make_centered_bboxes
+from sleap_nn.data.resizing import apply_pad_to_stride, apply_resizer
+
+
+class BottomUpStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for BottomUp pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps and part affinity fields for every
+    data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        pafs_head: DictConfig object with all the keys in the `head_config` section
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type )
+            for PAFs.
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        pafs_head: DictConfig,
+        edge_inds: list,
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Constructs a BottomUpStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.pafs_head = pafs_head
+        self.edge_inds = edge_inds
+        self.max_stride = max_stride
+        self.scale = scale
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["image"], ex["instances"] = apply_intensity_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["image"], ex["instances"] = apply_geometric_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.geometric
+                )
+
+        # resize the image
+        ex["image"], ex["instances"] = apply_resizer(
+            ex["image"],
+            ex["instances"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(
+            ex["instances"],
+            img_hw=img_hw,
+            num_instances=ex["num_instances"],
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+            is_centroids=False,
+        )
+
+        # pafs
+        pafs = generate_pafs(
+            ex["instances"],
+            img_hw=img_hw,
+            sigma=self.pafs_head.sigma,
+            output_stride=self.pafs_head.output_stride,
+            edge_inds=torch.Tensor(self.edge_inds),
+            flatten_channels=True,
+        )
+
+        ex["confidence_maps"] = confidence_maps
+        ex["part_affinity_fields"] = pafs
+
+        return ex
+
+
+class CenteredInstanceStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for CeneteredInstance pipeline.
+
+    The `__getitem__()` applies augmentation, re-crops `instance_image` to original crop size,
+    resizes and pads image (if needed for the given max_stride), and generates confidence maps
+    for every data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        crop_hw: Height and width of the crop in pixels.
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        crop_hw: Tuple[int],
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Construct a CenteredInstanceStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.crop_hw = crop_hw
+        self.scale = scale
+        self.max_stride = max_stride
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["instance_image"], ex["instance"] = apply_intensity_augmentation(
+                    ex["instance_image"], ex["instance"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["instance_image"], ex["instance"] = apply_geometric_augmentation(
+                    ex["instance_image"], ex["instance"], **self.aug_config.geometric
+                )
+
+        # Re-crop to original crop size
+        self.crop_hw = list(self.crop_hw)
+        ex["instance_bbox"] = torch.unsqueeze(
+            make_centered_bboxes(ex["centroid"][0], self.crop_hw[0], self.crop_hw[1]), 0
+        )
+        ex["instance_image"] = crop_and_resize(
+            ex["instance_image"], boxes=ex["instance_bbox"], size=self.crop_hw
+        )
+        point = ex["instance_bbox"][0][0]
+        center_instance = ex["instance"] - point
+        centered_centroid = ex["centroid"] - point
+
+        ex["instance"] = center_instance.unsqueeze(0)  # (n_samples=1, n_nodes, 2)
+        ex["centroid"] = centered_centroid.unsqueeze(0)  # (n_samples=1, 2)
+
+        # resize the image
+        ex["instance_image"], ex["instance"] = apply_resizer(
+            ex["instance_image"],
+            ex["instance"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["instance_image"] = apply_pad_to_stride(
+            ex["instance_image"], max_stride=self.max_stride
+        )
+
+        img_hw = ex["instance_image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(
+            ex["instance"],
+            img_hw=img_hw,
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+        )
+
+        ex["confidence_maps"] = confidence_maps
+
+        return ex
+
+
+class CentroidStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for Centroid pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps for every data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Construct a CentroidStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.max_stride = max_stride
+        self.scale = scale
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["image"], ex["centroids"] = apply_intensity_augmentation(
+                    ex["image"], ex["centroids"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["image"], ex["centroids"] = apply_geometric_augmentation(
+                    ex["image"], ex["centroids"], **self.aug_config.geometric
+                )
+
+        # resize the image
+        ex["image"], ex["centroids"] = apply_resizer(
+            ex["image"],
+            ex["centroids"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(
+            ex["centroids"],
+            img_hw=img_hw,
+            num_instances=ex["num_instances"],
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+            is_centroids=True,
+        )
+
+        ex["centroids_confidence_maps"] = confidence_maps
+
+        return ex
+
+
+class SingleInstanceStreamingDataset(ld.StreamingDataset):
+    """StreamingDataset for SingleInstance pipeline.
+
+    The `__getitem__()` applies augmentation, resizes and pads image (if needed for the
+    given max_stride), and generates confidence maps for every data sample stored in `.bin` files.
+
+    Args:
+        confmap_head: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        scale: Factor to resize the image dimensions by, specified as either a float scalar
+            or as a 2-tuple of [scale_x, scale_y]. If a scalar is provided, both dimensions
+            are resized by the same factor. Default: 1.0.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        augmentation_config: Augmentation parameters. (`data_config.preprocessing.augmentation_config`
+            section in the config file.)
+    """
+
+    def __init__(
+        self,
+        confmap_head: DictConfig,
+        max_stride: int,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        augmentation_config: DictConfig = None,
+        *args,
+        **kwargs,
+    ):
+        """Construct a SingleInstanceStreamingDataset."""
+        super().__init__(*args, **kwargs)
+
+        self.confmap_head = confmap_head
+        self.max_stride = max_stride
+        self.scale = scale
+        self.apply_aug = apply_aug
+        self.aug_config = augmentation_config
+
+    def __getitem__(self, index):
+        """Apply augmentation and generate confidence maps."""
+        ex = super().__getitem__(index)
+
+        # Augmentation
+        if self.apply_aug:
+            if "intensity" in self.aug_config:
+                ex["image"], ex["instances"] = apply_intensity_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.intensity
+                )
+
+            if "geometric" in self.aug_config:
+                ex["image"], ex["instances"] = apply_geometric_augmentation(
+                    ex["image"], ex["instances"], **self.aug_config.geometric
+                )
+
+        # resize the image
+        ex["image"], ex["instances"] = apply_resizer(
+            ex["image"],
+            ex["instances"],
+            scale=self.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
+
+        img_hw = ex["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(
+            ex["instances"],
+            img_hw=img_hw,
+            sigma=self.confmap_head.sigma,
+            output_stride=self.confmap_head.output_stride,
+        )
+
+        ex["confidence_maps"] = confidence_maps
+
+        return ex

--- a/tests/data/test_get_data_chunks.py
+++ b/tests/data/test_get_data_chunks.py
@@ -1,0 +1,239 @@
+import sleap_io as sio
+
+from sleap_nn.data.get_data_chunks import (
+    bottomup_data_chunks,
+    centered_instance_data_chunks,
+    centroid_data_chunks,
+    single_instance_data_chunks,
+)
+
+
+def test_bottomup_data_chunks(minimal_instance, config):
+    """Test `bottomup_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            bottomup_data_chunks(
+                (lf, idx), data_config=config.data_config, max_instances=4
+            )
+        )
+
+    assert len(samples) == 1
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 1, 384, 384)
+    assert samples[0]["instances"].shape == (1, 4, 2, 2)
+
+    # test `is_rgb`
+    config.data_config.preprocessing.is_rgb = True
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            bottomup_data_chunks(
+                (lf, idx),
+                data_config=config.data_config,
+                max_instances=2,
+            )
+        )
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 3, 384, 384)
+    assert samples[0]["instances"].shape == (1, 2, 2, 2)
+
+
+def test_centered_instance_data_chunks(minimal_instance, config):
+    """Test `centered_instance_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    samples = []
+    for idx, lf in enumerate(labels):
+        res = centered_instance_data_chunks(
+            (lf, idx),
+            data_config=config.data_config,
+            anchor_ind=0,
+            crop_size=(160, 160),
+            max_instances=4,
+        )
+        samples.extend(res)
+
+    assert len(samples) == 2
+
+    gt_keys = [
+        "instance_image",
+        "instance",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "instance_bbox",
+        "centroid",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["instance_image"].shape == (1, 1, 226, 226)
+    assert samples[0]["instance"].shape == (1, 2, 2)
+
+    # test `is_rgb`
+    config.data_config.preprocessing.scale = 1.0
+    config.data_config.preprocessing.is_rgb = True
+    samples = []
+    for idx, lf in enumerate(labels):
+        res = centered_instance_data_chunks(
+            (lf, idx),
+            data_config=config.data_config,
+            anchor_ind=0,
+            crop_size=(160, 160),
+            max_instances=2,
+        )
+        samples.extend(res)
+
+    gt_keys = [
+        "instance_image",
+        "instance",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "instance_bbox",
+        "centroid",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["instance_image"].shape == (1, 3, 226, 226)
+    assert samples[0]["instance"].shape == (1, 2, 2)
+
+
+def test_centroid_data_chunks(minimal_instance, config):
+    """Test `centroid_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            centroid_data_chunks(
+                (lf, idx),
+                data_config=config.data_config,
+                max_instances=4,
+                anchor_ind=0,
+            )
+        )
+
+    assert len(samples) == 1
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "centroids",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 1, 384, 384)
+    assert samples[0]["instances"].shape == (1, 4, 2, 2)
+    assert samples[0]["centroids"].shape == (1, 4, 2)
+
+    # test  `is_rgb`
+    samples = []
+    config.data_config.preprocessing.is_rgb = True
+    for idx, lf in enumerate(labels):
+        samples.append(
+            centroid_data_chunks(
+                (lf, idx),
+                data_config=config.data_config,
+                max_instances=2,
+                anchor_ind=0,
+            )
+        )
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+        "centroids",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 3, 384, 384)
+    assert samples[0]["instances"].shape == (1, 2, 2, 2)
+    assert samples[0]["centroids"].shape == (1, 2, 2)
+
+
+def test_single_instance_data_chunks(minimal_instance, config):
+    """Test `single_instance_data_chunks` function."""
+    labels = sio.load_slp(minimal_instance)
+    # Making our minimal 2-instance example into a single instance example.
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            single_instance_data_chunks((lf, idx), data_config=config.data_config)
+        )
+
+    assert len(samples) == 1
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 1, 384, 384)
+    assert samples[0]["instances"].shape == (1, 1, 2, 2)
+
+    # test `is_rgb`
+    config.data_config.preprocessing.is_rgb = True
+    samples = []
+    for idx, lf in enumerate(labels):
+        samples.append(
+            single_instance_data_chunks((lf, idx), data_config=config.data_config)
+        )
+
+    gt_keys = [
+        "image",
+        "instances",
+        "frame_idx",
+        "video_idx",
+        "num_instances",
+        "orig_size",
+    ]
+    for k in gt_keys:
+        assert k in samples[0]
+
+    assert samples[0]["image"].shape == (1, 3, 384, 384)
+    assert samples[0]["instances"].shape == (1, 1, 2, 2)

--- a/tests/data/test_instance_cropping.py
+++ b/tests/data/test_instance_cropping.py
@@ -8,7 +8,7 @@ from sleap_nn.data.instance_cropping import (
     generate_crops,
     make_centered_bboxes,
 )
-from sleap_nn.data.normalization import Normalizer
+from sleap_nn.data.normalization import Normalizer, apply_normalization
 from sleap_nn.data.resizing import SizeMatcher, Resizer, PadToStride
 from sleap_nn.data.providers import LabelsReader, process_lf
 
@@ -91,6 +91,7 @@ def test_generate_crops(minimal_instance):
     labels = sio.load_slp(minimal_instance)
     lf = labels[0]
     ex = process_lf(lf, 0, 2)
+    ex["image"] = apply_normalization(ex["image"])
 
     centroids = generate_centroids(ex["instances"], 0)
     cropped_ex = generate_crops(

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -101,3 +101,4 @@ def test_process_lf(minimal_instance):
     assert ex["image"].shape == torch.Size([1, 1, 384, 384])
     assert ex["instances"].shape == torch.Size([1, 4, 2, 2])
     assert torch.isnan(ex["instances"][:, 2:, :, :]).all()
+    assert not torch.is_floating_point(ex["image"])

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -1,0 +1,246 @@
+from pathlib import Path
+from omegaconf import DictConfig
+import functools
+import litdata as ld
+import shutil
+import sleap_io as sio
+from sleap_nn.data.get_data_chunks import (
+    bottomup_data_chunks,
+    centered_instance_data_chunks,
+    centroid_data_chunks,
+    single_instance_data_chunks,
+)
+from sleap_nn.data.streaming_datasets import (
+    BottomUpStreamingDataset,
+    CenteredInstanceStreamingDataset,
+    CentroidStreamingDataset,
+    SingleInstanceStreamingDataset,
+)
+
+
+def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test BottomUpStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+    edge_inds = labels.skeletons[0].edge_inds
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        bottomup_data_chunks, data_config=config.data_config, max_instances=2
+    )
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+        pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+
+        dataset = BottomUpStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            pafs_head=pafs_head,
+            edge_inds=edge_inds,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+        assert samples[0]["part_affinity_fields"].shape == (50, 50, 2)
+
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = BottomUpStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            pafs_head=pafs_head,
+            edge_inds=edge_inds,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+            apply_aug=True,
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+        assert samples[0]["part_affinity_fields"].shape == (75, 75, 2)
+
+    finally:
+        shutil.rmtree(dir_path)
+
+
+def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test CenteredInstanceStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        centered_instance_data_chunks,
+        data_config=config.data_config,
+        max_instances=2,
+        crop_size=(160, 160),
+        anchor_ind=0,
+    )
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+        dataset = CenteredInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            crop_hw=(160, 160),
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 2
+
+        assert samples[0]["instance_image"].shape == (1, 1, 100, 100)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 50, 50)
+
+    finally:
+        shutil.rmtree(dir_path)
+
+
+def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test CentroidStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        centroid_data_chunks,
+        data_config=config.data_config,
+        max_instances=2,
+        anchor_ind=0,
+    )
+
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+        dataset = CentroidStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["centroids_confidence_maps"].shape == (1, 1, 100, 100)
+
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = CentroidStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+            apply_aug=True,
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["centroids_confidence_maps"].shape == (1, 1, 150, 150)
+
+    finally:
+        shutil.rmtree(dir_path)
+
+
+def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
+    """Test SingleInstanceStreamingDataset class."""
+    labels = sio.load_slp(minimal_instance)
+
+    dir_path = Path(sleap_data_dir) / "data_chunks"
+
+    partial_func = functools.partial(
+        single_instance_data_chunks,
+        data_config=config.data_config,
+    )
+
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+    ld.optimize(
+        fn=partial_func,
+        inputs=[(x, labels.videos.index(x.video)) for x in labels],
+        output_dir=str(dir_path),
+        chunk_size=4,
+    )
+
+    try:
+
+        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+        dataset = SingleInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            confmap_head=confmap_head,
+            max_stride=100,
+            scale=0.5,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 200, 200)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+
+        # test with random crop
+        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
+        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
+        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
+        dataset = SingleInstanceStreamingDataset(
+            augmentation_config=config.data_config.augmentation_config,
+            apply_aug=True,
+            confmap_head=confmap_head,
+            max_stride=2,
+            scale=1.0,
+            input_dir=str(dir_path),
+        )
+
+        samples = list(iter(dataset))
+        assert len(samples) == 1
+
+        assert samples[0]["image"].shape == (1, 1, 300, 300)
+        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
+
+    finally:
+        shutil.rmtree(dir_path)

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -60,6 +60,9 @@ def config(sleap_data_dir):
                 },
                 "use_augmentations_train": True,
                 "augmentation_config": {
+                    "intensity": {
+                        "contrast_p": 1.0,
+                    },
                     "geometric": {
                         "rotation": 180.0,
                         "scale": None,


### PR DESCRIPTION
This is the second PR for https://github.com/talmolab/sleap-nn/issues/80. Here, we implement the get_chunks() method for each model pipeline. This method handles all the data preprocessing functions (except augmentation, resizing, padding to stride and confidence map (or pafs) generation) to extract dictionaries from .slp file and save them as .bin files.