### PR TITLE
Add output stride to backbone config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
           conda list
           pip freeze
 
+      # - name: Check opencv dependency
+      #   if: ${{ startsWith(matrix.os, 'windows') }}
+      #   run: |
+      #     dir C:\Users\runneradmin\miniconda3\envs\sleap-nn\Lib\site-packages\cv2
+
+      - name: Reinstall OpenCV
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+          pip uninstall -y opencv-python opencv-contrib-python py-opencv
+          pip install --no-cache-dir opencv-contrib-python-headless
+
       - name: Test with pytest (with coverage)
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
       - name: Reinstall OpenCV
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: |
-          pip uninstall -y opencv-python opencv-contrib-python py-opencv
           pip install --no-cache-dir opencv-contrib-python-headless
 
       - name: Test with pytest (with coverage)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,6 @@ jobs:
           conda list
           pip freeze
 
-      - name: Install graphics dependencies on Ubuntu
-        # https://github.com/conda-forge/opencv-feedstock/issues/401
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        shell: bash -l {0}
-        run: |
-          sudo apt-get update && sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1 libglx-mesa0
-
       - name: Test with pytest (with coverage)
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,13 @@ jobs:
           conda list
           pip freeze
 
+      - name: Install graphics dependencies on Ubuntu
+        # https://github.com/conda-forge/opencv-feedstock/issues/401
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        shell: bash -l {0}
+        run: |
+          sudo apt-get update && sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1 libglx-mesa0
+
       - name: Test with pytest (with coverage)
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        pip install --upgrade pip
         pip install --editable .[dev]
 
     - name: Run Black

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,15 +90,10 @@ jobs:
           conda list
           pip freeze
 
-      # - name: Check opencv dependency
+      # - name: Reinstall OpenCV
       #   if: ${{ startsWith(matrix.os, 'windows') }}
       #   run: |
-      #     dir C:\Users\runneradmin\miniconda3\envs\sleap-nn\Lib\site-packages\cv2
-
-      - name: Reinstall OpenCV
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        run: |
-          pip install --no-cache-dir opencv-contrib-python-headless
+      #     pip install --no-cache-dir opencv-contrib-python-headless
 
       - name: Test with pytest (with coverage)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
         pip install --editable .[dev]
 
     - name: Run Black

--- a/docs/config.md
+++ b/docs/config.md
@@ -84,6 +84,7 @@ The config file has three main sections:
         recover details from higher scales. Default: True.
         - `stacks`: (int) Number of upsampling blocks in the decoder. Default is 3.
         - `convs_per_block`: (int) Number of convolutional layers per block. Default is 2.
+        - `output_stride`: (int) Determines the number of upsampling blocks in the network.
     - `backbone_config`: (for ConvNext)
         - `arch`: (Default is `Tiny` architecture config. No need to provide if `model_type` is provided)
             - `depths`: (List(int)) Number of layers in each block. Default: [3, 3, 9, 3].
@@ -99,6 +100,7 @@ The config file has three main sections:
         convolutions for upsampling. Interpolation is faster but transposed
         convolutions may be able to learn richer or more complex upsampling to
         recover details from higher scales. Default: True.
+        - `output_stride`: (int) Determines the number of upsampling blocks in the network.
     - `backbone_config`: (for SwinT. Default is `Tiny` architecture.)
         - `model_type`: (str) One of the ConvNext architecture types: ["tiny", "small", "base"]. Default: "tiny". 
         - `arch`: Dictionary of embed dimension, depths and number of heads in each layer.
@@ -115,6 +117,7 @@ The config file has three main sections:
         convolutions for upsampling. Interpolation is faster but transposed
         convolutions may be able to learn richer or more complex upsampling to
         recover details from higher scales. Default: True.
+        - `output_stride`: (int) Determines the number of upsampling blocks in the network.
     - `head_configs`: (Dict) Dictionary with the following keys having head configs for the model to be trained. **Note**: Configs should be provided only for the model to train and others should be `None`.
         - `single_instance`: 
             - `confmaps`:

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,8 @@ channels:
 dependencies:
   - python=3.9
   - pytorch-cuda=11.8
+  - numpy
+  - sleap-io
   - pydantic
   - lightning
   - cudnn
@@ -18,19 +20,16 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  - opencv
   - ffmpeg
+  - opencv
   - imageio
-  - imageio-ffmpeg >=0.5.0
   - av
   - omegaconf
   - wandb
   - kornia
