### PR TITLE
Add `scale` argument to custom datasets

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -38,6 +38,7 @@ class BaseDataset(Dataset):
         data_config: Data-related configuration. (`data_config` section in the config file).
         max_stride: Scalar integer specifying the maximum stride that the image must be
             divisible by.
+        scale: Factor to resize the image dimensions by, specified as a float. Default: 1.0.
         apply_aug: `True` if augmentations should be applied to the data pipeline,
             else `False`. Default: `False`.
         max_hw: Maximum height and width of images across the labels file. If `max_height` and
@@ -55,6 +56,7 @@ class BaseDataset(Dataset):
         labels: sio.Labels,
         data_config: DictConfig,
         max_stride: int,
+        scale: float = 1.0,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
         np_chunks: bool = False,
@@ -67,6 +69,7 @@ class BaseDataset(Dataset):
         self.data_config = data_config
         self.curr_idx = 0
         self.max_stride = max_stride
+        self.scale = scale
         self.apply_aug = apply_aug
         self.max_hw = max_hw
         self.max_instances = get_max_instances(self.labels)
@@ -151,7 +154,7 @@ class BaseDataset(Dataset):
             sample["image"], sample["instances"] = apply_resizer(
                 sample["image"],
                 sample["instances"],
-                scale=self.data_config.preprocessing.scale,
+                scale=self.scale,
             )
 
             # Pad the image (if needed) according max stride
@@ -197,6 +200,7 @@ class BottomUpDataset(BaseDataset):
         data_config: Data-related configuration. (`data_config` section in the config file).
         max_stride: Scalar integer specifying the maximum stride that the image must be
             divisible by.
+        scale: Factor to resize the image dimensions by, specified as a float. Default: 1.0.
         apply_aug: `True` if augmentations should be applied to the data pipeline,
             else `False`. Default: `False`.
         max_hw: Maximum height and width of images across the labels file. If `max_height` and
@@ -221,6 +225,7 @@ class BottomUpDataset(BaseDataset):
         confmap_head_config: DictConfig,
         pafs_head_config: DictConfig,
         max_stride: int,
+        scale: float = 1.0,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
         np_chunks: bool = False,
@@ -232,6 +237,7 @@ class BottomUpDataset(BaseDataset):
             labels=labels,
             data_config=data_config,
             max_stride=max_stride,
+            scale=scale,
             apply_aug=apply_aug,
             max_hw=max_hw,
             np_chunks=np_chunks,
@@ -312,6 +318,7 @@ class CenteredInstanceDataset(BaseDataset):
         data_config: Data-related configuration. (`data_config` section in the config file).
         max_stride: Scalar integer specifying the maximum stride that the image must be
             divisible by.
+        scale: Factor to resize the image dimensions by, specified as a float. Default: 1.0.
         apply_aug: `True` if augmentations should be applied to the data pipeline,
             else `False`. Default: `False`.
         max_hw: Maximum height and width of images across the labels file. If `max_height` and
@@ -337,6 +344,7 @@ class CenteredInstanceDataset(BaseDataset):
         crop_hw: Tuple[int],
         confmap_head_config: DictConfig,
         max_stride: int,
+        scale: float = 1.0,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
         np_chunks: bool = False,
@@ -348,6 +356,7 @@ class CenteredInstanceDataset(BaseDataset):
             labels=labels,
             data_config=data_config,
             max_stride=max_stride,
+            scale=scale,
             apply_aug=apply_aug,
             max_hw=max_hw,
             np_chunks=np_chunks,
@@ -414,7 +423,7 @@ class CenteredInstanceDataset(BaseDataset):
             image, instances = apply_resizer(
                 image,
                 instances,
-                scale=self.data_config.preprocessing.scale,
+                scale=self.scale,
             )
 
             # get the centroids based on the anchor idx
@@ -551,6 +560,7 @@ class CentroidDataset(BaseDataset):
         data_config: Data-related configuration. (`data_config` section in the config file).
         max_stride: Scalar integer specifying the maximum stride that the image must be
             divisible by.
