### PR TITLE
Remove `random_crop` augmentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -59,9 +59,6 @@ The config file has three main sections:
             - `mixup_lambda`: (float) min-max value of mixup strength. Default is 0-1. *Default*: `None`.
             - `mixup_p`: (float) Probability of applying random mixup v2. *Default*=0.0
             - `input_key`: (str) Can be `image` or `instance`. The input_key `instance` expects the KorniaAugmenter to follow the InstanceCropper else `image` otherwise for default.
-            - `random_crop_p`: (float) Probability of applying random crop.
-            - `random_crop_height`: (int) Desired output height of the random crop.
-            - `random_crop_width`: (int) Desired output height of the random crop.
 - `model_config`: 
     - `init_weight`: (str) model weights initialization method. "default" uses kaiming uniform initialization and "xavier" uses Xavier initialization method.
     - `pre_trained_weights`: (str) Pretrained weights file name supported only for ConvNext and SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights","ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"]. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].

--- a/docs/config_centroid.yaml
+++ b/docs/config_centroid.yaml
@@ -36,9 +36,6 @@ data_config:
       erase_p: 0
       mixup_lambda: null
       mixup_p: 0
-      random_crop_p: 0
-      crop_height: 160
-      crop_width: 160
 
 model_config:
   init_weights: xavier

