### PR TITLE
Move all params to config

### DIFF
--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -131,8 +131,8 @@ class AugmentationConfig:
         geometric: Configuration options for geometric augmentations like rotation, scaling, translation etc. If None, no geometric augmentations will be applied.
     """
 
-    intensity: Optional[IntensityConfig] = field(factory=IntensityConfig)
-    geometric: Optional[GeometricConfig] = field(factory=GeometricConfig)
+    intensity: Optional[IntensityConfig] = IntensityConfig()
+    geometric: Optional[GeometricConfig] = GeometricConfig()
 
 
 @define
@@ -141,19 +141,36 @@ class DataConfig:
 
     train_labels_path: (str) Path to training data (.slp file)
     val_labels_path: (str) Path to validation data (.slp file)
-    provider: (str) Provider class to read the input sleap files. Only "LabelsReader" supported for the training pipeline.
-    user_instances_only: (bool) True if only user labeled instances should be used for training. If False, both user labeled and predicted instances would be used. Default: True.
-    chunk_size: (int) Size of each chunk (in MB). Default: 100.  # Your list shows "100" in quotes
+    provider: (str) Provider class to read the input sleap files. Only "LabelsReader"
+        supported for the training pipeline.
+    user_instances_only: (bool) True if only user labeled instances should be used for
+        training. If False, both user labeled and predicted instances would be used. Default: True.
+    data_pipeline_fw: (str) Framework to create the data loaders.
+        One of [`litdata`, `torch_dataset`, `torch_dataset_np_chunks`].
+    np_chunks_path: (str) Path to save `.npz` chunks created with `torch_dataset_np_chunks` data pipeline framework.
+        If `None`, the working dir is used.
+    use_existing_np_chunks: (bool) Use existing train and val chunks in the `np_chunks_path`.
+    chunks_dir_path: Path to chunks dir (this dir should contain `train_chunks`
+                and `val_chunks` folder.). If `None`, `bin` files are generated.
+    chunk_size: (int) Size of each chunk (in MB). Default: 100.  # Your list shows "100" in quotes.
+    delete_chunks_after_training: (bool) If `False`, the chunks (numpy or litdata chunks)
+        are retained after training. Else, the chunks are deleted.
     preprocessing: Configuration options related to data preprocessing.
     use_augmentations_train: (bool) True if the data augmentation should be applied to the training data, else False.
-    augmentation_config: Configurations related to augmentation  # Your list specifies "(only if use_augmentations is True)"
+    augmentation_config: Configurations related to augmentation.
+        # Your list specifies "(only if use_augmentations is True)"
     """
 
     train_labels_path: str = MISSING
     val_labels_path: str = MISSING
     provider: str = "LabelsReader"
     user_instances_only: bool = True
+    data_pipeline_fw: str = "torch_dataset"
+    np_chunks_path: Optional[str] = None
+    use_existing_np_chunks: bool = False
+    chunks_dir_path: Optional[str] = None
     chunk_size: int = 100
-    preprocessing: PreprocessingConfig = field(factory=PreprocessingConfig)
+    delete_chunks_after_training: bool = True
+    preprocessing: PreprocessingConfig = PreprocessingConfig()
     use_augmentations_train: bool = False
-    augmentation_config: AugmentationConfig = field(factory=AugmentationConfig)
+    augmentation_config: AugmentationConfig = AugmentationConfig()

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -376,6 +376,10 @@ class ModelConfig:
             ConvNext and SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights",
             "ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"].
             For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].
+        pretrained_backbone_weights: Path of the `ckpt` file with which the backbone
+            is initialized. If `None`, random init is used.
+        pretrained_head_weights: Path of the `ckpt` file with which the head layers
+            are initialized. If `None`, random init is used.
         backbone_config: initialize either UNetConfig, ConvNextConfig, or SwinTConfig
             based on input from backbone_type
         head_configs: (Dict) Dictionary with the following keys having head configs for
@@ -394,8 +398,10 @@ class ModelConfig:
             value
         ),
     )