-  - sleap-io
   - matplotlib
   - rich
   - pynwb
-  - ndx-pose<0.2.0
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - pytorch
   - nvidia
   - conda-forge
-  - defaults
 
 dependencies:
   - python=3.9
@@ -27,6 +26,7 @@ dependencies:
   - omegaconf
   - wandb
   - kornia
+  - sleap-io
   - matplotlib
   - rich
   - pynwb

--- a/environment.yml
+++ b/environment.yml
@@ -19,9 +19,9 @@ dependencies:
   - scipy
   - attrs
   - opencv
-  - ffmpeg<6.1.0
+  - ffmpeg
   - imageio
-  - imageio-ffmpeg
+  - imageio-ffmpeg >=0.5.0
   - av
   - omegaconf
   - wandb
@@ -30,7 +30,7 @@ dependencies:
   - matplotlib
   - rich
   - pynwb
-  - ndx-pose
+  - ndx-pose<0.2.0
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -17,7 +17,7 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  - opencv
+  - opencv-contrib-python
   - ffmpeg<6.1.0
   - imageio
   - imageio-ffmpeg

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -17,7 +17,7 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  - opencv-contrib-python
+  - opencv-python
   - ffmpeg<6.1.0
   - imageio
   - imageio-ffmpeg

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -17,9 +17,9 @@ dependencies:
   - scipy
   - attrs
   - opencv
-  - ffmpeg<6.1.0
+  - ffmpeg
   - imageio
-  - imageio-ffmpeg
+  - imageio-ffmpeg >=0.5.0
   - av
   - omegaconf
   - wandb
@@ -29,7 +29,7 @@ dependencies:
   - rich
   - pynwb
   - sleap-io
-  - ndx-pose
+  - ndx-pose<0.2.0
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -3,7 +3,6 @@ name: sleap-nn
 channels:
   - pytorch
   - conda-forge
-  - defaults
 
 dependencies:
   - python=3.9
@@ -29,6 +28,7 @@ dependencies:
   - matplotlib
   - rich
   - pynwb
+  - sleap-io
   - ndx-pose
   - pip
   - pip:

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -17,7 +17,7 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  - opencv-python
+  - opencv
   - ffmpeg<6.1.0
   - imageio
   - imageio-ffmpeg

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -6,6 +6,8 @@ channels:
 
 dependencies:
   - python=3.9
+  - numpy
+  - sleap-io
   - pytorch
   - pydantic
   - lightning
@@ -16,20 +18,16 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  - opencv
   - ffmpeg
+  - opencv
   - imageio
-  - imageio-ffmpeg >=0.5.0
   - av
   - omegaconf
   - wandb
-  - ffmpeg
   - kornia
   - matplotlib
   - rich
   - pynwb
-  - sleap-io
-  - ndx-pose<0.2.0
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -17,7 +17,7 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  - opencv
+  # - opencv
   - ffmpeg<6.1.0
   - imageio
   - imageio-ffmpeg
@@ -33,4 +33,5 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - opencv-python-headless
     - litdata

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -17,7 +17,7 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  # - opencv
+  - opencv
   - ffmpeg<6.1.0
   - imageio
   - imageio-ffmpeg
@@ -33,5 +33,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
-    - opencv-python-headless
     - litdata

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -3,7 +3,6 @@ name: sleap-nn
 channels:
   - pytorch
   - conda-forge
-  - defaults
 
 dependencies:
   - python=3.9
@@ -26,6 +25,7 @@ dependencies:
   - ffmpeg
   - kornia
   - matplotlib
+  - sleap-io
   - rich
   - pynwb
   - ndx-pose

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -6,6 +6,8 @@ channels:
 
 dependencies:
   - python=3.9
+  - numpy
+  - sleap-io
   - pydantic
   - lightning
   - pytorch
@@ -15,20 +17,16 @@ dependencies:
   - simplejson
   - scipy
   - attrs
-  - opencv
   - ffmpeg
+  - opencv
   - imageio
-  - imageio-ffmpeg >=0.5.0
   - av
   - omegaconf
   - wandb
-  - ffmpeg
   - kornia
   - matplotlib
-  - sleap-io
   - rich
   - pynwb
-  - ndx-pose<0.2.0
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -16,9 +16,9 @@ dependencies:
   - scipy
   - attrs
   - opencv
-  - ffmpeg<6.1.0
+  - ffmpeg
   - imageio