--- a/sleap_nn/data/augmentation.py
+++ b/sleap_nn/data/augmentation.py
@@ -123,9 +123,6 @@ def apply_geometric_augmentation(
     erase_p: float = 0.0,
     mixup_lambda: Union[Optional[float], Tuple[float, float], None] = None,
     mixup_p: float = 0.0,
-    random_crop_height: int = 0,
-    random_crop_width: int = 0,
-    random_crop_p: float = 0.0,
 ) -> Tuple[torch.Tensor]:
     """Apply kornia geometric augmentation on image and instances.
 
@@ -153,9 +150,6 @@ def apply_geometric_augmentation(
         erase_p: Probability of applying random erase.
         mixup_lambda: min-max value of mixup strength. Default is 0-1. Default: `None`.
         mixup_p: Probability of applying random mixup v2.
-        random_crop_height: Desired output height of the crop. Must be int.
-        random_crop_width: Desired output width of the crop. Must be int.
-        random_crop_p: Probability of applying random crop.
 
 
     Returns:
@@ -195,19 +189,6 @@ def apply_geometric_augmentation(
                 same_on_batch=True,
             )
         )
-    if random_crop_p > 0:
-        if random_crop_height > 0 and random_crop_width > 0:
-            aug_stack.append(
-                K.augmentation.RandomCrop(
-                    size=(random_crop_height, random_crop_width),
-                    pad_if_needed=True,
-                    p=random_crop_p,
-                    keepdim=True,
-                    same_on_batch=True,
-                )
-            )
-        else:
-            raise ValueError(f"random_crop_hw height and width must be greater than 0.")
 
     augmenter = AugmentationSequential(
         *aug_stack,
@@ -350,9 +331,6 @@ class KorniaAugmenter(IterDataPipe):
         erase_p: Probability of applying random erase.
         mixup_lambda: min-max value of mixup strength. Default is 0-1. Default: `None`.
         mixup_p: Probability of applying random mixup v2.
-        random_crop_height: Desired output height of the crop. Must be int.
-        random_crop_width: Desired output width of the crop. Must be int.
-        random_crop_p: Probability of applying random crop.
         input_key: Can be `image` or `instance`. The input_key `instance` expects the
             the KorniaAugmenter to follow the InstanceCropper else `image` otherwise
             for default.
@@ -398,9 +376,6 @@ class KorniaAugmenter(IterDataPipe):
         erase_p: float = 0.0,
         mixup_lambda: Union[Optional[float], Tuple[float, float], None] = None,
         mixup_p: float = 0.0,
-        random_crop_height: int = 0,
-        random_crop_width: int = 0,
-        random_crop_p: float = 0.0,
         image_key: str = "image",
         instance_key: str = "instances",
     ) -> None:
@@ -431,9 +406,6 @@ class KorniaAugmenter(IterDataPipe):
         self.erase_p = erase_p
         self.mixup_lambda = mixup_lambda
         self.mixup_p = mixup_p
-        self.random_crop_height = random_crop_height
-        self.random_crop_width = random_crop_width
-        self.random_crop_p = random_crop_p
         self.image_key = image_key
         self.instance_key = instance_key
 
@@ -505,21 +477,6 @@ class KorniaAugmenter(IterDataPipe):
                     same_on_batch=True,
                 )
             )
-        if self.random_crop_p > 0:
-            if self.random_crop_height > 0 and self.random_crop_width > 0:
-                aug_stack.append(
-                    K.augmentation.RandomCrop(
-                        size=(self.random_crop_height, self.random_crop_width),
-                        pad_if_needed=True,
-                        p=self.random_crop_p,
-                        keepdim=True,
-                        same_on_batch=True,
-                    )
-                )
-            else:
-                raise ValueError(
-                    f"random_crop_hw height and width must be greater than 0."
-                )
 
         self.augmenter = AugmentationSequential(
             *aug_stack,

--- a/sleap_nn/data/pipelines.py
+++ b/sleap_nn/data/pipelines.py
@@ -191,16 +191,6 @@ class SingleInstanceConfmapsPipeline:
                     instance_key="instances",
                 )
 
-            if "random_crop" in self.data_config.augmentation_config:
-                datapipe = KorniaAugmenter(
-                    datapipe,
-                    random_crop_height=self.data_config.augmentation_config.random_crop.crop_height,
-                    random_crop_width=self.data_config.augmentation_config.random_crop.crop_width,
-                    random_crop_p=self.data_config.augmentation_config.random_crop.random_crop_p,
-                    image_key="image",
-                    instance_key="instances",
-                )
-
         datapipe = Resizer(datapipe, scale=self.data_config.preprocessing.scale)
         datapipe = PadToStride(datapipe, max_stride=self.max_stride)
 
@@ -288,15 +278,6 @@ class CentroidConfmapsPipeline:
                 datapipe = KorniaAugmenter(
                     datapipe,
                     **dict(self.data_config.augmentation_config.geometric),
-                    image_key="image",
-                    instance_key="instances",
-                )
-            if "random_crop" in self.data_config.augmentation_config:
-                datapipe = KorniaAugmenter(
-                    datapipe,
-                    random_crop_height=self.data_config.augmentation_config.random_crop.crop_height,
-                    random_crop_width=self.data_config.augmentation_config.random_crop.crop_width,
-                    random_crop_p=self.data_config.augmentation_config.random_crop.random_crop_p,
                     image_key="image",
                     instance_key="instances",
                 )
@@ -390,16 +371,6 @@ class BottomUpPipeline:
                 datapipe = KorniaAugmenter(
                     datapipe,
                     **dict(self.data_config.augmentation_config.geometric),
-                    image_key="image",
-                    instance_key="instances",
-                )
-
-            if "random_crop" in self.data_config.augmentation_config:
-                datapipe = KorniaAugmenter(
-                    datapipe,
-                    random_crop_height=self.data_config.augmentation_config.random_crop.crop_height,
-                    random_crop_width=self.data_config.augmentation_config.random_crop.crop_width,
-                    random_crop_p=self.data_config.augmentation_config.random_crop.random_crop_p,
                     image_key="image",
                     instance_key="instances",
                 )

--- a/tests/data/test_augmentation.py
+++ b/tests/data/test_augmentation.py
@@ -76,9 +76,6 @@ def test_apply_geometric_augmentation(minimal_instance):
         ex["instances"],
         scale=0.5,
         affine_p=1.0,
-        random_crop_height=100,
-        random_crop_width=100,
-        random_crop_p=1.0,
         erase_p=1.0,
         mixup_p=1.0,
     )
@@ -86,15 +83,8 @@ def test_apply_geometric_augmentation(minimal_instance):
     assert torch.is_tensor(img)
     assert torch.is_tensor(pts)
     assert not torch.equal(img, ex["image"])
-    assert img.shape == (1, 1, 100, 100)
+    assert img.shape == (1, 1, 384, 384)
     assert pts.shape == (1, 2, 2, 2)
-
-    with pytest.raises(
-        ValueError, match="crop_hw height and width must be greater than 0."
-    ):
-        img, pts = apply_geometric_augmentation(
-            ex["image"], ex["instances"], random_crop_p=1.0, random_crop_height=0
-        )
 
 
 def test_kornia_augmentation(minimal_instance):
@@ -112,9 +102,6 @@ def test_kornia_augmentation(minimal_instance):
         erase_p=1.0,
         mixup_p=1.0,
         mixup_lambda=(0.0, 1.0),
-        random_crop_height=384,
-        random_crop_width=384,
-        random_crop_p=1.0,
     )
 
     # Test all augmentations.
@@ -125,16 +112,3 @@ def test_kornia_augmentation(minimal_instance):
     assert torch.is_tensor(pts)
     assert img.shape == (1, 1, 384, 384)
     assert pts.shape == (1, 2, 2, 2)
-
-    # Test RandomCrop value error.
-    p = LabelsReaderDP.from_filename(minimal_instance)
-    p = Normalizer(p)
-    with pytest.raises(
-        ValueError, match="crop_hw height and width must be greater than 0."
-    ):
-        p = KorniaAugmenter(
-            p,
-            random_crop_height=0,
-            random_crop_width=0,
-            random_crop_p=1.0,
-        )

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -252,9 +252,6 @@ def test_centered_instance_dataset(minimal_instance):
                     "erase_p": 0.5,
                     "mixup_lambda": None,
                     "mixup_p": 0.5,
-                    "random_crop_p": 0.0,
-                    "random_crop_height": 160,
-                    "random_crop_width": 160,
                 },
             },
         }
@@ -327,9 +324,6 @@ def test_centered_instance_dataset(minimal_instance):
                     "erase_p": 0.5,
                     "mixup_lambda": None,
                     "mixup_p": 0.5,
-                    "random_crop_p": 0.0,
-                    "random_crop_height": 160,
-                    "random_crop_width": 160,
                 },
             },
         }
@@ -445,9 +439,6 @@ def test_centroid_dataset(minimal_instance):
                     "erase_p": 0.5,
                     "mixup_lambda": None,
                     "mixup_p": 0.5,
-                    "random_crop_p": 1.0,
-                    "random_crop_height": 160,
-                    "random_crop_width": 160,
                 },
             },
         }
@@ -478,8 +469,8 @@ def test_centroid_dataset(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 160, 160)
-    assert sample["centroids_confidence_maps"].shape == (1, 1, 80, 80)
+    assert sample["image"].shape == (1, 1, 384, 384)
+    assert sample["centroids_confidence_maps"].shape == (1, 1, 192, 192)
 
 
 def test_single_instance_dataset(minimal_instance):
@@ -568,9 +559,6 @@ def test_single_instance_dataset(minimal_instance):
                     "erase_p": 0.5,
                     "mixup_lambda": None,
                     "mixup_p": 0.5,
-                    "random_crop_p": 1.0,
-                    "random_crop_height": 160,
-                    "random_crop_width": 160,
                 },
             },
         }
@@ -598,6 +586,6 @@ def test_single_instance_dataset(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 160, 160)
-    assert sample["confidence_maps"].shape == (1, 2, 80, 80)
+    assert sample["image"].shape == (1, 1, 384, 384)
+    assert sample["confidence_maps"].shape == (1, 2, 192, 192)
     assert sample["instances"].shape == (1, 1, 2, 2)

--- a/tests/data/test_pipelines.py
+++ b/tests/data/test_pipelines.py
@@ -149,11 +149,6 @@ def test_topdownconfmapspipeline(minimal_instance):
             },
             "use_augmentations_train": True,
             "augmentation_config": {
-                "random_crop": {
-                    "random_crop_p": 0.0,
-                    "crop_height": 160,
-                    "crop_width": 160,
-                },
                 "intensity": {
                     "uniform_noise_min": 0.0,
                     "uniform_noise_max": 0.04,
@@ -229,11 +224,6 @@ def test_topdownconfmapspipeline(minimal_instance):
             },
             "use_augmentations_train": True,
             "augmentation_config": {
-                "random_crop": {
-                    "random_crop_p": 0.0,
-                    "crop_height": 160,
-                    "crop_width": 160,
-                },
                 "intensity": {
                     "uniform_noise_min": 0.0,
                     "uniform_noise_max": 0.04,
@@ -359,11 +349,6 @@ def test_singleinstanceconfmapspipeline(minimal_instance):
             },
             "use_augmentations_train": True,
             "augmentation_config": {
-                "random_crop": {
-                    "random_crop_p": 1.0,
-                    "crop_height": 160,
-                    "crop_width": 160,
-                },
                 "intensity": {
                     "uniform_noise_min": 0.0,
                     "uniform_noise_max": 0.04,
@@ -420,8 +405,8 @@ def test_singleinstanceconfmapspipeline(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 160, 160)
-    assert sample["confidence_maps"].shape == (1, 2, 80, 80)
+    assert sample["image"].shape == (1, 1, 384, 384)
+    assert sample["confidence_maps"].shape == (1, 2, 192, 192)
     assert sample["instances"].shape == (1, 1, 2, 2)
 
 
@@ -476,11 +461,6 @@ def test_centroidconfmapspipeline(minimal_instance):
             },
             "use_augmentations_train": True,
             "augmentation_config": {
-                "random_crop": {
-                    "random_crop_p": 1.0,
-                    "crop_height": 160,
-                    "crop_width": 160,
-                },
                 "intensity": {
                     "uniform_noise_min": 0.0,
                     "uniform_noise_max": 0.04,
@@ -536,8 +516,8 @@ def test_centroidconfmapspipeline(minimal_instance):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["image"].shape == (1, 1, 160, 160)
-    assert sample["centroids_confidence_maps"].shape == (1, 1, 80, 80)
+    assert sample["image"].shape == (1, 1, 384, 384)
+    assert sample["centroids_confidence_maps"].shape == (1, 1, 192, 192)
 
 
 def test_bottomuppipeline(minimal_instance):
@@ -631,160 +611,3 @@ def test_bottomuppipeline(minimal_instance):
     assert sample["image"].shape == (1, 1, 192, 192)
     assert sample["confidence_maps"].shape == (1, 2, 96, 96)
     assert sample["part_affinity_fields"].shape == (2, 48, 48)
-
-    # with padding
-    base_bottom_config = OmegaConf.create(
-        {
-            "preprocessing": {
-                "max_height": None,
-                "max_width": None,
-                "scale": 1.0,
-                "is_rgb": False,
-            },
-            "use_augmentations_train": True,
-            "augmentation_config": {
-                "random_crop": {
-                    "random_crop_p": 1.0,
-                    "crop_height": 100,
-                    "crop_width": 100,
-                },
-                "intensity": {
-                    "uniform_noise_min": 0.0,
-                    "uniform_noise_max": 0.04,
-                    "uniform_noise_p": 0.5,
-                    "gaussian_noise_mean": 0.02,
-                    "gaussian_noise_std": 0.004,
-                    "gaussian_noise_p": 0.5,
-                    "contrast_min": 0.5,
-                    "contrast_max": 2.0,
-                    "contrast_p": 0.5,
-                    "brightness": 0.0,
-                    "brightness_p": 0.5,
-                },
-                "geometric": {
-                    "rotation": 15.0,
-                    "scale": 0.05,
-                    "translate_width": 0.02,
-                    "translate_height": 0.02,
-                    "affine_p": 0.5,
-                    "erase_scale_min": 0.0001,
-                    "erase_scale_max": 0.01,
-                    "erase_ratio_min": 1,
-                    "erase_ratio_max": 1,
-                    "erase_p": 0.5,
-                    "mixup_lambda": None,
-                    "mixup_p": 0.5,
-                },
-            },
-        }
-    )
-
-    pipeline = BottomUpPipeline(
-        data_config=base_bottom_config,
-        max_stride=32,
-        confmap_head=confmap_head,
-        pafs_head=pafs_head,
-    )
-    data_provider = LabelsReaderDP(labels=sio.load_slp(minimal_instance))
-
-    datapipe = pipeline.make_training_pipeline(
-        data_provider=data_provider,
-        use_augmentations=base_bottom_config.use_augmentations_train,
-    )
-
-    gt_sample_keys = [
-        "image",
-        "video_idx",
-        "frame_idx",
-        "confidence_maps",
-        "orig_size",
-        "num_instances",
-        "part_affinity_fields",
-    ]
-
-    sample = next(iter(datapipe))
-    assert len(sample.keys()) == len(gt_sample_keys)
-
-    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
-        assert gt_key == key
-    assert sample["image"].shape == (1, 1, 128, 128)
-    assert sample["confidence_maps"].shape == (1, 2, 64, 64)
-    assert sample["part_affinity_fields"].shape == (2, 32, 32)
-
-    # with random crop
-    base_bottom_config = OmegaConf.create(
-        {
-            "preprocessing": {
-                "max_height": None,
-                "max_width": None,
-                "scale": 1.0,
-                "is_rgb": False,
-            },
-            "use_augmentations_train": True,
-            "augmentation_config": {
-                "random_crop": {
-                    "random_crop_p": 1.0,
-                    "crop_height": 160,
-                    "crop_width": 160,
-                },
-                "intensity": {
-                    "uniform_noise_min": 0.0,
-                    "uniform_noise_max": 0.04,
-                    "uniform_noise_p": 0.5,
-                    "gaussian_noise_mean": 0.02,
-                    "gaussian_noise_std": 0.004,
-                    "gaussian_noise_p": 0.5,
-                    "contrast_min": 0.5,
-                    "contrast_max": 2.0,
-                    "contrast_p": 0.5,
-                    "brightness": 0.0,
-                    "brightness_p": 0.5,
-                },
-                "geometric": {
-                    "rotation": 15.0,
-                    "scale": 0.05,
-                    "translate_width": 0.02,
-                    "translate_height": 0.02,
-                    "affine_p": 0.5,
-                    "erase_scale_min": 0.0001,
-                    "erase_scale_max": 0.01,
-                    "erase_ratio_min": 1,
-                    "erase_ratio_max": 1,
-                    "erase_p": 0.5,
-                    "mixup_lambda": None,
-                    "mixup_p": 0.5,
-                },
-            },
-        }
-    )
-
-    pipeline = BottomUpPipeline(
-        data_config=base_bottom_config,
-        max_stride=32,
-        confmap_head=confmap_head,
-        pafs_head=pafs_head,
-    )
-
-    data_provider = LabelsReaderDP(labels=sio.load_slp(minimal_instance))
-    datapipe = pipeline.make_training_pipeline(
-        data_provider=data_provider,
-        use_augmentations=base_bottom_config.use_augmentations_train,
-    )
-
-    gt_sample_keys = [
-        "image",
-        "video_idx",
-        "frame_idx",
-        "confidence_maps",
-        "orig_size",
-        "num_instances",
-        "part_affinity_fields",
-    ]
-
-    sample = next(iter(datapipe))
-    assert len(sample.keys()) == len(gt_sample_keys)
-
-    for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
-        assert gt_key == key
-    assert sample["image"].shape == (1, 1, 160, 160)
-    assert sample["confidence_maps"].shape == (1, 2, 80, 80)

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -64,50 +64,6 @@ def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
     finally:
         shutil.rmtree(dir_path)
 
-    dir_path = Path(sleap_data_dir) / "data_chunks"
-
-    partial_func = functools.partial(
-        bottomup_data_chunks,
-        data_config=config.data_config,
-        max_instances=2,
-        max_hw=max_hw,
-        scale=1.0,
-    )
-    ld.optimize(
-        fn=partial_func,
-        inputs=[(x, labels.videos.index(x.video)) for x in labels],
-        output_dir=str(dir_path),
-        chunk_size=4,
-    )
-
-    try:
-        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
-        pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
-
-        # test with random crop
-        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
-        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
-        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
-        dataset = BottomUpStreamingDataset(
-            augmentation_config=config.data_config.augmentation_config,
-            confmap_head=confmap_head,
-            pafs_head=pafs_head,
-            edge_inds=edge_inds,
-            max_stride=2,
-            input_dir=str(dir_path),
-            apply_aug=True,
-        )
-
-        samples = list(iter(dataset))
-        assert len(samples) == 1
-
-        assert samples[0]["image"].shape == (1, 1, 300, 300)
-        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
-        assert samples[0]["part_affinity_fields"].shape == (2, 75, 75)
-
-    finally:
-        shutil.rmtree(dir_path)
-
 
 def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
     """Test CenteredInstanceStreamingDataset class."""
@@ -197,49 +153,6 @@ def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
     finally:
         shutil.rmtree(dir_path)
 
-        dir_path = Path(sleap_data_dir) / "data_chunks"
-
-    partial_func = functools.partial(
-        centroid_data_chunks,
-        data_config=config.data_config,
-        max_instances=2,
-        anchor_ind=0,
-        max_hw=max_hw,
-        scale=1.0,
-    )
-
-    ld.optimize(
-        fn=partial_func,
-        inputs=[(x, labels.videos.index(x.video)) for x in labels],
-        output_dir=str(dir_path),
-        chunk_size=4,
-    )
-
-    try:
-
-        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
-
-        # test with random crop
-        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
-        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
-        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
-        dataset = CentroidStreamingDataset(
-            augmentation_config=config.data_config.augmentation_config,
-            confmap_head=confmap_head,
-            max_stride=2,
-            input_dir=str(dir_path),
-            apply_aug=True,
-        )
-
-        samples = list(iter(dataset))
-        assert len(samples) == 1
-
-        assert samples[0]["image"].shape == (1, 1, 300, 300)
-        assert samples[0]["centroids_confidence_maps"].shape == (1, 1, 150, 150)
-
-    finally:
-        shutil.rmtree(dir_path)
-
 
 def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
     """Test SingleInstanceStreamingDataset class."""
@@ -280,46 +193,6 @@ def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, con
 
         assert samples[0]["image"].shape == (1, 1, 200, 200)
         assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
-
-    finally:
-        shutil.rmtree(dir_path)
-
-    dir_path = Path(sleap_data_dir) / "data_chunks"
-
-    partial_func = functools.partial(
-        single_instance_data_chunks, data_config=config.data_config, max_hw=max_hw
-    )
-
-    for lf in labels:
-        lf.instances = lf.instances[:1]
-    ld.optimize(
-        fn=partial_func,
-        inputs=[(x, labels.videos.index(x.video)) for x in labels],
-        output_dir=str(dir_path),
-        chunk_size=4,
-    )
-
-    try:
-
-        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
-
-        # test with random crop
-        config.data_config.augmentation_config.geometric["random_crop_p"] = 1.0
-        config.data_config.augmentation_config.geometric["random_crop_height"] = 300
-        config.data_config.augmentation_config.geometric["random_crop_width"] = 300
-        dataset = SingleInstanceStreamingDataset(
-            augmentation_config=config.data_config.augmentation_config,
-            apply_aug=True,
-            confmap_head=confmap_head,
-            max_stride=2,
-            input_dir=str(dir_path),
-        )
-
-        samples = list(iter(dataset))
-        assert len(samples) == 1
-
-        assert samples[0]["image"].shape == (1, 1, 300, 300)
-        assert samples[0]["confidence_maps"].shape == (1, 2, 150, 150)
 
     finally:
         shutil.rmtree(dir_path)


### PR DESCRIPTION
This PR removes `random_crop` augmentation from the list of geometric augmentation in sleap_nn, to remove any potential conflicts, particularly with existing cropping for centered-instance model. 