### PR TITLE
Fix lr scheduler config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -185,9 +185,7 @@ The config file has three main sections:
     - `optimizer`
         - `lr`: (float) Learning rate of type float. *Default*: `1e-3`.
         - `amsgrad`: (bool) Enable AMSGrad with the optimizer. *Default*: `False`.
-    - `lr_scheduler`
-        - `scheduler`: (str) Name of the scheduler to use. Valid schedulers: `"StepLR"`, `"ReduceLROnPlateau"`.
-        *Default*: `None`.
+    - `lr_scheduler`: (Dict) Dictionary with the following keys having lr scheduler configs for different schedulers. **Note**: Configs should only be provided for one of the schedulers and others should be `None`.
         - `step_lr`:
             - `step_size`: (int) Period of learning rate decay. If `step_size`=10, then every 10 epochs, learning rate will be reduced by a factor of `gamma`. *Default*: `10`.
             - `gamma`: (float) Multiplicative factor of learning rate decay.*Default*: `0.1`.

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -135,30 +135,12 @@ class LRSchedulerConfig:
     """Configuration for lr_scheduler.
 
     Attributes:
-        scheduler: (str) Name of the scheduler to use. Valid schedulers: "StepLR", "ReduceLROnPlateau".
         step_lr: Configuration for StepLR scheduler.
         reduce_lr_on_plateau: Configuration for ReduceLROnPlateau scheduler.
     """
 
-    scheduler: str = field(
-        default="ReduceLROnPlateau",
-        validator=lambda instance, attr, value: instance.validate_scheduler(),
-    )
     step_lr: Optional[StepLRConfig] = None
     reduce_lr_on_plateau: Optional[ReduceLROnPlateauConfig] = None