-  - imageio-ffmpeg
+  - imageio-ffmpeg >=0.5.0
   - av
   - omegaconf
   - wandb
@@ -28,7 +28,7 @@ dependencies:
   - sleap-io
   - rich
   - pynwb
-  - ndx-pose
+  - ndx-pose<0.2.0
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "av",
     "kornia",
     "hydra-core",
-    "sleap-io>=0.1.10",
 ]
 dynamic = ["version", "readme"]
 

--- a/sleap_nn/architectures/convnext.py
+++ b/sleap_nn/architectures/convnext.py
@@ -227,7 +227,7 @@ class ConvNextWrapper(nn.Module):
         return self.dec.x_in_shape
 
     @classmethod
-    def from_config(cls, config: OmegaConf, output_stride: int):
+    def from_config(cls, config: OmegaConf):
         """Create ConvNextWrapper from a config."""
         return cls(
             in_channels=config.in_channels,
@@ -237,7 +237,7 @@ class ConvNextWrapper(nn.Module):
             filters_rate=config.filters_rate,
             convs_per_block=config.convs_per_block,
             up_interpolate=config.up_interpolate,
-            output_stride=output_stride,
+            output_stride=config.output_stride,
             stem_patch_kernel=config.stem_patch_kernel,
             stem_patch_stride=config.stem_patch_stride,
         )

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -28,9 +28,7 @@ from sleap_nn.architectures.convnext import ConvNextWrapper
 from sleap_nn.architectures.swint import SwinTWrapper
 
 
-def get_backbone(
-    backbone: str, backbone_config: DictConfig, output_stride: int
-) -> nn.Module:
+def get_backbone(backbone: str, backbone_config: DictConfig) -> nn.Module:
     """Get a backbone model `nn.Module` based on the provided name.
 
     This function returns an instance of a PyTorch `nn.Module`
@@ -39,7 +37,6 @@ def get_backbone(
     Args:
         backbone (str): Name of the backbone. Supported values are 'unet'.
         backbone_config (DictConfig): A config for the backbone.
-        output_stride (int): Output stride to compute the number of down blocks.
 
     Returns:
         nn.Module: An instance of the requested backbone model.
@@ -54,9 +51,7 @@ def get_backbone(
             f"Unsupported backbone: {backbone}. Supported backbones are: {', '.join(backbones.keys())}"
         )
 
-    backbone = backbones[backbone].from_config(
-        backbone_config, output_stride=output_stride
-    )
+    backbone = backbones[backbone].from_config(backbone_config)
 
     return backbone
 
@@ -139,7 +134,6 @@ class Model(nn.Module):
         self.backbone = get_backbone(
             self.backbone_type,
             backbone_config,
-            min_output_stride,
         )
 
         strides = self.backbone.dec.current_strides

--- a/sleap_nn/architectures/swint.py
+++ b/sleap_nn/architectures/swint.py
@@ -261,7 +261,7 @@ class SwinTWrapper(nn.Module):
         return self.dec.x_in_shape
 
     @classmethod
-    def from_config(cls, config: OmegaConf, output_stride: int):
+    def from_config(cls, config: OmegaConf):
         """Create SwinTWrapper from a config."""
         return cls(
             in_channels=config.in_channels,
@@ -273,7 +273,7 @@ class SwinTWrapper(nn.Module):
             filters_rate=config.filters_rate,
             convs_per_block=config.convs_per_block,
             up_interpolate=config.up_interpolate,
-            output_stride=output_stride,
+            output_stride=config.output_stride,
             stem_patch_stride=config.stem_patch_stride,
         )
 

--- a/sleap_nn/architectures/unet.py
+++ b/sleap_nn/architectures/unet.py
@@ -121,13 +121,13 @@ class UNet(nn.Module):
         )
 
     @classmethod
-    def from_config(cls, config: OmegaConf, output_stride: int):
+    def from_config(cls, config: OmegaConf):
         """Create UNet from a config."""
         stem_blocks = 0
         if config.stem_stride is not None:
             stem_blocks = np.log2(config.stem_stride).astype(int)
         down_blocks = np.log2(config.max_stride).astype(int) - stem_blocks
-        up_blocks = np.log2(config.max_stride / output_stride).astype(int)
+        up_blocks = np.log2(config.max_stride / config.output_stride).astype(int)
         return cls(
             in_channels=config.in_channels,
             kernel_size=config.kernel_size,
@@ -140,7 +140,7 @@ class UNet(nn.Module):
             middle_block=config.middle_block,
             up_interpolate=config.up_interpolate,
             stacks=config.stacks,
-            output_stride=output_stride,
+            output_stride=config.output_stride,
         )
 
     @property

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -5,8 +5,7 @@ the parameters required to initialize the model config.
 """
 
 from attrs import define, field