-    backbone_config: BackboneConfig = field(factory=BackboneConfig)
-    head_configs: HeadConfig = field(factory=HeadConfig)
+    pretrained_backbone_weights: Optional[str] = None
+    pretrained_head_weights: Optional[str] = None
+    backbone_config: BackboneConfig = BackboneConfig()
+    head_configs: HeadConfig = HeadConfig()
 
     def validate_backbone_type(self, value):
         """Validate backbone_type.

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -143,10 +143,8 @@ class LRSchedulerConfig:
         default="ReduceLROnPlateau",
         validator=lambda instance, attr, value: instance.validate_scheduler(),
     )
-    step_lr: StepLRConfig = field(factory=StepLRConfig)
-    reduce_lr_on_plateau: ReduceLROnPlateauConfig = field(
-        factory=ReduceLROnPlateauConfig
-    )
+    step_lr: StepLRConfig = StepLRConfig()
+    reduce_lr_on_plateau: ReduceLROnPlateauConfig = ReduceLROnPlateauConfig()
 
     def validate_scheduler(self):
         """Scheduler Validation.
@@ -201,9 +199,9 @@ class TrainerConfig:
         early_stopping: create an early_stopping configuration
     """
 
-    train_data_loader: DataLoaderConfig = field(factory=DataLoaderConfig)
-    val_data_loader: DataLoaderConfig = field(factory=DataLoaderConfig)
-    model_ckpt: ModelCkptConfig = field(factory=ModelCkptConfig)
+    train_data_loader: DataLoaderConfig = DataLoaderConfig()
+    val_data_loader: DataLoaderConfig = DataLoaderConfig()
+    model_ckpt: ModelCkptConfig = ModelCkptConfig()
     trainer_devices: Any = field(
         default="auto",
         validator=lambda inst, attr, val: TrainerConfig.validate_trainer_devices(val),
@@ -223,9 +221,9 @@ class TrainerConfig:
         default="Adam",
         validator=lambda inst, attr, val: TrainerConfig.validate_optimizer_name(val),
     )
-    optimizer: OptimizerConfig = field(factory=OptimizerConfig)
-    lr_scheduler: LRSchedulerConfig = field(factory=LRSchedulerConfig)
-    early_stopping: EarlyStoppingConfig = field(factory=EarlyStoppingConfig)
+    optimizer: OptimizerConfig = OptimizerConfig()
+    lr_scheduler: LRSchedulerConfig = LRSchedulerConfig()
+    early_stopping: EarlyStoppingConfig = EarlyStoppingConfig()
 
     def __attrs_post_init__(self):
         """Post Initialization Validation.

--- a/sleap_nn/config/training_job_config.py
+++ b/sleap_nn/config/training_job_config.py
@@ -38,8 +38,9 @@ class TrainingJobConfig:
     """Configuration of a training job.
 
     Attributes:
-        data: Configuration options related to the training data.
-        model: Configuration options related to the model architecture.
+        data_config: Configuration options related to the training data.
+        model_config: Configuration options related to the model architecture.
+        trainer_config: Configuration ooptions related to model training.
         outputs: Configuration options related to outputs during training.
         name: Optional name for this configuration profile.
         description: Optional description of the configuration.
@@ -65,7 +66,7 @@ class TrainingJobConfig:
         Returns:
             A OmegaConf instance parsed from the YAML text, validated against the schema.
         """
-        schema = OmegaConf.structured(cls)
+        schema = OmegaConf.structured(cls())
         config = OmegaConf.create(yaml_data)
         config = OmegaConf.merge(schema, config)
         OmegaConf.to_container(config, resolve=True, throw_on_missing=True)
