### PR TITLE
Add caching to Torch Datasets pipeline

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1,5 +1,6 @@
 """Custom `torch.utils.data.Dataset`s for different model types."""
 
+from kornia.geometry.transform import crop_and_resize
 from typing import Dict, Iterator, List, Optional, Tuple
 from omegaconf import DictConfig
 import numpy as np
@@ -22,6 +23,7 @@ from sleap_nn.data.augmentation import (
 )
 from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
 from sleap_nn.data.edge_maps import generate_pafs
+from sleap_nn.data.instance_cropping import make_centered_bboxes
 from sleap_nn.data.normalization import apply_normalization
 from sleap_nn.data.resizing import apply_pad_to_stride, apply_resizer
 
@@ -115,35 +117,56 @@ class BottomUpDataset(BaseDataset):
         self.pafs_head_config = pafs_head_config
 
         self.edge_inds = self.labels.skeletons[0].edge_inds
+        self.cache = {}
+        self._fill_cache()
+
+    def _fill_cache(self):
+        """Load all samples to cache."""
+        for lf_idx, lf in enumerate(self.labels):
+            video_idx = self._get_video_idx(lf)
+
+            # get dict
+            sample = process_lf(
+                lf,
+                video_idx=video_idx,
+                max_instances=self.max_instances,
+                user_instances_only=self.data_config.user_instances_only,
+            )
+
+            # apply normalization
+            sample["image"] = apply_normalization(sample["image"])
+
+            if self.data_config.preprocessing.is_rgb:
+                sample["image"] = convert_to_rgb(sample["image"])
+            else:
+                sample["image"] = convert_to_grayscale(sample["image"])
+
+            # size matcher
+            sample["image"], eff_scale = apply_sizematcher(
+                sample["image"],
+                max_height=self.max_hw[0],
+                max_width=self.max_hw[1],
+            )
+            sample["instances"] = sample["instances"] * eff_scale
+
+            # resize image
+            sample["image"], sample["instances"] = apply_resizer(
+                sample["image"],
+                sample["instances"],
+                scale=self.data_config.preprocessing.scale,
+            )
+
+            # Pad the image (if needed) according max stride
+            sample["image"] = apply_pad_to_stride(
+                sample["image"], max_stride=self.max_stride
+            )
+
+            self.cache[lf_idx] = sample.copy()
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image, confmaps and pafs for given index."""
-        lf = self.labels[index]
-        video_idx = self._get_video_idx(lf)
 
-        # get dict
-        sample = process_lf(
-            lf,
-            video_idx=video_idx,
-            max_instances=self.max_instances,
-            user_instances_only=self.data_config.user_instances_only,
-        )
-
-        # apply normalization
-        sample["image"] = apply_normalization(sample["image"])
-
-        if self.data_config.preprocessing.is_rgb:
-            sample["image"] = convert_to_rgb(sample["image"])
-        else:
-            sample["image"] = convert_to_grayscale(sample["image"])
-
-        # size matcher
-        sample["image"], eff_scale = apply_sizematcher(
-            sample["image"],
-            max_height=self.max_hw[0],
-            max_width=self.max_hw[1],
-        )
-        sample["instances"] = sample["instances"] * eff_scale
+        sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:
@@ -160,18 +183,6 @@ class BottomUpDataset(BaseDataset):
                     sample["instances"],
                     **self.data_config.augmentation_config.geometric,
                 )
-
-        # resize image
-        sample["image"], sample["instances"] = apply_resizer(
-            sample["image"],
-            sample["instances"],
-            scale=self.data_config.preprocessing.scale,
-        )
-
-        # Pad the image (if needed) according max stride
-        sample["image"] = apply_pad_to_stride(
-            sample["image"], max_stride=self.max_stride
-        )
 
         img_hw = sample["image"].shape[-2:]
 
@@ -246,6 +257,87 @@ class CenteredInstanceDataset(BaseDataset):
         self.confmap_head_config = confmap_head_config
         self.instance_idx_list = self._get_instance_idx_list()
         self.cache_lf = [None, None]
+        self.cache = {}
+        self._fill_cache()
+
+    def _fill_cache(self):
+        """Load all samples to cache."""
+        for idx, (lf_idx, inst_idx) in enumerate(self.instance_idx_list):
+            lf = self.labels[lf_idx]
+            video_idx = self._get_video_idx(lf)
+
+            # Filter to user instances
+            if self.data_config.user_instances_only:
+                if lf.user_instances is not None and len(lf.user_instances) > 0:
+                    lf.instances = lf.user_instances
+
+            if lf_idx == self.cache_lf[0]:
+                img = self.cache_lf[1]
+            else:
+                img = lf.image
+                self.cache_lf = [lf_idx, img]
+
+            image = np.transpose(img, (2, 0, 1))  # HWC -> CHW
+
+            instances = []
+            for inst in lf:
+                if not inst.is_empty:
+                    instances.append(inst.numpy())
+            instances = np.stack(instances, axis=0)
+
+            # Add singleton time dimension for single frames.
+            image = np.expand_dims(image, axis=0)  # (n_samples=1, C, H, W)
+            instances = np.expand_dims(
+                instances, axis=0
+            )  # (n_samples=1, num_instances, num_nodes, 2)
+
+            instances = torch.from_numpy(instances.astype("float32"))
+            image = torch.from_numpy(image)
+
+            num_instances, _ = instances.shape[1:3]
+            orig_img_height, orig_img_width = image.shape[-2:]
+
+            instances = instances[:, inst_idx]
+
+            # apply normalization
+            image = apply_normalization(image)
+
+            if self.data_config.preprocessing.is_rgb:
+                image = convert_to_rgb(image)
+            else:
+                image = convert_to_grayscale(image)
+
+            # size matcher
+            image, eff_scale = apply_sizematcher(
+                image,
+                max_height=self.max_hw[0],
+                max_width=self.max_hw[1],
+            )
+            instances = instances * eff_scale
+
+            # get the centroids based on the anchor idx
+            centroids = generate_centroids(
+                instances, anchor_ind=self.confmap_head_config.anchor_part
+            )
+
+            instance, centroid = instances[0], centroids[0]  # (n_samples=1)
+
+            crop_size = np.array(self.crop_hw) * np.sqrt(
+                2
+            )  # crop extra for rotation augmentation
+            crop_size = crop_size.astype(np.int32).tolist()
+
+            sample = generate_crops(image, instance, centroid, self.crop_hw)
+
+            sample["frame_idx"] = torch.tensor(lf.frame_idx, dtype=torch.int32)
+            sample["video_idx"] = torch.tensor(video_idx, dtype=torch.int32)
+            sample["num_instances"] = num_instances
+            sample["orig_size"] = torch.Tensor([orig_img_height, orig_img_width])
+
+            self.cache[idx] = sample.copy()
+
+        for video in self.labels.videos:
+            video.close()
 
     def _get_instance_idx_list(self) -> List[Tuple[int]]:
         """Return list of tuples with indices of labelled frames and instances."""
@@ -261,124 +353,71 @@ class CenteredInstanceDataset(BaseDataset):
 
     def __getitem__(self, index) -> Dict:
         """Return dict with cropped image and confmaps of instance for given index."""
-        lf_idx, inst_idx = self.instance_idx_list[index]
-
-        lf = self.labels[lf_idx]
-        video_idx = self._get_video_idx(lf)
-
-        # get dict
-        # Filter to user instances
-        if self.data_config.user_instances_only:
-            if lf.user_instances is not None and len(lf.user_instances) > 0:
-                lf.instances = lf.user_instances
-
-        if lf_idx == self.cache_lf[0]:
-            img = self.cache_lf[1]
-        else:
-            img = lf.image
-            self.cache_lf = [lf_idx, img]
-
-        image = np.transpose(img, (2, 0, 1))  # HWC -> CHW
-
-        instances = []
-        for inst in lf:
-            if not inst.is_empty:
-                instances.append(inst.numpy())
-        instances = np.stack(instances, axis=0)
-
-        # Add singleton time dimension for single frames.
-        image = np.expand_dims(image, axis=0)  # (n_samples=1, C, H, W)
-        instances = np.expand_dims(
-            instances, axis=0
-        )  # (n_samples=1, num_instances, num_nodes, 2)
-
-        instances = torch.from_numpy(instances.astype("float32"))
-
-        num_instances, _ = instances.shape[1:3]
-        img_height, img_width = image.shape[-2:]
-
-        sample = {
-            "image": torch.from_numpy(image),
-            "instances": instances,
-            "video_idx": torch.tensor(video_idx, dtype=torch.int32),
-            "frame_idx": torch.tensor(lf.frame_idx, dtype=torch.int32),
-            "orig_size": torch.Tensor([img_height, img_width]),
-            "num_instances": num_instances,
-        }
-
-        sample["instances"] = sample["instances"][:, inst_idx]
-
-        # apply normalization
-        sample["image"] = apply_normalization(sample["image"])
-
-        if self.data_config.preprocessing.is_rgb:
-            sample["image"] = convert_to_rgb(sample["image"])
-        else:
-            sample["image"] = convert_to_grayscale(sample["image"])
-
-        # size matcher
-        sample["image"], eff_scale = apply_sizematcher(
-            sample["image"],
-            max_height=self.max_hw[0],
-            max_width=self.max_hw[1],
-        )
-        sample["instances"] = sample["instances"] * eff_scale
+        sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:
             if "intensity" in self.data_config.augmentation_config:
-                sample["image"], sample["instances"] = apply_intensity_augmentation(
-                    sample["image"],
-                    sample["instances"],
-                    **self.data_config.augmentation_config.intensity,
+                sample["instance_image"], sample["instance"] = (
+                    apply_intensity_augmentation(
+                        sample["instance_image"],
+                        sample["instance"],
+                        **self.data_config.augmentation_config.intensity,
+                    )
                 )
 
             if "geometric" in self.data_config.augmentation_config:
-                sample["image"], sample["instances"] = apply_geometric_augmentation(
-                    sample["image"],
-                    sample["instances"],
-                    **self.data_config.augmentation_config.geometric,
+                sample["instance_image"], sample["instance"] = (
+                    apply_geometric_augmentation(
+                        sample["instance_image"],
+                        sample["instance"],
+                        **self.data_config.augmentation_config.geometric,
+                    )
                 )
 
-        # get the centroids based on the anchor idx
-        centroids = generate_centroids(
-            sample["instances"], anchor_ind=self.confmap_head_config.anchor_part
+        # re-crop to original crop size
+        sample["instance_bbox"] = torch.unsqueeze(
+            make_centered_bboxes(
+                sample["centroid"][0], self.crop_hw[0], self.crop_hw[1]
+            ),
+            0,
+        )  # (n_samples=1, 4, 2)
+
+        sample["instance_image"] = crop_and_resize(
+            sample["instance_image"], boxes=sample["instance_bbox"], size=self.crop_hw
         )
+        point = sample["instance_bbox"][0][0]
+        center_instance = sample["instance"] - point
+        centered_centroid = sample["centroid"] - point
 
-        instance, centroid = sample["instances"][0], centroids[0]  # (n_samples=1)
-
-        res = generate_crops(sample["image"], instance, centroid, self.crop_hw)
-
-        res["frame_idx"] = sample["frame_idx"]
-        res["video_idx"] = sample["video_idx"]
-        res["num_instances"] = sample["num_instances"]
-        res["orig_size"] = sample["orig_size"]
+        sample["instance"] = center_instance  # (n_samples=1, n_nodes, 2)
+        sample["centroid"] = centered_centroid  # (n_samples=1, 2)
 
         # resize image
-        res["instance_image"], res["instance"] = apply_resizer(
-            res["instance_image"],
-            res["instance"],
+        sample["instance_image"], sample["instance"] = apply_resizer(
+            sample["instance_image"],
+            sample["instance"],
             scale=self.data_config.preprocessing.scale,
         )
 
         # Pad the image (if needed) according max stride
-        res["instance_image"] = apply_pad_to_stride(
-            res["instance_image"], max_stride=self.max_stride
+        sample["instance_image"] = apply_pad_to_stride(
+            sample["instance_image"], max_stride=self.max_stride
         )
 
-        img_hw = res["instance_image"].shape[-2:]
+        img_hw = sample["instance_image"].shape[-2:]
 
         # Generate confidence maps
         confidence_maps = generate_confmaps(
-            res["instance"],
+            sample["instance"],
             img_hw=img_hw,
             sigma=self.confmap_head_config.sigma,
             output_stride=self.confmap_head_config.output_stride,
         )
 
-        res["confidence_maps"] = confidence_maps
+        sample["confidence_maps"] = confidence_maps
 
-        return res
+        return sample
 
 
 class CentroidDataset(BaseDataset):
@@ -417,35 +456,62 @@ class CentroidDataset(BaseDataset):
             max_hw=max_hw,
         )
         self.confmap_head_config = confmap_head_config
+        self.cache = {}
+        self._fill_cache()
+
+    def _fill_cache(self):
+        """Load all samples to cache."""
+        for lf_idx, lf in enumerate(self.labels):
+            video_idx = self._get_video_idx(lf)
+
+            # get dict
+            sample = process_lf(
+                lf,
+                video_idx=video_idx,
+                max_instances=self.max_instances,
+                user_instances_only=self.data_config.user_instances_only,
+            )
+
+            # apply normalization
+            sample["image"] = apply_normalization(sample["image"])
+
+            if self.data_config.preprocessing.is_rgb:
+                sample["image"] = convert_to_rgb(sample["image"])
+            else:
+                sample["image"] = convert_to_grayscale(sample["image"])
+
+            # size matcher
+            sample["image"], eff_scale = apply_sizematcher(
+                sample["image"],
+                max_height=self.max_hw[0],
+                max_width=self.max_hw[1],
+            )
+            sample["instances"] = sample["instances"] * eff_scale
+
+            # get the centroids based on the anchor idx
+            centroids = generate_centroids(
+                sample["instances"], anchor_ind=self.confmap_head_config.anchor_part
+            )
+
+            sample["centroids"] = centroids
+
+            # resize image
+            sample["image"], sample["centroids"] = apply_resizer(
+                sample["image"],
+                sample["centroids"],
+                scale=self.data_config.preprocessing.scale,
+            )
+
+            # Pad the image (if needed) according max stride
+            sample["image"] = apply_pad_to_stride(
+                sample["image"], max_stride=self.max_stride
+            )
+
+            self.cache[lf_idx] = sample.copy()
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for centroids for given index."""
-        lf = self.labels[index]
-        video_idx = self._get_video_idx(lf)
-
-        # get dict
-        sample = process_lf(
-            lf,
-            video_idx=video_idx,
-            max_instances=self.max_instances,
-            user_instances_only=self.data_config.user_instances_only,
-        )
-
-        # apply normalization
-        sample["image"] = apply_normalization(sample["image"])
-
-        if self.data_config.preprocessing.is_rgb:
-            sample["image"] = convert_to_rgb(sample["image"])
-        else:
-            sample["image"] = convert_to_grayscale(sample["image"])
-
-        # size matcher
-        sample["image"], eff_scale = apply_sizematcher(
-            sample["image"],
-            max_height=self.max_hw[0],
-            max_width=self.max_hw[1],
-        )
-        sample["instances"] = sample["instances"] * eff_scale
+        sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:
@@ -462,25 +528,6 @@ class CentroidDataset(BaseDataset):
                     sample["instances"],
                     **self.data_config.augmentation_config.geometric,
                 )
