### PR TITLE
Fix size matcher

### DIFF
--- a/sleap_nn/data/resizing.py
+++ b/sleap_nn/data/resizing.py
@@ -109,22 +109,14 @@ def apply_sizematcher(
     max_height: Optional[int] = None,
     max_width: Optional[int] = None,
 ):
-    """Apply scaling and padding to smaller image to (max_height, max_width) shape."""
+    """Apply scaling and padding to image to (max_height, max_width) shape."""
     img_height, img_width = image.shape[-2:]
     # pad images to max_height and max_width
     if max_height is None:
         max_height = img_height
     if max_width is None:
         max_width = img_width
-    if img_height > max_height:
-        message = f"Max height {max_height} should be greater than the current image height: {img_height}"
-        logger.error(message)
-        raise ValueError(message)
-    if img_width > max_width:
-        message = f"Max width {max_width} should be greater than the current image width: {img_width}"
-        logger.error(message)
-        raise ValueError(message)
-    if img_height < max_height or img_width < max_width:
+    if img_height != max_height or img_width != max_width:
         hratio = max_height / img_height
         wratio = max_width / img_width
 

--- a/tests/data/test_resizing.py
+++ b/tests/data/test_resizing.py
@@ -138,16 +138,5 @@ def test_apply_sizematcher(caplog, minimal_instance):
     image, _ = apply_sizematcher(ex["image"])
     assert image.shape == torch.Size([1, 1, 384, 384])
 
-    with pytest.raises(
-        Exception,
-        match=f"Max height {100} should be greater than the current image height: {384}",
-    ):
-        image = apply_sizematcher(ex["image"], max_height=100, max_width=500)
-    assert "Max height" in caplog.text
-
-    with pytest.raises(
-        Exception,
-        match=f"Max width {100} should be greater than the current image width: {384}",
-    ):
-        image = apply_sizematcher(ex["image"], max_height=500, max_width=100)
-    assert "Max width" in caplog.text
+    image, eff = apply_sizematcher(ex["image"], 100, 480)
+    assert image.shape == torch.Size([1, 1, 100, 480])


### PR DESCRIPTION
Currently, resizing only works if the images are to be resized to a higher resolution. This PR ensures images could be resized to any given dimension, maintaining the aspect ratio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced image resizing behavior to apply consistent scaling and padding when dimensions differ from the expected sizes.
- **Tests**
	- Updated validation to ensure resized images meet the designated shape requirements under typical conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->