### PR TITLE
Add torch Dataset classes

### DIFF
--- a/initial_config.yaml
+++ b/initial_config.yaml
@@ -37,7 +37,7 @@ model_config:
     stacks: 1
     stem_stride: null
     middle_block: true
-    up_interpolate: true
+    up_interpolate: false
   head_configs:
     single_instance: null
     centroid: null

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1,0 +1,590 @@
+"""Custom `torch.utils.data.Dataset`s for different model types."""
+
+from typing import Dict, Iterator, List, Optional, Tuple
+from omegaconf import DictConfig
+import numpy as np
+import torch
+import torchvision.transforms as T
+from torch.utils.data import Dataset
+import sleap_io as sio
+from sleap_nn.data.instance_centroids import generate_centroids
+from sleap_nn.data.instance_cropping import generate_crops
+from sleap_nn.data.normalization import (
+    apply_normalization,
+    convert_to_grayscale,
+    convert_to_rgb,
+)
+from sleap_nn.data.providers import get_max_instances, get_max_height_width, process_lf
+from sleap_nn.data.resizing import apply_sizematcher, apply_resizer
+from sleap_nn.data.augmentation import (
+    apply_geometric_augmentation,
+    apply_intensity_augmentation,
+)
+from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
+from sleap_nn.data.edge_maps import generate_pafs
+from sleap_nn.data.normalization import apply_normalization
+from sleap_nn.data.resizing import apply_pad_to_stride, apply_resizer
+
+
+class BaseDataset(Dataset):
+    """Base class for custom torch Datasets.
+
+    Attributes:
+        labels: Source `sio.Labels` object.
+        data_config: Data-related configuration. (`data_config` section in the config file).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
+    """
+
+    def __init__(
+        self,
+        labels: sio.Labels,
+        data_config: DictConfig,
+        max_stride: int,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+    ) -> None:
+        """Initialize class attributes."""
+        super().__init__()
+        self.labels = labels
+        self.data_config = data_config
+        self.max_stride = max_stride
+        self.apply_aug = apply_aug
+        self.max_hw = max_hw
+        self.max_instances = get_max_instances(self.labels)
+
+    def _get_video_idx(self, lf):
+        """Return indsample of `lf.video` in `labels.videos`."""
+        return self.labels.videos.index(lf.video)
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset."""
+        return len(self.labels)
+
+    def __getitem__(self, index) -> Dict:
+        """Returns the sample dict for given index."""
+        pass
+
+
+class BottomUpDataset(BaseDataset):
+    """Dataset class for bottom-up models.
+
+    Attributes:
+        labels: Source `sio.Labels` object.
+        data_config: Data-related configuration. (`data_config` section in the config file).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
+        confmap_head_config: DictConfig object with all the keys in the `head_config` section.
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        pafs_head_config: DictConfig object with all the keys in the `head_config` section
+            (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type )
+            for PAFs.
+    """
+
+    def __init__(
+        self,
+        labels: sio.Labels,
+        data_config: DictConfig,
+        confmap_head_config: DictConfig,
+        pafs_head_config: DictConfig,
+        max_stride: int,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+    ) -> None:
+        """Initialize class attributes."""
+        super().__init__(
+            labels=labels,
+            data_config=data_config,
+            max_stride=max_stride,
+            apply_aug=apply_aug,
+            max_hw=max_hw,
+        )
+        self.confmap_head_config = confmap_head_config
+        self.pafs_head_config = pafs_head_config
+
+        self.edge_inds = self.labels.skeletons[0].edge_inds
+
+    def __len__(self) -> int:
+        """Return number of `LabeledFrames` in the labels object."""
+        return len(self.labels)
+
+    def __getitem__(self, index) -> Dict:
+        """Return dict with image, confmaps and pafs for given index."""
+        lf = self.labels[index]
+        video_idx = self._get_video_idx(lf)
+
+        # get dict
+        sample = process_lf(
+            lf,
+            video_idx=video_idx,
+            max_instances=self.max_instances,
+            user_instances_only=self.data_config.user_instances_only,
+        )
+
+        # apply normalization
+        sample["image"] = apply_normalization(sample["image"])
+
+        if self.data_config.preprocessing.is_rgb:
+            sample["image"] = convert_to_rgb(sample["image"])
+        else:
+            sample["image"] = convert_to_grayscale(sample["image"])
+
+        # size matcher
+        sample["image"], eff_scale = apply_sizematcher(
+            sample["image"],
+            max_height=self.max_hw[0],
+            max_width=self.max_hw[1],
+        )
+        sample["instances"] = sample["instances"] * eff_scale
+
+        # apply augmentation
+        if self.apply_aug:
+            if "intensity" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_intensity_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.intensity,
+                )
+
+            if "geometric" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_geometric_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.geometric,
+                )
+
+        # resize image
+        sample["image"], sample["instances"] = apply_resizer(
+            sample["image"],
+            sample["instances"],
+            scale=self.data_config.preprocessing.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        sample["image"] = apply_pad_to_stride(
+            sample["image"], max_stride=self.max_stride
+        )
+
+        img_hw = sample["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(
+            sample["instances"],
+            img_hw=img_hw,
+            num_instances=sample["num_instances"],
+            sigma=self.confmap_head_config.sigma,
+            output_stride=self.confmap_head_config.output_stride,
+            is_centroids=False,
+        )
+
+        # pafs
+        pafs = generate_pafs(
+            sample["instances"],
+            img_hw=img_hw,
+            sigma=self.pafs_head_config.sigma,
+            output_stride=self.pafs_head_config.output_stride,
+            edge_inds=torch.Tensor(self.edge_inds),
+            flatten_channels=True,
+        )
+
+        sample["confidence_maps"] = confidence_maps
+        sample["part_affinity_fields"] = pafs
+
+        return sample
+
+
+class CenteredInstanceDataset(BaseDataset):
+    """Dataset class for instance-centered confidence map models.
+
+    Attributes:
+        labels: Source `sio.Labels` object.
+        data_config: Data-related configuration. (`data_config` section in the config file).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
+        confmap_head_config: DictConfig object with all the keys in the `head_config` section.
+        (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+        crop_hw: Height and width of the crop in pixels.
+
+    Note: If scale is provided for centered-instance model, the images are cropped out
+    of original image according to given crop height and width and then the cropped
+    images are scaled.
+    """
+
+    def __init__(
+        self,
+        labels: sio.Labels,
+        data_config: DictConfig,
+        crop_hw: Tuple[int],
+        confmap_head_config: DictConfig,
+        max_stride: int,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+    ) -> None:
+        """Initialize class attributes."""
+        super().__init__(
+            labels=labels,
+            data_config=data_config,
+            max_stride=max_stride,
+            apply_aug=apply_aug,
+            max_hw=max_hw,
+        )
+        self.crop_hw = crop_hw
+        self.confmap_head_config = confmap_head_config
+        self.instance_idx_list = self._get_instance_idx_list()
+
+    def _get_instance_idx_list(self) -> List[Tuple[int]]:
+        """Return list of tuples with indices of labelled frames and instances."""
+        instance_idx_list = []
+        for lf_idx, lf in enumerate(self.labels):
+            for inst_idx, _ in enumerate(lf.instances):
+                instance_idx_list.append((lf_idx, inst_idx))
+        return instance_idx_list
+
+    def __len__(self) -> int:
+        """Return number of instances in the labels object."""
+        return len(self.instance_idx_list)
+
+    def __getitem__(self, index) -> Dict:
+        """Return dict with cropped image and confmaps of instance for given index."""
+        lf_idx, inst_idx = self.instance_idx_list[index]
+
+        lf = self.labels[lf_idx]
+        video_idx = self._get_video_idx(lf)
+
+        # get dict
+        sample = process_lf(
+            lf,
+            video_idx=video_idx,
+            max_instances=None,
+            user_instances_only=self.data_config.user_instances_only,
+        )
+
+        sample["instances"] = sample["instances"][:, inst_idx]
+
+        # apply normalization
+        sample["image"] = apply_normalization(
+            sample["image"]
+        )  # TODO: get img with cache
+
+        if self.data_config.preprocessing.is_rgb:
+            sample["image"] = convert_to_rgb(sample["image"])
+        else:
+            sample["image"] = convert_to_grayscale(sample["image"])
+
+        # size matcher
+        sample["image"], eff_scale = apply_sizematcher(
+            sample["image"],
+            max_height=self.max_hw[0],
+            max_width=self.max_hw[1],
+        )
+        sample["instances"] = sample["instances"] * eff_scale
+
+        # apply augmentation
+        if self.apply_aug:
+            if "intensity" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_intensity_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.intensity,
+                )
+
+            if "geometric" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_geometric_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.geometric,
+                )
+
+        # get the centroids based on the anchor idx
+        centroids = generate_centroids(
+            sample["instances"], anchor_ind=self.confmap_head_config.anchor_part
+        )
+
+        instances, centroids = sample["instances"][0], centroids[0]  # (n_samples=1)
+        instance, centroid = instances[0], centroids[0]  # (num_instances=1, ...)
+
+        res = generate_crops(sample["image"], instance, centroid, self.crop_hw)
+
+        res["frame_idx"] = sample["frame_idx"]
+        res["video_idx"] = sample["video_idx"]
+        res["num_instances"] = sample["num_instances"]
+        res["orig_size"] = sample["orig_size"]
+
+        # resize image
+        res["instance_image"], res["instance"] = apply_resizer(
+            res["instance_image"],
+            res["instance"],
+            scale=self.data_config.preprocessing.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        res["instance_image"] = apply_pad_to_stride(
+            res["instance_image"], max_stride=self.max_stride
+        )
+
+        img_hw = res["instance_image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(
+            res["instance"],
+            img_hw=img_hw,
+            sigma=self.confmap_head_config.sigma,
+            output_stride=self.confmap_head_config.output_stride,
+        )
+
+        res["confidence_maps"] = confidence_maps
+
+        return res
+
+
+class CentroidDataset(BaseDataset):
+    """Dataset class for centroid models.
+
+    Attributes:
+        labels: Source `sio.Labels` object.
+        data_config: Data-related configuration. (`data_config` section in the config file).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
+        confmap_head_config: DictConfig object with all the keys in the `head_config` section.
+        (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+    """
+
+    def __init__(
+        self,
+        labels: sio.Labels,
+        data_config: DictConfig,
+        confmap_head_config: DictConfig,
+        max_stride: int,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+    ) -> None:
+        """Initialize class attributes."""
+        super().__init__(
+            labels=labels,
+            data_config=data_config,
+            max_stride=max_stride,
+            apply_aug=apply_aug,
+            max_hw=max_hw,
+        )
+        self.confmap_head_config = confmap_head_config
+
+    def __len__(self) -> int:
+        """Return number of `LabeledFrames` in the labels object."""
+        return len(self.labels)
+
+    def __getitem__(self, index) -> Dict:
+        """Return dict with image and confmaps for centroids for given index."""
+        lf = self.labels[index]
+        video_idx = self._get_video_idx(lf)
+
+        # get dict
+        sample = process_lf(
+            lf,
+            video_idx=video_idx,
+            max_instances=self.max_instances,
+            user_instances_only=self.data_config.user_instances_only,
+        )
+
+        # apply normalization
+        sample["image"] = apply_normalization(sample["image"])
+
+        if self.data_config.preprocessing.is_rgb:
+            sample["image"] = convert_to_rgb(sample["image"])
+        else:
+            sample["image"] = convert_to_grayscale(sample["image"])
+
+        # size matcher
+        sample["image"], eff_scale = apply_sizematcher(
+            sample["image"],
+            max_height=self.max_hw[0],
+            max_width=self.max_hw[1],
+        )
+        sample["instances"] = sample["instances"] * eff_scale
+
+        # apply augmentation
+        if self.apply_aug:
+            if "intensity" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_intensity_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.intensity,
+                )
+
+            if "geometric" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_geometric_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.geometric,
+                )
+
+        # get the centroids based on the anchor idx
+        centroids = generate_centroids(
+            sample["instances"], anchor_ind=self.confmap_head_config.anchor_part
+        )
+
+        sample["centroids"] = centroids
+
+        # resize image
+        sample["image"], sample["centroids"] = apply_resizer(
+            sample["image"],
+            sample["centroids"],
+            scale=self.data_config.preprocessing.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        sample["image"] = apply_pad_to_stride(
+            sample["image"], max_stride=self.max_stride
+        )
+
+        img_hw = sample["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_multiconfmaps(
+            sample["centroids"],
+            img_hw=img_hw,
+            num_instances=sample["num_instances"],
+            sigma=self.confmap_head_config.sigma,
+            output_stride=self.confmap_head_config.output_stride,
+            is_centroids=True,
+        )
+
+        sample["centroids_confidence_maps"] = confidence_maps
+
+        return sample
+
+
+class SingleInstanceDataset(BaseDataset):
+    """Dataset class for single-instance models.
+
+    Attributes:
+        labels: Source `sio.Labels` object.
+        data_config: Data-related configuration. (`data_config` section in the config file).
+        max_stride: Scalar integer specifying the maximum stride that the image must be
+            divisible by.
+        apply_aug: `True` if augmentations should be applied to the data pipeline,
+            else `False`. Default: `False`.
+        max_hw: Maximum height and width of images across the labels file. If `max_height` and
+           `max_width` in the config is None, then `max_hw` is used (computed with
+            `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
+            are used.
+        confmap_head_config: DictConfig object with all the keys in the `head_config` section.
+        (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
+    """
+
+    def __init__(
+        self,
+        labels: sio.Labels,
+        data_config: DictConfig,
+        confmap_head_config: DictConfig,
+        max_stride: int,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+    ) -> None:
+        """Initialize class attributes."""
+        super().__init__(
+            labels=labels,
+            data_config=data_config,
+            max_stride=max_stride,
+            apply_aug=apply_aug,
+            max_hw=max_hw,
+        )
+        self.confmap_head_config = confmap_head_config
+
+    def __len__(self) -> int:
+        """Return number of `LabeledFrames` in the labels object."""
+        return len(self.labels)
+
+    def __getitem__(self, index) -> Dict:
+        """Return dict with image and confmaps for instance for given index."""
+        lf = self.labels[index]
+        video_idx = self._get_video_idx(lf)
+
+        # get dict
+        sample = process_lf(
+            lf,
+            video_idx=video_idx,
+            max_instances=1,
+            user_instances_only=self.data_config.user_instances_only,
+        )
+
+        # apply normalization
+        sample["image"] = apply_normalization(sample["image"])
+
+        if self.data_config.preprocessing.is_rgb:
+            sample["image"] = convert_to_rgb(sample["image"])
+        else:
+            sample["image"] = convert_to_grayscale(sample["image"])
+
+        # size matcher
+        sample["image"], eff_scale = apply_sizematcher(
+            sample["image"],
+            max_height=self.max_hw[0],
+            max_width=self.max_hw[1],
+        )
+        sample["instances"] = sample["instances"] * eff_scale
+
+        # apply augmentation
+        if self.apply_aug:
+            if "intensity" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_intensity_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.intensity,
+                )
+
+            if "geometric" in self.data_config.augmentation_config:
+                sample["image"], sample["instances"] = apply_geometric_augmentation(
+                    sample["image"],
+                    sample["instances"],
+                    **self.data_config.augmentation_config.geometric,
+                )
+
+        # resize image
+        sample["image"], sample["instances"] = apply_resizer(
+            sample["image"],
+            sample["instances"],
+            scale=self.data_config.preprocessing.scale,
+        )
+
+        # Pad the image (if needed) according max stride
+        sample["image"] = apply_pad_to_stride(
+            sample["image"], max_stride=self.max_stride
+        )
+
+        img_hw = sample["image"].shape[-2:]
+
+        # Generate confidence maps
+        confidence_maps = generate_confmaps(
+            sample["instances"],
+            img_hw=img_hw,
+            sigma=self.confmap_head_config.sigma,
+            output_stride=self.confmap_head_config.output_stride,
+        )
+
+        sample["confidence_maps"] = confidence_maps
+
+        return sample

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -116,10 +116,6 @@ class BottomUpDataset(BaseDataset):
 
         self.edge_inds = self.labels.skeletons[0].edge_inds
 
-    def __len__(self) -> int:
-        """Return number of `LabeledFrames` in the labels object."""
-        return len(self.labels)
-
     def __getitem__(self, index) -> Dict:
         """Return dict with image, confmaps and pafs for given index."""
         lf = self.labels[index]
@@ -422,10 +418,6 @@ class CentroidDataset(BaseDataset):
         )
         self.confmap_head_config = confmap_head_config
 
-    def __len__(self) -> int:
-        """Return number of `LabeledFrames` in the labels object."""
-        return len(self.labels)
-
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for centroids for given index."""
         lf = self.labels[index]
@@ -543,10 +535,6 @@ class SingleInstanceDataset(BaseDataset):
             max_hw=max_hw,
         )
         self.confmap_head_config = confmap_head_config
-
-    def __len__(self) -> int:
-        """Return number of `LabeledFrames` in the labels object."""
-        return len(self.labels)
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for instance for given index."""

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -30,8 +30,8 @@ def get_max_instances(labels: sio.Labels):
 
 def get_max_height_width(labels: sio.Labels) -> Tuple[int, int]:
     """Return `(height, width)` that is the maximum of all videos."""
-    return max(video.shape[1] for video in labels.videos), max(
-        video.shape[2] for video in labels.videos
+    return int(max(video.shape[1] for video in labels.videos)), int(
+        max(video.shape[2] for video in labels.videos)
     )
 
 

--- a/sleap_nn/training/get_bin_files.py
+++ b/sleap_nn/training/get_bin_files.py
@@ -25,12 +25,13 @@ if __name__ == "__main__":
     parser.add_argument("--chunk_size", type=int)
     parser.add_argument("--scale", type=float)
     parser.add_argument("--crop_hw", type=int, default=None)
+    parser.add_argument("--max_height", type=int)
+    parser.add_argument("--max_width", type=int)
     args = parser.parse_args()
 
     config = OmegaConf.load(f"{args.dir_path}/initial_config.yaml")
 
     train_labels = sio.load_slp(config.data_config.train_labels_path)
-    max_height, max_width = get_max_height_width(train_labels)
     val_labels = sio.load_slp(config.data_config.val_labels_path)
     user_instances_only = False if args.user_instances_only == 0 else True
 
@@ -45,7 +46,7 @@ if __name__ == "__main__":
             single_instance_data_chunks,
             data_config=config.data_config,
             user_instances_only=user_instances_only,
-            max_hw=(max_height, max_width),
+            max_hw=(args.max_height, args.max_width),
             scale=args.scale,
         )
 
@@ -74,7 +75,7 @@ if __name__ == "__main__":
             crop_size=(args.crop_hw, args.crop_hw),
             anchor_ind=config.model_config.head_configs.centered_instance.confmaps.anchor_part,
             user_instances_only=user_instances_only,
-            max_hw=(max_height, max_width),
+            max_hw=(args.max_height, args.max_width),
             scale=args.scale,
         )
 
@@ -101,7 +102,7 @@ if __name__ == "__main__":
             max_instances=max_instances,
             anchor_ind=config.model_config.head_configs.centroid.confmaps.anchor_part,
             user_instances_only=user_instances_only,
-            max_hw=(max_height, max_width),
+            max_hw=(args.max_height, args.max_width),
             scale=args.scale,
         )
 
@@ -127,7 +128,7 @@ if __name__ == "__main__":
             data_config=config.data_config,
             max_instances=max_instances,
             user_instances_only=user_instances_only,
-            max_hw=(max_height, max_width),
+            max_hw=(args.max_height, args.max_width),
             scale=args.scale,
         )
 

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -260,7 +260,7 @@ class ModelTrainer:
 
         else:
             raise ValueError(
-                f"Moedl type: {self.model_type}. Ensure the heads config has one of the keys: [`bototmup`, `centroid`, `centered_instance`, `single_instance`]."
+                f"Model type: {self.model_type}. Ensure the heads config has one of the keys: [`bototmup`, `centroid`, `centered_instance`, `single_instance`]."
             )
 
         # train

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -62,7 +62,7 @@ def test_bottomup_dataset(minimal_instance):
                 "max_height": None,
                 "max_width": None,
                 "scale": 0.5,
-                "is_rgb": False,
+                "is_rgb": True,
             },
             "use_augmentations_train": False,
         }
@@ -92,7 +92,7 @@ def test_bottomup_dataset(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 192, 192)
+    assert sample["image"].shape == (1, 3, 192, 192)
     assert sample["confidence_maps"].shape == (1, 2, 96, 96)
     assert sample["part_affinity_fields"].shape == (48, 48, 2)
 
@@ -237,6 +237,7 @@ def test_bottomup_dataset(minimal_instance):
     ]
 
     sample = next(iter(dataset))
+    assert len(dataset) == 1
     assert len(sample.keys()) == len(gt_sample_keys)
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
@@ -298,7 +299,7 @@ def test_centered_instance_dataset(minimal_instance):
                 "max_height": None,
                 "max_width": None,
                 "scale": 1.0,
-                "is_rgb": False,
+                "is_rgb": True,
             },
             "use_augmentations_train": True,
             "augmentation_config": {
@@ -362,7 +363,7 @@ def test_centered_instance_dataset(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["instance_image"].shape == (1, 1, 104, 104)
+    assert sample["instance_image"].shape == (1, 3, 104, 104)
     assert sample["confidence_maps"].shape == (1, 2, 52, 52)
 
     # Test with resizing and padding
@@ -433,6 +434,7 @@ def test_centered_instance_dataset(minimal_instance):
     ]
 
     sample = next(iter(dataset))
+    assert len(dataset) == 2
     assert len(sample.keys()) == len(gt_sample_keys)
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
@@ -450,7 +452,7 @@ def test_centroid_dataset(minimal_instance):
                 "max_height": None,
                 "max_width": None,
                 "scale": 1.0,
-                "is_rgb": False,
+                "is_rgb": True,
             },
             "use_augmentations_train": False,
         }
@@ -480,7 +482,7 @@ def test_centroid_dataset(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 384, 384)
+    assert sample["image"].shape == (1, 3, 384, 384)
     assert sample["centroids_confidence_maps"].shape == (1, 1, 192, 192)
 
     base_centroid_data_config = OmegaConf.create(
@@ -548,6 +550,7 @@ def test_centroid_dataset(minimal_instance):
     ]
 
     sample = next(iter(dataset))
+    assert len(dataset) == 1
     assert len(sample.keys()) == len(gt_sample_keys)
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
@@ -571,7 +574,7 @@ def test_single_instance_dataset(minimal_instance):
                 "max_height": None,
                 "max_width": None,
                 "scale": 2.0,
-                "is_rgb": False,
+                "is_rgb": True,
             },
             "use_augmentations_train": False,
         }
@@ -588,6 +591,7 @@ def test_single_instance_dataset(minimal_instance):
     )
 
     sample = next(iter(dataset))
+    assert len(dataset) == 1
 
     gt_sample_keys = [
         "image",
@@ -601,7 +605,7 @@ def test_single_instance_dataset(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 768, 768)
+    assert sample["image"].shape == (1, 3, 768, 768)
     assert sample["confidence_maps"].shape == (1, 2, 384, 384)
 
     base_singleinstance_data_config = OmegaConf.create(

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -1,0 +1,480 @@
+from omegaconf import DictConfig, OmegaConf
+import sleap_io as sio
+from sleap_nn.data.custom_datasets import (
+    BottomUpDataset,
+    CenteredInstanceDataset,
+    CentroidDataset,
+    SingleInstanceDataset,
+)
+
+
+def test_bottomup_dataset(minimal_instance):
+    """Test BottomUpDataset class."""
+    base_bottom_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 1.0,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": False,
+        }
+    )
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+
+    dataset = BottomUpDataset(
+        data_config=base_bottom_config,
+        max_stride=32,
+        confmap_head_config=confmap_head,
+        pafs_head_config=pafs_head,
+        labels=sio.load_slp(minimal_instance),
+        apply_aug=base_bottom_config.use_augmentations_train,
+    )
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "video_idx",
+        "frame_idx",
+        "confidence_maps",
+        "orig_size",
+        "num_instances",
+        "part_affinity_fields",
+    ]
+    sample = next(iter(dataset))
+    assert len(sample.keys()) == len(gt_sample_keys)
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 384, 384)
+    assert sample["confidence_maps"].shape == (1, 2, 192, 192)
+    assert sample["part_affinity_fields"].shape == (96, 96, 2)
+
+    # with scaling
+    base_bottom_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 0.5,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": False,
+        }
+    )
+
+    dataset = BottomUpDataset(
+        data_config=base_bottom_config,
+        max_stride=32,
+        confmap_head_config=confmap_head,
+        pafs_head_config=pafs_head,
+        labels=sio.load_slp(minimal_instance),
+        apply_aug=base_bottom_config.use_augmentations_train,
+    )
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "video_idx",
+        "frame_idx",
+        "confidence_maps",
+        "orig_size",
+        "num_instances",
+        "part_affinity_fields",
+    ]
+    sample = next(iter(dataset))
+    assert len(sample.keys()) == len(gt_sample_keys)
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 192, 192)
+    assert sample["confidence_maps"].shape == (1, 2, 96, 96)
+    assert sample["part_affinity_fields"].shape == (48, 48, 2)
+
+    # with padding
+    base_bottom_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 1.0,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": True,
+            "augmentation_config": {
+                "intensity": {
+                    "uniform_noise_min": 0.0,
+                    "uniform_noise_max": 0.04,
+                    "uniform_noise_p": 0.5,
+                    "gaussian_noise_mean": 0.02,
+                    "gaussian_noise_std": 0.004,
+                    "gaussian_noise_p": 0.5,
+                    "contrast_min": 0.5,
+                    "contrast_max": 2.0,
+                    "contrast_p": 0.5,
+                    "brightness": 0.0,
+                    "brightness_p": 0.5,
+                },
+                "geometric": {
+                    "rotation": 15.0,
+                    "scale": 0.05,
+                    "translate_width": 0.02,
+                    "translate_height": 0.02,
+                    "affine_p": 0.5,
+                    "erase_scale_min": 0.0001,
+                    "erase_scale_max": 0.01,
+                    "erase_ratio_min": 1,
+                    "erase_ratio_max": 1,
+                    "erase_p": 0.5,
+                    "mixup_lambda": None,
+                    "mixup_p": 0.5,
+                    "random_crop_p": 1.0,
+                    "random_crop_height": 100,
+                    "random_crop_width": 100,
+                },
+            },
+        }
+    )
+
+    dataset = BottomUpDataset(
+        data_config=base_bottom_config,
+        max_stride=32,
+        confmap_head_config=confmap_head,
+        pafs_head_config=pafs_head,
+        labels=sio.load_slp(minimal_instance),
+        apply_aug=base_bottom_config.use_augmentations_train,
+    )
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "video_idx",
+        "frame_idx",
+        "confidence_maps",
+        "orig_size",
+        "num_instances",
+        "part_affinity_fields",
+    ]
+
+    sample = next(iter(dataset))
+    assert len(sample.keys()) == len(gt_sample_keys)
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 128, 128)
+    assert sample["confidence_maps"].shape == (1, 2, 64, 64)
+    assert sample["part_affinity_fields"].shape == (32, 32, 2)
+
+    # with random crop
+    base_bottom_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 1.0,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": True,
+            "augmentation_config": {
+                "intensity": {
+                    "uniform_noise_min": 0.0,
+                    "uniform_noise_max": 0.04,
+                    "uniform_noise_p": 0.5,
+                    "gaussian_noise_mean": 0.02,
+                    "gaussian_noise_std": 0.004,
+                    "gaussian_noise_p": 0.5,
+                    "contrast_min": 0.5,
+                    "contrast_max": 2.0,
+                    "contrast_p": 0.5,
+                    "brightness": 0.0,
+                    "brightness_p": 0.5,
+                },
+                "geometric": {
+                    "rotation": 15.0,
+                    "scale": 0.05,
+                    "translate_width": 0.02,
+                    "translate_height": 0.02,
+                    "affine_p": 0.5,
+                    "erase_scale_min": 0.0001,
+                    "erase_scale_max": 0.01,
+                    "erase_ratio_min": 1,
+                    "erase_ratio_max": 1,
+                    "erase_p": 0.5,
+                    "mixup_lambda": None,
+                    "mixup_p": 0.5,
+                    "random_crop_p": 1.0,
+                    "random_crop_height": 160,
+                    "random_crop_width": 160,
+                },
+            },
+        }
+    )
+    dataset = BottomUpDataset(
+        data_config=base_bottom_config,
+        max_stride=32,
+        confmap_head_config=confmap_head,
+        pafs_head_config=pafs_head,
+        labels=sio.load_slp(minimal_instance),
+        apply_aug=base_bottom_config.use_augmentations_train,
+    )
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "video_idx",
+        "frame_idx",
+        "confidence_maps",
+        "orig_size",
+        "num_instances",
+        "part_affinity_fields",
+    ]
+
+    sample = next(iter(dataset))
+    assert len(sample.keys()) == len(gt_sample_keys)
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 160, 160)
+    assert sample["confidence_maps"].shape == (1, 2, 80, 80)
+
+
+def test_centroid_dataset(minimal_instance):
+    """Test CentroidDataset class."""
+    base_centroid_data_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 1.0,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": False,
+        }
+    )
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": 0})
+
+    dataset = CentroidDataset(
+        data_config=base_centroid_data_config,
+        max_stride=32,
+        confmap_head_config=confmap_head,
+        apply_aug=base_centroid_data_config.use_augmentations_train,
+        labels=sio.load_slp(minimal_instance),
+    )
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "centroids",
+        "video_idx",
+        "frame_idx",
+        "centroids_confidence_maps",
+        "orig_size",
+        "num_instances",
+    ]
+    sample = next(iter(dataset))
+    assert len(sample.keys()) == len(gt_sample_keys)
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 384, 384)
+    assert sample["centroids_confidence_maps"].shape == (1, 1, 192, 192)
+
+    base_centroid_data_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 1.0,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": True,
+            "augmentation_config": {
+                "intensity": {
+                    "uniform_noise_min": 0.0,
+                    "uniform_noise_max": 0.04,
+                    "uniform_noise_p": 0.5,
+                    "gaussian_noise_mean": 0.02,
+                    "gaussian_noise_std": 0.004,
+                    "gaussian_noise_p": 0.5,
+                    "contrast_min": 0.5,
+                    "contrast_max": 2.0,
+                    "contrast_p": 0.5,
+                    "brightness": 0.0,
+                    "brightness_p": 0.5,
+                },
+                "geometric": {
+                    "rotation": 15.0,
+                    "scale": 0.05,
+                    "translate_width": 0.02,
+                    "translate_height": 0.02,
+                    "affine_p": 0.5,
+                    "erase_scale_min": 0.0001,
+                    "erase_scale_max": 0.01,
+                    "erase_ratio_min": 1,
+                    "erase_ratio_max": 1,
+                    "erase_p": 0.5,
+                    "mixup_lambda": None,
+                    "mixup_p": 0.5,
+                    "random_crop_p": 1.0,
+                    "random_crop_height": 160,
+                    "random_crop_width": 160,
+                },
+            },
+        }
+    )
+
+    dataset = CentroidDataset(
+        data_config=base_centroid_data_config,
+        max_stride=32,
+        confmap_head_config=confmap_head,
+        apply_aug=base_centroid_data_config.use_augmentations_train,
+        labels=sio.load_slp(minimal_instance),
+    )
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "centroids",
+        "video_idx",
+        "frame_idx",
+        "centroids_confidence_maps",
+        "orig_size",
+        "num_instances",
+    ]
+
+    sample = next(iter(dataset))
+    assert len(sample.keys()) == len(gt_sample_keys)
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 160, 160)
+    assert sample["centroids_confidence_maps"].shape == (1, 1, 80, 80)
+
+
+def test_single_instance_dataset(minimal_instance):
+    """Test the SingleInstanceDataset."""
+    labels = sio.load_slp(minimal_instance)
+
+    # Making our minimal 2-instance example into a single instance example.
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+
+    base_singleinstance_data_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 2.0,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": False,
+        }
+    )
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": 0})
+
+    dataset = SingleInstanceDataset(
+        data_config=base_singleinstance_data_config,
+        max_stride=8,
+        confmap_head_config=confmap_head,
+        labels=labels,
+        apply_aug=base_singleinstance_data_config.use_augmentations_train,
+    )
+
+    sample = next(iter(dataset))
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "video_idx",
+        "frame_idx",
+        "num_instances",
+        "confidence_maps",
+        "orig_size",
+    ]
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 768, 768)
+    assert sample["confidence_maps"].shape == (1, 2, 384, 384)
+
+    base_singleinstance_data_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 1.0,
+                "is_rgb": False,
+            },
+            "use_augmentations_train": True,
+            "augmentation_config": {
+                "intensity": {
+                    "uniform_noise_min": 0.0,
+                    "uniform_noise_max": 0.04,
+                    "uniform_noise_p": 0.5,
+                    "gaussian_noise_mean": 0.02,
+                    "gaussian_noise_std": 0.004,
+                    "gaussian_noise_p": 0.5,
+                    "contrast_min": 0.5,
+                    "contrast_max": 2.0,
+                    "contrast_p": 0.5,
+                    "brightness": 0.0,
+                    "brightness_p": 0.5,
+                },
+                "geometric": {
+                    "rotation": 15.0,
+                    "scale": 0.05,
+                    "translate_width": 0.02,
+                    "translate_height": 0.02,
+                    "affine_p": 0.5,
+                    "erase_scale_min": 0.0001,
+                    "erase_scale_max": 0.01,
+                    "erase_ratio_min": 1,
+                    "erase_ratio_max": 1,
+                    "erase_p": 0.5,
+                    "mixup_lambda": None,
+                    "mixup_p": 0.5,
+                    "random_crop_p": 1.0,
+                    "random_crop_height": 160,
+                    "random_crop_width": 160,
+                },
+            },
+        }
+    )
+
+    dataset = SingleInstanceDataset(
+        data_config=base_singleinstance_data_config,
+        max_stride=8,
+        confmap_head_config=confmap_head,
+        labels=labels,
+        apply_aug=base_singleinstance_data_config.use_augmentations_train,
+    )
+
+    sample = next(iter(dataset))
+
+    gt_sample_keys = [
+        "image",
+        "instances",
+        "video_idx",
+        "frame_idx",
+        "confidence_maps",
+        "orig_size",
+        "num_instances",
+    ]
+
+    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
+        assert gt_key == key
+    assert sample["image"].shape == (1, 1, 160, 160)
+    assert sample["confidence_maps"].shape == (1, 2, 80, 80)
+    assert sample["instances"].shape == (1, 1, 2, 2)

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -224,10 +224,31 @@ def test_topdown_predictor(
     )
 
     assert np.all(np.abs(head_layer_ckpt - model_weights) < 1e-6)
-    print(
-        f"centered instance model: ",
-        predictor.inference_model.instance_peaks.torch_model.model,
+
+    # load only backbone and head ckpt as None - centered instance
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_ckpt],
+        backbone_ckpt_path=Path(minimal_instance_ckpt) / "best.ckpt",
+        head_ckpt_path=None,
+        peak_threshold=0.03,
+        max_instances=6,
+        preprocess_config=OmegaConf.create(preprocess_config),
     )
+
+    ckpt = torch.load(Path(minimal_instance_ckpt) / "best.ckpt")
+    backbone_ckpt = ckpt["state_dict"][
+        "model.backbone.enc.encoder_stack.0.blocks.0.weight"
+    ][0, 0, :].numpy()
+
+    model_weights = (
+        next(predictor.inference_model.instance_peaks.torch_model.model.parameters())[
+            0, 0, :
+        ]
+        .detach()
+        .numpy()
+    )
+
+    assert np.all(np.abs(backbone_ckpt - model_weights) < 1e-6)
 
     # check loading diff head ckpt for centroid
     preprocess_config = {
@@ -246,11 +267,32 @@ def test_topdown_predictor(
         preprocess_config=OmegaConf.create(preprocess_config),
     )
 
-    print(
-        f"centroid model: ", predictor.inference_model.centroid_crop.torch_model.model
+    ckpt = torch.load(Path(minimal_instance_ckpt) / "best.ckpt")
+    backbone_ckpt = ckpt["state_dict"][
+        "model.backbone.enc.encoder_stack.0.blocks.0.weight"
+    ][0, 0, :].numpy()
+
+    model_weights = (
+        next(predictor.inference_model.centroid_crop.torch_model.model.parameters())[
+            0, 0, :
+        ]
+        .detach()
+        .numpy()
     )
 
-    ckpt = torch.load(Path(minimal_instance_ckpt) / "best.ckpt")
+    assert np.all(np.abs(backbone_ckpt - model_weights) < 1e-6)
+
+    # load only backbone and head ckpt as None - centroid
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_centroid_ckpt],
+        backbone_ckpt_path=Path(minimal_instance_centroid_ckpt) / "best.ckpt",
+        head_ckpt_path=None,
+        peak_threshold=0.03,
+        max_instances=6,
+        preprocess_config=OmegaConf.create(preprocess_config),
+    )
+
+    ckpt = torch.load(Path(minimal_instance_centroid_ckpt) / "best.ckpt")
     backbone_ckpt = ckpt["state_dict"][
         "model.backbone.enc.encoder_stack.0.blocks.0.weight"
     ][0, 0, :].numpy()

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -25,7 +25,35 @@ from lightning.pytorch.loggers import WandbLogger
 import shutil
 
 
-def test_create_data_loader(config, tmp_path: str):
+def test_create_data_loader_torch_dataset(config, tmp_path):
+    """Test _create_data_loader function of ModelTrainer class."""
+    # test centered-instance pipeline
+
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+    )
+    # without explicitly providing crop_hw
+    config_copy = config.copy()
+    OmegaConf.update(config_copy, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
+    model_trainer = ModelTrainer(config_copy, data_pipeline_fw="torch_dataset")
+    model_trainer._create_data_loaders_torch_dataset()
+    assert len(list(iter(model_trainer.train_data_loader))) == 2
+    assert len(list(iter(model_trainer.val_data_loader))) == 2
+    sample = next(iter(model_trainer.train_data_loader))
+    assert sample["instance_image"].shape == (1, 1, 1, 104, 104)
+
+    # test exception
+    config_copy = config.copy()
+    head_config = config_copy.model_config.head_configs.centered_instance
+    del config_copy.model_config.head_configs.centered_instance
+    OmegaConf.update(config_copy, "model_config.head_configs.topdown", head_config)
+    model_trainer = ModelTrainer(config_copy, data_pipeline_fw="torch_dataset")
+    with pytest.raises(ValueError):
+        model_trainer._create_data_loaders_torch_dataset()
+
+
+def test_create_data_loader_litdata(config, tmp_path: str):
     """Test _create_data_loader function of ModelTrainer class."""
     # test centered-instance pipeline
 
@@ -37,7 +65,7 @@ def test_create_data_loader(config, tmp_path: str):
     OmegaConf.update(config_copy, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
     model_trainer = ModelTrainer(config_copy)
-    model_trainer._create_data_loaders()
+    model_trainer._create_data_loaders_litdata()
     assert len(list(iter(model_trainer.train_data_loader))) == 2
     assert len(list(iter(model_trainer.val_data_loader))) == 2
     sample = next(iter(model_trainer.train_data_loader))
@@ -53,7 +81,7 @@ def test_create_data_loader(config, tmp_path: str):
     OmegaConf.update(config_copy, "model_config.head_configs.topdown", head_config)
     model_trainer = ModelTrainer(config_copy)
     with pytest.raises(Exception):
-        model_trainer._create_data_loaders()
+        model_trainer._create_data_loaders_litdata()
 
 
 def test_wandb():
@@ -70,7 +98,7 @@ def test_wandb():
     reason="Flaky test (The training test runs on Ubuntu for a long time: >6hrs and then fails.)",
 )
 # TODO: Revisit this test later (Failing on ubuntu)
-def test_trainer(config, tmp_path: str):
+def test_trainer_litdata(config, tmp_path: str):
     OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
     model_trainer = ModelTrainer(config)
     assert model_trainer.dir_path == "."
@@ -175,63 +203,6 @@ def test_trainer(config, tmp_path: str):
 
     #######
 
-    # check resume training
-    config_copy = config.copy()
-    OmegaConf.update(config_copy, "trainer_config.max_epochs", 4)
-    OmegaConf.update(
-        config_copy,
-        "trainer_config.resume_ckpt_path",
-        f"{Path(config.trainer_config.save_ckpt_path).joinpath('last.ckpt')}",
-    )
-    training_config = OmegaConf.load(
-        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
-    )
-    prv_runid = training_config.trainer_config.wandb.run_id
-    OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
-    trainer = ModelTrainer(config_copy)
-    trainer.train()
-
-    checkpoint = torch.load(
-        Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    )
-    assert checkpoint["epoch"] == 3
-
-    training_config = OmegaConf.load(
-        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
-    )
-    assert training_config.trainer_config.wandb.run_id == prv_runid
-    os.remove((Path(trainer.dir_path) / "best.ckpt").as_posix())
-    os.remove((Path(trainer.dir_path) / "last.ckpt").as_posix())
-    shutil.rmtree((Path(trainer.dir_path) / "lightning_logs").as_posix())
-
-    #######
-
-    # check early stopping
-    config_early_stopping = config.copy()
-    OmegaConf.update(
-        config_early_stopping, "trainer_config.early_stopping.min_delta", 1e-1
-    )
-    OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
-    OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
-    OmegaConf.update(
-        config_early_stopping, "trainer_config.lr_scheduler.scheduler", None
-    )
-    OmegaConf.update(
-        config_early_stopping,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_model_trainer/",
-    )
-
-    trainer = ModelTrainer(config_early_stopping)
-    trainer.train()
-
-    checkpoint = torch.load(
-        Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
-    )
-    assert checkpoint["epoch"] == 1
-
-    #######
-
     # For Single instance model
     single_instance_config = config.copy()
     head_config = single_instance_config.model_config.head_configs.centered_instance
@@ -321,6 +292,261 @@ def test_trainer(config, tmp_path: str):
     OmegaConf.update(bottomup_config, "trainer_config.steps_per_epoch", 10)
 
     trainer = ModelTrainer(bottomup_config)
+    trainer._initialize_model()
+    assert isinstance(trainer.model, BottomUpModel)
+
+
+def test_trainer_torch_dataset(config, tmp_path: str):
+    OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
+    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    assert model_trainer.dir_path == "."
+
+    #####
+
+    # # for topdown centered instance model
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+    )
+
+    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    model_trainer.train()
+
+    # disable ckpt, check if ckpt is created
+    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("training_config.yaml")
+        .exists()
+    )
+    assert not (
+        Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+    )
+
+    #######
+
+    # update save_ckpt to True and test step lr
+    OmegaConf.update(config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(config, "trainer_config.use_wandb", True)
+    OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
+    OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "StepLR")
+    OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.step_size", 10)
+    OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.gamma", 0.5)
+
+    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    model_trainer.train()
+
+    # check if wandb folder is created
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("wandb").exists()
+
+    folder_created = Path(config.trainer_config.save_ckpt_path).exists()
+    assert folder_created
+    files = [
+        str(x)
+        for x in Path(config.trainer_config.save_ckpt_path).iterdir()
+        if x.is_file()
+    ]
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("initial_config.yaml")
+        .exists()
+    )
+    assert (
+        Path(config.trainer_config.save_ckpt_path)
+        .joinpath("training_config.yaml")
+        .exists()
+    )
+    training_config = OmegaConf.load(
+        f"{config.trainer_config.save_ckpt_path}/training_config.yaml"
+    )
+    assert training_config.trainer_config.wandb.run_id is not None
+    assert training_config.model_config.total_params is not None
+    assert training_config.trainer_config.wandb.api_key == ""
+    assert training_config.data_config.skeletons
+    assert training_config.data_config.preprocessing.crop_hw == (104, 104)
+
+    # check if ckpt is created
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt").exists()
+    assert Path(config.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
+
+    checkpoint = torch.load(
+        Path(config.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    )
+    assert checkpoint["epoch"] == 1
+
+    # check if skeleton is saved in ckpt file
+    assert checkpoint["config"]
+    assert checkpoint["config"]["trainer_config"]["wandb"]["api_key"] == ""
+    assert len(checkpoint["config"]["data_config"]["skeletons"].keys()) == 1
+
+    # check for training metrics csv
+    path = Path(config.trainer_config.save_ckpt_path).joinpath(
+        "lightning_logs/version_0/"
+    )
+    files = [str(x) for x in Path(path).iterdir() if x.is_file()]
+    metrics = False
+    for i in files:
+        if "metrics.csv" in i:
+            metrics = True
+            break
+    assert metrics
+    df = pd.read_csv(
+        Path(config.trainer_config.save_ckpt_path).joinpath(
+            "lightning_logs/version_0/metrics.csv"
+        )
+    )
+    assert abs(df.loc[0, "learning_rate"] - config.trainer_config.optimizer.lr) <= 1e-4
+    assert not df.val_loss.isnull().all()
+    assert not df.train_loss.isnull().all()
+
+    #######
+
+    # check resume training
+    config_copy = config.copy()
+    OmegaConf.update(config_copy, "trainer_config.max_epochs", 4)
+    OmegaConf.update(
+        config_copy,
+        "trainer_config.resume_ckpt_path",
+        f"{Path(config.trainer_config.save_ckpt_path).joinpath('last.ckpt')}",
+    )
+    training_config = OmegaConf.load(
+        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
+    )
+    prv_runid = training_config.trainer_config.wandb.run_id
+    OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
+    trainer = ModelTrainer(config_copy, data_pipeline_fw="torch_dataset")
+    trainer.train()
+
+    checkpoint = torch.load(
+        Path(config_copy.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    )
+    assert checkpoint["epoch"] == 3
+
+    training_config = OmegaConf.load(
+        f"{config_copy.trainer_config.save_ckpt_path}/training_config.yaml"
+    )
+    assert training_config.trainer_config.wandb.run_id == prv_runid
+    os.remove((Path(trainer.dir_path) / "best.ckpt").as_posix())
+    os.remove((Path(trainer.dir_path) / "last.ckpt").as_posix())
+    shutil.rmtree((Path(trainer.dir_path) / "lightning_logs").as_posix())
+
+    #######
+
+    # check early stopping
+    config_early_stopping = config.copy()
+    OmegaConf.update(
+        config_early_stopping, "trainer_config.early_stopping.min_delta", 1e-1
+    )
+    OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
+    OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
+    OmegaConf.update(
+        config_early_stopping, "trainer_config.lr_scheduler.scheduler", None
+    )
+    OmegaConf.update(
+        config_early_stopping,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_model_trainer/",
+    )
+
+    trainer = ModelTrainer(config_early_stopping, data_pipeline_fw="torch_dataset")
+    trainer.train()
+
+    checkpoint = torch.load(
+        Path(config_early_stopping.trainer_config.save_ckpt_path).joinpath("last.ckpt")
+    )
+    assert checkpoint["epoch"] == 1
+
+    #######
+
+    # For Single instance model
+    single_instance_config = config.copy()
+    head_config = single_instance_config.model_config.head_configs.centered_instance
+    del single_instance_config.model_config.head_configs.centered_instance
+    OmegaConf.update(
+        single_instance_config, "model_config.head_configs.single_instance", head_config
+    )
+    del (
+        single_instance_config.model_config.head_configs.single_instance.confmaps.anchor_part
+    )
+
+    trainer = ModelTrainer(single_instance_config, data_pipeline_fw="torch_dataset")
+    trainer._initialize_model()
+    assert isinstance(trainer.model, SingleInstanceModel)
+
+    #######
+
+    # Centroid model
+    centroid_config = config.copy()
+    OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
+    del centroid_config.model_config.head_configs.centered_instance
+    del centroid_config.model_config.head_configs.centroid["confmaps"].part_names
+
+    if (Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
+        os.remove(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt"
+            ).as_posix()
+        )
+        os.remove(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "last.ckpt"
+            ).as_posix()
+        )
+        shutil.rmtree(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "lightning_logs"
+            ).as_posix()
+        )
+
+    OmegaConf.update(centroid_config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
+    OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
+    OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
+
+    trainer = ModelTrainer(centroid_config, data_pipeline_fw="torch_dataset")
+
+    trainer._initialize_model()
+    assert isinstance(trainer.model, CentroidModel)
+
+    #######
+
+    # bottom up model
+    bottomup_config = config.copy()
+    OmegaConf.update(bottomup_config, "model_config.head_configs.bottomup", head_config)
+    paf = {
+        "edges": [("part1", "part2")],
+        "sigma": 4,
+        "output_stride": 4,
+        "loss_weight": 1.0,
+    }
+    del bottomup_config.model_config.head_configs.bottomup["confmaps"].anchor_part
+    del bottomup_config.model_config.head_configs.centered_instance
+    bottomup_config.model_config.head_configs.bottomup["pafs"] = paf
+    bottomup_config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
+
+    if (Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
+        os.remove(
+            (
+                Path(bottomup_config.trainer_config.save_ckpt_path) / "best.ckpt"
+            ).as_posix()
+        )
+        os.remove(
+            (
+                Path(bottomup_config.trainer_config.save_ckpt_path) / "last.ckpt"
+            ).as_posix()
+        )
+        shutil.rmtree(
+            (
+                Path(bottomup_config.trainer_config.save_ckpt_path) / "lightning_logs"
+            ).as_posix()
+        )
+
+    OmegaConf.update(bottomup_config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(bottomup_config, "trainer_config.use_wandb", False)
+    OmegaConf.update(bottomup_config, "trainer_config.max_epochs", 1)
+    OmegaConf.update(bottomup_config, "trainer_config.steps_per_epoch", 10)
+
+    trainer = ModelTrainer(bottomup_config, data_pipeline_fw="torch_dataset")
     trainer._initialize_model()
     assert isinstance(trainer.model, BottomUpModel)
 
@@ -437,7 +663,7 @@ def test_topdown_centered_instance_model(config, tmp_path: str):
     )
 
     model_trainer = ModelTrainer(config)
-    model_trainer._create_data_loaders()
+    model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
     input_cm = input_["confidence_maps"]
     preds = model(input_["instance_image"])
@@ -477,7 +703,7 @@ def test_topdown_centered_instance_model(config, tmp_path: str):
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
     model_trainer = ModelTrainer(config)
-    model_trainer._create_data_loaders()
+    model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
     input_cm = input_["confidence_maps"]
     preds = model(input_["instance_image"])
@@ -513,7 +739,7 @@ def test_centroid_model(config, tmp_path: str):
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
     model_trainer = ModelTrainer(config)
-    model_trainer._create_data_loaders()
+    model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
     input_cm = input_["centroids_confidence_maps"]
     preds = model(input_["image"])
@@ -542,7 +768,7 @@ def test_single_instance_model(config, tmp_path: str):
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
     model_trainer = ModelTrainer(config)
-    model_trainer._create_data_loaders()
+    model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
     model = SingleInstanceModel(config, None, "single_instance")
 
@@ -594,7 +820,7 @@ def test_bottomup_model(config, tmp_path: str):
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
     model_trainer = ModelTrainer(config)
-    model_trainer._create_data_loaders()
+    model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
 
     model = BottomUpModel(config, None, "bottomup")
@@ -628,7 +854,7 @@ def test_bottomup_model(config, tmp_path: str):
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
     model_trainer = ModelTrainer(config)
-    model_trainer._create_data_loaders()
+    model_trainer._create_data_loaders_litdata()
     skeletons = model_trainer.skeletons
     input_ = next(iter(model_trainer.train_data_loader))
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -302,6 +302,11 @@ def test_trainer_litdata(config, tmp_path: str):
     assert isinstance(trainer.model, BottomUpModel)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("li"),
+    reason="Flaky test (The training test runs on Ubuntu for a long time: >6hrs and then fails.)",
+)
+# TODO: Revisit this test later (Failing on ubuntu)
 def test_trainer_torch_dataset(config, tmp_path: str):
     OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
     model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
@@ -824,16 +829,6 @@ def test_single_instance_model(config, tmp_path: str):
     shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     # torch dataset
-    head_config = config.model_config.head_configs.centered_instance
-    del config.model_config.head_configs.centered_instance
-    OmegaConf.update(config, "model_config.head_configs.single_instance", head_config)
-    del config.model_config.head_configs.single_instance.confmaps.anchor_part
-
-    OmegaConf.update(config, "model_config.init_weights", "xavier")
-
-    OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
-    )
     model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
     model_trainer._create_data_loaders_torch_dataset()
     input_ = next(iter(model_trainer.train_data_loader))


### PR DESCRIPTION
This is the first PR for #119. The torch `Dataset` modules for each model type is implemented. The user has the flexibility to choose   the data pipeline framework: LitData or vanilla torch `Dataset`s, which is passed as an argument while initializing `sleap_nn.training.model_trainer.ModelTrainer` class. 