### PR TITLE
Specify custom anchor index in Inference pipeline

### DIFF
--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -574,7 +574,7 @@ class TopDownPredictor(Predictor):
                 ("cpu", "cuda", "mkldnn", "opengl", "opencl", "ideep", "hip", "msnpu").
                 Default: "cpu"
             preprocess_config: (OmegaConf) OmegaConf object with keys as the parameters
-                in the `data_config.preprocessing` section.
+                in the `data_config.preprocessing` section and the `anchor_ind`.
 
         Returns:
             An instance of `TopDownPredictor` with the loaded models.
@@ -704,6 +704,7 @@ class TopDownPredictor(Predictor):
             return_confmaps=return_confmaps,
             device=device,
             preprocess_config=preprocess_config,
+            anchor_ind=preprocess_config["anchor_ind"],
         )
 
         obj._initialize_inference_model()
@@ -1792,6 +1793,7 @@ def main(
         "crop_hw": crop_hw,
         "max_width": max_width,
         "max_height": max_height,
+        "anchor_ind": anchor_ind,
     }
 
     if provider == "VideoReader":
@@ -1829,9 +1831,6 @@ def main(
             of_window_size=of_window_size,
             of_max_levels=of_max_levels,
         )
-
-    if isinstance(predictor, TopDownPredictor):
-        predictor.anchor_ind = anchor_ind
 
     if isinstance(predictor, BottomUpPredictor):
         predictor.inference_model.paf_scorer.max_edge_length_ratio = (

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -220,6 +220,7 @@ def test_topdown_predictor(
         "crop_hw": None,
         "max_width": None,
         "max_height": None,
+        "anchor_ind": None,
     }
 
     predictor = Predictor.from_model_paths(
@@ -277,6 +278,7 @@ def test_topdown_predictor(
         "crop_hw": None,
         "max_width": None,
         "max_height": None,
+        "anchor_ind": None,
     }
 
     predictor = Predictor.from_model_paths(
@@ -359,6 +361,7 @@ def test_topdown_predictor(
         "crop_hw": None,
         "max_width": None,
         "max_height": None,
+        "anchor_ind": None,
     }
 
     predictor = Predictor.from_model_paths(
@@ -441,6 +444,7 @@ def test_topdown_predictor(
         "crop_hw": None,
         "max_width": None,
         "max_height": None,
+        "anchor_ind": None,
     }
 
     predictor = Predictor.from_model_paths(
@@ -523,6 +527,7 @@ def test_topdown_predictor(
         "crop_hw": None,
         "max_width": None,
         "max_height": None,
+        "anchor_ind": None,
     }
 
     predictor = Predictor.from_model_paths(
@@ -605,6 +610,7 @@ def test_topdown_predictor(
         "crop_hw": None,
         "max_width": None,
         "max_height": None,
+        "anchor_ind": None,
     }
 
     predictor = Predictor.from_model_paths(


### PR DESCRIPTION
Currently, `sleap_nn.inference.predictors.main` takes in user-specified `anchor_ind` but the code was considering the anchor index only from the config, even if custom `anchor_ind` is provided. This PR fixes this bug to consider user-provided anchor index if provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced model configuration by allowing users to specify a custom anchor index through configuration settings. This improvement streamlines the initialization process and ensures consistent behavior across different model components.
  
- **Tests**
  - Updated test configurations to include the new `anchor_ind` parameter in the `preprocess_config` dictionary, expanding configuration options for the `Predictor` class instantiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->