### PR TITLE
Delete `.bin` files after training

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -161,7 +161,7 @@ The config file has three main sections:
     - `use_wandb`: (bool) True to enable wandb logging.
     - `save_ckpt`: (bool) True to enable checkpointing. 
     - `save_ckpt_path`: (str) Directory path to save the training config and checkpoint files. *Default*: "./"
-    - `bin_files_path`: (str) Temp directory to save the `.bin` files while training. This dir need not be unique for each model as this creates a unique sub-folder with timestamp (`<bin_files_path>/chunks_<timestamp>`) in the specified directory. If `None`, it uses the `save_ckpt_path`.
+    - `bin_files_path`: (str) Temp directory to save the `.bin` files while training. This dir need not be unique for each model as this creates a unique sub-folder with timestamp (`<bin_files_path>/chunks_<timestamp>`) in the specified directory, which is then deleted once the training is done. If `None`, it uses the `save_ckpt_path`.
     - `resume_ckpt_path`: (str) Path to `.ckpt` file from which training is resumed. *Default*: `None`.
     - `wandb`: (Only if `use_wandb` is `True`, else skip this)
         - `entity`: (str) Entity of wandb project.

--- a/initial_config.yaml
+++ b/initial_config.yaml
@@ -1,0 +1,99 @@
+data_config:
+  provider: LabelsReaderDP
+  train_labels_path: C:\Users\TalmoLab\Desktop\Divya\sleap-nn\tests\assets/minimal_instance.pkg.slp
+  val_labels_path: C:\Users\TalmoLab\Desktop\Divya\sleap-nn\tests\assets/minimal_instance.pkg.slp
+  preprocessing:
+    is_rgb: false
+    max_width: null
+    max_height: null
+    scale: 1.0
+    crop_hw:
+    - 160
+    - 160
+  use_augmentations_train: true
+  augmentation_config:
+    intensity:
+      contrast_p: 1.0
+    geometric:
+      rotation: 180.0
+      scale: null
+      translate_width: 0
+      translate_height: 0
+      affine_p: 0.5
+model_config:
+  init_weights: default
+  pre_trained_weights: null
+  backbone_type: unet
+  backbone_config:
+    in_channels: 1
+    kernel_size: 3
+    filters: 16
+    filters_rate: 1.5
+    max_stride: 8
+    convs_per_block: 2
+    stacks: 1
+    stem_stride: null
+    middle_block: true
+    up_interpolate: true
+  head_configs:
+    single_instance: null
+    centroid: null
+    bottomup: null
+    centered_instance:
+      confmaps:
+        part_names:
+        - '0'
+        - '1'
+        anchor_part: 1
+        sigma: 1.5
+        output_stride: 2
+trainer_config:
+  train_data_loader:
+    batch_size: 1
+    shuffle: true
+    num_workers: 2
+  val_data_loader:
+    batch_size: 1
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: true
+  early_stopping:
+    stop_training_on_plateau: true
+    min_delta: 1.0e-08
+    patience: 20
+  trainer_devices: 1
+  trainer_accelerator: cpu
+  enable_progress_bar: false
+  steps_per_epoch: null
+  max_epochs: 2
+  seed: 1000
+  use_wandb: false
+  save_ckpt: false
+  save_ckpt_path: null
+  bin_files_path: null
+  resume_ckpt_path: null
+  wandb:
+    entity: null
+    project: test
+    name: test_run
+    wandb_mode: offline
+    api_key: ''
+    prv_runid: null
+    log_params:
+    - trainer_config.optimizer_name
+    - trainer_config.optimizer.amsgrad
+    - trainer_config.optimizer.lr
+    - model_config.backbone_type
+    - model_config.init_weights
+  optimizer_name: Adam
+  optimizer:
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    threshold: 1.0e-07
+    threshold_mode: rel
+    cooldown: 3
+    patience: 5
+    factor: 0.5
+    min_lr: 1.0e-08

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -466,11 +466,11 @@ class ModelTrainer:
             OmegaConf.save(
                 config=self.config, f=f"{self.dir_path}/training_config.yaml"
             )
-            print("Deleting `.bin` dir...")
-            if Path(self.bin_files_path).exists():
-                shutil.rmtree(
-                    (Path(self.bin_files_path)).as_posix(),
-                )
+            # print("Deleting `.bin` dir...")
+            # if Path(self.bin_files_path).exists():
+            #     shutil.rmtree(
+            #         (Path(self.bin_files_path)).as_posix(),
+            #     )
 
 
 class TrainingModel(L.LightningModule):

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -466,18 +466,12 @@ class ModelTrainer:
             OmegaConf.save(
                 config=self.config, f=f"{self.dir_path}/training_config.yaml"
             )
-            # TODO: (ubuntu test failing (running for > 6hrs) with the below lines)
-            # print("Deleting training and validation files...")
-            # if (Path(self.dir_path) / "train_chunks").exists():
-            #     shutil.rmtree(
-            #         (Path(self.dir_path) / "train_chunks").as_posix(),
-            #         ignore_errors=True,
-            #     )
-            # if (Path(self.dir_path) / "val_chunks").exists():
-            #     shutil.rmtree(
-            #         (Path(self.dir_path) / "val_chunks").as_posix(),
-            #         ignore_errors=True,
-            #     )
+            print("Deleting `.bin` dir...")
+            if Path(self.bin_files_path).exists():
+                shutil.rmtree(
+                    (Path(self.bin_files_path)).as_posix(),
+                    ignore_errors=True,
+                )
 
 
 class TrainingModel(L.LightningModule):

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -470,7 +470,6 @@ class ModelTrainer:
             if Path(self.bin_files_path).exists():
                 shutil.rmtree(
                     (Path(self.bin_files_path)).as_posix(),
-                    ignore_errors=True,
                 )
 
 

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -468,9 +468,7 @@ class ModelTrainer:
             )
             print("Deleting `.bin` dir...")
             if Path(self.bin_files_path).exists():
-                shutil.rmtree(
-                    (Path(self.bin_files_path)).as_posix(),
-                )
+                shutil.rmtree((Path(self.bin_files_path)).as_posix())
 
 
 class TrainingModel(L.LightningModule):

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -467,8 +467,8 @@ class ModelTrainer:
                 config=self.config, f=f"{self.dir_path}/training_config.yaml"
             )
             print("Deleting `.bin` dir...")
-            if Path(self.bin_files_path).exists():
-                shutil.rmtree((Path(self.bin_files_path)).as_posix())
+            # if Path(self.bin_files_path).exists():
+            #     shutil.rmtree((Path(self.bin_files_path)).as_posix())
 
 
 class TrainingModel(L.LightningModule):

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -466,11 +466,11 @@ class ModelTrainer:
             OmegaConf.save(
                 config=self.config, f=f"{self.dir_path}/training_config.yaml"
             )
