### PR TITLE
Add `CyclerDataLoader` to ensure minimum steps per epoch

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -789,7 +789,7 @@ class CyclerDataLoader(DataLoader):
 
     def __len__(self):
         """Returns the length of the batch sampler's sampler."""
-        return len(self.batch_sampler.sampler)
+        return int(1e6)
 
     def __iter__(self):
         """Creates a sampler that repeats indefinitely."""

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -31,7 +31,6 @@ from torchvision.models.convnext import (
     ConvNeXt_Small_Weights,
     ConvNeXt_Large_Weights,
 )
-from torch.utils.data.dataloader import DataLoader
 import sleap_io as sio
 from sleap_nn.architectures.model import Model
 from sleap_nn.data.custom_datasets import (
@@ -39,6 +38,7 @@ from sleap_nn.data.custom_datasets import (
     CenteredInstanceDataset,
     CentroidDataset,
     SingleInstanceDataset,
+    CyclerDataLoader,
 )
 from sleap_nn.data.instance_cropping import find_instance_crop_size
 from sleap_nn.data.providers import get_max_height_width
@@ -102,6 +102,8 @@ class ModelTrainer:
 
         # initialize attributes
         self.model = None
+        self.train_dataset = None
+        self.val_dataset = None
         self.train_data_loader = None
         self.val_data_loader = None
         self.bin_files_path = None
@@ -223,7 +225,7 @@ class ModelTrainer:
                 )
 
         if self.model_type == "bottomup":