-
-        # get the centroids based on the anchor idx
-        centroids = generate_centroids(
-            sample["instances"], anchor_ind=self.confmap_head_config.anchor_part
-        )
-
-        sample["centroids"] = centroids
-
-        # resize image
-        sample["image"], sample["centroids"] = apply_resizer(
-            sample["image"],
-            sample["centroids"],
-            scale=self.data_config.preprocessing.scale,
-        )
-
-        # Pad the image (if needed) according max stride
-        sample["image"] = apply_pad_to_stride(
-            sample["image"], max_stride=self.max_stride
-        )
 
         img_hw = sample["image"].shape[-2:]
 
@@ -535,35 +582,55 @@ class SingleInstanceDataset(BaseDataset):
             max_hw=max_hw,
         )
         self.confmap_head_config = confmap_head_config
+        self.cache = {}
+        self._fill_cache()
+
+    def _fill_cache(self):
+        """Load all samples to cache."""
+        for lf_idx, lf in enumerate(self.labels):
+            video_idx = self._get_video_idx(lf)
+
+            # get dict
+            sample = process_lf(
+                lf,
+                video_idx=video_idx,
+                max_instances=1,
+                user_instances_only=self.data_config.user_instances_only,
+            )
+
+            # apply normalization
+            sample["image"] = apply_normalization(sample["image"])
+
+            if self.data_config.preprocessing.is_rgb:
+                sample["image"] = convert_to_rgb(sample["image"])
+            else:
+                sample["image"] = convert_to_grayscale(sample["image"])
+
+            # size matcher
+            sample["image"], eff_scale = apply_sizematcher(
+                sample["image"],
+                max_height=self.max_hw[0],
+                max_width=self.max_hw[1],
+            )
+            sample["instances"] = sample["instances"] * eff_scale
+
+            # resize image
+            sample["image"], sample["instances"] = apply_resizer(
+                sample["image"],
+                sample["instances"],
+                scale=self.data_config.preprocessing.scale,
+            )
+
+            # Pad the image (if needed) according max stride
+            sample["image"] = apply_pad_to_stride(
+                sample["image"], max_stride=self.max_stride
+            )
+
+            self.cache[lf_idx] = sample.copy()
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for instance for given index."""
-        lf = self.labels[index]
-        video_idx = self._get_video_idx(lf)
-
-        # get dict
-        sample = process_lf(
-            lf,
-            video_idx=video_idx,
-            max_instances=1,
-            user_instances_only=self.data_config.user_instances_only,
-        )
-
-        # apply normalization
-        sample["image"] = apply_normalization(sample["image"])
-
-        if self.data_config.preprocessing.is_rgb:
-            sample["image"] = convert_to_rgb(sample["image"])
-        else:
-            sample["image"] = convert_to_grayscale(sample["image"])
-
-        # size matcher
-        sample["image"], eff_scale = apply_sizematcher(
-            sample["image"],
-            max_height=self.max_hw[0],
-            max_width=self.max_hw[1],
-        )
-        sample["instances"] = sample["instances"] * eff_scale
+        sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:
@@ -580,18 +647,6 @@ class SingleInstanceDataset(BaseDataset):
                     sample["instances"],
                     **self.data_config.augmentation_config.geometric,
                 )
-
-        # resize image
-        sample["image"], sample["instances"] = apply_resizer(
-            sample["image"],
-            sample["instances"],
-            scale=self.data_config.preprocessing.scale,
-        )
-
-        # Pad the image (if needed) according max stride
-        sample["image"] = apply_pad_to_stride(
-            sample["image"], max_stride=self.max_stride
-        )
 
         img_hw = sample["image"].shape[-2:]
 

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -163,9 +163,11 @@ class BottomUpDataset(BaseDataset):
 
             self.cache[lf_idx] = sample.copy()
 
+        for video in self.labels.videos:
+            video.close()
+
     def __getitem__(self, index) -> Dict:
         """Return dict with image, confmaps and pafs for given index."""
-
         sample = self.cache[index]
 
         # apply augmentation
@@ -509,6 +511,9 @@ class CentroidDataset(BaseDataset):
 
             self.cache[lf_idx] = sample.copy()
 
+        for video in self.labels.videos:
+            video.close()
+
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for centroids for given index."""
         sample = self.cache[index]
