### PR TITLE
Add max stride to Convnext and Swint backbones

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -76,8 +76,7 @@ The config file has three main sections:
             - `kernel_size`: (int) Size of the convolutional kernels. Default is 3.
             - `filters`: (int) Base number of filters in the network. Default is 32
             - `filters_rate`: (float) Factor to adjust the number of filters per block. Default is 1.5.
-            - `max_stride`: (int) Scalar integer specifying the maximum stride that the image must be
-            divisible by. Default is 16.
+            - `max_stride`: (int) Scalar integer specifying the maximum stride which is used to compute the number of down blocks. Default is 16.
             - `stem_stride`: (int) If not None, will create additional "down" blocks for initial
             downsampling based on the stride. These will be configured identically to the down blocks below. Default is None.
             - `middle_block`: (bool) If True, add an additional block at the end of the encoder. Default is True.
@@ -93,6 +92,7 @@ The config file has three main sections:
                 - `depths`: (List(int)) Number of layers in each block. Default: [3, 3, 9, 3].
                 - `channels`: (List(int)) Number of channels in each block. Default: [96, 192, 384, 768].
             - `model_type`: (str) One of the ConvNext architecture types: ["tiny", "small", "base", "large"]. Default: "tiny". 
+            - `max_stride`: (int) Factor by which input image size is reduced through the layers. This is always `16` for all convnext architectures.
             - `stem_patch_kernel`: (int) Size of the convolutional kernels in the stem layer. Default is 4.
             - `stem_patch_stride`: (int) Convolutional stride in the stem layer. Default is 2.
             - `in_channels`: (int) Number of input channels. Default is 1.
@@ -109,6 +109,7 @@ The config file has three main sections:
             - `arch`: Dictionary of embed dimension, depths and number of heads in each layer.
             Default is "Tiny architecture".
             {'embed': 96, 'depths': [2,2,6,2], 'channels':[3, 6, 12, 24]}
+            - `max_stride`: (int) Factor by which input image size is reduced through the layers. This is always `16` for all swint architectures.
             - `patch_size`: (List[int]) Patch size for the stem layer of SwinT. Default: [4,4].
             - `stem_patch_stride`: (int) Stride for the patch. Default is 2.
             - `window_size`: (List[int]) Window size. Default: [7,7].

--- a/docs/config_bottomup.yaml
+++ b/docs/config_bottomup.yaml
@@ -47,6 +47,7 @@ model_config:
 #     up_interpolate: True
 #     stem_patch_kernel: 4
 #     stem_patch_stride: 2
+#     max_stride: 16
 
 # pre_trained_weights: Swin_T_Weights
 # backbone_config:
@@ -62,6 +63,7 @@ model_config:
 #     convs_per_block: 2
 #     up_interpolate: True
 #     stem_patch_stride: 2
+#     max_stride: 16
 
   head_configs:
     single_instance: 

--- a/sleap_nn/architectures/convnext.py
+++ b/sleap_nn/architectures/convnext.py
@@ -152,7 +152,8 @@ class ConvNextWrapper(nn.Module):
             convolutions for upsampling. Interpolation is faster but transposed
             convolutions may be able to learn richer or more complex upsampling to
             recover details from higher scales.
-
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all convnext architectures.
     Attributes:
         Inherits all attributes from torch.nn.Module.
     """
@@ -169,6 +170,7 @@ class ConvNextWrapper(nn.Module):
         filters_rate: int = 2,
         convs_per_block: int = 2,
         up_interpolate: bool = True,
+        max_stride: int = 16,
     ) -> None:
         """Initialize the class."""
         super().__init__()
@@ -176,6 +178,7 @@ class ConvNextWrapper(nn.Module):
         self.in_channels = in_channels
         self.kernel_size = kernel_size
         self.filters_rate = filters_rate
+        self.max_stride = max_stride
         arch_types = {
             "tiny": {"depths": [3, 3, 9, 3], "channels": [96, 192, 384, 768]},
             "small": {"depths": [3, 3, 27, 3], "channels": [96, 192, 384, 768]},
@@ -240,6 +243,7 @@ class ConvNextWrapper(nn.Module):
             output_stride=config.output_stride,
             stem_patch_kernel=config.stem_patch_kernel,
             stem_patch_stride=config.stem_patch_stride,
+            max_stride=config.max_stride,
         )
 
     def forward(self, x: torch.Tensor) -> Tuple[List[torch.Tensor], List]:

--- a/sleap_nn/architectures/convnext.py
+++ b/sleap_nn/architectures/convnext.py
@@ -152,8 +152,8 @@ class ConvNextWrapper(nn.Module):
             convolutions for upsampling. Interpolation is faster but transposed
             convolutions may be able to learn richer or more complex upsampling to
             recover details from higher scales.
-        max_stride: Factor by which input image size is reduced through the layers.
-            This is always `16` for all convnext architectures.
+        max_stride: Factor by which input image size is reduced through the layers. This is always `16` for all convnext architectures.
+
     Attributes:
         Inherits all attributes from torch.nn.Module.
     """

