### PR TITLE
Fix running inference on Bottom-up models with CUDA

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -369,7 +369,7 @@ def match_frame_pairs(
 
 
 def compute_dists(
-    positive_pairs: List[Tuple[sio.Instance, sio.PredictedInstance, Any]]
+    positive_pairs: List[Tuple[sio.Instance, sio.PredictedInstance, Any]],
 ) -> Dict[str, Union[np.ndarray, List[int], List[str]]]:
     """Compute Euclidean distances between matched pairs of instances.
 

--- a/sleap_nn/inference/paf_grouping.py
+++ b/sleap_nn/inference/paf_grouping.py
@@ -184,7 +184,7 @@ def make_line_subs(
     Y = torch.cat(
         (src_peaks[:, 1].unsqueeze(dim=-1), dst_peaks[:, 1].unsqueeze(dim=-1)), dim=-1
     ).to(torch.float64)
-    samples = torch.Tensor([0, 1], device=X.device).repeat(n_candidates, 1)
+    samples = torch.tensor([0, 1], device=X.device).repeat(n_candidates, 1)
     samples_new = torch.linspace(0, 1, steps=n_line_points, device=X.device).repeat(
         n_candidates, 1
     )


### PR DESCRIPTION
This PR fixes a bug that occurs while running inference on bottom-up models with CUDA. The error was associated with using legacy tensor constructor (`torch.Tensor`), which doesn't support assigning device on construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated tensor initialization method for improved consistency with recommended practices.
  - Adjusted the function signature of `compute_dists` to enhance code clarity without impacting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->