-            # print("Deleting `.bin` dir...")
-            # if Path(self.bin_files_path).exists():
-            #     shutil.rmtree(
-            #         (Path(self.bin_files_path)).as_posix(),
-            #     )
+            print("Deleting `.bin` dir...")
+            if Path(self.bin_files_path).exists():
+                shutil.rmtree(
+                    (Path(self.bin_files_path)).as_posix(),
+                )
 
 
 class TrainingModel(L.LightningModule):

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -65,11 +65,6 @@ def test_wandb():
     wandb.finish()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("li"),
-    reason="Flaky test (The training test runs on Ubuntu for a long time: >6hrs and then fails.)",
-)
-# TODO: Revisit this test later (Failing on ubuntu)
 def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
     model_trainer = ModelTrainer(config)

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -94,8 +94,6 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     assert not (
         Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
     )
-    # shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
-    # shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     #######
 
@@ -170,8 +168,6 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
     assert not df.val_loss.isnull().all()
     assert not df.train_loss.isnull().all()
-    # shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
-    # shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     #######
 
@@ -195,8 +191,6 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
         Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
     )
     assert checkpoint["epoch"] == 3
-    # shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
-    # shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
 
     training_config = OmegaConf.load(
         f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
@@ -228,8 +222,6 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
         Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
     )
     assert checkpoint["epoch"] == 1
-    # shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
-    # shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
 
     #######
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -90,248 +90,269 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
         Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
     )
 
-    #######
+    if Path(model_trainer.bin_files_path).exists():
+        shutil.rmtree((Path(model_trainer.bin_files_path)).as_posix())
 
-    # update save_ckpt to True
+    ## for topdown with wandb and ckpt
     # OmegaConf.update(config, "trainer_config.save_ckpt", True)
-    # OmegaConf.update(config, "trainer_config.use_wandb", True)
+    # OmegaConf.update(config, "trainer_config.use_wandb", False)
     # OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
     # OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
 
     # model_trainer = ModelTrainer(config)
     # model_trainer.train()
 
-    # # check if wandb folder is created
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
-
-    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    # assert folder_created
-    # files = [
-    #     str(x)
-    #     for x in Path(config.trainer_config.save_ckpt_path).iterdir()
-    #     if x.is_file()
-    # ]
-    # assert (
-    #     Path(config.trainer_config.save_ckpt_path)
-    #     .joinpath("initial_config.yaml")
-    #     .exists()
-    # )
     # assert (
     #     Path(config.trainer_config.save_ckpt_path)
     #     .joinpath("training_config.yaml")
     #     .exists()
     # )
-    # training_config = OmegaConf.load(
-    #     f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
-    # )
-    # assert training_config.trainer_config.wandb.run_id is not None
-    # assert training_config.model_config.total_params is not None
-    # assert training_config.trainer_config.wandb.api_key == ""
-    # assert training_config.data_config.skeletons
-    # assert training_config.data_config.preprocessing.crop_hw == (104, 104)
-
-    # # check if ckpt is created
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
-
-    # checkpoint = torch.load(
-    # Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    # )
-    # assert checkpoint["epoch"] == 1
-
-    # # check if skeleton is saved in ckpt file
-    # assert checkpoint["config"]
-    # assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
-    # assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
-
-    # # check for training metrics csv
-    # path = Path(config.trainer_config.save_ckpt_path).joinpath(
-    #     "lightning_logs/version_0/"
-    # )
-    # files = [str(x) for x in Path(path).iterdir() if x.is_file()]
-    # metrics = False
-    # for i in files:
-    #     if "metrics.csv" in i:
-    #         metrics = True
-    #         break
-    # assert metrics
-    # df = pd.read_csv(
-    #     Path(config.trainer_config.save_ckpt_path).joinpath(
-    #         "lightning_logs/version_0/metrics.csv"
-    #     )
-    # )
-    # assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
-    # assert not df.val_loss.isnull().all()
-    # assert not df.train_loss.isnull().all()
-
-    # shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
-    # shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
-
-    # #######
-
-    # # check resume training
-    # config_copy = config.copy()
-    # OmegaConf.update(config_copy, "trainer_config.max_epochs", 4)
-    # OmegaConf.update(
-    #     config_copy,
-    #     "trainer_config.resume_ckpt_path",
-    #     f"{Path(config.trainer_config.save_ckpt_path).joinpath('last.ckpt')}",
-    # )
-    # training_config = OmegaConf.load(
-    #     f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
-    # )
-    # prv_runid = training_config.trainer_config.wandb.run_id
-    # OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
-    # trainer = ModelTrainer(config_copy)
-    # trainer.train()
-
-    # checkpoint = torch.load(
-    #     Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    # )
-    # assert checkpoint["epoch"] == 3
-
-    # training_config = OmegaConf.load(
-    #     f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
-    # )
-    # assert training_config.trainer_config.wandb.run_id == prv_runid
-    # os.remove((Path(trainer.dir_path) / "best.ckpt").as_posix())
-    # os.remove((Path(trainer.dir_path) / "last.ckpt").as_posix())
-    # shutil.rmtree((Path(trainer.dir_path) / "lightning_logs").as_posix())
-
-    # #######
-
-    # # check early stopping
-    # config_early_stopping = config.copy()
-    # OmegaConf.update(
-    #     config_early_stopping, "trainer_config.early_stopping.min_delta", 1e-1
-    # )
-    # OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
-    # OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
-    # OmegaConf.update(
-    #     config_early_stopping,
-    #     "trainer_config.save_ckpt_path",
-    #     f"{tmp_path}/test_model_trainer/",
+    # assert (
+    #     Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
     # )
 
-    # trainer = ModelTrainer(config_early_stopping)
-    # trainer.train()
+    #######
 
-    # checkpoint = torch.load(
-    #     Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    # )
-    # assert checkpoint["epoch"] == 1
+    # update save_ckpt to True
+    OmegaConf.update(config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(config, "trainer_config.use_wandb", True)
+    OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
 
-    # #######
+    model_trainer = ModelTrainer(config)
+    model_trainer.train()
 
-    # # For Single instance model
-    # single_instance_config = config.copy()
-    # head_config = single_instance_config.model_config.head_configs.centered_instance
-    # del single_instance_config.model_config.head_configs.centered_instance
-    # OmegaConf.update(
-    #     single_instance_config, "model_config.head_configs.single_instance", head_config
-    # )
-    # del (
-    #     single_instance_config.model_config.head_configs.single_instance.confmaps.anchor_part
-    # )
+    # check if wandb folder is created
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
 
-    # trainer = ModelTrainer(single_instance_config)
-    # trainer._initialize_model()
-    # assert isinstance(trainer.model, SingleInstanceModel)
+    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    assert folder_created
+    files = [
+        str(x)
+        for x in Path(config.trainer_config.save_ckpt_path).iterdir()
+        if x.is_file()
+    ]
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("initial_config.yaml")
+        .exists()
+    )
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("training_config.yaml")
+        .exists()
+    )
+    training_config = OmegaConf.load(
+        f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
+    )
+    assert training_config.trainer_config.wandb.run_id is not None
+    assert training_config.model_config.total_params is not None
+    assert training_config.trainer_config.wandb.api_key == ""
+    assert training_config.data_config.skeletons
+    assert training_config.data_config.preprocessing.crop_hw == (104, 104)
 
