### PR TITLE
Move ld.optimize to a subprocess

### DIFF
--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -179,11 +179,11 @@ class Model(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the model."""
-        if self.input_expand_channels != 1:
-            input_list = []
-            for _ in range(self.input_expand_channels):
-                input_list.append(x)
-            x = torch.concatenate(input_list, dim=-3)
+        # if self.input_expand_channels != 1:
+        #     input_list = []
+        #     for _ in range(self.input_expand_channels):
+        #         input_list.append(x)
+        #     x = torch.concatenate(input_list, dim=-3)
         backbone_outputs = self.backbone(x)
 
         outputs = {}

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -179,11 +179,6 @@ class Model(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the model."""
-        # if self.input_expand_channels != 1:
-        #     input_list = []
-        #     for _ in range(self.input_expand_channels):
-        #         input_list.append(x)
-        #     x = torch.concatenate(input_list, dim=-3)
         backbone_outputs = self.backbone(x)
 
         outputs = {}

--- a/sleap_nn/training/get_bin_files.py
+++ b/sleap_nn/training/get_bin_files.py
@@ -1,0 +1,142 @@
+"""Function to generate `.bin` files."""
+
+import argparse
+import functools
+import litdata as ld
+from pathlib import Path
+from omegaconf import OmegaConf
+import sleap_io as sio
+
+from sleap_nn.data.providers import get_max_instances
+from sleap_nn.data.get_data_chunks import (
+    bottomup_data_chunks,
+    centered_instance_data_chunks,
+    centroid_data_chunks,
+    single_instance_data_chunks,
+)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dir_path", type=str)
+    parser.add_argument("--user_instances_only", type=str)
+    parser.add_argument("--model_type", type=str)
+    parser.add_argument("--num_workers", type=int)
+    parser.add_argument("--chunk_size", type=int)
+    parser.add_argument("--crop_hw", type=int, default=None)
+    args = parser.parse_args()
+
+    config = OmegaConf.load(f"{args.dir_path}/initial_config.yaml")
+
+    train_labels = sio.load_slp(config.data_config.train_labels_path)
+    val_labels = sio.load_slp(config.data_config.val_labels_path)
+    user_instances_only = False if args.user_instances_only == 0 else True
+
+    max_stride = config.model_config.backbone_config.max_stride
+    max_instances = get_max_instances(train_labels)
+
+    print("Starting data-chunk generation...")
+
+    if args.model_type == "single_instance":
+
+        factory_get_chunks = functools.partial(
+            single_instance_data_chunks,
+            data_config=config.data_config,
+            user_instances_only=user_instances_only,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, train_labels.videos.index(x.video)) for x in train_labels],
+            output_dir=(Path(args.dir_path) / "train_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, val_labels.videos.index(x.video)) for x in val_labels],
+            output_dir=(Path(args.dir_path) / "val_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+    elif args.model_type == "centered_instance":
+
+        factory_get_chunks = functools.partial(
+            centered_instance_data_chunks,
+            data_config=config.data_config,
+            max_instances=max_instances,
+            crop_size=(args.crop_hw, args.crop_hw),
+            anchor_ind=config.model_config.head_configs.centered_instance.confmaps.anchor_part,
+            user_instances_only=user_instances_only,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, train_labels.videos.index(x.video)) for x in train_labels],
+            output_dir=(Path(args.dir_path) / "train_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, val_labels.videos.index(x.video)) for x in val_labels],
+            output_dir=(Path(args.dir_path) / "val_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+    elif args.model_type == "centroid":
+        factory_get_chunks = functools.partial(
+            centroid_data_chunks,
+            data_config=config.data_config,
+            max_instances=max_instances,
+            anchor_ind=config.model_config.head_configs.centroid.confmaps.anchor_part,
+            user_instances_only=user_instances_only,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, train_labels.videos.index(x.video)) for x in train_labels],
+            output_dir=(Path(args.dir_path) / "train_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, val_labels.videos.index(x.video)) for x in val_labels],
+            output_dir=(Path(args.dir_path) / "val_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+    elif args.model_type == "bottomup":
+        factory_get_chunks = functools.partial(
+            bottomup_data_chunks,
+            data_config=config.data_config,
+            max_instances=max_instances,
+            user_instances_only=user_instances_only,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, train_labels.videos.index(x.video)) for x in train_labels],
+            output_dir=(Path(args.dir_path) / "train_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+        ld.optimize(
+            fn=factory_get_chunks,
+            inputs=[(x, val_labels.videos.index(x.video)) for x in val_labels],
+            output_dir=(Path(args.dir_path) / "val_chunks").as_posix(),
+            num_workers=args.num_workers,
+            chunk_size=args.chunk_size,
+        )
+
+    else:
+        raise ValueError(
+            f"{args.model_type} is not defined. Please choose one of `single_instance`, `centered_instance`, `centroid`, `bottomup`."
+        )

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -89,7 +89,7 @@ class ModelTrainer:
         self.model = None
         self.train_data_loader = None
         self.val_data_loader = None
-        self.crop_hw = None
+        self.crop_hw = -1
 
         # check which head type to choose the model
         for k, v in self.config.model_config.head_configs.items():

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -154,14 +154,13 @@ class ModelTrainer:
 
     def _create_data_loaders(self):
         """Create a DataLoader for train, validation and test sets using the data_config."""
-        with open(f"{self.dir_path}/get_bin_files.py", "w") as file:
-            file.write(inspect.getsource(get_bin_files))
 
         def run_subprocess():
             process = subprocess.Popen(
                 [
                     "python",
-                    f"{self.dir_path}/get_bin_files.py",
+                    "-m",
+                    f"sleap_nn.training.get_bin_files",
                     "--dir_path",
                     f"{self.dir_path}",
                     "--user_instances_only",
@@ -448,7 +447,6 @@ class ModelTrainer:
             #         (Path(self.dir_path) / "val_chunks").as_posix(),
             #         ignore_errors=True,
             #     )
-            # TODO: delete .py file
 
 
 class TrainingModel(L.LightningModule):

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -323,12 +323,13 @@ def test_topdown_centered_instance_model(config, tmp_path: str):
     OmegaConf.update(
         config, "model_config.pre_trained_weights", "ConvNeXt_Tiny_Weights"
     )
+    OmegaConf.update(config, "data_config.preprocessing.is_rgb", True)
     OmegaConf.update(config, "model_config.backbone_type", "convnext")
     OmegaConf.update(
         config,
         "model_config.backbone_config",
         {
-            "in_channels": 1,
+            "in_channels": 3,
             "model_type": "tiny",
             "arch": None,
             "kernel_size": 3,


### PR DESCRIPTION
This PR moves the data chunk generation (ld.optimize) to a subprocess to enable training in jupyter notebooks. currently, we're not able to train the model in a jupyter notebook directly (trainer.train()) as the ld.optimize should be exposed to main to handle the multi-processing processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a command-line interface for generating binary files tailored to specific model types.
	- Enhanced the `ModelTrainer` class with improved data processing and model initialization logic.

- **Bug Fixes**
	- Improved handling of input channel expansion in model processing.

- **Tests**
	- Added and modified tests to validate model behavior, checkpoint existence, and training metrics.
	- Enhanced error handling and assertions for training steps.

- **Chores**
	- Implemented cleanup operations in tests to maintain a consistent testing environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->