@@ -627,6 +632,9 @@ class SingleInstanceDataset(BaseDataset):
             )
 
             self.cache[lf_idx] = sample.copy()
+
+        for video in self.labels.videos:
+            video.close()
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for instance for given index."""

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -134,9 +134,6 @@ def test_bottomup_dataset(minimal_instance):
                     "erase_p": 0.5,
                     "mixup_lambda": None,
                     "mixup_p": 0.5,
-                    "random_crop_p": 1.0,
-                    "random_crop_height": 100,
-                    "random_crop_width": 100,
                 },
             },
         }
@@ -144,7 +141,7 @@ def test_bottomup_dataset(minimal_instance):
 
     dataset = BottomUpDataset(
         data_config=base_bottom_config,
-        max_stride=32,
+        max_stride=256,
         confmap_head_config=confmap_head,
         pafs_head_config=pafs_head,
         labels=sio.load_slp(minimal_instance),
@@ -167,83 +164,9 @@ def test_bottomup_dataset(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 128, 128)
-    assert sample["confidence_maps"].shape == (1, 2, 64, 64)
-    assert sample["part_affinity_fields"].shape == (2, 32, 32)
-
-    # with random crop
-    base_bottom_config = OmegaConf.create(
-        {
-            "user_instances_only": True,
-            "preprocessing": {
-                "max_height": None,
-                "max_width": None,
-                "scale": 1.0,
-                "is_rgb": False,
-            },
-            "use_augmentations_train": True,
-            "augmentation_config": {
-                "intensity": {
-                    "uniform_noise_min": 0.0,
-                    "uniform_noise_max": 0.04,
-                    "uniform_noise_p": 0.5,
-                    "gaussian_noise_mean": 0.02,
-                    "gaussian_noise_std": 0.004,
-                    "gaussian_noise_p": 0.5,
-                    "contrast_min": 0.5,
-                    "contrast_max": 2.0,
-                    "contrast_p": 0.5,
-                    "brightness": 0.0,
-                    "brightness_p": 0.5,
-                },
-                "geometric": {
-                    "rotation": 15.0,
-                    "scale": 0.05,
-                    "translate_width": 0.02,
-                    "translate_height": 0.02,
-                    "affine_p": 0.5,
-                    "erase_scale_min": 0.0001,
-                    "erase_scale_max": 0.01,
-                    "erase_ratio_min": 1,
-                    "erase_ratio_max": 1,
-                    "erase_p": 0.5,
-                    "mixup_lambda": None,
-                    "mixup_p": 0.5,
-                    "random_crop_p": 1.0,
-                    "random_crop_height": 160,
-                    "random_crop_width": 160,
-                },
-            },
-        }
-    )
-    dataset = BottomUpDataset(
-        data_config=base_bottom_config,
-        max_stride=32,
-        confmap_head_config=confmap_head,
-        pafs_head_config=pafs_head,
-        labels=sio.load_slp(minimal_instance),
-        apply_aug=base_bottom_config.use_augmentations_train,
-    )
-
-    gt_sample_keys = [
-        "image",
-        "instances",
-        "video_idx",
-        "frame_idx",
-        "confidence_maps",
-        "orig_size",
-        "num_instances",
-        "part_affinity_fields",
-    ]
-
-    sample = next(iter(dataset))
-    assert len(dataset) == 1
-    assert len(sample.keys()) == len(gt_sample_keys)
-
-    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
-        assert gt_key == key
-    assert sample["image"].shape == (1, 1, 160, 160)
-    assert sample["confidence_maps"].shape == (1, 2, 80, 80)
+    assert sample["image"].shape == (1, 1, 512, 512)
+    assert sample["confidence_maps"].shape == (1, 2, 256, 256)
+    assert sample["part_affinity_fields"].shape == (2, 128, 128)
 
 
 def test_centered_instance_dataset(minimal_instance):


### PR DESCRIPTION
This is the second PR for https://github.com/talmolab/sleap-nn/issues/119. We implement in-memory caching by pre-loading the samples in a dictionary and applying augmentations in the `__getitem__()`  function to ensure randomness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced dataset classes with caching mechanisms for improved data handling.
	- Added a method to generate centered bounding boxes in the `CenteredInstanceDataset` class.
	- Introduced a method for cropping and resizing images in the `SingleInstanceDataset` class.

- **Bug Fixes**
	- Refactored sample retrieval to reduce redundancy and improve efficiency.

- **Tests**
	- Updated test cases to reflect changes in dataset configurations and output tensor shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->