-from enum import Enum
-from sleap_nn.config.utils import oneof, get_output_strides_from_heads
+from sleap_nn.config.utils import oneof
 from typing import Optional, List
 
 
@@ -408,10 +407,6 @@ class ModelConfig:
     pretrained_head_weights: Optional[str] = None
     backbone_config: BackboneConfig = BackboneConfig()
     head_configs: HeadConfig = HeadConfig()
-    output_strides = get_output_strides_from_heads(head_configs)
-    backbone_config.output_stride = min(output_strides)
-    if backbone_config.max_stride < max(output_strides):
-        backbone_config.max_stride = max(output_strides)
 
     def validate_backbone_type(self, value):
         """Validate backbone_type.

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -1,5 +1,18 @@
 """Utilities for config building and validation."""
 
+from sleap_nn.config.model_config import ModelConfig, HeadConfig, BackboneConfig
+
+
+def get_output_strides_from_heads(head_config: HeadConfig):
+    """Get list of strides from head configs."""
+    output_strides_from_heads = []
+    for head_type in head_config:
+        for head_layer in head_type:
+            output_strides_from_heads.append(
+                head_type[f"{head_layer}"]["output_stride"]
+            )
+    return output_strides_from_heads
+
 
 def oneof(attrs_cls, must_be_set: bool = False):
     """Ensure that the decorated attrs class only has a single attribute set.

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -8,7 +8,7 @@ def get_output_strides_from_heads(head_configs: DictConfig):
     output_strides_from_heads = []
     for head_type in head_configs:
         if head_configs[head_type] is not None:
-            for head_layer in head_type:
+            for head_layer in head_configs[head_type]:
                 output_strides_from_heads.append(
                     head_configs[head_type][head_layer]["output_stride"]
                 )

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -1,16 +1,17 @@
 """Utilities for config building and validation."""
 
-from sleap_nn.config.model_config import ModelConfig, HeadConfig, BackboneConfig
+from omegaconf import DictConfig
 
 
-def get_output_strides_from_heads(head_config: HeadConfig):
-    """Get list of strides from head configs."""
+def get_output_strides_from_heads(head_configs: DictConfig):
+    """Get list of output strides from head configs."""
     output_strides_from_heads = []
-    for head_type in head_config:
-        for head_layer in head_type:
-            output_strides_from_heads.append(
-                head_type[f"{head_layer}"]["output_stride"]
-            )
+    for head_type in head_configs:
+        if head_configs[head_type] is not None:
+            for head_layer in head_type:
+                output_strides_from_heads.append(
+                    head_configs[head_type][head_layer]["output_stride"]
+                )
     return output_strides_from_heads
 
 

--- a/sleap_nn/inference/paf_grouping.py
+++ b/sleap_nn/inference/paf_grouping.py
@@ -975,7 +975,7 @@ def group_instances_sample(
 
         `predicted_instances`: The grouped coordinates for each instance as an array of
         shape `(n_instances, n_nodes, 2)` and dtype `float32`. Missing peaks are
-        represented by `np.NaN`s.
+        represented by `np.nan`s.
 
         `predicted_peak_scores`: The confidence map values for each peak as an array of
         `(n_instances, n_nodes)` and dtype `float32`.

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -4,6 +4,9 @@ from typing import Any, Dict, List, Union, Deque, DefaultDict, Optional
 from collections import defaultdict
 import attrs
 import cv2
+
+print(f"############### OPENCV Missing dependencies:")
+print(cv2.getBuildInformation())
 import numpy as np
 
 import sleap_io as sio

--- a/tests/architectures/test_convnext.py
+++ b/tests/architectures/test_convnext.py
@@ -21,10 +21,11 @@ def test_convnext_reference():
             "up_interpolate": True,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
-    convnext = ConvNextWrapper.from_config(config, output_stride=1)
+    convnext = ConvNextWrapper.from_config(config)
 
     in_channels = int(
         convnext.max_channels / config.filters_rate ** len(convnext.dec.decoder_stack)
@@ -108,10 +109,11 @@ def test_convnext_reference():
             "up_interpolate": True,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 4,
+            "output_stride": 1,
         }
     )
 