+        scale: Factor to resize the image dimensions by, specified as a float. Default: 1.0.
         apply_aug: `True` if augmentations should be applied to the data pipeline,
             else `False`. Default: `False`.
         max_hw: Maximum height and width of images across the labels file. If `max_height` and
@@ -571,6 +581,7 @@ class CentroidDataset(BaseDataset):
         data_config: DictConfig,
         confmap_head_config: DictConfig,
         max_stride: int,
+        scale: float = 1.0,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
         np_chunks: bool = False,
@@ -582,6 +593,7 @@ class CentroidDataset(BaseDataset):
             labels=labels,
             data_config=data_config,
             max_stride=max_stride,
+            scale=scale,
             apply_aug=apply_aug,
             max_hw=max_hw,
             np_chunks=np_chunks,
@@ -626,7 +638,7 @@ class CentroidDataset(BaseDataset):
             sample["image"], sample["instances"] = apply_resizer(
                 sample["image"],
                 sample["instances"],
-                scale=self.data_config.preprocessing.scale,
+                scale=self.scale,
             )
 
             # get the centroids based on the anchor idx
@@ -712,6 +724,7 @@ class SingleInstanceDataset(BaseDataset):
         data_config: Data-related configuration. (`data_config` section in the config file).
         max_stride: Scalar integer specifying the maximum stride that the image must be
             divisible by.
+        scale: Factor to resize the image dimensions by, specified as a float. Default: 1.0.
         apply_aug: `True` if augmentations should be applied to the data pipeline,
             else `False`. Default: `False`.
         max_hw: Maximum height and width of images across the labels file. If `max_height` and
@@ -732,6 +745,7 @@ class SingleInstanceDataset(BaseDataset):
         data_config: DictConfig,
         confmap_head_config: DictConfig,
         max_stride: int,
+        scale: float = 1.0,
         apply_aug: bool = False,
         max_hw: Tuple[Optional[int]] = (None, None),
         np_chunks: bool = False,
@@ -743,6 +757,7 @@ class SingleInstanceDataset(BaseDataset):
             labels=labels,
             data_config=data_config,
             max_stride=max_stride,
+            scale=scale,
             apply_aug=apply_aug,
             max_hw=max_hw,
             np_chunks=np_chunks,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -222,6 +222,9 @@ class ModelTrainer:
             self.config.data_config.preprocessing.max_height = self.max_height
             self.config.data_config.preprocessing.max_width = self.max_width
 
+        if self.config.data_config.preprocessing.scale is None:
+            self.config.data_config.preprocessing.scale = 1.0
+
         if self.model_type == "centered_instance":
             # compute crop size
             self.crop_hw = self.config.data_config.preprocessing.crop_hw
@@ -289,6 +292,7 @@ class ModelTrainer:
                 confmap_head_config=self.config.model_config.head_configs.bottomup.confmaps,
                 pafs_head_config=self.config.model_config.head_configs.bottomup.pafs,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=self.config.data_config.use_augmentations_train,
                 max_hw=(self.max_height, self.max_width),
                 np_chunks=self.np_chunks,
@@ -301,6 +305,7 @@ class ModelTrainer:
                 confmap_head_config=self.config.model_config.head_configs.bottomup.confmaps,
                 pafs_head_config=self.config.model_config.head_configs.bottomup.pafs,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=False,
                 max_hw=(self.max_height, self.max_width),
                 np_chunks=self.np_chunks,
@@ -314,6 +319,7 @@ class ModelTrainer:
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centered_instance.confmaps,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=self.config.data_config.use_augmentations_train,
                 crop_hw=(self.crop_hw, self.crop_hw),
                 max_hw=(self.max_height, self.max_width),
@@ -326,6 +332,7 @@ class ModelTrainer:
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centered_instance.confmaps,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=False,
                 crop_hw=(self.crop_hw, self.crop_hw),
                 max_hw=(self.max_height, self.max_width),
@@ -340,6 +347,7 @@ class ModelTrainer:
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centroid.confmaps,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=self.config.data_config.use_augmentations_train,
                 max_hw=(self.max_height, self.max_width),
                 np_chunks=self.np_chunks,
