### PR TITLE
Add option to load trained weights for Head layers

### DIFF
--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -89,7 +89,7 @@ def config(sleap_data_dir):
                     "stacks": 1,
                     "stem_stride": None,
                     "middle_block": True,
-                    "up_interpolate": True,
+                    "up_interpolate": False,
                 },
                 "head_configs": {
                     "single_instance": None,


### PR DESCRIPTION
This PR adds an option to load trained weights for head layers right before training (instead of random initialization) for transfer learning. The `.ckpt` paths can be passed to `ModelTrainer.train(backbone_trained_ckpts_path=<your_path>, head_trained_ckpts_path=<your_path>)`.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced model training with separate weight handling for backbone and head components.
	- Updated configuration settings for improved data processing and model training.

- **Bug Fixes**
	- Improved error handling for loading model weights.

- **Tests**
	- Introduced a new test for verifying loading of trained weights for backbone and head layers.
	- Updated existing tests to align with new checkpoint loading logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->