-    convnext = ConvNextWrapper.from_config(config, output_stride=1)
+    convnext = ConvNextWrapper.from_config(config)
 
     convnext.eval()
 
@@ -138,10 +140,11 @@ def test_convnext_reference():
             "up_interpolate": True,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
-    convnext = ConvNextWrapper.from_config(config, output_stride=1)
+    convnext = ConvNextWrapper.from_config(config)
 
     in_channels = int(
         convnext.max_channels / config.filters_rate ** len(convnext.dec.decoder_stack)
@@ -181,10 +184,11 @@ def test_convnext_reference():
             "up_interpolate": True,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
-    convnext = ConvNextWrapper.from_config(config, output_stride=1)
+    convnext = ConvNextWrapper.from_config(config)
 
     in_channels = int(
         convnext.max_channels / config.filters_rate ** len(convnext.dec.decoder_stack)

--- a/tests/architectures/test_model.py
+++ b/tests/architectures/test_model.py
@@ -22,13 +22,13 @@ def test_get_backbone():
             "stem_stride": None,
             "middle_block": True,
             "up_interpolate": True,
+            "output_stride": 1,
         }
     )
 
     backbone = get_backbone(
         "unet",
         base_unet_model_config,
-        output_stride=1,
     )
     assert isinstance(backbone, torch.nn.Module)
 
@@ -44,18 +44,18 @@ def test_get_backbone():
             "up_interpolate": True,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
     backbone = get_backbone(
         "convnext",
         base_convnext_model_config,
-        output_stride=1,
     )
     assert isinstance(backbone, torch.nn.Module)
 
     with pytest.raises(KeyError):
-        _ = get_backbone("invalid_input", base_unet_model_config, 1)
+        _ = get_backbone("invalid_input", base_unet_model_config)
 
     # swint
     base_convnext_model_config = OmegaConf.create(
@@ -70,18 +70,18 @@ def test_get_backbone():
             "convs_per_block": 2,
             "up_interpolate": True,
             "stem_patch_stride": 4,
+            "output_stride": 1,
         }
     )
 
     backbone = get_backbone(
         "swint",
         base_convnext_model_config,
-        output_stride=1,
     )
     assert isinstance(backbone, torch.nn.Module)
 
     with pytest.raises(KeyError):
-        _ = get_backbone("invalid_input", base_unet_model_config, output_stride=1)
+        _ = get_backbone("invalid_input", base_unet_model_config)
 
 
 def test_get_head():
@@ -118,6 +118,7 @@ def test_unet_model():
             "stem_stride": None,
             "middle_block": True,
             "up_interpolate": True,
+            "output_stride": 1,
         }
     )
 
@@ -167,6 +168,7 @@ def test_unet_model():
             "stem_stride": None,
             "middle_block": True,
             "up_interpolate": True,
+            "output_stride": 1,
         }
     )
 
@@ -216,6 +218,7 @@ def test_unet_model():
             "stem_stride": None,
             "middle_block": True,
             "up_interpolate": False,
+            "output_stride": 1,
         }
     )
 
@@ -267,6 +270,7 @@ def test_convnext_model():
             "up_interpolate": True,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
@@ -334,6 +338,7 @@ def test_convnext_model():
             "up_interpolate": True,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 4,
+            "output_stride": 1,
         }
     )
 
@@ -401,6 +406,7 @@ def test_convnext_model():
             "up_interpolate": False,
             "stem_patch_kernel": 4,
             "stem_patch_stride": 4,
+            "output_stride": 1,
         }
     )
 
@@ -473,6 +479,7 @@ def test_swint_model():
             "convs_per_block": 2,
             "up_interpolate": True,
             "stem_patch_stride": 4,
+            "output_stride": 1,
         }
     )
 
@@ -542,6 +549,7 @@ def test_swint_model():
             "up_interpolate": False,
             "stem_patch_stride": 4,
             "stem_stride": None,
+            "output_stride": 1,
         }
     )
 

--- a/tests/architectures/test_swint.py
+++ b/tests/architectures/test_swint.py
@@ -22,10 +22,11 @@ def test_swint_reference():
             "convs_per_block": 2,
             "up_interpolate": True,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
-    swint = SwinTWrapper.from_config(config, output_stride=1)
+    swint = SwinTWrapper.from_config(config)
 
     in_channels = int(
         swint.max_channels / config.filters_rate ** len(swint.dec.decoder_stack)
@@ -130,10 +131,11 @@ def test_swint_reference():
             "convs_per_block": 2,
             "up_interpolate": True,
             "stem_patch_stride": 4,
+            "output_stride": 1,
         }
     )
 
