### PR TITLE
Replace `eval` with an explicit mapping dictionary

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -50,6 +50,19 @@ from sleap_nn.data.streaming_datasets import (
 )
 from sleap_nn.training.utils import check_memory, xavier_init_weights
 
+MODEL_WEIGHTS = {
+    "Swin_T_Weights": Swin_T_Weights,
+    "Swin_S_Weights": Swin_S_Weights,
+    "Swin_B_Weights": Swin_B_Weights,
+    "Swin_V2_T_Weights": Swin_V2_T_Weights,
+    "Swin_V2_S_Weights": Swin_V2_S_Weights,
+    "Swin_V2_B_Weights": Swin_V2_B_Weights,
+    "ConvNeXt_Base_Weights": ConvNeXt_Base_Weights,
+    "ConvNeXt_Tiny_Weights": ConvNeXt_Tiny_Weights,
+    "ConvNeXt_Small_Weights": ConvNeXt_Small_Weights,
+    "ConvNeXt_Large_Weights": ConvNeXt_Large_Weights,
+}
+
 
 class ModelTrainer:
     """Train sleap-nn model using PyTorch Lightning.
@@ -788,9 +801,9 @@ class TrainingModel(L.LightningModule):
         self.head_trained_ckpts_path = head_trained_ckpts_path
         self.input_expand_channels = self.model_config.backbone_config.in_channels
         if self.model_config.pre_trained_weights:  # only for swint and convnext
-            ckpt = eval(self.model_config.pre_trained_weights).DEFAULT.get_state_dict(
-                progress=True, check_hash=True
-            )
+            ckpt = MODEL_WEIGHTS[
+                self.model_config.pre_trained_weights
+            ].DEFAULT.get_state_dict(progress=True, check_hash=True)
             input_channels = ckpt["features.0.0.weight"].shape[-3]
             if self.model_config.backbone_config.in_channels != input_channels:
                 self.input_expand_channels = input_channels


### PR DESCRIPTION
This PR removes the usage of `eval` while [loading pre-trained weights](https://github.com/talmolab/sleap-nn/blob/bc75aaff0109dbc5249e7faad18cb4b88b233192/sleap_nn/training/model_trainer.py#L682) for ConvNext and SwinT models. We instead use a dictionary to map the strings to the corresponding objects.