### PR TITLE
Resize images before cropping in Centered-instance model

### DIFF
--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -505,6 +505,9 @@ class TopDownPredictor(Predictor):
                 max_stride=max_stride,
                 input_scale=self.confmap_config.data_config.preprocessing.scale,
             )
+            centroid_crop_layer.precrop_resize = (
+                self.confmap_config.data_config.preprocessing.scale
+            )
 
         if self.centroid_config is None and self.confmap_config is not None:
             self.instances_key = (

--- a/sleap_nn/inference/topdown.py
+++ b/sleap_nn/inference/topdown.py
@@ -44,6 +44,9 @@ class CentroidCrop(L.LightningModule):
         crop_hw: Tuple (height, width) representing the crop size.
         input_scale: Float indicating if the images should be resized before being
             passed to the model.
+        precrop_resize: Float indicating the factor by which the original images
+            (not images resized for centroid model) should be resized before cropping.
+            Note: This resize happens only after getting the predictions for centroid model.
         max_stride: Maximum stride in a model that the images must be divisible by.
             If > 1, this will pad the bottom and right of the images to ensure they meet
             this divisibility criteria. Padding is applied after the scaling specified
@@ -68,6 +71,7 @@ class CentroidCrop(L.LightningModule):
         return_crops: bool = False,
         crop_hw: Optional[List[int]] = None,
         input_scale: float = 1.0,
+        precrop_resize: float = 1.0,
         max_stride: int = 1,
         use_gt_centroids: bool = False,
         anchor_ind: Optional[int] = None,
@@ -85,6 +89,7 @@ class CentroidCrop(L.LightningModule):
         self.return_crops = return_crops
         self.crop_hw = crop_hw
         self.input_scale = input_scale
+        self.precrop_resize = precrop_resize
         self.max_stride = max_stride
         self.use_gt_centroids = use_gt_centroids
         self.anchor_ind = anchor_ind
@@ -196,6 +201,12 @@ class CentroidCrop(L.LightningModule):
 
             if self.return_crops:
                 crops_dict = self._generate_crops(inputs)
+                inputs["image"] = resize_image(inputs["image"], self.precrop_resize)
+                inputs["centroids"] *= self.precrop_resize
+                scaled_refined_peaks = []
+                for ref_peak in self.refined_peaks_batched:
+                    scaled_refined_peaks.append(ref_peak * self.precrop_resize)
+                self.refined_peaks_batched = scaled_refined_peaks
                 return crops_dict
             else:
                 return inputs
@@ -251,6 +262,12 @@ class CentroidCrop(L.LightningModule):
 
         # Generate crops if return_crops=True to pass the crops to CenteredInstance model.
         if self.return_crops:
+            inputs["image"] = resize_image(inputs["image"], self.precrop_resize)
+            scaled_refined_peaks = []
+            for ref_peak in self.refined_peaks_batched:
+                scaled_refined_peaks.append(ref_peak * self.precrop_resize)
+            self.refined_peaks_batched = scaled_refined_peaks
+
             inputs.update(
                 {
                     "centroids": self.refined_peaks_batched,
@@ -391,8 +408,8 @@ class FindInstancePeaks(L.LightningModule):
             refinement as an integer scalar.
         return_confmaps: If `True`, the confidence maps will be returned together with
             the predicted peaks.
-        input_scale: Float indicating if the images should be resized before being
-            passed to the model.
+        input_scale: Float indicating the scale with which the images were scaled before
+            cropping.
         max_stride: Maximum stride in a model that the images must be divisible by.
             If > 1, this will pad the bottom and right of the images to ensure they meet
             this divisibility criteria. Padding is applied after the scaling specified
@@ -450,12 +467,11 @@ class FindInstancePeaks(L.LightningModule):
         """
         # Network forward pass.
         # resize and pad the input image
-        orig_image = inputs["instance_image"]
-        scaled_image = resize_image(orig_image, self.input_scale)
+        input_image = inputs["instance_image"]
         if self.max_stride != 1:
-            scaled_image = apply_pad_to_stride(scaled_image, self.max_stride)
+            input_image = apply_pad_to_stride(input_image, self.max_stride)
 
-        cms = self.torch_model(scaled_image)
+        cms = self.torch_model(input_image)
 
         peak_points, peak_vals = find_global_peaks(
             cms.detach(),

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -186,6 +186,7 @@ class ModelTrainer:
                     train_labels,
                     maximum_stride=self.max_stride,
                     min_crop_size=min_crop_size,
+                    input_scaling=self.config.data_config.preprocessing.scale,
                 )
                 self.crop_hw = crop_size
                 self.config.data_config.preprocessing.crop_hw = (

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -420,8 +420,8 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
         assert gt_key == key
-    assert sample["instance_image"].shape == (1, 1, 208, 208)
-    assert sample["confidence_maps"].shape == (1, 2, 104, 104)
+    assert sample["instance_image"].shape == (1, 1, 112, 112)
+    assert sample["confidence_maps"].shape == (1, 2, 56, 56)
 
 
 def test_centroid_dataset(minimal_instance, tmp_path):

--- a/tests/inference/test_topdown.py
+++ b/tests/inference/test_topdown.py
@@ -248,12 +248,11 @@ def test_find_instance_peaks(config, minimal_instance, minimal_instance_ckpt):
         output_stride=2,
         peak_threshold=0,
         return_confmaps=True,
-        input_scale=0.5,
     )
     outputs = []
     outputs.append(find_peaks_layer(res))
     assert "pred_confmaps" in outputs[0].keys()
-    assert outputs[0]["pred_confmaps"].shape[-2:] == (40, 40)
+    assert outputs[0]["pred_confmaps"].shape[-2:] == (80, 80)
 
 
 def test_topdown_inference_model(


### PR DESCRIPTION
This PR fixes the issue of resizing images before cropping in the centered-instance pipeline. Currently, we generate crops from the original images and then resize the crops (if `scale` is provided by the user in the `data_config.preprocessing.scale`). In this PR, we apply resizer on the original images first and then generate crops from the scaled images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary, here are the release notes:

- **New Features**
	- Added support for grouping Weights & Biases (WandB) experiment runs
	- Introduced numpy chunk-based data loading for more efficient dataset processing

- **Improvements**
	- Enhanced data augmentation pipeline by removing random cropping configurations
	- Simplified dataset and inference model preprocessing
	- Increased flexibility in data loading and training configurations

- **Changes**
	- Removed random crop parameters from augmentation methods
	- Updated dataset and inference model initialization processes
	- Modified configuration handling for training and data processing

- **Performance**
	- Optimized data loading mechanisms
	- Streamlined augmentation and preprocessing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->