--- a/sleap_nn/architectures/swint.py
+++ b/sleap_nn/architectures/swint.py
@@ -177,7 +177,8 @@ class SwinTWrapper(nn.Module):
             convolutions for upsampling. Interpolation is faster but transposed
             convolutions may be able to learn richer or more complex upsampling to
             recover details from higher scales.
-
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all swint architectures.
 
     Attributes:
         Inherits all attributes from torch.nn.Module.
@@ -196,6 +197,7 @@ class SwinTWrapper(nn.Module):
         filters_rate: int = 2,
         convs_per_block: int = 2,
         up_interpolate: bool = True,
+        max_stride: int = 16,
     ) -> None:
         """Initialize the class."""
         super().__init__()
@@ -204,6 +206,7 @@ class SwinTWrapper(nn.Module):
         self.patch_size = patch_size
         self.kernel_size = kernel_size
         self.filters_rate = filters_rate
+        self.max_stride = max_stride
         arch_types = {
             "tiny": {"embed": 96, "depths": [2, 2, 6, 2], "num_heads": [3, 6, 12, 24]},
             "small": {
@@ -275,6 +278,7 @@ class SwinTWrapper(nn.Module):
             up_interpolate=config.up_interpolate,
             output_stride=config.output_stride,
             stem_patch_stride=config.stem_patch_stride,
+            max_stride=config.max_stride,
         )
 
     def forward(self, x: torch.Tensor) -> Tuple[List[torch.Tensor], List]:

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -169,6 +169,8 @@ class ConvNextConfig:
             of 2 results in confidence maps that are 0.5x the size of the input.
             Increasing this value can considerably speed up model performance and
             decrease memory requirements, at the cost of decreased spatial resolution.
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all convnext architectures.
     """
 
     model_type: str = "tiny"  # Options: tiny, small, base, large
@@ -183,6 +185,7 @@ class ConvNextConfig:
     convs_per_block: int = 2
     up_interpolate: bool = True
     output_stride: int = 1
+    max_stride: int = 16
 
 
 @define
@@ -214,6 +217,8 @@ class ConvNextSmallConfig:
             of 2 results in confidence maps that are 0.5x the size of the input.
             Increasing this value can considerably speed up model performance and
             decrease memory requirements, at the cost of decreased spatial resolution.
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all convnext architectures.
     """
 
     model_type: str = "small"  # Options: tiny, small, base, large
@@ -228,6 +233,7 @@ class ConvNextSmallConfig:
     convs_per_block: int = 2
     up_interpolate: bool = True
     output_stride: int = 1
+    max_stride: int = 16
 
 
 @define
@@ -259,6 +265,8 @@ class ConvNextBaseConfig:
             of 2 results in confidence maps that are 0.5x the size of the input.
             Increasing this value can considerably speed up model performance and
             decrease memory requirements, at the cost of decreased spatial resolution.
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all convnext architectures.
     """
 
     model_type: str = "base"  # Options: tiny, small, base, large
@@ -273,6 +281,7 @@ class ConvNextBaseConfig:
     convs_per_block: int = 2
     up_interpolate: bool = True
     output_stride: int = 1
+    max_stride: int = 16
 
 
 @define
@@ -304,6 +313,8 @@ class ConvNextLargeConfig:
             of 2 results in confidence maps that are 0.5x the size of the input.
             Increasing this value can considerably speed up model performance and
             decrease memory requirements, at the cost of decreased spatial resolution.
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all convnext architectures.
     """
 
     model_type: str = "large"  # Options: tiny, small, base, large
@@ -318,6 +329,7 @@ class ConvNextLargeConfig:
     convs_per_block: int = 2
     up_interpolate: bool = True
     output_stride: int = 1
+    max_stride: int = 16
 
 
 @define
@@ -347,6 +359,8 @@ class SwinTConfig:
             of 2 results in confidence maps that are 0.5x the size of the input.
             Increasing this value can considerably speed up model performance and
             decrease memory requirements, at the cost of decreased spatial resolution.
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all swint architectures.
     """
 
     model_type: str = field(
@@ -369,6 +383,7 @@ class SwinTConfig:
     convs_per_block: int = 2
     up_interpolate: bool = True
     output_stride: int = 1
+    max_stride: int = 16
 
     def validate_model_type(self, value):
         """Validate model_type.
@@ -409,6 +424,8 @@ class SwinTSmallConfig:
             of 2 results in confidence maps that are 0.5x the size of the input.
             Increasing this value can considerably speed up model performance and
             decrease memory requirements, at the cost of decreased spatial resolution.
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all swint architectures.
     """
 
     model_type: str = field(
@@ -431,6 +448,7 @@ class SwinTSmallConfig:
     convs_per_block: int = 2
     up_interpolate: bool = True
     output_stride: int = 1
+    max_stride: int = 16
 
     def validate_model_type(self, value):
         """Validate model_type.
@@ -471,6 +489,8 @@ class SwinTBaseConfig:
             of 2 results in confidence maps that are 0.5x the size of the input.
             Increasing this value can considerably speed up model performance and
             decrease memory requirements, at the cost of decreased spatial resolution.
+        max_stride: Factor by which input image size is reduced through the layers.
+            This is always `16` for all swint architectures.
     """
 
     model_type: str = field(
@@ -493,6 +513,7 @@ class SwinTBaseConfig:
     convs_per_block: int = 2
     up_interpolate: bool = True
     output_stride: int = 1
+    max_stride: int = 16
 
     def validate_model_type(self, value):
         """Validate model_type.

--- a/tests/architectures/test_convnext.py
+++ b/tests/architectures/test_convnext.py
@@ -22,6 +22,7 @@ def test_convnext_reference():
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -110,6 +111,7 @@ def test_convnext_reference():
             "stem_patch_kernel": 4,
             "stem_patch_stride": 4,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -141,6 +143,7 @@ def test_convnext_reference():
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -185,6 +188,7 @@ def test_convnext_reference():
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 

--- a/tests/architectures/test_model.py
+++ b/tests/architectures/test_model.py
@@ -61,6 +61,7 @@ def test_get_backbone(caplog):
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -88,6 +89,7 @@ def test_get_backbone(caplog):
             "up_interpolate": True,
             "stem_patch_stride": 4,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -289,6 +291,7 @@ def test_convnext_model():
             "stem_patch_kernel": 4,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -357,6 +360,7 @@ def test_convnext_model():
             "stem_patch_kernel": 4,
             "stem_patch_stride": 4,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -425,6 +429,7 @@ def test_convnext_model():
             "stem_patch_kernel": 4,
             "stem_patch_stride": 4,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -498,6 +503,7 @@ def test_swint_model():
             "up_interpolate": True,
             "stem_patch_stride": 4,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -568,6 +574,7 @@ def test_swint_model():
             "stem_patch_stride": 4,
             "stem_stride": None,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 

--- a/tests/architectures/test_swint.py
+++ b/tests/architectures/test_swint.py
@@ -23,6 +23,7 @@ def test_swint_reference():
             "up_interpolate": True,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -132,6 +133,7 @@ def test_swint_reference():
             "up_interpolate": True,
             "stem_patch_stride": 4,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -163,6 +165,7 @@ def test_swint_reference():
             "up_interpolate": True,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 
@@ -208,6 +211,7 @@ def test_swint_reference():
             "up_interpolate": True,
             "stem_patch_stride": 2,
             "output_stride": 1,
+            "max_stride": 16,
         }
     )
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -160,6 +160,44 @@ def test_train_method(minimal_instance, tmp_path: str):
     assert (Path(tmp_path) / "test_train_method").joinpath("pred_val.slp").exists()
     assert (Path(tmp_path) / "test_train_method").joinpath("pred_test.slp").exists()
 