-            train_dataset = BottomUpDataset(
+            self.train_dataset = BottomUpDataset(
                 labels=train_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.bottomup.confmaps,
@@ -234,7 +236,7 @@ class ModelTrainer:
                 np_chunks=self.np_chunks,
                 np_chunks_path=self.train_np_chunks_path,
             )
-            val_dataset = BottomUpDataset(
+            self.val_dataset = BottomUpDataset(
                 labels=val_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.bottomup.confmaps,
@@ -247,7 +249,7 @@ class ModelTrainer:
             )
 
         elif self.model_type == "centered_instance":
-            train_dataset = CenteredInstanceDataset(
+            self.train_dataset = CenteredInstanceDataset(
                 labels=train_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centered_instance.confmaps,
@@ -258,7 +260,7 @@ class ModelTrainer:
                 np_chunks=self.np_chunks,
                 np_chunks_path=self.train_np_chunks_path,
             )
-            val_dataset = CenteredInstanceDataset(
+            self.val_dataset = CenteredInstanceDataset(
                 labels=val_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centered_instance.confmaps,
@@ -271,7 +273,7 @@ class ModelTrainer:
             )
 
         elif self.model_type == "centroid":
-            train_dataset = CentroidDataset(
+            self.train_dataset = CentroidDataset(
                 labels=train_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centroid.confmaps,
@@ -281,7 +283,7 @@ class ModelTrainer:
                 np_chunks=self.np_chunks,
                 np_chunks_path=self.train_np_chunks_path,
             )
-            val_dataset = CentroidDataset(
+            self.val_dataset = CentroidDataset(
                 labels=val_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centroid.confmaps,
@@ -293,7 +295,7 @@ class ModelTrainer:
             )
 
         elif self.model_type == "single_instance":
-            train_dataset = SingleInstanceDataset(
+            self.train_dataset = SingleInstanceDataset(
                 labels=train_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.single_instance.confmaps,
@@ -303,7 +305,7 @@ class ModelTrainer:
                 np_chunks=self.np_chunks,
                 np_chunks_path=self.train_np_chunks_path,
             )
-            val_dataset = SingleInstanceDataset(
+            self.val_dataset = SingleInstanceDataset(
                 labels=val_labels,
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.single_instance.confmaps,
@@ -320,9 +322,8 @@ class ModelTrainer:
             )
 
         # train
-        # TODO: cycler - to ensure minimum steps per epoch
-        self.train_data_loader = DataLoader(
-            train_dataset,
+        self.train_data_loader = CyclerDataLoader(
+            self.train_dataset,
             shuffle=self.config.trainer_config.train_data_loader.shuffle,
             batch_size=self.config.trainer_config.train_data_loader.batch_size,
             num_workers=self.config.trainer_config.train_data_loader.num_workers,
@@ -340,8 +341,8 @@ class ModelTrainer:
         )
 
         # val
-        self.val_data_loader = DataLoader(
-            val_dataset,
+        self.val_data_loader = CyclerDataLoader(
+            self.val_dataset,
             shuffle=False,
             batch_size=self.config.trainer_config.val_data_loader.batch_size,
             num_workers=self.config.trainer_config.val_data_loader.num_workers,
@@ -694,6 +695,12 @@ class ModelTrainer:
                 f"{self.data_pipeline_fw} is not a valid option. Please choose one of `litdata` or `torch_dataset`."
             )
 
+        if self.steps_per_epoch is None:
+            self.steps_per_epoch = (
+                len(self.train_dataset)
+                // self.config.trainer_config.train_data_loader.batch_size
+            )
+
         self.trainer = L.Trainer(
             callbacks=callbacks,
             logger=logger,
@@ -703,6 +710,8 @@ class ModelTrainer:
             accelerator=self.config.trainer_config.trainer_accelerator,
             enable_progress_bar=self.config.trainer_config.enable_progress_bar,
             limit_train_batches=self.steps_per_epoch,
+            limit_val_batches=len(self.val_dataset)
+            // self.config.trainer_config.val_data_loader.batch_size,
         )
 
         try:

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -350,7 +350,7 @@ class ModelTrainer:
         # val
         self.val_data_loader = CyclerDataLoader(
             dataset=self.val_dataset,
-            steps_per_epoch=len(self.val_data_loader.dataset)
+            steps_per_epoch=len(self.val_dataset)
             // self.config.trainer_config.val_data_loader.batch_size,
             shuffle=False,
             batch_size=self.config.trainer_config.val_data_loader.batch_size,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -697,7 +697,7 @@ class ModelTrainer:
 
         if self.steps_per_epoch is None:
             self.steps_per_epoch = (
-                len(self.train_dataset)
+                len(self.train_data_loader.dataset)
                 // self.config.trainer_config.train_data_loader.batch_size
             )
 
@@ -710,7 +710,7 @@ class ModelTrainer:
             accelerator=self.config.trainer_config.trainer_accelerator,
             enable_progress_bar=self.config.trainer_config.enable_progress_bar,
             limit_train_batches=self.steps_per_epoch,
-            limit_val_batches=len(self.val_dataset)
+            limit_val_batches=len(self.val_data_loader.dataset)
             // self.config.trainer_config.val_data_loader.batch_size,
         )
 

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -753,5 +753,5 @@ def test_cycler_dataloader(minimal_instance, tmp_path):
 
     dl = iter(CyclerDataLoader(dataset, batch_size=1, num_workers=0))
 
-    for _ in range(5):
+    for _ in range(10):
         ex = next(dl)

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -5,6 +5,7 @@ from sleap_nn.data.custom_datasets import (
     CenteredInstanceDataset,
     CentroidDataset,
     SingleInstanceDataset,
+    CyclerDataLoader,
 )
 
 
@@ -715,3 +716,42 @@ def test_single_instance_dataset(minimal_instance, tmp_path):
     assert sample["image"].shape == (1, 1, 384, 384)
     assert sample["confidence_maps"].shape == (1, 2, 192, 192)
     assert sample["instances"].shape == (1, 1, 2, 2)
+
+
+def test_cycler_dataloader(minimal_instance, tmp_path):
+    labels = sio.load_slp(minimal_instance)
+
+    # Making our minimal 2-instance example into a single instance example.
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+
+    base_singleinstance_data_config = OmegaConf.create(
+        {
+            "user_instances_only": True,
+            "preprocessing": {
+                "max_height": None,
+                "max_width": None,
+                "scale": 2.0,
+                "is_rgb": True,
+            },
+            "use_augmentations_train": False,
+        }
+    )
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": 0})
+
+    dataset = SingleInstanceDataset(
+        data_config=base_singleinstance_data_config,
+        max_stride=8,
+        confmap_head_config=confmap_head,
+        labels=labels,
+        apply_aug=base_singleinstance_data_config.use_augmentations_train,
+        np_chunks=False,
+    )
+
+    assert len(list(iter(dataset))) == 1
+
+    dl = iter(CyclerDataLoader(dataset, batch_size=1, num_workers=0))
+
+    for _ in range(5):
+        ex = next(dl)

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -751,7 +751,11 @@ def test_cycler_dataloader(minimal_instance, tmp_path):
 
     assert len(list(iter(dataset))) == 1
 
-    dl = iter(CyclerDataLoader(dataset, batch_size=1, num_workers=0))
+    dl = iter(
+        CyclerDataLoader(
+            dataset=dataset, batch_size=1, num_workers=0, steps_per_epoch=10
+        )
+    )
 
     for _ in range(10):
-        ex = next(dl)
+        _ = next(dl)

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -38,8 +38,8 @@ def test_create_data_loader_torch_dataset(config, tmp_path):
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
     model_trainer = ModelTrainer(config_copy, data_pipeline_fw="torch_dataset")
     model_trainer._create_data_loaders_torch_dataset()
-    assert len(list(iter(model_trainer.train_data_loader))) == 2
-    assert len(list(iter(model_trainer.val_data_loader))) == 2
+    assert len(list(iter(model_trainer.train_dataset))) == 2
+    assert len(list(iter(model_trainer.val_dataset))) == 2
     sample = next(iter(model_trainer.train_data_loader))
     assert sample["instance_image"].shape == (1, 1, 1, 104, 104)
 
@@ -53,8 +53,8 @@ def test_create_data_loader_torch_dataset(config, tmp_path):
         np_chunks_path=f"{tmp_path}/np_chunks/",
     )
     model_trainer._create_data_loaders_torch_dataset()
-    assert len(list(iter(model_trainer.train_data_loader))) == 2
-    assert len(list(iter(model_trainer.val_data_loader))) == 2
+    assert len(list(iter(model_trainer.train_dataset))) == 2
+    assert len(list(iter(model_trainer.val_dataset))) == 2
     sample = next(iter(model_trainer.train_data_loader))
     assert sample["instance_image"].shape == (1, 1, 1, 104, 104)
 
@@ -81,8 +81,8 @@ def test_create_data_loader_litdata(config, tmp_path: str):
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
     model_trainer = ModelTrainer(config_copy)
     model_trainer._create_data_loaders_litdata()
-    assert len(list(iter(model_trainer.train_data_loader))) == 2
-    assert len(list(iter(model_trainer.val_data_loader))) == 2
+    assert len(list(iter(model_trainer.train_dataset))) == 2
+    assert len(list(iter(model_trainer.val_dataset))) == 2
     sample = next(iter(model_trainer.train_data_loader))
     assert sample["instance_image"].shape == (1, 1, 1, 104, 104)
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -81,8 +81,8 @@ def test_create_data_loader_litdata(config, tmp_path: str):
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
     model_trainer = ModelTrainer(config_copy)
     model_trainer._create_data_loaders_litdata()
-    assert len(list(iter(model_trainer.train_dataset))) == 2
-    assert len(list(iter(model_trainer.val_dataset))) == 2
+    assert len(list(iter(model_trainer.train_data_loader))) == 2
+    assert len(list(iter(model_trainer.val_data_loader))) == 2
     sample = next(iter(model_trainer.train_data_loader))
     assert sample["instance_image"].shape == (1, 1, 1, 104, 104)
 

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -585,7 +585,7 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     # check exception for lr scheduler
     OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "ReduceLR")
     with pytest.raises(ValueError):
-        trainer = ModelTrainer(config)
+        trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
         trainer.train()
 
     OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "StepLR")


### PR DESCRIPTION
This PR adds a custom `DataLoader` to cycle through the samples and run for the given steps per epoch (if the given step size is higher than (`number of samples / batch size`)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `CyclerDataLoader` for continuous dataset iteration.
	- Enhanced dataset handling with improved iteration capabilities.
	- Added support for infinite data loading during training and validation.

- **Improvements**
	- Updated data loading mechanism to provide more flexible dataset management.
	- Modified dataset length and indexing methods for better performance.

- **Testing**
	- Added comprehensive test for `CyclerDataLoader` functionality.
	- Adjusted assertions in existing tests to focus on datasets instead of data loaders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->