### PR TITLE
Add config to WandB

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -170,7 +170,6 @@ The config file has three main sections:
         - `api_key`: (str) API key. The API key is masked when saved to config files.
         - `wandb_mode`: (str) "offline" if only local logging is required. Default: "None".
         - `prv_runid`: (str) Previous run ID if training should be resumed from a previous ckpt. *Default*: `None`.
-        - `log_params`: (List[str]) List of config parameters to save it in wandb logs. For example, to save learning rate from trainer config section, use "trainer_config.optimizer.lr" (provide the full path to the specific config parameter).
     - `optimizer_name`: (str) Optimizer to be used. One of ["Adam", "AdamW"].
     - `optimizer`
         - `lr`: (float) Learning rate of type float. *Default*: 1e-3

--- a/docs/config_centroid.yaml
+++ b/docs/config_centroid.yaml
@@ -123,12 +123,6 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid:
-    log_params:
-    - trainer_config.optimizer_name
-    - trainer_config.optimizer.amsgrad
-    - trainer_config.optimizer.lr
-    - model_config.backbone_type
-    - model_config.init_weights
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "av",
     "kornia",
     "hydra-core",
-    "sleap-io>=0.1.0",
+    "sleap-io==0.1.10",
 ]
 dynamic = ["version", "readme"]
 

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -440,7 +440,7 @@ class ModelTrainer:
             )
 
             if self.config.trainer_config.use_wandb:
-                wandb_logger.experiment.config.update(self.config)
+                wandb_logger.experiment.config.update(dict(self.config))
                 wandb_logger.experiment.config.update({"model_params": total_params})
 
         except KeyboardInterrupt:

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -440,13 +440,7 @@ class ModelTrainer:
             )
 
             if self.config.trainer_config.use_wandb:
-                for m in self.config.trainer_config.wandb.log_params:
-                    list_keys = m.split(".")
-                    key = list_keys[-1]
-                    value = self.config[list_keys[0]]
-                    for l in list_keys[1:]:
-                        value = value[l]
-                    wandb_logger.experiment.config.update({key: value})
+                wandb_logger.experiment.config.update(self.config)
                 wandb_logger.experiment.config.update({"model_params": total_params})
 
         except KeyboardInterrupt:

--- a/tests/assets/minimal_instance/initial_config.yaml
+++ b/tests/assets/minimal_instance/initial_config.yaml
@@ -75,12 +75,6 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid:
-    log_params:
-    - trainer_config.optimizer_name
-    - trainer_config.optimizer.amsgrad
-    - trainer_config.optimizer.lr
-    - model_config.backbone_type
-    - model_config.init_weights
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/tests/assets/minimal_instance/training_config.yaml
+++ b/tests/assets/minimal_instance/training_config.yaml
@@ -88,12 +88,6 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid: null
-    log_params:
-    - trainer_config.optimizer_name
-    - trainer_config.optimizer.amsgrad
-    - trainer_config.optimizer.lr
-    - model_config.backbone_type
-    - model_config.init_weights
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/tests/assets/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/initial_config.yaml
@@ -76,12 +76,6 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid:
-    log_params:
-    - trainer_config.optimizer_name
-    - trainer_config.optimizer.amsgrad
-    - trainer_config.optimizer.lr
-    - model_config.backbone_type
-    - model_config.init_weights
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/tests/assets/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/training_config.yaml
@@ -91,12 +91,6 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid:
-    log_params:
-    - trainer_config.optimizer_name
-    - trainer_config.optimizer.amsgrad
-    - trainer_config.optimizer.lr
-    - model_config.backbone_type
-    - model_config.init_weights
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/tests/assets/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/minimal_instance_centroid/initial_config.yaml
@@ -70,12 +70,6 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid:
-    log_params:
-    - trainer_config.optimizer_name
-    - trainer_config.optimizer.amsgrad
-    - trainer_config.optimizer.lr
-    - model_config.backbone_type
-    - model_config.init_weights
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/tests/assets/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/minimal_instance_centroid/training_config.yaml
@@ -81,13 +81,6 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid:
-    log_params:
-    - trainer_config.optimizer_name
-    - trainer_config.optimizer.amsgrad
-    - trainer_config.optimizer.lr
-    - model_config.backbone_type
-    - model_config.backbone_type
-    - model_config.init_weights
   optimizer_name: Adam
   optimizer:
     lr: 0.0001


### PR DESCRIPTION
This PR adds the config to WandB to log the training parameters. Since we're logging the entire config, `trainer_config.wandb.log_params` is removed from the config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for configuration files, detailing parameters for data, model, and training configurations.
	- Simplified logging configuration by removing unnecessary parameters in the Weights and Biases (WandB) integration across various YAML files.

- **Chores**
	- Updated dependency version for `sleap-io` to ensure compatibility.
	- Streamlined the logging process for model training configurations, improving clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->