### PR TITLE
Generate np chunks for caching

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -619,16 +619,16 @@ class CentroidDataset(BaseDataset):
         # apply augmentation
         if self.apply_aug:
             if "intensity" in self.data_config.augmentation_config:
-                sample["image"], sample["instances"] = apply_intensity_augmentation(
+                sample["image"], sample["centroids"] = apply_intensity_augmentation(
                     sample["image"],
-                    sample["instances"],
+                    sample["centroids"],
                     **self.data_config.augmentation_config.intensity,
                 )
 
             if "geometric" in self.data_config.augmentation_config:
-                sample["image"], sample["instances"] = apply_geometric_augmentation(
+                sample["image"], sample["centroids"] = apply_geometric_augmentation(
                     sample["image"],
-                    sample["instances"],
+                    sample["centroids"],
                     **self.data_config.augmentation_config.geometric,
                 )
 

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1,9 +1,12 @@
 """Custom `torch.utils.data.Dataset`s for different model types."""
 
 from kornia.geometry.transform import crop_and_resize
+from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Tuple
 from omegaconf import DictConfig
 import numpy as np
+from PIL import Image
+
 import torch
 import torchvision.transforms as T
 from torch.utils.data import Dataset
@@ -16,7 +19,7 @@ from sleap_nn.data.normalization import (
     convert_to_rgb,
 )
 from sleap_nn.data.providers import get_max_instances, get_max_height_width, process_lf
-from sleap_nn.data.resizing import apply_sizematcher, apply_resizer
+from sleap_nn.data.resizing import apply_pad_to_stride, apply_sizematcher, apply_resizer
 from sleap_nn.data.augmentation import (
     apply_geometric_augmentation,
     apply_intensity_augmentation,
@@ -24,8 +27,6 @@ from sleap_nn.data.augmentation import (
 from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
 from sleap_nn.data.edge_maps import generate_pafs
 from sleap_nn.data.instance_cropping import make_centered_bboxes
-from sleap_nn.data.normalization import apply_normalization
-from sleap_nn.data.resizing import apply_pad_to_stride, apply_resizer
 
 
 class BaseDataset(Dataset):
@@ -42,6 +43,9 @@ class BaseDataset(Dataset):
            `max_width` in the config is None, then `max_hw` is used (computed with
             `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
             are used.
+        np_chunks: If `True`, `.npz` chunks are generated and samples are loaded from
+            these chunks during training. Else, in-memory caching is used.
+        np_chunks_path: Path to save the `.npz` chunks. If `None`, current working dir is used.
     """
 
     def __init__(
@@ -51,6 +55,8 @@ class BaseDataset(Dataset):
         max_stride: int,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
+        np_chunks: bool = False,
+        np_chunks_path: Optional[str] = None,
     ) -> None:
         """Initialize class attributes."""
         super().__init__()
@@ -60,7 +66,20 @@ class BaseDataset(Dataset):
         self.apply_aug = apply_aug
         self.max_hw = max_hw
         self.max_instances = get_max_instances(self.labels)
+        self.np_chunks = np_chunks
+        self.np_chunks_path = np_chunks_path
+        if self.np_chunks_path is None:
+            self.np_chunks_path = "."
+        path = (
+            Path(self.np_chunks_path)
+            if isinstance(self.np_chunks_path, str)
+            else self.np_chunks_path
+        )
+        if not path.is_dir():
+            path.mkdir(parents=True, exist_ok=True)
 
+        self.transform_to_pil = T.ToPILImage()
+        self.transform_pil_to_tensor = T.ToTensor()
         self.cache = {}
 
     def _fill_cache(self):
@@ -104,7 +123,15 @@ class BaseDataset(Dataset):
                 sample["image"], max_stride=self.max_stride
             )
 
-            self.cache[lf_idx] = sample.copy()
+            if self.np_chunks:
+                sample["image"] = self.transform_to_pil(sample["image"].squeeze(dim=0))
+                for k, v in sample.items():
+                    if k != "image" and isinstance(v, torch.Tensor):
+                        sample[k] = v.numpy()
+                np.savez_compressed(f"{self.np_chunks_path}/sample_{lf_idx}", **sample)
+
+            else:
+                self.cache[lf_idx] = sample.copy()
 
         for video in self.labels.videos:
             video.close()
@@ -141,6 +168,9 @@ class BottomUpDataset(BaseDataset):
         pafs_head_config: DictConfig object with all the keys in the `head_config` section
             (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type )
             for PAFs.
+        np_chunks: If `True`, `.npz` chunks are generated and samples are loaded from
+            these chunks during training. Else, in-memory caching is used.
+        np_chunks_path: Path to save the `.npz` chunks. If `None`, current working dir is used.
     """
 
     def __init__(
@@ -152,6 +182,8 @@ class BottomUpDataset(BaseDataset):
         max_stride: int,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
+        np_chunks: bool = False,
+        np_chunks_path: Optional[str] = None,
     ) -> None:
         """Initialize class attributes."""
         super().__init__(
@@ -160,6 +192,8 @@ class BottomUpDataset(BaseDataset):
             max_stride=max_stride,
             apply_aug=apply_aug,
             max_hw=max_hw,
+            np_chunks=np_chunks,
+            np_chunks_path=np_chunks_path,
         )
         self.confmap_head_config = confmap_head_config
         self.pafs_head_config = pafs_head_config
@@ -169,7 +203,18 @@ class BottomUpDataset(BaseDataset):
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image, confmaps and pafs for given index."""
-        sample = self.cache[index]
+        if self.np_chunks:
+            ex = np.load(f"{self.np_chunks_path}/sample_{index}.npz")
+            sample = {}
+            for k, v in ex.items():
+                if k != "image":
+                    sample[k] = torch.from_numpy(v)
+                else:
+                    sample[k] = self.transform_pil_to_tensor(
+                        Image.fromarray(ex["image"])
+                    ).unsqueeze(dim=0)
+        else:
+            sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:
@@ -229,6 +274,9 @@ class CenteredInstanceDataset(BaseDataset):
            `max_width` in the config is None, then `max_hw` is used (computed with
             `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
             are used.
+        np_chunks: If `True`, `.npz` chunks are generated and samples are loaded from
+            these chunks during training. Else, in-memory caching is used.
+        np_chunks_path: Path to save the `.npz` chunks. If `None`, current working dir is used.
         confmap_head_config: DictConfig object with all the keys in the `head_config` section.
         (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
         crop_hw: Height and width of the crop in pixels.
@@ -247,6 +295,8 @@ class CenteredInstanceDataset(BaseDataset):
         max_stride: int,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
+        np_chunks: bool = False,
+        np_chunks_path: Optional[str] = None,
     ) -> None:
         """Initialize class attributes."""
         super().__init__(
@@ -255,6 +305,8 @@ class CenteredInstanceDataset(BaseDataset):
             max_stride=max_stride,
             apply_aug=apply_aug,
             max_hw=max_hw,
+            np_chunks=np_chunks,
+            np_chunks_path=np_chunks_path,
         )
         self.crop_hw = crop_hw
         self.confmap_head_config = confmap_head_config
@@ -336,7 +388,17 @@ class CenteredInstanceDataset(BaseDataset):
             sample["num_instances"] = num_instances
             sample["orig_size"] = torch.Tensor([orig_img_height, orig_img_width])
 
-            self.cache[idx] = sample.copy()
+            if self.np_chunks:
+                sample["instance_image"] = self.transform_to_pil(
+                    sample["instance_image"].squeeze(dim=0)
+                )
+                for k, v in sample.items():
+                    if k != "instance_image" and isinstance(v, torch.Tensor):
+                        sample[k] = v.numpy()
+                np.savez_compressed(f"{self.np_chunks_path}/sample_{idx}", **sample)
+
+            else:
+                self.cache[idx] = sample.copy()
 
         for video in self.labels.videos:
             video.close()
@@ -355,7 +417,18 @@ class CenteredInstanceDataset(BaseDataset):
 
     def __getitem__(self, index) -> Dict:
         """Return dict with cropped image and confmaps of instance for given index."""
-        sample = self.cache[index]
+        if self.np_chunks:
+            ex = np.load(f"{self.np_chunks_path}/sample_{index}.npz")
+            sample = {}
+            for k, v in ex.items():
+                if k != "instance_image":
+                    sample[k] = torch.from_numpy(v)
+                else:
+                    sample[k] = self.transform_pil_to_tensor(
+                        Image.fromarray(ex["instance_image"])
+                    ).unsqueeze(dim=0)
+        else:
+            sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:
@@ -436,6 +509,9 @@ class CentroidDataset(BaseDataset):
            `max_width` in the config is None, then `max_hw` is used (computed with
             `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
             are used.
+        np_chunks: If `True`, `.npz` chunks are generated and samples are loaded from
+            these chunks during training. Else, in-memory caching is used.
+        np_chunks_path: Path to save the `.npz` chunks. If `None`, current working dir is used.
         confmap_head_config: DictConfig object with all the keys in the `head_config` section.
         (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
     """
@@ -448,6 +524,8 @@ class CentroidDataset(BaseDataset):
         max_stride: int,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
+        np_chunks: bool = False,
+        np_chunks_path: Optional[str] = None,
     ) -> None:
         """Initialize class attributes."""
         super().__init__(
@@ -456,6 +534,8 @@ class CentroidDataset(BaseDataset):
             max_stride=max_stride,
             apply_aug=apply_aug,
             max_hw=max_hw,
+            np_chunks=np_chunks,
+            np_chunks_path=np_chunks_path,
         )
         self.confmap_head_config = confmap_head_config
         self._fill_cache()
@@ -508,14 +588,33 @@ class CentroidDataset(BaseDataset):
                 sample["image"], max_stride=self.max_stride
             )
 
-            self.cache[lf_idx] = sample.copy()
+            if self.np_chunks:
+                sample["image"] = self.transform_to_pil(sample["image"].squeeze(dim=0))
+                for k, v in sample.items():
+                    if k != "image" and isinstance(v, torch.Tensor):
+                        sample[k] = v.numpy()
+                np.savez_compressed(f"{self.np_chunks_path}/sample_{lf_idx}", **sample)
+
+            else:
+                self.cache[lf_idx] = sample.copy()
 
         for video in self.labels.videos:
             video.close()
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for centroids for given index."""
-        sample = self.cache[index]
+        if self.np_chunks:
+            ex = np.load(f"{self.np_chunks_path}/sample_{index}.npz")
+            sample = {}
+            for k, v in ex.items():
+                if k != "image":
+                    sample[k] = torch.from_numpy(v)
+                else:
+                    sample[k] = self.transform_pil_to_tensor(
+                        Image.fromarray(ex["image"])
+                    ).unsqueeze(dim=0)
+        else:
+            sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:
@@ -564,6 +663,9 @@ class SingleInstanceDataset(BaseDataset):
            `max_width` in the config is None, then `max_hw` is used (computed with
             `sleap_nn.data.providers.get_max_height_width`). Else the values in the config
             are used.
+        np_chunks: If `True`, `.npz` chunks are generated and samples are loaded from
+            these chunks during training. Else, in-memory caching is used.
+        np_chunks_path: Path to save the `.npz` chunks. If `None`, current working dir is used.
         confmap_head_config: DictConfig object with all the keys in the `head_config` section.
         (required keys: `sigma`, `output_stride` and `anchor_part` depending on the model type ).
     """
@@ -576,6 +678,8 @@ class SingleInstanceDataset(BaseDataset):
         max_stride: int,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
+        np_chunks: bool = False,
+        np_chunks_path: Optional[str] = None,
     ) -> None:
         """Initialize class attributes."""
         super().__init__(
@@ -584,13 +688,26 @@ class SingleInstanceDataset(BaseDataset):
             max_stride=max_stride,
             apply_aug=apply_aug,
             max_hw=max_hw,
+            np_chunks=np_chunks,
+            np_chunks_path=np_chunks_path,
         )
         self.confmap_head_config = confmap_head_config
         self._fill_cache()
 
     def __getitem__(self, index) -> Dict:
         """Return dict with image and confmaps for instance for given index."""
-        sample = self.cache[index]
+        if self.np_chunks:
+            ex = np.load(f"{self.np_chunks_path}/sample_{index}.npz")
+            sample = {}
+            for k, v in ex.items():
+                if k != "image":
+                    sample[k] = torch.from_numpy(v)
+                else:
+                    sample[k] = self.transform_pil_to_tensor(
+                        Image.fromarray(ex["image"])
+                    ).unsqueeze(dim=0)
+        else:
+            sample = self.cache[index]
 
         # apply augmentation
         if self.apply_aug:

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -84,6 +84,7 @@ class ModelTrainer:
                 (ii) model_config: backbone and head configs to be passed to `Model` class.
                 (iii) trainer_config: trainer configs like accelerator, optimiser params.
         data_pipeline_fw: Framework to create the data loaders. One of [`litdata`, `torch_dataset`, `torch_dataset_np_chunks`]
+        np_chunks_path: Path to save `.npz` chunks created with `torch_dataset_np_chunks` data pipeline framework.
     """
 
     def __init__(
@@ -577,6 +578,7 @@ class ModelTrainer:
         head_trained_ckpts_path: Optional[str] = None,
         delete_bin_files_after_training: bool = True,
         chunks_dir_path: Optional[str] = None,
+        delete_np_chunks_after_training: bool = True,
     ):
         """Initiate the training by calling the fit method of Trainer.
 
@@ -589,6 +591,8 @@ class ModelTrainer:
                 training. Else, the `bin` files are deleted.
             chunks_dir_path: Path to chunks dir (this dir should contain `train_chunks`
                 and `val_chunks` folder.). If `None`, `bin` files are generated.
+            delete_np_chunks_after_training: If `False`, the numpy chunks are retained after
+                training. Else, the numpy chunks are deleted.
 
         """
         logger = []
@@ -700,7 +704,7 @@ class ModelTrainer:
                 config=self.config, f=f"{self.dir_path}/training_config.yaml"
             )
 
-            if self.np_chunks:
+            if self.np_chunks and delete_np_chunks_after_training:
                 if (self.train_np_chunks_path).exists():
                     shutil.rmtree(
                         (self.train_np_chunks_path).as_posix(),


### PR DESCRIPTION
This PR adds an option to cache samples to disk as `.npz` files, apart from the in-memory caching available with torch Dataset pipeline in sleap-nn. These `.npz` files stores dictionaries with preprocessed images and keypoints extracted from the `.slp` file. In the `Dataset.__getitem__()` method, we apply augmentation, and generate confidence maps (and part affinity fields for bottom-up model) to ensure randomness. The `.npz` dir is then deleted at the end of training.

Example:

```py
from sleap_nn.training.model_trainer import ModelTrainer

trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset_np_chunks", np_chunks_path="./")

trainer.train()
```