-    # #######
+    # check if ckpt is created
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
 
-    # # Centroid model
-    # centroid_config = config.copy()
-    # OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
-    # del centroid_config.model_config.head_configs.centered_instance
-    # del centroid_config.model_config.head_configs.centroid["confmaps"].part_names
+    checkpoint = torch.load(
+        Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    )
+    assert checkpoint["epoch"] == 1
 
-    # if (Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
-    #     os.remove(
-    #         (
-    #             Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt"
-    #         ).as_posix()
-    #     )
-    #     os.remove(
-    #         (
-    #             Path(centroid_config.trainer_config.save_ckpt_path) / "last.ckpt"
-    #         ).as_posix()
-    #     )
-    #     shutil.rmtree(
-    #         (
-    #             Path(centroid_config.trainer_config.save_ckpt_path) / "lightning_logs"
-    #         ).as_posix()
-    #     )
+    # check if skeleton is saved in ckpt file
+    assert checkpoint["config"]
+    assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
+    assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
 
-    # OmegaConf.update(centroid_config, "trainer_config.save_ckpt", True)
-    # OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
-    # OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
-    # OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
+    # check for training metrics csv
+    path = Path(config.trainer_config.save_ckpt_path).joinpath(
+        "lightning_logs/version_0/"
+    )
+    files = [str(x) for x in Path(path).iterdir() if x.is_file()]
+    metrics = False
+    for i in files:
+        if "metrics.csv" in i:
+            metrics = True
+            break
+    assert metrics
+    df = pd.read_csv(
+        Path(config.trainer_config.save_ckpt_path).joinpath(
+            "lightning_logs/version_0/metrics.csv"
+        )
+    )
+    assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
+    assert not df.val_loss.isnull().all()
+    assert not df.train_loss.isnull().all()
 
-    # trainer = ModelTrainer(centroid_config)
+    shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
+    shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
-    # trainer._initialize_model()
-    # assert isinstance(trainer.model, CentroidModel)
+    #######
 
-    # #######
+    # check resume training
+    config_copy = config.copy()
+    OmegaConf.update(config_copy, "trainer_config.max_epochs", 4)
+    OmegaConf.update(
+        config_copy,
+        "trainer_config.resume_ckpt_path",
+        f"{Path(config.trainer_config.save_ckpt_path).joinpath('last.ckpt')}",
+    )
+    training_config = OmegaConf.load(
+        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
+    )
+    prv_runid = training_config.trainer_config.wandb.run_id
+    OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
+    trainer = ModelTrainer(config_copy)
+    trainer.train()
 
-    # # bottom up model
-    # bottomup_config = config.copy()
-    # OmegaConf.update(bottomup_config, "model_config.head_configs.bottomup", head_config)
-    # paf = {
-    #     "edges": [("part1", "part2")],
-    #     "sigma": 4,
-    #     "output_stride": 4,
-    #     "loss_weight": 1.0,
-    # }
-    # del bottomup_config.model_config.head_configs.bottomup["confmaps"].anchor_part
-    # del bottomup_config.model_config.head_configs.centered_instance
-    # bottomup_config.model_config.head_configs.bottomup["pafs"] = paf
-    # bottomup_config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
+    checkpoint = torch.load(
+        Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    )
+    assert checkpoint["epoch"] == 3
 
-    # if (Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
-    #     os.remove(
-    #         (
-    #             Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt"
-    #         ).as_posix()
-    #     )
-    #     os.remove(
-    #         (
-    #             Path(bottomup_config.trainer_config.save_ckpt_path) / "last.ckpt"
-    #         ).as_posix()
-    #     )
-    #     shutil.rmtree(
-    #         (
-    #             Path(bottomup_config.trainer_config.save_ckpt_path) / "lightning_logs"
-    #         ).as_posix()
-    #     )
+    training_config = OmegaConf.load(
+        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
+    )
+    assert training_config.trainer_config.wandb.run_id == prv_runid
+    os.remove((Path(trainer.dir_path) / "best.ckpt").as_posix())
+    os.remove((Path(trainer.dir_path) / "last.ckpt").as_posix())
+    shutil.rmtree((Path(trainer.dir_path) / "lightning_logs").as_posix())
 
-    # OmegaConf.update(bottomup_config, "trainer_config.save_ckpt", True)
-    # OmegaConf.update(bottomup_config, "trainer_config.use_wandb", False)
-    # OmegaConf.update(bottomup_config, "trainer_config.max_epochs", 1)
-    # OmegaConf.update(bottomup_config, "trainer_config.steps_per_epoch", 10)
+    #######
 
-    # trainer = ModelTrainer(bottomup_config)
-    # trainer._initialize_model()
-    # assert isinstance(trainer.model, BottomUpModel)
+    # check early stopping
+    config_early_stopping = config.copy()
+    OmegaConf.update(
+        config_early_stopping, "trainer_config.early_stopping.min_delta", 1e-1
+    )
+    OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
+    OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
+    OmegaConf.update(
+        config_early_stopping,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_model_trainer/",
+    )
 
-    # #######
+    trainer = ModelTrainer(config_early_stopping)
+    trainer.train()
 
-    # # check loading trained weights
-    # load_weights_config = config.copy()
-    # ckpt = torch.load((Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix())
-    # first_layer_ckpt = ckpt["state_dict"][
-    #     "model.backbone.enc.encoder_stack.0.blocks.0.weight"
-    # ][0, 0, :].numpy()
+    checkpoint = torch.load(
+        Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    )
+    assert checkpoint["epoch"] == 1
 
-    # trainer = ModelTrainer(load_weights_config)
-    # trainer._create_data_loaders()
-    # trainer._initialize_model(
-    #     (Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix()
-    # )
-    # model_ckpt = next(trainer.model.parameters())[0, 0, :].detach().numpy()
+    #######
 