+    # convnext
+    train(
+        train_labels_path=minimal_instance,
+        val_labels_path=minimal_instance,
+        test_file_path=minimal_instance,
+        max_epochs=1,
+        trainer_accelerator="cpu",
+        backbone_config="convnext",
+        head_configs="centered_instance",
+        save_ckpt=True,
+        save_ckpt_path=(Path(tmp_path) / "test_convnext").as_posix(),
+    )
+    folder_created = (Path(tmp_path) / "test_convnext").exists()
+    assert folder_created
+    assert (Path(tmp_path) / "test_convnext").joinpath("training_config.yaml").exists()
+    assert (Path(tmp_path) / "test_convnext").joinpath("best.ckpt").exists()
+    assert (Path(tmp_path) / "test_convnext").joinpath("pred_val.slp").exists()
+    assert (Path(tmp_path) / "test_convnext").joinpath("pred_test.slp").exists()
+
+    # swint
+    train(
+        train_labels_path=minimal_instance,
+        val_labels_path=minimal_instance,
+        test_file_path=minimal_instance,
+        max_epochs=1,
+        trainer_accelerator="cpu",
+        backbone_config="swint",
+        head_configs="centered_instance",
+        save_ckpt=True,
+        save_ckpt_path=(Path(tmp_path) / "test_swint").as_posix(),
+    )
+    folder_created = (Path(tmp_path) / "test_swint").exists()
+    assert folder_created
+    assert (Path(tmp_path) / "test_swint").joinpath("training_config.yaml").exists()
+    assert (Path(tmp_path) / "test_swint").joinpath("best.ckpt").exists()
+    assert (Path(tmp_path) / "test_swint").joinpath("pred_val.slp").exists()
+    assert (Path(tmp_path) / "test_swint").joinpath("pred_test.slp").exists()
+
     # with augmentations
     with pytest.raises(ValueError):
         train(


### PR DESCRIPTION
This addresses the bug described in #137 by adding a max stride parameter to convnext and swint backbones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced clarity in configuration guides by refining the description of the `max_stride` parameter across multiple model architectures.
  
- **New Features**
  - Introduced a configurable `max_stride` parameter with a default value of 16 to standardize image size reduction across model architectures.
  
- **Tests**
  - Updated test configurations to incorporate the new `max_stride` parameter, ensuring consistency in model behavior across various setups, including training scenarios for different backbone configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->