-
-    def validate_scheduler(self):
-        """Scheduler Validation.
-
-        Ensures scheduler is one of "ReduceLROnPlateau" or "StepLR"
-        """
-        valid_schedulers = ["ReduceLROnPlateau", "StepLR"]
-        if self.scheduler not in valid_schedulers:
-            message = (
-                f"scheduler must be one of {valid_schedulers}, got {self.scheduler}"
-            )
-            logger.error(message)
-            raise ValueError(message)
 
 
 @define

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -440,10 +440,7 @@ def get_trainer_config(
     optimizer: str = "Adam",
     learning_rate: float = 1e-3,
     amsgrad: bool = False,
-    lr_scheduler: Union[str, Dict[str, Any]] = {
-        "step_lr": None,
-        "reduce_lr_on_plateau": None,
-    },
+    lr_scheduler: Optional[Union[str, Dict[str, Any]]] = None,
     early_stopping: bool = False,
     early_stopping_min_delta: float = 0.0,
     early_stopping_patience: int = 1,
@@ -523,20 +520,22 @@ def get_trainer_config(
         batch_size=batch_size, shuffle=False, num_workers=num_workers
     )
 
-    lr_scheduler_cfg = None
+    lr_scheduler_cfg = LRSchedulerConfig()
     if isinstance(lr_scheduler, str):
         if lr_scheduler == "step_lr":
-            lr_scheduler_cfg = LRSchedulerConfig(step_lr=StepLRConfig())
+            lr_scheduler_cfg.step_lr = StepLRConfig()
         elif lr_scheduler == "reduce_lr_on_plateau":
-            lr_scheduler_cfg = LRSchedulerConfig(
-                reduce_lr_on_plateau=ReduceLROnPlateauConfig()
-            )
+            lr_scheduler_cfg.reduce_lr_on_plateau = ReduceLROnPlateauConfig()
         else:
             message = f"{lr_scheduler} is not a valid scheduler. Please choose one of ['step_lr', 'reduce_lr_on_plateau']"
             logger.error(message)
             raise ValueError(message)
     elif isinstance(lr_scheduler, dict):
-        lr_scheduler_cfg = LRSchedulerConfig()
+        if lr_scheduler is None:
+            lr_scheduler = {
+                "step_lr": None,
+                "reduce_lr_on_plateau": None,
+            }
         for k, v in lr_scheduler.items():
             if v is not None:
                 if k == "step_lr":
@@ -704,10 +703,7 @@ def train(
     optimizer: str = "Adam",
     learning_rate: float = 1e-3,
     amsgrad: bool = False,
-    lr_scheduler: Union[str, Dict[str, Any]] = {
-        "step_lr": None,
-        "reduce_lr_on_plateau": None,
-    },
+    lr_scheduler: Optional[Union[str, Dict[str, Any]]] = None,
     early_stopping: bool = False,
     early_stopping_min_delta: float = 0.0,
     early_stopping_patience: int = 1,

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -142,7 +142,6 @@ def test_lr_scheduler_config(caplog):
     # Check default values
     conf = TrainerConfig(
         lr_scheduler=LRSchedulerConfig(
-            scheduler="ReduceLROnPlateau",
             reduce_lr_on_plateau=ReduceLROnPlateauConfig(),
         )
     )
@@ -150,33 +149,22 @@ def test_lr_scheduler_config(caplog):
     conf_structured = OmegaConf.create(conf_dict)
 
     # Test ReduceLROnPlateau
-    assert conf_structured.lr_scheduler.scheduler == "ReduceLROnPlateau"
     assert conf_structured.lr_scheduler.reduce_lr_on_plateau.threshold == 1e-4
     assert conf_structured.lr_scheduler.reduce_lr_on_plateau.patience == 10
     assert conf_structured.lr_scheduler.reduce_lr_on_plateau.factor == 0.1
 
     # Test StepLR configuration
     custom_conf = TrainerConfig(
-        lr_scheduler=LRSchedulerConfig(
-            scheduler="StepLR", step_lr=StepLRConfig(step_size=5, gamma=0.5)
-        )
+        lr_scheduler=LRSchedulerConfig(step_lr=StepLRConfig(step_size=5, gamma=0.5))
     )
     custom_dict = asdict(custom_conf)  # Convert to dict for OmegaConf
     custom_structured = OmegaConf.create(custom_dict)
 
-    assert custom_structured.lr_scheduler.scheduler == "StepLR"
     assert custom_structured.lr_scheduler.step_lr.step_size == 5
     assert custom_structured.lr_scheduler.step_lr.gamma == 0.5
 
-    # Test validation
-    with pytest.raises(ValueError, match="scheduler must be one of"):
-        LRSchedulerConfig(scheduler="InvalidScheduler")
-    assert "scheduler" in caplog.text
-
     with pytest.raises(ValueError):
-        LRSchedulerConfig(
-            scheduler="StepLR", step_lr=StepLRConfig(step_size=-5, gamma=0.5)
-        )
+        LRSchedulerConfig(step_lr=StepLRConfig(step_size=-5, gamma=0.5))
 
 
 def test_early_stopping_config():

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -159,7 +159,6 @@ def config(sleap_data_dir):
                 "optimizer_name": "Adam",
                 "optimizer": {"lr": 0.0001, "amsgrad": False},
                 "lr_scheduler": {
-                    "scheduler": "ReduceLROnPlateau",
                     "reduce_lr_on_plateau": {
                         "threshold": 1e-07,
                         "threshold_mode": "rel",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -402,6 +402,33 @@ def test_train_method(minimal_instance, tmp_path: str):
     config = OmegaConf.load(f"{tmp_path}/test_scheduler/training_config.yaml")
     assert config.trainer_config.lr_scheduler.step_lr.step_size == 10
 
+    ## reduce lr on plateau
+    train(
+        train_labels_path=minimal_instance,
+        val_labels_path=minimal_instance,
+        max_epochs=1,
+        trainer_accelerator="cpu",
+        head_configs={
+            "centroid": {
+                "confmaps": {"anchor_part": None, "sigma": 2.5, "output_stride": 2}
+            }
+        },
+        save_ckpt=False,
+        save_ckpt_path=f"{tmp_path}/test_reducelr_scheduler",
+        lr_scheduler={
+            "reduce_lr_on_plateau": {
+                "threshold": 1e-5,
+                "threshold_mode": "rel",
+                "cooldown": 0,
+                "patience": 10,
+                "factor": 0.1,
+                "min_lr": 0.0,
+            }
+        },
+    )
+    config = OmegaConf.load(f"{tmp_path}/test_reducelr_scheduler/training_config.yaml")
+    assert config.trainer_config.lr_scheduler.reduce_lr_on_plateau.threshold == 1e-5
+
     ## invalid scheduler
     with pytest.raises(ValueError):
         train(

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -121,7 +121,6 @@ def sample_cfg(minimal_instance, tmp_path):
                 "optimizer_name": "Adam",
                 "optimizer": {"lr": 0.0001, "amsgrad": False},
                 "lr_scheduler": {
-                    "scheduler": "ReduceLROnPlateau",
                     "reduce_lr_on_plateau": {
                         "threshold": 1e-07,
                         "threshold_mode": "rel",
@@ -339,7 +338,7 @@ def test_train_method(minimal_instance, tmp_path: str):
     #     head_configs="single_instance",
     #     save_ckpt=True,
     #     save_ckpt_path=f"{tmp_path}/test_single_instabce",
-    #     lr_scheduler="ReduceLROnPlateau",
+    #     lr_scheduler="reduce_lr_on_plateau",
     # )
     # config = OmegaConf.load(f"{tmp_path}/test_single_instabce/training_config.yaml")
     # assert config.model_config.head_configs.single_instance is not None
@@ -353,7 +352,7 @@ def test_train_method(minimal_instance, tmp_path: str):
         head_configs="bottomup",
         save_ckpt=True,
         save_ckpt_path=f"{tmp_path}/test_bottomup",
-        lr_scheduler="ReduceLROnPlateau",
+        lr_scheduler="reduce_lr_on_plateau",
     )
     config = OmegaConf.load(f"{tmp_path}/test_bottomup/training_config.yaml")
     assert config.model_config.head_configs.bottomup is not None
@@ -377,7 +376,7 @@ def test_train_method(minimal_instance, tmp_path: str):
         },
         save_ckpt=True,
         save_ckpt_path=f"{tmp_path}/test_custom_head",
-        lr_scheduler="StepLR",
+        lr_scheduler="step_lr",
     )
     config = OmegaConf.load(f"{tmp_path}/test_custom_head/training_config.yaml")
     assert config.model_config.head_configs.centered_instance is not None
@@ -397,12 +396,24 @@ def test_train_method(minimal_instance, tmp_path: str):
         save_ckpt=False,
         save_ckpt_path=f"{tmp_path}/test_scheduler",
         lr_scheduler={
-            "scheduler": "StepLR",
             "step_lr": {"step_size": 10, "gamma": 0.1},
         },
     )
     config = OmegaConf.load(f"{tmp_path}/test_scheduler/training_config.yaml")
     assert config.trainer_config.lr_scheduler.step_lr.step_size == 10
+
+    ## invalid scheduler
+    with pytest.raises(ValueError):
+        train(
+            train_labels_path=minimal_instance,
+            val_labels_path=minimal_instance,
+            max_epochs=1,
+            trainer_accelerator="cpu",
+            head_configs="centered_instance",
+            save_ckpt=False,
+            save_ckpt_path=f"{tmp_path}/test_invalid_sch",
+            lr_scheduler="red_lr",
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -174,7 +174,6 @@ def test_trainer_litdata(caplog, config, tmp_path: str):
     OmegaConf.update(config, "trainer_config.use_wandb", True)
     OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
-    OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "StepLR")
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.step_size", 10)
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.gamma", 0.5)
 
@@ -403,7 +402,6 @@ def test_trainer_torch_dataset(caplog, config, tmp_path: str):
     OmegaConf.update(config, "trainer_config.use_wandb", True)
     OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
     OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
-    OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "StepLR")
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.step_size", 10)
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.gamma", 0.5)
 
@@ -516,7 +514,9 @@ def test_trainer_torch_dataset(caplog, config, tmp_path: str):
     )
     OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
     OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
-    OmegaConf.update(config_early_stopping, "trainer_config.lr_scheduler", None)
+    OmegaConf.update(
+        config_early_stopping, "trainer_config.lr_scheduler", {"step_lr": None}
+    )
     OmegaConf.update(
         config_early_stopping,
         "trainer_config.save_ckpt_path",
@@ -632,17 +632,6 @@ def test_trainer_torch_dataset(caplog, config, tmp_path: str):
     trainer = ModelTrainer(bottomup_config)
     trainer._initialize_model()
     assert isinstance(trainer.model, BottomUpModel)
-
-    #######
-
-    # check exception for lr scheduler
-    OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "ReduceLR")
-    with pytest.raises(ValueError):
-        trainer = ModelTrainer(config)
-        trainer.train()
-    assert "ReduceLR is not a valid scheduler." in caplog.text
-
-    OmegaConf.update(config, "trainer_config.lr_scheduler.scheduler", "StepLR")
 
 
 def test_trainer_load_trained_ckpts(config, tmp_path, minimal_instance_ckpt):


### PR DESCRIPTION
This PR solves #153 by removing the redundant `scheduler` parameter in the `lr_scheduler` config section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised configuration docs to describe a detailed dictionary-based approach for learning rate scheduling, offering enhanced flexibility for step-based and plateau-based setups.

- **Refactor**
  - Streamlined the scheduling configuration by replacing simple string values with a structured, lower-case key format, leading to improved clarity and robust error handling.

- **Tests**
  - Updated test cases to verify the new configuration structure and ensure consistent behavior with the revised scheduling options. 
  - Added tests to validate error handling for unsupported scheduler configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->