@@ -351,6 +359,7 @@ class ModelTrainer:
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.centroid.confmaps,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=False,
                 max_hw=(self.max_height, self.max_width),
                 np_chunks=self.np_chunks,
@@ -364,6 +373,7 @@ class ModelTrainer:
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.single_instance.confmaps,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=self.config.data_config.use_augmentations_train,
                 max_hw=(self.max_height, self.max_width),
                 np_chunks=self.np_chunks,
@@ -375,6 +385,7 @@ class ModelTrainer:
                 data_config=self.config.data_config,
                 confmap_head_config=self.config.model_config.head_configs.single_instance.confmaps,
                 max_stride=self.max_stride,
+                scale=self.config.data_config.preprocessing.scale,
                 apply_aug=False,
                 max_hw=(self.max_height, self.max_width),
                 np_chunks=self.np_chunks,

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -30,6 +30,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
     dataset = BottomUpDataset(
         data_config=base_bottom_config,
         max_stride=32,
+        scale=1.0,
         confmap_head_config=confmap_head,
         pafs_head_config=pafs_head,
         labels=sio.load_slp(minimal_instance),
@@ -72,6 +73,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
     dataset = BottomUpDataset(
         data_config=base_bottom_config,
         max_stride=32,
+        scale=0.5,
         confmap_head_config=confmap_head,
         pafs_head_config=pafs_head,
         labels=sio.load_slp(minimal_instance),
@@ -143,6 +145,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
     dataset = BottomUpDataset(
         data_config=base_bottom_config,
         max_stride=256,
+        scale=1.0,
         confmap_head_config=confmap_head,
         pafs_head_config=pafs_head,
         labels=sio.load_slp(minimal_instance),
@@ -173,6 +176,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
     dataset = BottomUpDataset(
         data_config=base_bottom_config,
         max_stride=32,
+        scale=1.0,
         confmap_head_config=confmap_head,
         pafs_head_config=pafs_head,
         labels=sio.load_slp(minimal_instance),
@@ -223,6 +227,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
     dataset = CenteredInstanceDataset(
         data_config=base_topdown_data_config,
         max_stride=16,
+        scale=1.0,
         confmap_head_config=confmap_head,
         crop_hw=crop_hw,
         labels=sio.load_slp(minimal_instance),
@@ -255,6 +260,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
     dataset = CenteredInstanceDataset(
         data_config=base_topdown_data_config,
         max_stride=16,
+        scale=1.0,
         confmap_head_config=confmap_head,
         crop_hw=crop_hw,
         labels=sio.load_slp(minimal_instance),
@@ -325,6 +331,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
     dataset = CenteredInstanceDataset(
         data_config=base_topdown_data_config,
         max_stride=8,
+        scale=1.0,
         confmap_head_config=confmap_head,
         crop_hw=(100, 100),
         labels=sio.load_slp(minimal_instance),
@@ -397,6 +404,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
     dataset = CenteredInstanceDataset(
         data_config=base_topdown_data_config,
         max_stride=16,
+        scale=2.0,
         confmap_head_config=confmap_head,
         crop_hw=(100, 100),
         labels=sio.load_slp(minimal_instance),
@@ -445,6 +453,7 @@ def test_centroid_dataset(minimal_instance, tmp_path):
     dataset = CentroidDataset(
         data_config=base_centroid_data_config,
         max_stride=32,
+        scale=1.0,
         confmap_head_config=confmap_head,
         apply_aug=base_centroid_data_config.use_augmentations_train,
         labels=sio.load_slp(minimal_instance),
@@ -475,6 +484,7 @@ def test_centroid_dataset(minimal_instance, tmp_path):
     dataset = CentroidDataset(
         data_config=base_centroid_data_config,
         max_stride=32,
+        scale=1.0,
         confmap_head_config=confmap_head,
         apply_aug=base_centroid_data_config.use_augmentations_train,
         labels=sio.load_slp(minimal_instance),
@@ -543,6 +553,7 @@ def test_centroid_dataset(minimal_instance, tmp_path):
     dataset = CentroidDataset(
         data_config=base_centroid_data_config,
         max_stride=32,
+        scale=1.0,
         confmap_head_config=confmap_head,
         apply_aug=base_centroid_data_config.use_augmentations_train,
         labels=sio.load_slp(minimal_instance),
@@ -596,6 +607,7 @@ def test_single_instance_dataset(minimal_instance, tmp_path):
     dataset = SingleInstanceDataset(
         data_config=base_singleinstance_data_config,
         max_stride=8,
+        scale=2.0,
         confmap_head_config=confmap_head,
         labels=labels,
         apply_aug=base_singleinstance_data_config.use_augmentations_train,
@@ -626,6 +638,7 @@ def test_single_instance_dataset(minimal_instance, tmp_path):
     dataset = SingleInstanceDataset(
         data_config=base_singleinstance_data_config,
         max_stride=8,
+        scale=2.0,
         confmap_head_config=confmap_head,
         labels=labels,
         apply_aug=base_singleinstance_data_config.use_augmentations_train,
@@ -694,6 +707,7 @@ def test_single_instance_dataset(minimal_instance, tmp_path):
     dataset = SingleInstanceDataset(
         data_config=base_singleinstance_data_config,
         max_stride=8,
+        scale=1.0,
         confmap_head_config=confmap_head,
         labels=labels,
         apply_aug=base_singleinstance_data_config.use_augmentations_train,
@@ -743,6 +757,7 @@ def test_cycler_dataloader(minimal_instance, tmp_path):
     dataset = SingleInstanceDataset(
         data_config=base_singleinstance_data_config,
         max_stride=8,
+        scale=2.0,
         confmap_head_config=confmap_head,
         labels=labels,
         apply_aug=base_singleinstance_data_config.use_augmentations_train,

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from omegaconf import DictConfig
 import functools
 import litdata as ld
-import shutil
 import sleap_io as sio
 from sleap_nn.data.get_data_chunks import (
     bottomup_data_chunks,
@@ -41,28 +40,24 @@ def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
         chunk_size=4,
     )
 
-    try:
-        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
-        pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
 
-        dataset = BottomUpStreamingDataset(
-            augmentation_config=config.data_config.augmentation_config,
-            confmap_head=confmap_head,
-            pafs_head=pafs_head,
-            edge_inds=edge_inds,
-            max_stride=100,
-            input_dir=str(dir_path),
-        )
+    dataset = BottomUpStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        pafs_head=pafs_head,
+        edge_inds=edge_inds,
+        max_stride=100,
+        input_dir=str(dir_path),
+    )
 
-        samples = list(iter(dataset))
-        assert len(samples) == 1
+    samples = list(iter(dataset))
+    assert len(samples) == 1
 
-        assert samples[0]["image"].shape == (1, 1, 200, 200)
-        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
-        assert samples[0]["part_affinity_fields"].shape == (2, 50, 50)
-
-    finally:
-        shutil.rmtree(dir_path)
+    assert samples[0]["image"].shape == (1, 1, 200, 200)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
+    assert samples[0]["part_affinity_fields"].shape == (2, 50, 50)
 
 
 def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
@@ -88,26 +83,22 @@ def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, c
         chunk_size=4,
     )
 
-    try:
-        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
 
-        dataset = CenteredInstanceStreamingDataset(
-            augmentation_config=config.data_config.augmentation_config,
-            confmap_head=confmap_head,
-            crop_hw=(160, 160),
-            max_stride=100,
-            input_dir=str(dir_path),
-            input_scale=0.5,
-        )
+    dataset = CenteredInstanceStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        crop_hw=(160, 160),
+        max_stride=100,
+        input_dir=str(dir_path),
+        input_scale=0.5,
+    )
 
-        samples = list(iter(dataset))
-        assert len(samples) == 2
+    samples = list(iter(dataset))
+    assert len(samples) == 2
 
-        assert samples[0]["instance_image"].shape == (1, 1, 100, 100)
-        assert samples[0]["confidence_maps"].shape == (1, 2, 50, 50)
-
-    finally:
-        shutil.rmtree(dir_path)
+    assert samples[0]["instance_image"].shape == (1, 1, 100, 100)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 50, 50)
 
 
 def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
@@ -133,25 +124,20 @@ def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
         chunk_size=4,
     )
 
-    try:
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
 
-        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    dataset = CentroidStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        max_stride=100,
+        input_dir=str(dir_path),
+    )
 
-        dataset = CentroidStreamingDataset(
-            augmentation_config=config.data_config.augmentation_config,
-            confmap_head=confmap_head,
-            max_stride=100,
-            input_dir=str(dir_path),
-        )
+    samples = list(iter(dataset))
+    assert len(samples) == 1
 
-        samples = list(iter(dataset))
-        assert len(samples) == 1
-
-        assert samples[0]["image"].shape == (1, 1, 200, 200)
-        assert samples[0]["centroids_confidence_maps"].shape == (1, 1, 100, 100)
-
-    finally:
-        shutil.rmtree(dir_path)
+    assert samples[0]["image"].shape == (1, 1, 200, 200)
+    assert samples[0]["centroids_confidence_maps"].shape == (1, 1, 100, 100)
 
 
 def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, config):
@@ -177,22 +163,17 @@ def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, con
         chunk_size=4,
     )
 
-    try:
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
 
-        confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    dataset = SingleInstanceStreamingDataset(
+        augmentation_config=config.data_config.augmentation_config,
+        confmap_head=confmap_head,
+        max_stride=100,
+        input_dir=str(dir_path),
+    )
 
-        dataset = SingleInstanceStreamingDataset(
-            augmentation_config=config.data_config.augmentation_config,
-            confmap_head=confmap_head,
-            max_stride=100,
-            input_dir=str(dir_path),
-        )
+    samples = list(iter(dataset))
+    assert len(samples) == 1
 
-        samples = list(iter(dataset))
-        assert len(samples) == 1
-
-        assert samples[0]["image"].shape == (1, 1, 200, 200)
-        assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)
-
-    finally:
-        shutil.rmtree(dir_path)
+    assert samples[0]["image"].shape == (1, 1, 200, 200)
+    assert samples[0]["confidence_maps"].shape == (1, 2, 100, 100)

--- a/tests/data/test_streaming_datasets.py
+++ b/tests/data/test_streaming_datasets.py
@@ -25,7 +25,7 @@ def test_bottomup_streaming_dataset(minimal_instance, sleap_data_dir, config):
     max_hw = get_max_height_width(labels)
     edge_inds = labels.skeletons[0].edge_inds
 
-    dir_path = Path(sleap_data_dir) / "data_chunks"
+    dir_path = Path(sleap_data_dir) / "test_bottomup_streaming_dataset_1"
 
     partial_func = functools.partial(
         bottomup_data_chunks,
@@ -70,7 +70,7 @@ def test_centered_instance_streaming_dataset(minimal_instance, sleap_data_dir, c
     labels = sio.load_slp(minimal_instance)
     max_hw = get_max_height_width(labels)
 
-    dir_path = Path(sleap_data_dir) / "data_chunks"
+    dir_path = Path(sleap_data_dir) / "test_centered_instance_streaming_dataset_1"
 
     partial_func = functools.partial(
         centered_instance_data_chunks,
@@ -115,7 +115,7 @@ def test_centroid_streaming_dataset(minimal_instance, sleap_data_dir, config):
     labels = sio.load_slp(minimal_instance)
     max_hw = get_max_height_width(labels)
 
-    dir_path = Path(sleap_data_dir) / "data_chunks"
+    dir_path = Path(sleap_data_dir) / "test_centroid_streaming_dataset_1"
 
     partial_func = functools.partial(
         centroid_data_chunks,
@@ -159,7 +159,7 @@ def test_single_instance_streaming_dataset(minimal_instance, sleap_data_dir, con
     labels = sio.load_slp(minimal_instance)
     max_hw = get_max_height_width(labels)
 
-    dir_path = Path(sleap_data_dir) / "data_chunks"
+    dir_path = Path(sleap_data_dir) / "test_single_instance_streaming_dataset_1"
 
     partial_func = functools.partial(
         single_instance_data_chunks,

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -63,7 +63,7 @@ def config(sleap_data_dir):
                     "is_rgb": False,
                     "max_width": None,
                     "max_height": None,
-                    "scale": 1.0,
+                    "scale": None,
                     "crop_hw": [160, 160],
                     "min_crop_size": None,
                 },

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -92,7 +92,9 @@ def test_create_data_loader_litdata(caplog, config, tmp_path: str):
     # test centered-instance pipeline
     OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_create_data_loader_litdata/",
     )
     # without explicitly providing crop_hw
     config_copy = config.copy()
@@ -150,7 +152,7 @@ def test_trainer_litdata(caplog, config, tmp_path: str):
     OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     # # for topdown centered instance model
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_trainer_litdata/"
     )
 
     model_trainer = ModelTrainer(config)
@@ -170,6 +172,9 @@ def test_trainer_litdata(caplog, config, tmp_path: str):
     #######
 
     # update save_ckpt to True and test step lr
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_trainer_litdata_2/"
+    )
     OmegaConf.update(config, "trainer_config.save_ckpt", True)
     OmegaConf.update(config, "trainer_config.use_wandb", True)
     OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
@@ -375,7 +380,9 @@ def test_trainer_torch_dataset(caplog, config, tmp_path: str):
 
     # # for topdown centered instance model
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_trainer_torch_dataset/",
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset_np_chunks")
     OmegaConf.update(config, "data_config.np_chunks_path", f"{tmp_path}/np_chunks/")
@@ -757,7 +764,9 @@ def test_topdown_centered_instance_model(config, tmp_path: str):
         backbone_type="unet",
     )
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_topdown_centered_instance_model_1/",
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
 
@@ -807,7 +816,9 @@ def test_topdown_centered_instance_model(config, tmp_path: str):
         backbone_type="convnext",
     )
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_topdown_centered_instance_model_2/",
     )
     model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_litdata()
@@ -844,7 +855,7 @@ def test_centroid_model(config, tmp_path: str):
     )
 
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_centroid_model_1/"
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     model_trainer = ModelTrainer(config)
@@ -869,7 +880,7 @@ def test_centroid_model(config, tmp_path: str):
     )
 
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_centroid_model_2/"
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
 
@@ -897,7 +908,9 @@ def test_single_instance_model(config, tmp_path: str):
     OmegaConf.update(config, "model_config.init_weights", "xavier")
 
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_single_instance_model_1/",
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     model_trainer = ModelTrainer(config)
@@ -937,6 +950,11 @@ def test_single_instance_model(config, tmp_path: str):
     shutil.rmtree((Path(model_trainer.val_litdata_chunks_path)).as_posix())
 
     # torch dataset
+    OmegaConf.update(
+        config,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_single_instance_model_2/",
+    )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer(config)
     model_trainer._create_data_loaders_torch_dataset()
@@ -990,7 +1008,7 @@ def test_bottomup_model(config, tmp_path: str):
     config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
 
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_bottomup_model_1/"
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "litdata")
     model_trainer = ModelTrainer(config)
@@ -1027,7 +1045,7 @@ def test_bottomup_model(config, tmp_path: str):
     config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
 
     OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_bottomup_model_2/"
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer(config)


### PR DESCRIPTION
This PR adds `scale` parameter to custom torch dataset classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable image scaling factor for dataset processing, allowing users to adjust the resizing behavior. The default remains 1.0 for seamless integration.

- **Documentation**
  - Enhanced documentation to clearly describe the new scaling option and its impact on image preprocessing.

- **Tests**
  - Updated test cases to include the new scaling parameter for various dataset classes, ensuring flexibility in testing configurations.
  - Modified test functions to utilize unique directory paths for better organization of test outputs.
  - Updated checkpoint paths in test functions to ensure unique identification for output organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->