### PR TITLE
Fix Normalization order in data pipelines

### DIFF
--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -159,7 +159,7 @@ def centered_instance_data_chunks(
             break
 
         res = generate_crops(
-            sample["image"].to(torch.float32), instance, centroid, crop_size
+            apply_normalization(sample["image"]), instance, centroid, crop_size
         )
 
         res["frame_idx"] = sample["frame_idx"]

--- a/sleap_nn/data/get_data_chunks.py
+++ b/sleap_nn/data/get_data_chunks.py
@@ -54,6 +54,8 @@ def bottomup_data_chunks(
 
     sample = process_lf(lf, video_idx, max_instances, user_instances_only)
 
+    sample["image"] = apply_normalization(sample["image"])
+
     if data_config.preprocessing.is_rgb:
         sample["image"] = convert_to_rgb(sample["image"])
     else:
@@ -126,6 +128,7 @@ def centered_instance_data_chunks(
     lf, video_idx = x
 
     sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+    sample["image"] = apply_normalization(sample["image"])
 
     if data_config.preprocessing.is_rgb:
         sample["image"] = convert_to_rgb(sample["image"])
@@ -158,9 +161,7 @@ def centered_instance_data_chunks(
         if cnt == sample["num_instances"]:
             break
 
-        res = generate_crops(
-            apply_normalization(sample["image"]), instance, centroid, crop_size
-        )
+        res = generate_crops(sample["image"], instance, centroid, crop_size)
 
         res["frame_idx"] = sample["frame_idx"]
         res["video_idx"] = sample["video_idx"]
@@ -217,6 +218,7 @@ def centroid_data_chunks(
     lf, video_idx = x
 
     sample = process_lf(lf, video_idx, max_instances, user_instances_only)
+    sample["image"] = apply_normalization(sample["image"])
 
     if data_config.preprocessing.is_rgb:
         sample["image"] = convert_to_rgb(sample["image"])
@@ -288,6 +290,7 @@ def single_instance_data_chunks(
     sample = process_lf(
         lf, video_idx, user_instances_only=user_instances_only, max_instances=1
     )
+    sample["image"] = apply_normalization(sample["image"])
 
     if data_config.preprocessing.is_rgb:
         sample["image"] = convert_to_rgb(sample["image"])

--- a/sleap_nn/data/streaming_datasets.py
+++ b/sleap_nn/data/streaming_datasets.py
@@ -64,7 +64,8 @@ class BottomUpStreamingDataset(ld.StreamingDataset):
         ex = super().__getitem__(index)
         transform = T.PILToTensor()
         ex["image"] = transform(ex["image"])
-        ex["image"] = ex["image"].unsqueeze(dim=0).to(torch.float32)
+        ex["image"] = ex["image"].unsqueeze(dim=0)
+        ex["image"] = apply_normalization(ex["image"])
 
         # Augmentation
         if self.apply_aug:
@@ -77,8 +78,6 @@ class BottomUpStreamingDataset(ld.StreamingDataset):
                 ex["image"], ex["instances"] = apply_geometric_augmentation(
                     ex["image"], ex["instances"], **self.aug_config.geometric
                 )
-
-        ex["image"] = apply_normalization(ex["image"])
 
         # Pad the image (if needed) according max stride
         ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
@@ -159,7 +158,9 @@ class CenteredInstanceStreamingDataset(ld.StreamingDataset):
         ex = super().__getitem__(index)
         transform = T.PILToTensor()
         ex["instance_image"] = transform(ex["instance_image"])
-        ex["instance_image"] = ex["instance_image"].unsqueeze(dim=0).to(torch.float32)
+        ex["instance_image"] = ex["instance_image"].unsqueeze(dim=0)
+        ex["instance_image"] = apply_normalization(ex["instance_image"])
+
         # Augmentation
         if self.apply_aug:
             if "intensity" in self.aug_config:
@@ -184,8 +185,6 @@ class CenteredInstanceStreamingDataset(ld.StreamingDataset):
 
         ex["instance"] = center_instance.unsqueeze(0)  # (n_samples=1, n_nodes, 2)
         ex["centroid"] = centered_centroid.unsqueeze(0)  # (n_samples=1, 2)
-
-        ex["instance_image"] = apply_normalization(ex["instance_image"])
 
         # Pad the image (if needed) according max stride
         ex["instance_image"] = apply_pad_to_stride(
@@ -246,7 +245,8 @@ class CentroidStreamingDataset(ld.StreamingDataset):
         ex = super().__getitem__(index)
         transform = T.PILToTensor()
         ex["image"] = transform(ex["image"])
-        ex["image"] = ex["image"].unsqueeze(dim=0).to(torch.float32)
+        ex["image"] = ex["image"].unsqueeze(dim=0)
+        ex["image"] = apply_normalization(ex["image"])
 
         # Augmentation
         if self.apply_aug:
@@ -259,8 +259,6 @@ class CentroidStreamingDataset(ld.StreamingDataset):
                 ex["image"], ex["centroids"] = apply_geometric_augmentation(
                     ex["image"], ex["centroids"], **self.aug_config.geometric
                 )
-
-        ex["image"] = apply_normalization(ex["image"])
 
         # Pad the image (if needed) according max stride
         ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)
@@ -321,7 +319,8 @@ class SingleInstanceStreamingDataset(ld.StreamingDataset):
         ex = super().__getitem__(index)
         transform = T.PILToTensor()
         ex["image"] = transform(ex["image"])
-        ex["image"] = ex["image"].unsqueeze(dim=0).to(torch.float32)
+        ex["image"] = ex["image"].unsqueeze(dim=0)
+        ex["image"] = apply_normalization(ex["image"])
 
         # Augmentation
         if self.apply_aug:
@@ -334,8 +333,6 @@ class SingleInstanceStreamingDataset(ld.StreamingDataset):
                 ex["image"], ex["instances"] = apply_geometric_augmentation(
                     ex["image"], ex["instances"], **self.aug_config.geometric
                 )
-
-        ex["image"] = apply_normalization(ex["image"])
 
         # Pad the image (if needed) according max stride
         ex["image"] = apply_pad_to_stride(ex["image"], max_stride=self.max_stride)

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -224,10 +224,31 @@ def test_topdown_predictor(
     )
 
     assert np.all(np.abs(head_layer_ckpt - model_weights) < 1e-6)
-    print(
-        f"centered instance model: ",
-        predictor.inference_model.instance_peaks.torch_model.model,
+
+    # load only backbone and head ckpt as None - centered instance
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_ckpt],
+        backbone_ckpt_path=Path(minimal_instance_ckpt) / "best.ckpt",
+        head_ckpt_path=None,
+        peak_threshold=0.03,
+        max_instances=6,
+        preprocess_config=OmegaConf.create(preprocess_config),
     )
+
+    ckpt = torch.load(Path(minimal_instance_ckpt) / "best.ckpt")
+    backbone_ckpt = ckpt["state_dict"][
+        "model.backbone.enc.encoder_stack.0.blocks.0.weight"
+    ][0, 0, :].numpy()
+
+    model_weights = (
+        next(predictor.inference_model.instance_peaks.torch_model.model.parameters())[
+            0, 0, :
+        ]
+        .detach()
+        .numpy()
+    )
+
+    assert np.all(np.abs(backbone_ckpt - model_weights) < 1e-6)
 
     # check loading diff head ckpt for centroid
     preprocess_config = {
@@ -246,11 +267,32 @@ def test_topdown_predictor(
         preprocess_config=OmegaConf.create(preprocess_config),
     )
 
-    print(
-        f"centroid model: ", predictor.inference_model.centroid_crop.torch_model.model
+    ckpt = torch.load(Path(minimal_instance_ckpt) / "best.ckpt")
+    backbone_ckpt = ckpt["state_dict"][
+        "model.backbone.enc.encoder_stack.0.blocks.0.weight"
+    ][0, 0, :].numpy()
+
+    model_weights = (
+        next(predictor.inference_model.centroid_crop.torch_model.model.parameters())[
+            0, 0, :
+        ]
+        .detach()
+        .numpy()
     )
 
-    ckpt = torch.load(Path(minimal_instance_ckpt) / "best.ckpt")
+    assert np.all(np.abs(backbone_ckpt - model_weights) < 1e-6)
+
+    # load only backbone and head ckpt as None - centroid
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_centroid_ckpt],
+        backbone_ckpt_path=Path(minimal_instance_centroid_ckpt) / "best.ckpt",
+        head_ckpt_path=None,
+        peak_threshold=0.03,
+        max_instances=6,
+        preprocess_config=OmegaConf.create(preprocess_config),
+    )
+
+    ckpt = torch.load(Path(minimal_instance_centroid_ckpt) / "best.ckpt")
     backbone_ckpt = ckpt["state_dict"][
         "model.backbone.enc.encoder_stack.0.blocks.0.weight"
     ][0, 0, :].numpy()


### PR DESCRIPTION
Currently, in `streaming_datasets.py`, we read the PIL images from `.bin` files, convert them to `torch.float32` tensors to pass the images to kornia augmentation transforms, and we normalize image (images are scaled to [0,1]) after augmentation is applied. Instead, in this PR, we normalize image before applying kornia augmentation to remove redundancy.