### PR TITLE
Auto compute max height and width from labels

### DIFF
--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -146,10 +146,12 @@ class Model(nn.Module):
         self.head_layers = nn.ModuleList([])
         for head in self.heads:
             in_channels = int(
-                self.backbone.max_channels
-                / (
-                    self.backbone_config.filters_rate
-                    ** len(self.backbone.dec.decoder_stack)
+                round(
+                    self.backbone.max_channels
+                    / (
+                        self.backbone_config.filters_rate
+                        ** len(self.backbone.dec.decoder_stack)
+                    )
                 )
             )
             if head.output_stride != min_output_stride:

--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -65,11 +65,12 @@ def bottomup_data_chunks(
         data_config.preprocessing.max_height,
         data_config.preprocessing.max_width,
     )
-    sample["image"] = apply_sizematcher(
+    sample["image"], eff_scale = apply_sizematcher(
         sample["image"],
         max_height=max_height if max_height is not None else max_hw[0],
         max_width=max_width if max_width is not None else max_hw[1],
     )
+    sample["instances"] = sample["instances"] * eff_scale
 
     return sample
 
@@ -128,11 +129,12 @@ def centered_instance_data_chunks(
         data_config.preprocessing.max_height,
         data_config.preprocessing.max_width,
     )
-    sample["image"] = apply_sizematcher(
+    sample["image"], eff_scale = apply_sizematcher(
         sample["image"],
         max_height=max_height if max_height is not None else max_hw[0],
         max_width=max_width if max_width is not None else max_hw[1],
     )
+    sample["instances"] = sample["instances"] * eff_scale
 
     # get the centroids based on the anchor idx
     centroids = generate_centroids(sample["instances"], anchor_ind=anchor_ind)
@@ -208,11 +210,13 @@ def centroid_data_chunks(
         data_config.preprocessing.max_height,
         data_config.preprocessing.max_width,
     )
-    sample["image"] = apply_sizematcher(
+    sample["image"], eff_scale = apply_sizematcher(
         sample["image"],
         max_height=max_height if max_height is not None else max_hw[0],
         max_width=max_width if max_width is not None else max_hw[1],
     )
+
+    sample["instances"] = sample["instances"] * eff_scale
 
     # get the centroids based on the anchor idx
     centroids = generate_centroids(sample["instances"], anchor_ind=anchor_ind)
@@ -270,10 +274,11 @@ def single_instance_data_chunks(
         data_config.preprocessing.max_height,
         data_config.preprocessing.max_width,
     )
-    sample["image"] = apply_sizematcher(
+    sample["image"], eff_scale = apply_sizematcher(
         sample["image"],
         max_height=max_height if max_height is not None else max_hw[0],
         max_width=max_width if max_width is not None else max_hw[1],
     )
+    sample["instances"] = sample["instances"] * eff_scale
 
     return sample

--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -21,6 +21,7 @@ def bottomup_data_chunks(
     x: Tuple[sio.LabeledFrame, int],
     data_config: DictConfig,
     max_instances: int,
+    max_hw: Tuple[int, int],
     user_instances_only: bool = True,
 ) -> Dict[str, torch.Tensor]:
     """Generate dict from `sio.LabeledFrame`.
@@ -35,6 +36,10 @@ def bottomup_data_chunks(
             index of lf.video in the source sio.labels.videos.
         data_config: Data-related configuration. (`data_config` section in the config file)
         max_instances: Maximum number of instances that could occur in a single LabeledFrame.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
         user_instances_only: True if filter labels only to user instances else False.
             Default: True.
 
@@ -56,10 +61,14 @@ def bottomup_data_chunks(
         sample["image"] = convert_to_grayscale(sample["image"])
 
     # size matcher
+    max_height, max_width = (
+        data_config.preprocessing.max_height,
+        data_config.preprocessing.max_width,
+    )
     sample["image"] = apply_sizematcher(
         sample["image"],
-        max_height=data_config.preprocessing.max_height,
-        max_width=data_config.preprocessing.max_width,
+        max_height=max_height if max_height is not None else max_hw[0],
+        max_width=max_width if max_width is not None else max_hw[1],
     )
 
     return sample
@@ -71,6 +80,7 @@ def centered_instance_data_chunks(
     max_instances: int,
     crop_size: Tuple[int],
     anchor_ind: Optional[int],
+    max_hw: Tuple[int, int],
     user_instances_only: bool = True,
 ) -> Iterator[Dict[str, torch.Tensor]]:
     """Generate dict from `sio.LabeledFrame`.
@@ -89,6 +99,10 @@ def centered_instance_data_chunks(
         anchor_ind: The index of the node to use as the anchor for the centroid. If not
             provided or if not present in the instance, the midpoint of the bounding box
             is used instead.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
         user_instances_only: True if filter labels only to user instances else False.
             Default: True.
 
@@ -110,10 +124,14 @@ def centered_instance_data_chunks(
         sample["image"] = convert_to_grayscale(sample["image"])
 
     # size matcher
+    max_height, max_width = (
+        data_config.preprocessing.max_height,
+        data_config.preprocessing.max_width,
+    )
     sample["image"] = apply_sizematcher(
         sample["image"],
-        max_height=data_config.preprocessing.max_height,
-        max_width=data_config.preprocessing.max_width,
+        max_height=max_height if max_height is not None else max_hw[0],
+        max_width=max_width if max_width is not None else max_hw[1],
     )
 
     # get the centroids based on the anchor idx
@@ -143,6 +161,7 @@ def centroid_data_chunks(
     data_config: DictConfig,
     max_instances: int,
     anchor_ind: Optional[int],
+    max_hw: Tuple[int, int],
     user_instances_only: bool = True,
 ) -> Dict[str, torch.Tensor]:
     """Generate dict from `sio.LabeledFrame`.
@@ -160,6 +179,10 @@ def centroid_data_chunks(
         anchor_ind: The index of the node to use as the anchor for the centroid. If not
             provided or if not present in the instance, the midpoint of the bounding box
             is used instead.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
         user_instances_only: True if filter labels only to user instances else False.
             Default: True.
 
@@ -181,10 +204,14 @@ def centroid_data_chunks(
         sample["image"] = convert_to_grayscale(sample["image"])
 
     # size matcher
+    max_height, max_width = (
+        data_config.preprocessing.max_height,
+        data_config.preprocessing.max_width,
+    )
     sample["image"] = apply_sizematcher(
         sample["image"],
-        max_height=data_config.preprocessing.max_height,
-        max_width=data_config.preprocessing.max_width,
+        max_height=max_height if max_height is not None else max_hw[0],
+        max_width=max_width if max_width is not None else max_hw[1],
     )
 
     # get the centroids based on the anchor idx
@@ -198,6 +225,7 @@ def centroid_data_chunks(
 def single_instance_data_chunks(
     x: Tuple[sio.LabeledFrame, int],
     data_config: DictConfig,
+    max_hw: Tuple[int, int],
     user_instances_only: bool = True,
 ) -> Dict[str, torch.Tensor]:
     """Generate dict from `sio.LabeledFrame`.
@@ -210,7 +238,11 @@ def single_instance_data_chunks(
     Args:
         x: Tuple (lf, video_idx) where lf is a `sio.LabeledFrame` and video_idx is the
             index of lf.video in the source sio.labels.videos.
-        data_config: Data-related configuration. (`data_config` section in the config file)
+        data_config: Data-related configuration. (`data_config` section in the config file).
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
         user_instances_only: True if filter labels only to user instances else False.
             Default: True.
 
@@ -234,10 +266,14 @@ def single_instance_data_chunks(
         sample["image"] = convert_to_grayscale(sample["image"])
 
     # size matcher
+    max_height, max_width = (
+        data_config.preprocessing.max_height,
+        data_config.preprocessing.max_width,
+    )
     sample["image"] = apply_sizematcher(
         sample["image"],
-        max_height=data_config.preprocessing.max_height,
-        max_width=data_config.preprocessing.max_width,
+        max_height=max_height if max_height is not None else max_hw[0],
+        max_width=max_width if max_width is not None else max_hw[1],
     )
 
     return sample

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -28,6 +28,13 @@ def get_max_instances(labels: sio.Labels):
     return max_instances
 
 
+def get_max_height_width(labels: sio.Labels) -> Tuple[int, int]:
+    """Return `(height, width)` that is the maximum of all videos."""
+    return max(video.shape[1] for video in labels.videos), max(
+        video.shape[2] for video in labels.videos
+    )
+
+
 def process_lf(
     lf: sio.LabeledFrame,
     video_idx: int,

--- a/sleap_nn/data/resizing.py
+++ b/sleap_nn/data/resizing.py
@@ -108,30 +108,48 @@ def apply_sizematcher(
     max_height: Optional[int] = None,
     max_width: Optional[int] = None,
 ):
-    """Apply padding to smaller image to (max_height, max_width) shape."""
+    """Apply scaling and padding to smaller image to (max_height, max_width) shape."""
     img_height, img_width = image.shape[-2:]
     # pad images to max_height and max_width
     if max_height is None:
         max_height = img_height
     if max_width is None:
         max_width = img_width
-    pad_height = max_height - img_height
-    pad_width = max_width - img_width
-    if pad_height < 0:
+    if img_height > max_height:
         raise ValueError(
             f"Max height {max_height} should be greater than the current image height: {img_height}"
         )
-    if pad_width < 0:
+    if img_width > max_width:
         raise ValueError(
             f"Max width {max_width} should be greater than the current image width: {img_width}"
         )
-    image = F.pad(
-        image,
-        (0, pad_width, 0, pad_height),
-        mode="constant",
-    ).to(torch.float32)
+    if img_height < max_height or img_width < max_width:
+        hratio = max_height / img_height
+        wratio = max_width / img_width
 
-    return image
+        if hratio > wratio:
+            eff_scale_ratio = wratio
+            target_h = int(round(img_height * wratio))
+            target_w = int(round(img_width * wratio))
+        else:
+            eff_scale_ratio = hratio
+            target_w = int(round(img_width * hratio))
+            target_h = int(round(img_height * hratio))
+
+        image = tvf.resize(image, size=(target_h, target_w))
+
+        pad_height = max_height - target_h
+        pad_width = max_width - target_w
+
+        image = F.pad(
+            image,
+            (0, pad_width, 0, pad_height),
+            mode="constant",
+        ).to(torch.float32)
+
+        return image, eff_scale_ratio
+    else:
+        return image, 1
 
 
 class Resizer(IterDataPipe):

--- a/sleap_nn/training/get_bin_files.py
+++ b/sleap_nn/training/get_bin_files.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from omegaconf import OmegaConf
 import sleap_io as sio
 
-from sleap_nn.data.providers import get_max_instances
+from sleap_nn.data.providers import get_max_instances, get_max_height_width
 from sleap_nn.data.get_data_chunks import (
     bottomup_data_chunks,
     centered_instance_data_chunks,
@@ -28,6 +28,7 @@ if __name__ == "__main__":
     config = OmegaConf.load(f"{args.dir_path}/initial_config.yaml")
 
     train_labels = sio.load_slp(config.data_config.train_labels_path)
+    max_height, max_width = get_max_height_width(train_labels)
     val_labels = sio.load_slp(config.data_config.val_labels_path)
     user_instances_only = False if args.user_instances_only == 0 else True
 
@@ -42,6 +43,7 @@ if __name__ == "__main__":
             single_instance_data_chunks,
             data_config=config.data_config,
             user_instances_only=user_instances_only,
+            max_hw=(max_height, max_width),
         )
 
         ld.optimize(
@@ -69,6 +71,7 @@ if __name__ == "__main__":
             crop_size=(args.crop_hw, args.crop_hw),
             anchor_ind=config.model_config.head_configs.centered_instance.confmaps.anchor_part,
             user_instances_only=user_instances_only,
+            max_hw=(max_height, max_width),
         )
 
         ld.optimize(
@@ -94,6 +97,7 @@ if __name__ == "__main__":
             max_instances=max_instances,
             anchor_ind=config.model_config.head_configs.centroid.confmaps.anchor_part,
             user_instances_only=user_instances_only,
+            max_hw=(max_height, max_width),
         )
 
         ld.optimize(
@@ -118,6 +122,7 @@ if __name__ == "__main__":
             data_config=config.data_config,
             max_instances=max_instances,
             user_instances_only=user_instances_only,
+            max_hw=(max_height, max_width),
         )
 
         ld.optimize(

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -41,7 +41,7 @@ import sleap_io as sio
 from sleap_nn.architectures.model import Model
 from sleap_nn.data.cycler import CyclerIterDataPipe as Cycler
 from sleap_nn.data.instance_cropping import find_instance_crop_size
-from sleap_nn.data.providers import get_max_instances
+from sleap_nn.data.providers import get_max_height_width
 from sleap_nn.data.get_data_chunks import (
     bottomup_data_chunks,
     centered_instance_data_chunks,
@@ -131,6 +131,14 @@ class ModelTrainer:
             and self.config.data_config.chunk_size is not None
             else 100
         )
+
+        max_height, max_width = get_max_height_width(train_labels)
+        if (
+            self.config.data_config.preprocessing.max_height is None
+            and self.config.data_config.preprocessing.max_width is None
+        ):
+            self.config.data_config.preprocessing.max_height = max_height
+            self.config.data_config.preprocessing.max_width = max_width
 
         if self.model_type == "centered_instance":
             # compute crop size

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -157,6 +157,10 @@ class ModelTrainer:
                     min_crop_size=min_crop_size,
                 )
                 self.crop_hw = crop_size
+                self.config.data_config.preprocessing.crop_hw = (
+                    self.crop_hw,
+                    self.crop_hw,
+                )
             else:
                 self.crop_hw = self.crop_hw[0]
 
@@ -222,7 +226,6 @@ class ModelTrainer:
             )
 
         elif self.model_type == "centered_instance":
-            self.config.data_config.preprocessing.crop_hw = (self.crop_hw, self.crop_hw)
 
             train_dataset = CenteredInstanceStreamingDataset(
                 input_dir=(Path(self.dir_path) / "train_chunks").as_posix(),

--- a/tests/data/test_get_data_chunks.py
+++ b/tests/data/test_get_data_chunks.py
@@ -7,15 +7,21 @@ from sleap_nn.data.get_data_chunks import (
     single_instance_data_chunks,
 )
 
+from sleap_nn.data.providers import get_max_height_width
+
 
 def test_bottomup_data_chunks(minimal_instance, config):
     """Test `bottomup_data_chunks` function."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
     samples = []
     for idx, lf in enumerate(labels):
         samples.append(
             bottomup_data_chunks(
-                (lf, idx), data_config=config.data_config, max_instances=4
+                (lf, idx),
+                data_config=config.data_config,
+                max_instances=4,
+                max_hw=max_hw,
             )
         )
 
@@ -44,6 +50,7 @@ def test_bottomup_data_chunks(minimal_instance, config):
                 (lf, idx),
                 data_config=config.data_config,
                 max_instances=2,
+                max_hw=max_hw,
             )
         )
 
@@ -65,6 +72,7 @@ def test_bottomup_data_chunks(minimal_instance, config):
 def test_centered_instance_data_chunks(minimal_instance, config):
     """Test `centered_instance_data_chunks` function."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
     samples = []
     for idx, lf in enumerate(labels):
         res = centered_instance_data_chunks(
@@ -73,6 +81,7 @@ def test_centered_instance_data_chunks(minimal_instance, config):
             anchor_ind=0,
             crop_size=(160, 160),
             max_instances=4,
+            max_hw=max_hw,
         )
         samples.extend(res)
 
@@ -105,6 +114,7 @@ def test_centered_instance_data_chunks(minimal_instance, config):
             anchor_ind=0,
             crop_size=(160, 160),
             max_instances=2,
+            max_hw=max_hw,
         )
         samples.extend(res)
 
@@ -128,6 +138,7 @@ def test_centered_instance_data_chunks(minimal_instance, config):
 def test_centroid_data_chunks(minimal_instance, config):
     """Test `centroid_data_chunks` function."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
     samples = []
     for idx, lf in enumerate(labels):
         samples.append(
@@ -136,6 +147,7 @@ def test_centroid_data_chunks(minimal_instance, config):
                 data_config=config.data_config,
                 max_instances=4,
                 anchor_ind=0,
+                max_hw=max_hw,
             )
         )
 
@@ -167,6 +179,7 @@ def test_centroid_data_chunks(minimal_instance, config):
                 data_config=config.data_config,
                 max_instances=2,
                 anchor_ind=0,
+                max_hw=max_hw,
             )
         )
 
@@ -190,6 +203,7 @@ def test_centroid_data_chunks(minimal_instance, config):
 def test_single_instance_data_chunks(minimal_instance, config):
     """Test `single_instance_data_chunks` function."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
     # Making our minimal 2-instance example into a single instance example.
     for lf in labels:
         lf.instances = lf.instances[:1]
@@ -197,7 +211,9 @@ def test_single_instance_data_chunks(minimal_instance, config):
     samples = []
     for idx, lf in enumerate(labels):
         samples.append(
-            single_instance_data_chunks((lf, idx), data_config=config.data_config)
+            single_instance_data_chunks(
+                (lf, idx), data_config=config.data_config, max_hw=max_hw
+            )
         )
 
     assert len(samples) == 1
@@ -221,7 +237,9 @@ def test_single_instance_data_chunks(minimal_instance, config):
     samples = []
     for idx, lf in enumerate(labels):
         samples.append(
-            single_instance_data_chunks((lf, idx), data_config=config.data_config)
+            single_instance_data_chunks(
+                (lf, idx), data_config=config.data_config, max_hw=max_hw
+            )
         )
 
     gt_keys = [

--- a/tests/data/test_resizing.py
+++ b/tests/data/test_resizing.py
@@ -115,6 +115,9 @@ def test_apply_sizematcher(minimal_instance):
     image, _ = apply_sizematcher(ex["image"], 500, 500)
     assert image.shape == torch.Size([1, 1, 500, 500])
 
+    image, _ = apply_sizematcher(ex["image"], 700, 600)
+    assert image.shape == torch.Size([1, 1, 700, 600])
+
     image, _ = apply_sizematcher(ex["image"])
     assert image.shape == torch.Size([1, 1, 384, 384])
 

--- a/tests/data/test_resizing.py
+++ b/tests/data/test_resizing.py
@@ -112,10 +112,10 @@ def test_apply_sizematcher(minimal_instance):
     lf = labels[0]
     ex = process_lf(lf, 0, 2)
 
-    image = apply_sizematcher(ex["image"], 500, 500)
+    image, _ = apply_sizematcher(ex["image"], 500, 500)
     assert image.shape == torch.Size([1, 1, 500, 500])
 
-    image = apply_sizematcher(ex["image"])
+    image, _ = apply_sizematcher(ex["image"])
     assert image.shape == torch.Size([1, 1, 384, 384])
 
     with pytest.raises(

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -10,6 +10,7 @@ from sleap_nn.data.get_data_chunks import (
     centroid_data_chunks,
     single_instance_data_chunks,
 )
+from sleap_nn.data.providers import get_max_height_width
 from sleap_nn.data.streaming_datasets import (
     BottomUpStreamingDataset,
     CenteredInstanceStreamingDataset,
@@ -21,12 +22,16 @@ from sleap_nn.data.streaming_datasets import (
 def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
     """Test BottomUpStreamingDataset class."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
     edge_inds = labels.skeletons[0].edge_inds
 
     dir_path = Path(sleap_data_dir) / "data_chunks"
 
     partial_func = functools.partial(
-        bottomup_data_chunks, data_config=config.data_config, max_instances=2
+        bottomup_data_chunks,
+        data_config=config.data_config,
+        max_instances=2,
+        max_hw=max_hw,
     )
     ld.optimize(
         fn=partial_func,
@@ -85,6 +90,7 @@ def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
 def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
     """Test CenteredInstanceStreamingDataset class."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
 
     dir_path = Path(sleap_data_dir) / "data_chunks"
 
@@ -94,6 +100,7 @@ def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, c
         max_instances=2,
         crop_size=(160, 160),
         anchor_ind=0,
+        max_hw=max_hw,
     )
     ld.optimize(
         fn=partial_func,
@@ -127,6 +134,7 @@ def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, c
 def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
     """Test CentroidStreamingDataset class."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
 
     dir_path = Path(sleap_data_dir) / "data_chunks"
 
@@ -135,6 +143,7 @@ def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
         data_config=config.data_config,
         max_instances=2,
         anchor_ind=0,
+        max_hw=max_hw,
     )
 
     ld.optimize(
@@ -188,12 +197,12 @@ def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
 def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
     """Test SingleInstanceStreamingDataset class."""
     labels = sio.load_slp(minimal_instance)
+    max_hw = get_max_height_width(labels)
 
     dir_path = Path(sleap_data_dir) / "data_chunks"
 
     partial_func = functools.partial(
-        single_instance_data_chunks,
-        data_config=config.data_config,
+        single_instance_data_chunks, data_config=config.data_config, max_hw=max_hw
     )
 
     for lf in labels:


### PR DESCRIPTION
This PR adds the functionality to compute the maximum height and width of images across the labels file based on which the images are padded to ensure the image shapes are consistent across the dataset. Previously, users were required to provide the max height and width in the config (`data_config.preprocessing`). If these fields are `None`, then the images wouldn't be padded even if the dimensions were inconsistent.

With this PR, if the `max_height` and `max_width` provided by the user in the config are `None`, the data pipeline computes these automatically from the labels file, which are then used for padding. If values are explicitly set in the config, the user-defined values will take precedence over the computed ones.