### PR TITLE
Fix max instances in TopDown Inference

### DIFF
--- a/sleap_nn/inference/bottomup.py
+++ b/sleap_nn/inference/bottomup.py
@@ -153,9 +153,9 @@ class BottomUpInferenceModel(L.LightningModule):
         }
 
         if self.return_confmaps:
-            out["confmaps"] = cms
+            out["pred_confmaps"] = cms
         if self.return_pafs:
-            out["part_affinity_fields"] = pafs
+            out["pred_part_affinity_fields"] = pafs
         if self.return_paf_graph:
             out["peaks"] = cms_peaks
             out["peak_vals"] = cms_peak_vals

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -327,9 +327,10 @@ class Predictor(ABC):
                         ex["image"], self.preprocess_config["max_stride"]
                     )
                 outputs_list = self.inference_model(ex)
-                for output in outputs_list:
-                    output = self._convert_tensors_to_numpy(output)
-                    yield output
+                if outputs_list is not None:
+                    for output in outputs_list:
+                        output = self._convert_tensors_to_numpy(output)
+                        yield output
 
         self.pipeline.join()
 
@@ -1638,12 +1639,12 @@ def main(
     model_paths: List[str],
     backbone_ckpt_path: Optional[str] = None,
     head_ckpt_path: Optional[str] = None,
-    max_instances: int = None,
-    max_width: int = None,
-    max_height: int = None,
+    max_instances: Optional[int] = None,
+    max_width: Optional[int] = None,
+    max_height: Optional[int] = None,
     is_rgb: bool = False,
     anchor_ind: Optional[int] = None,
-    provider: str = "LabelsReader",
+    provider: Optional[str] = None,
     batch_size: int = 4,
     queue_maxsize: int = 8,
     videoreader_start_idx: Optional[int] = None,
@@ -1701,7 +1702,7 @@ def main(
         anchor_ind: (int) The index of the node to use as the anchor for the centroid. If not
                 provided, the anchor idx in the `training_config.yaml` is used instead.
         provider: (str) Provider class to read the input sleap files.
-                Either "LabelsReader" or "VideoReader". Default: LabelsReader.
+                Either "LabelsReader" or "VideoReader". Default: None.
         batch_size: (int) Number of samples per batch. Default: 4.
         queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
         videoreader_start_idx: (int) Start index of the frames to read. Default: None.
@@ -1795,6 +1796,12 @@ def main(
         "max_height": max_height,
         "anchor_ind": anchor_ind,
     }
+
+    if provider is None:
+        if data_path.endswith(".slp"):
+            provider = "LabelsReader"
+        else:
+            provider = "VideoReader"
 
     if provider == "VideoReader":
         preprocess_config["video_queue_maxsize"] = queue_maxsize

--- a/tests/inference/test_bottomup.py
+++ b/tests/inference/test_bottomup.py
@@ -68,7 +68,7 @@ def test_bottomup_inference_model(
     )
 
     output = inference_layer(ex)[0]
-    assert "confmaps" not in output.keys()
+    assert "pred_confmaps" not in output.keys()
     assert output["pred_instance_peaks"].is_nested
     assert tuple(output["pred_instance_peaks"][0].shape)[1:] == (2, 2)
     assert tuple(output["pred_peak_values"][0].shape)[1:] == (2,)
@@ -97,8 +97,8 @@ def test_bottomup_inference_model(
     )
 
     output = inference_layer(ex)[0]
-    assert tuple(output["confmaps"].shape) == (1, 2, 192, 192)
-    assert tuple(output["part_affinity_fields"].shape) == (1, 96, 96, 2)
+    assert tuple(output["pred_confmaps"].shape) == (1, 2, 192, 192)
+    assert tuple(output["pred_part_affinity_fields"].shape) == (1, 96, 96, 2)
     assert output["pred_instance_peaks"].is_nested
     assert output["peaks"][0].shape[-1] == 2
     assert tuple(output["pred_instance_peaks"][0].shape)[1:] == (2, 2)

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -121,7 +121,6 @@ def test_topdown_predictor(
     pred_labels = main(
         model_paths=[minimal_instance_centroid_ckpt],
         data_path="./tests/assets/minimal_instance.pkg.slp",
-        provider="LabelsReader",
         make_labels=False,
         max_instances=max_instances,
         peak_threshold=0.1,
@@ -137,7 +136,6 @@ def test_topdown_predictor(
     pred_labels = main(
         model_paths=[minimal_instance_centroid_ckpt, minimal_instance_ckpt],
         data_path="./tests/assets/centered_pair_small.mp4",
-        provider="VideoReader",
         make_labels=True,
         max_instances=6,
         peak_threshold=[0.0, 0.0],

--- a/tests/inference/test_topdown.py
+++ b/tests/inference/test_topdown.py
@@ -200,7 +200,7 @@ def test_find_instance_peaks_groundtruth(
     output = topdown_inf_layer(ex)[0]
 
     assert "pred_instance_peaks" in output.keys()
-    assert output["pred_instance_peaks"].shape == (2, 2, 2)
+    assert output["pred_instance_peaks"].shape == (1, 2, 2, 2)
     assert output["pred_peak_values"].shape == (2, 2)
 
 

--- a/tests/inference/test_topdown.py
+++ b/tests/inference/test_topdown.py
@@ -90,11 +90,11 @@ def test_centroid_inference_model(config, minimal_instance, tmp_path):
     # return crops = False
     layer = CentroidCrop(
         torch_model=model,
-        peak_threshold=0.0,
+        peak_threshold=0.0125,
         refinement="integral",
         integral_patch_size=5,
         output_stride=2,
-        return_confmaps=False,
+        return_confmaps=True,
         max_instances=6,
         return_crops=False,
         crop_hw=(160, 160),
@@ -104,6 +104,7 @@ def test_centroid_inference_model(config, minimal_instance, tmp_path):
     assert tuple(out["centroids"].shape) == (1, 1, 6, 2)
     assert tuple(out["centroid_vals"].shape) == (1, 6)
     assert "instance_image" not in out.keys()
+    assert "pred_centroid_confmaps" in out.keys()
 
     # return crops = True
     layer = CentroidCrop(
@@ -112,7 +113,7 @@ def test_centroid_inference_model(config, minimal_instance, tmp_path):
         refinement="integral",
         integral_patch_size=5,
         output_stride=2,
-        return_confmaps=False,
+        return_confmaps=True,
         max_instances=2,
         return_crops=True,
         crop_hw=(160, 160),


### PR DESCRIPTION
Currently, the TopDown predictor always expects a values for `max_instances` from the user. However, this should be made optional. If the user doesn't provide a value, this should be automatically inferred from the number of predicted centroids. This PR handles this by setting the max instances to the maximum number of predicted centroids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling to prevent runtime errors during data processing.
  
- **Refactor**
  - Updated output naming conventions for clarity and consistency.
  - Improved input parameter flexibility with dynamic provider selection based on file types.
  - Streamlined detection and cropping logic to handle varying instance counts reliably.

- **Tests**
  - Adjusted test cases to align with the updated output structures, including changes to peak detection sensitivity and output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->