-    # assert np.all(np.abs(first_layer_ckpt - model_ckpt) < 1e-3)
+    # For Single instance model
+    single_instance_config = config.copy()
+    head_config = single_instance_config.model_config.head_configs.centered_instance
+    del single_instance_config.model_config.head_configs.centered_instance
+    OmegaConf.update(
+        single_instance_config, "model_config.head_configs.single_instance", head_config
+    )
+    del (
+        single_instance_config.model_config.head_configs.single_instance.confmaps.anchor_part
+    )
+
+    trainer = ModelTrainer(single_instance_config)
+    trainer._initialize_model()
+    assert isinstance(trainer.model, SingleInstanceModel)
+
+    #######
+
+    # Centroid model
+    centroid_config = config.copy()
+    OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
+    del centroid_config.model_config.head_configs.centered_instance
+    del centroid_config.model_config.head_configs.centroid["confmaps"].part_names
+
+    if (Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
+        os.remove(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt"
+            ).as_posix()
+        )
+        os.remove(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "last.ckpt"
+            ).as_posix()
+        )
+        shutil.rmtree(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "lightning_logs"
+            ).as_posix()
+        )
+
+    OmegaConf.update(centroid_config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
+    OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
+    OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
+
+    trainer = ModelTrainer(centroid_config)
+
+    trainer._initialize_model()
+    assert isinstance(trainer.model, CentroidModel)
+
+    #######
+
+    # bottom up model
+    bottomup_config = config.copy()
+    OmegaConf.update(bottomup_config, "model_config.head_configs.bottomup", head_config)
+    paf = {
+        "edges": [("part1", "part2")],
+        "sigma": 4,
+        "output_stride": 4,
+        "loss_weight": 1.0,
+    }
+    del bottomup_config.model_config.head_configs.bottomup["confmaps"].anchor_part
+    del bottomup_config.model_config.head_configs.centered_instance
+    bottomup_config.model_config.head_configs.bottomup["pafs"] = paf
+    bottomup_config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
+
+    if (Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
+        os.remove(
+            (
+                Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt"
+            ).as_posix()
+        )
+        os.remove(
+            (
+                Path(bottomup_config.trainer_config.save_ckpt_path) / "last.ckpt"
+            ).as_posix()
+        )
+        shutil.rmtree(
+            (
+                Path(bottomup_config.trainer_config.save_ckpt_path) / "lightning_logs"
+            ).as_posix()
+        )
+
+    OmegaConf.update(bottomup_config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(bottomup_config, "trainer_config.use_wandb", False)
+    OmegaConf.update(bottomup_config, "trainer_config.max_epochs", 1)
+    OmegaConf.update(bottomup_config, "trainer_config.steps_per_epoch", 10)
+
+    trainer = ModelTrainer(bottomup_config)
+    trainer._initialize_model()
+    assert isinstance(trainer.model, BottomUpModel)
+
+    #######
+
+    # check loading trained weights
+    load_weights_config = config.copy()
+    ckpt = torch.load((Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix())
+    first_layer_ckpt = ckpt["state_dict"][
+        "model.backbone.enc.encoder_stack.0.blocks.0.weight"
+    ][0, 0, :].numpy()
+
+    trainer = ModelTrainer(load_weights_config)
+    trainer._create_data_loaders()
+    trainer._initialize_model(
+        (Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix()
+    )
+    model_ckpt = next(trainer.model.parameters())[0, 0, :].detach().numpy()
+
+    assert np.all(np.abs(first_layer_ckpt - model_ckpt) < 1e-3)
 
     # shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
     # shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -76,19 +76,19 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
-    # model_trainer = ModelTrainer(config)
-    # model_trainer.train()
+    model_trainer = ModelTrainer(config)
+    model_trainer.train()
 
-    # # disable ckpt, check if ckpt is created
-    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    # assert (
-    #     Path(config.trainer_config.save_ckpt_path)
-    #     .joinpath("training_config.yaml")
-    #     .exists()
-    # )
-    # assert not (
-    #     Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
-    # )
+    # disable ckpt, check if ckpt is created
+    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("training_config.yaml")
+        .exists()
+    )
+    assert not (
+        Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+    )
 
     #######
 
@@ -163,6 +163,9 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
     assert not df.val_loss.isnull().all()
     assert not df.train_loss.isnull().all()
+
+    shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
+    shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     # #######
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -73,22 +73,22 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     #####
 
     # # for topdown centered instance model
-    OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
-    )
-    model_trainer = ModelTrainer(config)
-    model_trainer.train()
+    # OmegaConf.update(
+    #     config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+    # )
+    # model_trainer = ModelTrainer(config)
+    # model_trainer.train()
 
-    # disable ckpt, check if ckpt is created
-    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    assert (
-        Path(config.trainer_config.save_ckpt_path)
-        .joinpath("training_config.yaml")
-        .exists()
-    )
-    assert not (
-        Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
-    )
+    # # disable ckpt, check if ckpt is created
+    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    # assert (
+    #     Path(config.trainer_config.save_ckpt_path)
+    #     .joinpath("training_config.yaml")
+    #     .exists()
+    # )
+    # assert not (
+    #     Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+    # )
 
     #######
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -93,8 +93,8 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     #######
 
     # update save_ckpt to True
-    OmegaConf.update(config, "trainer_config.save_ckpt", True)
-    OmegaConf.update(config, "trainer_config.use_wandb", False)
+    OmegaConf.update(config, "trainer_config.save_ckpt", False)
+    OmegaConf.update(config, "trainer_config.use_wandb", True)
     OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
 
@@ -102,7 +102,7 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     model_trainer.train()
 
     # check if wandb folder is created
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
 
     folder_created = Path(config.trainer_config.save_ckpt_path).exists()
     assert folder_created
@@ -124,45 +124,45 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     training_config = OmegaConf.load(
         f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
     )
-    # assert training_config.trainer_config.wandb.run_id is not None
+    assert training_config.trainer_config.wandb.run_id is not None
     assert training_config.model_config.total_params is not None
-    # assert training_config.trainer_config.wandb.api_key == ""
+    assert training_config.trainer_config.wandb.api_key == ""
     assert training_config.data_config.skeletons
     assert training_config.data_config.preprocessing.crop_hw == (104, 104)
 
     # check if ckpt is created
-    assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
-    assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
 
-    checkpoint = torch.load(
-        Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    )
-    assert checkpoint["epoch"] == 1
+    # checkpoint = torch.load(
+    # Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    # )
+    # assert checkpoint["epoch"] == 1
 
     # check if skeleton is saved in ckpt file
-    assert checkpoint["config"]
+    # assert checkpoint["config"]
     # assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
-    assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
+    # assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
 
     # check for training metrics csv
-    path = Path(config.trainer_config.save_ckpt_path).joinpath(
-        "lightning_logs/version_0/"
-    )
-    files = [str(x) for x in Path(path).iterdir() if x.is_file()]
-    metrics = False
-    for i in files:
-        if "metrics.csv" in i:
-            metrics = True
-            break
-    assert metrics
-    df = pd.read_csv(
-        Path(config.trainer_config.save_ckpt_path).joinpath(
-            "lightning_logs/version_0/metrics.csv"
-        )
-    )
-    assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
-    assert not df.val_loss.isnull().all()
-    assert not df.train_loss.isnull().all()
+    # path = Path(config.trainer_config.save_ckpt_path).joinpath(
+    #     "lightning_logs/version_0/"
+    # )
+    # files = [str(x) for x in Path(path).iterdir() if x.is_file()]
+    # metrics = False
+    # for i in files:
+    #     if "metrics.csv" in i:
+    #         metrics = True
+    #         break
+    # assert metrics
+    # df = pd.read_csv(
+    #     Path(config.trainer_config.save_ckpt_path).joinpath(
+    #         "lightning_logs/version_0/metrics.csv"
+    #     )
+    # )
+    # assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
+    # assert not df.val_loss.isnull().all()
+    # assert not df.train_loss.isnull().all()
 
     # shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
     # shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -70,67 +70,67 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     model_trainer = ModelTrainer(config)
     assert model_trainer.dir_path == "."
 
-    #####
-
-    # # for topdown centered instance model
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
-    # model_trainer = ModelTrainer(config)
-    # model_trainer.train()
 
-    # # disable ckpt, check if ckpt is created
-    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    # assert (
-    #     Path(config.trainer_config.save_ckpt_path)
-    #     .joinpath("training_config.yaml")
-    #     .exists()
-    # )
-    # assert not (
-    #     Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
-    # )
+    #####
 
-    #######
-
-    # update save_ckpt to True
-    OmegaConf.update(config, "trainer_config.save_ckpt", False)
-    OmegaConf.update(config, "trainer_config.use_wandb", False)
-    OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
-    OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
-
+    # # for topdown centered instance model
     model_trainer = ModelTrainer(config)
     model_trainer.train()
 
-    # check if wandb folder is created
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
-
-    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    assert folder_created
-    # files = [
-    #     str(x)
-    #     for x in Path(config.trainer_config.save_ckpt_path).iterdir()
-    #     if x.is_file()
-    # ]
-    assert (
-        Path(config.trainer_config.save_ckpt_path)
-        .joinpath("initial_config.yaml")
-        .exists()
-    )
+    # disable ckpt, check if ckpt is created
     assert (
         Path(config.trainer_config.save_ckpt_path)
         .joinpath("training_config.yaml")
         .exists()
     )
-    training_config = OmegaConf.load(
-        f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
+    assert not (
+        Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
     )
-    assert training_config.trainer_config.wandb.run_id is not None
-    assert training_config.model_config.total_params is not None
-    # assert training_config.trainer_config.wandb.api_key == ""
-    assert training_config.data_config.skeletons
-    assert training_config.data_config.preprocessing.crop_hw == (104, 104)
 
-    # check if ckpt is created
+    #######
+
+    # update save_ckpt to True
+    # OmegaConf.update(config, "trainer_config.save_ckpt", True)
+    # OmegaConf.update(config, "trainer_config.use_wandb", True)
+    # OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
+    # OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
+
+    # model_trainer = ModelTrainer(config)
+    # model_trainer.train()
+
+    # # check if wandb folder is created
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
+
+    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    # assert folder_created
+    # files = [
+    #     str(x)
+    #     for x in Path(config.trainer_config.save_ckpt_path).iterdir()
+    #     if x.is_file()
+    # ]
+    # assert (
+    #     Path(config.trainer_config.save_ckpt_path)
+    #     .joinpath("initial_config.yaml")
+    #     .exists()
+    # )
+    # assert (
+    #     Path(config.trainer_config.save_ckpt_path)
+    #     .joinpath("training_config.yaml")
+    #     .exists()
+    # )
+    # training_config = OmegaConf.load(
+    #     f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
+    # )
+    # assert training_config.trainer_config.wandb.run_id is not None
+    # assert training_config.model_config.total_params is not None
+    # assert training_config.trainer_config.wandb.api_key == ""
+    # assert training_config.data_config.skeletons
+    # assert training_config.data_config.preprocessing.crop_hw == (104, 104)
+
+    # # check if ckpt is created
     # assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
     # assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
 
@@ -139,12 +139,12 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     # )
     # assert checkpoint["epoch"] == 1
 
-    # check if skeleton is saved in ckpt file
+    # # check if skeleton is saved in ckpt file
     # assert checkpoint["config"]
     # assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
     # assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
 
-    # check for training metrics csv
+    # # check for training metrics csv
     # path = Path(config.trainer_config.save_ckpt_path).joinpath(
     #     "lightning_logs/version_0/"
     # )

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -92,77 +92,77 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
 
     #######
 
-    # # update save_ckpt to True
-    # OmegaConf.update(config, "trainer_config.save_ckpt", True)
-    # OmegaConf.update(config, "trainer_config.use_wandb", True)
-    # OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
-    # OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
+    # update save_ckpt to True
+    OmegaConf.update(config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(config, "trainer_config.use_wandb", True)
+    OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
 
-    # model_trainer = ModelTrainer(config)
-    # model_trainer.train()
+    model_trainer = ModelTrainer(config)
+    model_trainer.train()
 
-    # # check if wandb folder is created
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
+    # check if wandb folder is created
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
 
-    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    # assert folder_created
-    # files = [
-    #     str(x)
-    #     for x in Path(config.trainer_config.save_ckpt_path).iterdir()
-    #     if x.is_file()
-    # ]
-    # assert (
-    #     Path(config.trainer_config.save_ckpt_path)
-    #     .joinpath("initial_config.yaml")
-    #     .exists()
-    # )
-    # assert (
-    #     Path(config.trainer_config.save_ckpt_path)
-    #     .joinpath("training_config.yaml")
-    #     .exists()
-    # )
-    # training_config = OmegaConf.load(
-    #     f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
-    # )
-    # assert training_config.trainer_config.wandb.run_id is not None
-    # assert training_config.model_config.total_params is not None
-    # assert training_config.trainer_config.wandb.api_key == ""
-    # assert training_config.data_config.skeletons
-    # assert training_config.data_config.preprocessing.crop_hw == (104, 104)
+    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    assert folder_created
+    files = [
+        str(x)
+        for x in Path(config.trainer_config.save_ckpt_path).iterdir()
+        if x.is_file()
+    ]
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("initial_config.yaml")
+        .exists()
+    )
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("training_config.yaml")
+        .exists()
+    )
+    training_config = OmegaConf.load(
+        f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
+    )
+    assert training_config.trainer_config.wandb.run_id is not None
+    assert training_config.model_config.total_params is not None
+    assert training_config.trainer_config.wandb.api_key == ""
+    assert training_config.data_config.skeletons
+    assert training_config.data_config.preprocessing.crop_hw == (104, 104)
 
-    # # check if ckpt is created
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
-    # assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+    # check if ckpt is created
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
 
-    # checkpoint = torch.load(
-    #     Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    # )
-    # assert checkpoint["epoch"] == 1
+    checkpoint = torch.load(
+        Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    )
+    assert checkpoint["epoch"] == 1
 
-    # # check if skeleton is saved in ckpt file
-    # assert checkpoint["config"]
-    # assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
-    # assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
+    # check if skeleton is saved in ckpt file
+    assert checkpoint["config"]
+    assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
+    assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
 
-    # # check for training metrics csv
-    # path = Path(config.trainer_config.save_ckpt_path).joinpath(
-    #     "lightning_logs/version_0/"
-    # )
-    # files = [str(x) for x in Path(path).iterdir() if x.is_file()]
-    # metrics = False
-    # for i in files:
-    #     if "metrics.csv" in i:
-    #         metrics = True
-    #         break
-    # assert metrics
-    # df = pd.read_csv(
-    #     Path(config.trainer_config.save_ckpt_path).joinpath(
-    #         "lightning_logs/version_0/metrics.csv"
-    #     )
-    # )
-    # assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
-    # assert not df.val_loss.isnull().all()
-    # assert not df.train_loss.isnull().all()
+    # check for training metrics csv
+    path = Path(config.trainer_config.save_ckpt_path).joinpath(
+        "lightning_logs/version_0/"
+    )
+    files = [str(x) for x in Path(path).iterdir() if x.is_file()]
+    metrics = False
+    for i in files:
+        if "metrics.csv" in i:
+            metrics = True
+            break
+    assert metrics
+    df = pd.read_csv(
+        Path(config.trainer_config.save_ckpt_path).joinpath(
+            "lightning_logs/version_0/metrics.csv"
+        )
+    )
+    assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
+    assert not df.val_loss.isnull().all()
+    assert not df.train_loss.isnull().all()
 
     # #######
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -102,7 +102,7 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     model_trainer.train()
 
     # check if wandb folder is created
-    assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
 
     folder_created = Path(config.trainer_config.save_ckpt_path).exists()
     assert folder_created
@@ -124,9 +124,9 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     training_config = OmegaConf.load(
         f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
     )
-    assert training_config.trainer_config.wandb.run_id is not None
+    # assert training_config.trainer_config.wandb.run_id is not None
     assert training_config.model_config.total_params is not None
-    assert training_config.trainer_config.wandb.api_key == ""
+    # assert training_config.trainer_config.wandb.api_key == ""
     assert training_config.data_config.skeletons
     assert training_config.data_config.preprocessing.crop_hw == (104, 104)
 
@@ -141,7 +141,7 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
 
     # check if skeleton is saved in ckpt file
     assert checkpoint["config"]
-    assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
+    # assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
     assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
 
     # check for training metrics csv

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -106,11 +106,11 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
 
     folder_created = Path(config.trainer_config.save_ckpt_path).exists()
     assert folder_created
-    files = [
-        str(x)
-        for x in Path(config.trainer_config.save_ckpt_path).iterdir()
-        if x.is_file()
-    ]
+    # files = [
+    #     str(x)
+    #     for x in Path(config.trainer_config.save_ckpt_path).iterdir()
+    #     if x.is_file()
+    # ]
     assert (
         Path(config.trainer_config.save_ckpt_path)
         .joinpath("initial_config.yaml")

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -94,8 +94,8 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     assert not (
         Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
     )
-    shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
-    shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
+    # shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
+    # shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     #######
 
@@ -170,8 +170,8 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
     assert not df.val_loss.isnull().all()
     assert not df.train_loss.isnull().all()
-    shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
-    shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
+    # shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
+    # shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     #######
 
@@ -195,8 +195,8 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
         Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
     )
     assert checkpoint["epoch"] == 3
-    shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
-    shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
+    # shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
+    # shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
 
     training_config = OmegaConf.load(
         f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
@@ -228,8 +228,8 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
         Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
     )
     assert checkpoint["epoch"] == 1
-    shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
-    shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
+    # shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
+    # shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
 
     #######
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -76,25 +76,25 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
-    model_trainer = ModelTrainer(config)
-    model_trainer.train()
+    # model_trainer = ModelTrainer(config)
+    # model_trainer.train()
 
-    # disable ckpt, check if ckpt is created
-    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    assert (
-        Path(config.trainer_config.save_ckpt_path)
-        .joinpath("training_config.yaml")
-        .exists()
-    )
-    assert not (
-        Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
-    )
+    # # disable ckpt, check if ckpt is created
+    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    # assert (
+    #     Path(config.trainer_config.save_ckpt_path)
+    #     .joinpath("training_config.yaml")
+    #     .exists()
+    # )
+    # assert not (
+    #     Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+    # )
 
     #######
 
     # update save_ckpt to True
     OmegaConf.update(config, "trainer_config.save_ckpt", True)
-    OmegaConf.update(config, "trainer_config.use_wandb", True)
+    OmegaConf.update(config, "trainer_config.use_wandb", False)
     OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
 
@@ -164,8 +164,8 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     assert not df.val_loss.isnull().all()
     assert not df.train_loss.isnull().all()
 
-    shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
-    shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
+    # shutil.rmtree((Path(model_trainer.bin_files_path) / "train_chunks").as_posix())
+    # shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     # #######
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -73,9 +73,9 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     #####
 
     # # for topdown centered instance model
-    # OmegaConf.update(
-    #     config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
-    # )
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+    )
     # model_trainer = ModelTrainer(config)
     # model_trainer.train()
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -94,7 +94,7 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
 
     # update save_ckpt to True
     OmegaConf.update(config, "trainer_config.save_ckpt", False)
-    OmegaConf.update(config, "trainer_config.use_wandb", True)
+    OmegaConf.update(config, "trainer_config.use_wandb", False)
     OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
 
@@ -102,7 +102,7 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     model_trainer.train()
 
     # check if wandb folder is created
-    assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
 
     folder_created = Path(config.trainer_config.save_ckpt_path).exists()
     assert folder_created
@@ -126,7 +126,7 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
     )
     assert training_config.trainer_config.wandb.run_id is not None
     assert training_config.model_config.total_params is not None
-    assert training_config.trainer_config.wandb.api_key == ""
+    # assert training_config.trainer_config.wandb.api_key == ""
     assert training_config.data_config.skeletons
     assert training_config.data_config.preprocessing.crop_hw == (104, 104)
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -92,246 +92,246 @@ def test_trainer(config, tmp_path: str, minimal_instance_bottomup_ckpt: str):
 
     #######
 
-    # update save_ckpt to True
-    OmegaConf.update(config, "trainer_config.save_ckpt", True)
-    OmegaConf.update(config, "trainer_config.use_wandb", True)
-    OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
-    OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
+    # # update save_ckpt to True
+    # OmegaConf.update(config, "trainer_config.save_ckpt", True)
+    # OmegaConf.update(config, "trainer_config.use_wandb", True)
+    # OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
+    # OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
 
-    model_trainer = ModelTrainer(config)
-    model_trainer.train()
+    # model_trainer = ModelTrainer(config)
+    # model_trainer.train()
 
-    # check if wandb folder is created
-    assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
+    # # check if wandb folder is created
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
 
-    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
-    assert folder_created
-    files = [
-        str(x)
-        for x in Path(config.trainer_config.save_ckpt_path).iterdir()
-        if x.is_file()
-    ]
-    assert (
-        Path(config.trainer_config.save_ckpt_path)
-        .joinpath("initial_config.yaml")
-        .exists()
-    )
-    assert (
-        Path(config.trainer_config.save_ckpt_path)
-        .joinpath("training_config.yaml")
-        .exists()
-    )
-    training_config = OmegaConf.load(
-        f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
-    )
-    assert training_config.trainer_config.wandb.run_id is not None
-    assert training_config.model_config.total_params is not None
-    assert training_config.trainer_config.wandb.api_key == ""
-    assert training_config.data_config.skeletons
-    assert training_config.data_config.preprocessing.crop_hw == (104, 104)
+    # folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    # assert folder_created
+    # files = [
+    #     str(x)
+    #     for x in Path(config.trainer_config.save_ckpt_path).iterdir()
+    #     if x.is_file()
+    # ]
+    # assert (
+    #     Path(config.trainer_config.save_ckpt_path)
+    #     .joinpath("initial_config.yaml")
+    #     .exists()
+    # )
+    # assert (
+    #     Path(config.trainer_config.save_ckpt_path)
+    #     .joinpath("training_config.yaml")
+    #     .exists()
+    # )
+    # training_config = OmegaConf.load(
+    #     f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
+    # )
+    # assert training_config.trainer_config.wandb.run_id is not None
+    # assert training_config.model_config.total_params is not None
+    # assert training_config.trainer_config.wandb.api_key == ""
+    # assert training_config.data_config.skeletons
+    # assert training_config.data_config.preprocessing.crop_hw == (104, 104)
 
-    # check if ckpt is created
-    assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
-    assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+    # # check if ckpt is created
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
+    # assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
 
-    checkpoint = torch.load(
-        Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    )
-    assert checkpoint["epoch"] == 1
+    # checkpoint = torch.load(
+    #     Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    # )
+    # assert checkpoint["epoch"] == 1
 
-    # check if skeleton is saved in ckpt file
-    assert checkpoint["config"]
-    assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
-    assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
+    # # check if skeleton is saved in ckpt file
+    # assert checkpoint["config"]
+    # assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
+    # assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
 
-    # check for training metrics csv
-    path = Path(config.trainer_config.save_ckpt_path).joinpath(
-        "lightning_logs/version_0/"
-    )
-    files = [str(x) for x in Path(path).iterdir() if x.is_file()]
-    metrics = False
-    for i in files:
-        if "metrics.csv" in i:
-            metrics = True
-            break
-    assert metrics
-    df = pd.read_csv(
-        Path(config.trainer_config.save_ckpt_path).joinpath(
-            "lightning_logs/version_0/metrics.csv"
-        )
-    )
-    assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
-    assert not df.val_loss.isnull().all()
-    assert not df.train_loss.isnull().all()
+    # # check for training metrics csv
+    # path = Path(config.trainer_config.save_ckpt_path).joinpath(
+    #     "lightning_logs/version_0/"
+    # )
+    # files = [str(x) for x in Path(path).iterdir() if x.is_file()]
+    # metrics = False
+    # for i in files:
+    #     if "metrics.csv" in i:
+    #         metrics = True
+    #         break
+    # assert metrics
+    # df = pd.read_csv(
+    #     Path(config.trainer_config.save_ckpt_path).joinpath(
+    #         "lightning_logs/version_0/metrics.csv"
+    #     )
+    # )
+    # assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
+    # assert not df.val_loss.isnull().all()
+    # assert not df.train_loss.isnull().all()
 
-    #######
+    # #######
 
-    # check resume training
-    config_copy = config.copy()
-    OmegaConf.update(config_copy, "trainer_config.max_epochs", 4)
-    OmegaConf.update(
-        config_copy,
-        "trainer_config.resume_ckpt_path",
-        f"{Path(config.trainer_config.save_ckpt_path).joinpath('last.ckpt')}",
-    )
-    training_config = OmegaConf.load(
-        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
-    )
-    prv_runid = training_config.trainer_config.wandb.run_id
-    OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
-    trainer = ModelTrainer(config_copy)
-    trainer.train()
+    # # check resume training
+    # config_copy = config.copy()
+    # OmegaConf.update(config_copy, "trainer_config.max_epochs", 4)
+    # OmegaConf.update(
+    #     config_copy,
+    #     "trainer_config.resume_ckpt_path",
+    #     f"{Path(config.trainer_config.save_ckpt_path).joinpath('last.ckpt')}",
+    # )
+    # training_config = OmegaConf.load(
+    #     f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
+    # )
+    # prv_runid = training_config.trainer_config.wandb.run_id
+    # OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
+    # trainer = ModelTrainer(config_copy)
+    # trainer.train()
 
-    checkpoint = torch.load(
-        Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    )
-    assert checkpoint["epoch"] == 3
+    # checkpoint = torch.load(
+    #     Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    # )
+    # assert checkpoint["epoch"] == 3
 
-    training_config = OmegaConf.load(
-        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
-    )
-    assert training_config.trainer_config.wandb.run_id == prv_runid
-    os.remove((Path(trainer.dir_path) / "best.ckpt").as_posix())
-    os.remove((Path(trainer.dir_path) / "last.ckpt").as_posix())
-    shutil.rmtree((Path(trainer.dir_path) / "lightning_logs").as_posix())
+    # training_config = OmegaConf.load(
+    #     f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
+    # )
+    # assert training_config.trainer_config.wandb.run_id == prv_runid
+    # os.remove((Path(trainer.dir_path) / "best.ckpt").as_posix())
+    # os.remove((Path(trainer.dir_path) / "last.ckpt").as_posix())
+    # shutil.rmtree((Path(trainer.dir_path) / "lightning_logs").as_posix())
 
-    #######
+    # #######
 
-    # check early stopping
-    config_early_stopping = config.copy()
-    OmegaConf.update(
-        config_early_stopping, "trainer_config.early_stopping.min_delta", 1e-1
-    )
-    OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
-    OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
-    OmegaConf.update(
-        config_early_stopping,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_model_trainer/",
-    )
+    # # check early stopping
+    # config_early_stopping = config.copy()
+    # OmegaConf.update(
+    #     config_early_stopping, "trainer_config.early_stopping.min_delta", 1e-1
+    # )
+    # OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
+    # OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
+    # OmegaConf.update(
+    #     config_early_stopping,
+    #     "trainer_config.save_ckpt_path",
+    #     f"{tmp_path}/test_model_trainer/",
+    # )
 
-    trainer = ModelTrainer(config_early_stopping)
-    trainer.train()
+    # trainer = ModelTrainer(config_early_stopping)
+    # trainer.train()
 
-    checkpoint = torch.load(
-        Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    )
-    assert checkpoint["epoch"] == 1
+    # checkpoint = torch.load(
+    #     Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    # )
+    # assert checkpoint["epoch"] == 1
 
-    #######
+    # #######
 
-    # For Single instance model
-    single_instance_config = config.copy()
-    head_config = single_instance_config.model_config.head_configs.centered_instance
-    del single_instance_config.model_config.head_configs.centered_instance
-    OmegaConf.update(
-        single_instance_config, "model_config.head_configs.single_instance", head_config
-    )
-    del (
-        single_instance_config.model_config.head_configs.single_instance.confmaps.anchor_part
-    )
+    # # For Single instance model
+    # single_instance_config = config.copy()
+    # head_config = single_instance_config.model_config.head_configs.centered_instance
+    # del single_instance_config.model_config.head_configs.centered_instance
+    # OmegaConf.update(
+    #     single_instance_config, "model_config.head_configs.single_instance", head_config
+    # )
+    # del (
+    #     single_instance_config.model_config.head_configs.single_instance.confmaps.anchor_part
+    # )
 
-    trainer = ModelTrainer(single_instance_config)
-    trainer._initialize_model()
-    assert isinstance(trainer.model, SingleInstanceModel)
+    # trainer = ModelTrainer(single_instance_config)
+    # trainer._initialize_model()
+    # assert isinstance(trainer.model, SingleInstanceModel)
 
-    #######
+    # #######
 
-    # Centroid model
-    centroid_config = config.copy()
-    OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
-    del centroid_config.model_config.head_configs.centered_instance
-    del centroid_config.model_config.head_configs.centroid["confmaps"].part_names
+    # # Centroid model
+    # centroid_config = config.copy()
+    # OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
+    # del centroid_config.model_config.head_configs.centered_instance
+    # del centroid_config.model_config.head_configs.centroid["confmaps"].part_names
 
-    if (Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
-        os.remove(
-            (
-                Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt"
-            ).as_posix()
-        )
-        os.remove(
-            (
-                Path(centroid_config.trainer_config.save_ckpt_path) / "last.ckpt"
-            ).as_posix()
-        )
-        shutil.rmtree(
-            (
-                Path(centroid_config.trainer_config.save_ckpt_path) / "lightning_logs"
-            ).as_posix()
-        )
+    # if (Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
+    #     os.remove(
+    #         (
+    #             Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt"
+    #         ).as_posix()
+    #     )
+    #     os.remove(
+    #         (
+    #             Path(centroid_config.trainer_config.save_ckpt_path) / "last.ckpt"
+    #         ).as_posix()
+    #     )
+    #     shutil.rmtree(
+    #         (
+    #             Path(centroid_config.trainer_config.save_ckpt_path) / "lightning_logs"
+    #         ).as_posix()
+    #     )
 
-    OmegaConf.update(centroid_config, "trainer_config.save_ckpt", True)
-    OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
-    OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
-    OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
+    # OmegaConf.update(centroid_config, "trainer_config.save_ckpt", True)
+    # OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
+    # OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
+    # OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
 
-    trainer = ModelTrainer(centroid_config)
+    # trainer = ModelTrainer(centroid_config)
 
-    trainer._initialize_model()
-    assert isinstance(trainer.model, CentroidModel)
+    # trainer._initialize_model()
+    # assert isinstance(trainer.model, CentroidModel)
 
-    #######
+    # #######
 
-    # bottom up model
-    bottomup_config = config.copy()
-    OmegaConf.update(bottomup_config, "model_config.head_configs.bottomup", head_config)
-    paf = {
-        "edges": [("part1", "part2")],
-        "sigma": 4,
-        "output_stride": 4,
-        "loss_weight": 1.0,
-    }
-    del bottomup_config.model_config.head_configs.bottomup["confmaps"].anchor_part
-    del bottomup_config.model_config.head_configs.centered_instance
-    bottomup_config.model_config.head_configs.bottomup["pafs"] = paf
-    bottomup_config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
+    # # bottom up model
+    # bottomup_config = config.copy()
+    # OmegaConf.update(bottomup_config, "model_config.head_configs.bottomup", head_config)
+    # paf = {
+    #     "edges": [("part1", "part2")],
+    #     "sigma": 4,
+    #     "output_stride": 4,
+    #     "loss_weight": 1.0,
+    # }
+    # del bottomup_config.model_config.head_configs.bottomup["confmaps"].anchor_part
+    # del bottomup_config.model_config.head_configs.centered_instance
+    # bottomup_config.model_config.head_configs.bottomup["pafs"] = paf
+    # bottomup_config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
 
-    if (Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
-        os.remove(
-            (
-                Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt"
-            ).as_posix()
-        )
-        os.remove(
-            (
-                Path(bottomup_config.trainer_config.save_ckpt_path) / "last.ckpt"
-            ).as_posix()
-        )
-        shutil.rmtree(
-            (
-                Path(bottomup_config.trainer_config.save_ckpt_path) / "lightning_logs"
-            ).as_posix()
-        )
+    # if (Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
+    #     os.remove(
+    #         (
+    #             Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt"
+    #         ).as_posix()
+    #     )
+    #     os.remove(
+    #         (
+    #             Path(bottomup_config.trainer_config.save_ckpt_path) / "last.ckpt"
+    #         ).as_posix()
+    #     )
+    #     shutil.rmtree(
+    #         (
+    #             Path(bottomup_config.trainer_config.save_ckpt_path) / "lightning_logs"
+    #         ).as_posix()
+    #     )
 
-    OmegaConf.update(bottomup_config, "trainer_config.save_ckpt", True)
-    OmegaConf.update(bottomup_config, "trainer_config.use_wandb", False)
-    OmegaConf.update(bottomup_config, "trainer_config.max_epochs", 1)
-    OmegaConf.update(bottomup_config, "trainer_config.steps_per_epoch", 10)
+    # OmegaConf.update(bottomup_config, "trainer_config.save_ckpt", True)
+    # OmegaConf.update(bottomup_config, "trainer_config.use_wandb", False)
+    # OmegaConf.update(bottomup_config, "trainer_config.max_epochs", 1)
+    # OmegaConf.update(bottomup_config, "trainer_config.steps_per_epoch", 10)
 
-    trainer = ModelTrainer(bottomup_config)
-    trainer._initialize_model()
-    assert isinstance(trainer.model, BottomUpModel)
+    # trainer = ModelTrainer(bottomup_config)
+    # trainer._initialize_model()
+    # assert isinstance(trainer.model, BottomUpModel)
 
-    #######
+    # #######
 
-    # check loading trained weights
-    load_weights_config = config.copy()
-    ckpt = torch.load((Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix())
-    first_layer_ckpt = ckpt["state_dict"][
-        "model.backbone.enc.encoder_stack.0.blocks.0.weight"
-    ][0, 0, :].numpy()
+    # # check loading trained weights
+    # load_weights_config = config.copy()
+    # ckpt = torch.load((Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix())
+    # first_layer_ckpt = ckpt["state_dict"][
+    #     "model.backbone.enc.encoder_stack.0.blocks.0.weight"
+    # ][0, 0, :].numpy()
 
-    trainer = ModelTrainer(load_weights_config)
-    trainer._create_data_loaders()
-    trainer._initialize_model(
-        (Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix()
-    )
-    model_ckpt = next(trainer.model.parameters())[0, 0, :].detach().numpy()
+    # trainer = ModelTrainer(load_weights_config)
+    # trainer._create_data_loaders()
+    # trainer._initialize_model(
+    #     (Path(minimal_instance_bottomup_ckpt) / "best.ckpt").as_posix()
+    # )
+    # model_ckpt = next(trainer.model.parameters())[0, 0, :].detach().numpy()
 
-    assert np.all(np.abs(first_layer_ckpt - model_ckpt) < 1e-3)
+    # assert np.all(np.abs(first_layer_ckpt - model_ckpt) < 1e-3)
 
-    shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
-    shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
+    # shutil.rmtree((Path(trainer.bin_files_path) / "train_chunks").as_posix())
+    # shutil.rmtree((Path(trainer.bin_files_path) / "val_chunks").as_posix())
 
 
 def test_topdown_centered_instance_model(config, tmp_path: str):


### PR DESCRIPTION
Currently, the `.bin` files generated by `ld.optimize` is retained even after training. This PR deletes the sub-directory containing the `train_chunks` and `val_chunks` folders after training is done.