### PR TITLE
Fix crop size

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -381,7 +381,7 @@ class CenteredInstanceDataset(BaseDataset):
             )  # crop extra for rotation augmentation
             crop_size = crop_size.astype(np.int32).tolist()
 
-            sample = generate_crops(image, instance, centroid, self.crop_hw)
+            sample = generate_crops(image, instance, centroid, crop_size)
 
             sample["frame_idx"] = torch.tensor(lf.frame_idx, dtype=torch.int32)
             sample["video_idx"] = torch.tensor(video_idx, dtype=torch.int32)


### PR DESCRIPTION
Currently, we pass the actual `crop_size` to generate the initial crops. However, we need to crop extra to avoid blacking of edges and re-crop after augmentation is applied. This PR fixes the crop size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced dataset cropping mechanism to better support image rotation augmentation
	- Adjusted crop generation to provide more flexible image sampling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->