@@ -82,7 +83,7 @@ class TrainingJobConfig:
         Returns:
           A OmegaConf instance parsed from the YAML file.
         """
-        schema = OmegaConf.structured(cls)
+        schema = OmegaConf.structured(cls())
         config = OmegaConf.load(filename)
         config = OmegaConf.merge(schema, config)
         OmegaConf.to_container(config, resolve=True, throw_on_missing=True)
@@ -100,7 +101,7 @@ class TrainingJobConfig:
 
         # Handle any special cases (like enums) that need manual conversion
         if config_dict.get("model", {}).get("backbone_type"):
-            config_dict["model"]["backbone_type"] = self.model.backbone_type
+            config_dict["model"]["backbone_type"] = self.model_config.backbone_type
 
         # Create OmegaConf object and save if filename provided
         conf = OmegaConf.create(config_dict)

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -52,6 +52,11 @@ def config(sleap_data_dir):
                 "train_labels_path": f"{sleap_data_dir}/minimal_instance.pkg.slp",
                 "val_labels_path": f"{sleap_data_dir}/minimal_instance.pkg.slp",
                 "user_instances_only": True,
+                "data_pipeline_fw": "torch_dataset",
+                "np_chunks_path": None,
+                "chunks_dir_path": None,
+                "use_existing_np_chunks": False,
+                "delete_chunks_after_training": True,
                 "chunk_size": 100,
                 "preprocessing": {
                     "is_rgb": False,
@@ -78,6 +83,8 @@ def config(sleap_data_dir):
             "model_config": {
                 "init_weights": "default",
                 "pre_trained_weights": None,
+                "pretrained_backbone_weights": None,
+                "pretrained_head_weights": None,
                 "backbone_type": "unet",
                 "backbone_config": {
                     "in_channels": 1,

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -36,7 +36,8 @@ def test_create_data_loader_torch_dataset(config, tmp_path):
     config_copy = config.copy()
     OmegaConf.update(config_copy, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
-    model_trainer = ModelTrainer(config_copy, data_pipeline_fw="torch_dataset")
+    OmegaConf.update(config_copy, "data_config.data_pipeline_fw", "torch_dataset")
+    model_trainer = ModelTrainer(config_copy)
     model_trainer._create_data_loaders_torch_dataset()
     assert len(list(iter(model_trainer.train_dataset))) == 2
     assert len(list(iter(model_trainer.val_dataset))) == 2
@@ -47,11 +48,13 @@ def test_create_data_loader_torch_dataset(config, tmp_path):
     config_copy = config.copy()
     OmegaConf.update(config_copy, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
-    model_trainer = ModelTrainer(
-        config_copy,
-        data_pipeline_fw="torch_dataset_np_chunks",
-        np_chunks_path=f"{tmp_path}/np_chunks/",
+    OmegaConf.update(
+        config_copy, "data_config.data_pipeline_fw", "torch_dataset_np_chunks"
     )
+    OmegaConf.update(
+        config_copy, "data_config.np_chunks_path", f"{tmp_path}/np_chunks/"
+    )
+    model_trainer = ModelTrainer(config_copy)
     model_trainer._create_data_loaders_torch_dataset()
     assert len(list(iter(model_trainer.train_dataset))) == 2
     assert len(list(iter(model_trainer.val_dataset))) == 2
@@ -63,7 +66,7 @@ def test_create_data_loader_torch_dataset(config, tmp_path):
     head_config = config_copy.model_config.head_configs.centered_instance
     del config_copy.model_config.head_configs.centered_instance
     OmegaConf.update(config_copy, "model_config.head_configs.topdown", head_config)
-    model_trainer = ModelTrainer(config_copy, data_pipeline_fw="torch_dataset")
+    model_trainer = ModelTrainer(config_copy)
     with pytest.raises(ValueError):
         model_trainer._create_data_loaders_torch_dataset()
 
@@ -71,7 +74,7 @@ def test_create_data_loader_torch_dataset(config, tmp_path):
 def test_create_data_loader_litdata(config, tmp_path: str):
     """Test _create_data_loader function of ModelTrainer class."""
     # test centered-instance pipeline
-
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
@@ -121,11 +124,12 @@ def test_trainer_litdata(config, tmp_path: str):
     #####
     # test incorrect value for data fww
     with pytest.raises(ValueError):
-        model_trainer = ModelTrainer(config, data_pipeline_fw="torch")
+        OmegaConf.update(config, "data_config.data_pipeline_fw", "torch")
+        model_trainer = ModelTrainer(config)
         model_trainer.train()
 
     #####
-
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     # # for topdown centered instance model
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
@@ -323,30 +327,28 @@ def test_trainer_litdata(config, tmp_path: str):
 )
 # TODO: Revisit this test later (Failing on ubuntu)
 def test_trainer_torch_dataset(config, tmp_path: str):
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
-    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    model_trainer = ModelTrainer(config)
     assert model_trainer.dir_path == "."
 
     ##### test for reusing np chunks path
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset_np_chunks")
+    OmegaConf.update(config, "data_config.np_chunks_path", tmp_path)
+    OmegaConf.update(config, "data_config.use_existing_np_chunks", True)
     with pytest.raises(Exception):
-        model_trainer = ModelTrainer(
-            config,
-            data_pipeline_fw="torch_dataset_np_chunks",
-            np_chunks_path=tmp_path,
-            use_existing_np_chunks=True,
-        )
+        model_trainer = ModelTrainer(config)
 
     Path.mkdir(Path(tmp_path) / "train_chunks", parents=True)
     file_path = Path(tmp_path) / "train_chunks" / "sample.npz"
     np.savez_compressed(file_path, {1: 10})
 
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset_np_chunks")
+    OmegaConf.update(config, "data_config.np_chunks_path", tmp_path)
+    OmegaConf.update(config, "data_config.use_existing_np_chunks", True)
+
     with pytest.raises(Exception):
-        model_trainer = ModelTrainer(
-            config,
-            data_pipeline_fw="torch_dataset_np_chunks",
-            np_chunks_path=tmp_path,
-            use_existing_np_chunks=True,
-        )
+        model_trainer = ModelTrainer(config)
 
     #####
 
@@ -354,12 +356,11 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset_np_chunks")
+    OmegaConf.update(config, "data_config.np_chunks_path", f"{tmp_path}/np_chunks/")
+    OmegaConf.update(config, "data_config.use_existing_np_chunks", False)
 
-    model_trainer = ModelTrainer(
-        config,
-        data_pipeline_fw="torch_dataset_np_chunks",
-        np_chunks_path=f"{tmp_path}/np_chunks/",
-    )
+    model_trainer = ModelTrainer(config)
     model_trainer.train()
 
     # disable ckpt, check if ckpt is created
@@ -384,7 +385,9 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.step_size", 10)
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.gamma", 0.5)
 
-    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
+
+    model_trainer = ModelTrainer(config)
     model_trainer.train()
 
     # check if wandb folder is created
@@ -465,7 +468,8 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     )
     prv_runid = training_config.trainer_config.wandb.run_id
     OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
-    trainer = ModelTrainer(config_copy, data_pipeline_fw="torch_dataset")
+    OmegaConf.update(config_copy, "data_config.data_pipeline_fw", "torch_dataset")
+    trainer = ModelTrainer(config_copy)
     trainer.train()
 
     checkpoint = torch.load(
@@ -498,8 +502,11 @@ def test_trainer_torch_dataset(config, tmp_path: str):
         "trainer_config.save_ckpt_path",
         f"{tmp_path}/test_model_trainer/",
     )
+    OmegaConf.update(
+        config_early_stopping, "data_config.data_pipeline_fw", "torch_dataset"
+    )
 
-    trainer = ModelTrainer(config_early_stopping, data_pipeline_fw="torch_dataset")
+    trainer = ModelTrainer(config_early_stopping)
     trainer.train()
 
     checkpoint = torch.load(
@@ -519,8 +526,11 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     del (
         single_instance_config.model_config.head_configs.single_instance.confmaps.anchor_part
     )
+    OmegaConf.update(
+        single_instance_config, "data_config.data_pipeline_fw", "torch_dataset"
+    )
 
-    trainer = ModelTrainer(single_instance_config, data_pipeline_fw="torch_dataset")
+    trainer = ModelTrainer(single_instance_config)
     trainer._initialize_model()
     assert isinstance(trainer.model, SingleInstanceModel)
 
@@ -554,7 +564,9 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
     OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
 
-    trainer = ModelTrainer(centroid_config, data_pipeline_fw="torch_dataset")
+    OmegaConf.update(centroid_config, "data_config.data_pipeline_fw", "torch_dataset")
+
+    trainer = ModelTrainer(centroid_config)
 
     trainer._initialize_model()
     assert isinstance(trainer.model, CentroidModel)
@@ -597,7 +609,7 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     OmegaConf.update(bottomup_config, "trainer_config.max_epochs", 1)
     OmegaConf.update(bottomup_config, "trainer_config.steps_per_epoch", 10)
 
-    trainer = ModelTrainer(bottomup_config, data_pipeline_fw="torch_dataset")
+    trainer = ModelTrainer(bottomup_config)
     trainer._initialize_model()
     assert isinstance(trainer.model, BottomUpModel)
 
@@ -606,7 +618,7 @@ def test_trainer_torch_dataset(config, tmp_path: str):
     # check exception for lr scheduler
     OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "ReduceLR")
     with pytest.raises(ValueError):
-        trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+        trainer = ModelTrainer(config)
         trainer.train()
 
     OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "StepLR")
@@ -637,10 +649,10 @@ def test_trainer_load_trained_ckpts(config, tmp_path, minimal_instance_ckpt):
 
     trainer = ModelTrainer(load_weights_config)
     trainer._initialize_model(
-        backbone_trained_ckpts_path=(
+        pretrained_backbone_weights=(
             Path(minimal_instance_ckpt) / "best.ckpt"
         ).as_posix(),
-        head_trained_ckpts_path=(Path(minimal_instance_ckpt) / "best.ckpt").as_posix(),
+        pretrained_head_weights=(Path(minimal_instance_ckpt) / "best.ckpt").as_posix(),
     )
     model_ckpt = next(trainer.model.parameters())[0, 0, :].detach().numpy()
 
@@ -661,6 +673,7 @@ def test_trainer_load_trained_ckpts(config, tmp_path, minimal_instance_ckpt):
 def test_reuse_bin_files(config, tmp_path: str):
     """Test reusing `.bin` files."""
     # Centroid model
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     centroid_config = config.copy()
     head_config = config.model_config.head_configs.centered_instance
     OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
@@ -694,15 +707,19 @@ def test_reuse_bin_files(config, tmp_path: str):
     OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
     OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
     OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
+    OmegaConf.update(centroid_config, "data_config.delete_chunks_after_training", False)
 
     # test reusing bin files
     trainer1 = ModelTrainer(centroid_config)
-    trainer1.train(delete_bin_files_after_training=False)
+    trainer1.train()
 
-    trainer2 = ModelTrainer(centroid_config)
-    trainer2.train(
-        chunks_dir_path=(trainer1.train_input_dir).split("train_chunks")[0],
+    OmegaConf.update(
+        centroid_config,
+        "data_config.chunks_dir_path",
+        (trainer1.train_input_dir).split("train_chunks")[0],
     )
+    trainer2 = ModelTrainer(centroid_config)
+    trainer2.train()
 
 
 def test_topdown_centered_instance_model(config, tmp_path: str):
@@ -790,6 +807,7 @@ def test_centroid_model(config, tmp_path: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
@@ -812,7 +830,9 @@ def test_centroid_model(config, tmp_path: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
-    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
+
+    model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_torch_dataset()
     input_ = next(iter(model_trainer.train_data_loader))
     input_cm = input_["centroids_confidence_maps"]
@@ -838,6 +858,7 @@ def test_single_instance_model(config, tmp_path: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
@@ -870,7 +891,8 @@ def test_single_instance_model(config, tmp_path: str):
     shutil.rmtree((Path(model_trainer.bin_files_path) / "val_chunks").as_posix())
 
     # torch dataset
-    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
+    model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_torch_dataset()
     input_ = next(iter(model_trainer.train_data_loader))
     model = SingleInstanceModel(config, None, "single_instance")
@@ -919,6 +941,7 @@ def test_bottomup_model(config, tmp_path: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_litdata()
     input_ = next(iter(model_trainer.train_data_loader))
@@ -953,7 +976,8 @@ def test_bottomup_model(config, tmp_path: str):
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
-    model_trainer = ModelTrainer(config, data_pipeline_fw="torch_dataset")
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
+    model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_torch_dataset()
     skeletons = model_trainer.skeletons
     input_ = next(iter(model_trainer.train_data_loader))


### PR DESCRIPTION
This PR moves all parameters from `ModelTrainer` class to the main config. This will be useful to create an entry point function for training which takes in all arguments, constructs a `TrainingJobConfig` and passes to the `ModelTrainer` class.