-    swint = SwinTWrapper.from_config(config, output_stride=1)
+    swint = SwinTWrapper.from_config(config)
 
     swint.eval()
 
@@ -160,10 +162,11 @@ def test_swint_reference():
             "convs_per_block": 2,
             "up_interpolate": True,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
-    swint = SwinTWrapper.from_config(config, output_stride=1)
+    swint = SwinTWrapper.from_config(config)
 
     in_channels = int(
         swint.max_channels / config.filters_rate ** len(swint.dec.decoder_stack)
@@ -204,10 +207,11 @@ def test_swint_reference():
             "convs_per_block": 2,
             "up_interpolate": True,
             "stem_patch_stride": 2,
+            "output_stride": 1,
         }
     )
 
-    swint = SwinTWrapper.from_config(config, output_stride=1)
+    swint = SwinTWrapper.from_config(config)
 
     in_channels = int(
         swint.max_channels / config.filters_rate ** len(swint.dec.decoder_stack)

--- a/tests/architectures/test_unet.py
+++ b/tests/architectures/test_unet.py
@@ -30,10 +30,11 @@ def test_unet_reference():
             "middle_block": True,
             "up_interpolate": True,
             "block_contraction": False,
+            "output_stride": 1,
         }
     )
 
-    unet = UNet.from_config(config=config, output_stride=1)
+    unet = UNet.from_config(config=config)
 
     in_channels = int(
         unet.max_channels / config.filters_rate ** len(unet.dec.decoder_stack)
@@ -129,10 +130,11 @@ def test_unet_reference():
             "middle_block": True,
             "up_interpolate": True,
             "block_contraction": False,
+            "output_stride": 1,
         }
     )
 
-    unet = UNet.from_config(config=config, output_stride=1)
+    unet = UNet.from_config(config=config)
 
     in_channels = int(
         unet.max_channels / config.filters_rate ** len(unet.dec.decoder_stack)

--- a/tests/assets/minimal_instance/training_config.yaml
+++ b/tests/assets/minimal_instance/training_config.yaml
@@ -47,6 +47,7 @@ model_config:
     stem_stride: null
     middle_block: true
     up_interpolate: false
+    output_stride: 2
   head_configs:
     single_instance: null
     bottom_up: null
@@ -88,7 +89,7 @@ trainer_config:
     wandb_mode: ''
     api_key: ''
     prv_runid: null
-    group:
+    group: null
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/tests/assets/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/training_config.yaml
@@ -43,6 +43,7 @@ model_config:
     stem_stride: null
     middle_block: true
     up_interpolate: false
+    output_stride: 2
   head_configs:
     single_instance: null
     centered_instance: null

--- a/tests/assets/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/minimal_instance_centroid/training_config.yaml
@@ -43,6 +43,7 @@ model_config:
     stem_stride: null
     middle_block: true
     up_interpolate: false
+    output_stride: 2
   head_configs:
     single_instance: null
     centered_instance: null

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -97,6 +97,7 @@ def config(sleap_data_dir):
                     "stem_stride": None,
                     "middle_block": True,
                     "up_interpolate": False,
+                    "output_stride": 2,
                 },
                 "head_configs": {
                     "single_instance": None,

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -124,7 +124,7 @@ def test_tracker(minimal_instance_ckpt):
 
     # Test with NaNs
     tracker.candidate.tracker_queue[0].features[0] = np.full(
-        tracker.candidate.tracker_queue[0].features[0].shape, np.NaN
+        tracker.candidate.tracker_queue[0].features[0].shape, np.nan
     )
     tracked_instances = tracker.track(pred_instances, 0)
     assert len(tracker.candidate.current_tracks) == 2


### PR DESCRIPTION
This PR adds the `output_stride` parameter to the `backbone_config` to remove the dependency on output strides from head config.

#139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to adjust the output resolution of models, enhancing control over the upsampling behavior.

- **Refactor**
  - Streamlined model configuration by eliminating redundant parameter passing—the output stride is now sourced directly from configuration settings.
  - Updated tests and configuration setups to align with these changes.

- **Documentation**
  - Updated documentation to reflect the new configuration option.

- **Chores**
  - Improved dependency handling and CI steps, including upgrading dependencies and adding graphics-related installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->