### PR TITLE
Save config with chunks

### DIFF
--- a/initial_config.yaml
+++ b/initial_config.yaml
@@ -1,0 +1,106 @@
+data_config:
+  provider: LabelsReader
+  train_labels_path: /Users/divyasesh/Desktop/its_me/sleap-nn/tests/assets/minimal_instance.pkg.slp
+  val_labels_path: /Users/divyasesh/Desktop/its_me/sleap-nn/tests/assets/minimal_instance.pkg.slp
+  test_file_path: null
+  user_instances_only: true
+  data_pipeline_fw: torch_dataset
+  np_chunks_path: null
+  litdata_chunks_path: null
+  use_existing_chunks: false
+  delete_chunks_after_training: true
+  chunk_size: 100
+  preprocessing:
+    is_rgb: false
+    max_width: null
+    max_height: null
+    scale: null
+    crop_hw:
+    - 160
+    - 160
+    min_crop_size: null
+  use_augmentations_train: true
+  augmentation_config:
+    intensity:
+      contrast_p: 1.0
+    geometric:
+      rotation: 180.0
+      scale: null
+      translate_width: 0
+      translate_height: 0
+      affine_p: 0.5
+model_config:
+  init_weights: default
+  pre_trained_weights: null
+  pretrained_backbone_weights: null
+  pretrained_head_weights: null
+  backbone_config:
+    unet:
+      in_channels: 1
+      kernel_size: 3
+      filters: 16
+      filters_rate: 1.5
+      max_stride: 8
+      convs_per_block: 2
+      stacks: 1
+      stem_stride: null
+      middle_block: true
+      up_interpolate: false
+      output_stride: 2
+  head_configs:
+    single_instance: null
+    centroid: null
+    bottomup: null
+    centered_instance:
+      confmaps:
+        part_names:
+        - '0'
+        - '1'
+        anchor_part: 1
+        sigma: 1.5
+        output_stride: 2
+trainer_config:
+  train_data_loader:
+    batch_size: 1
+    shuffle: true
+    num_workers: 2
+  val_data_loader:
+    batch_size: 1
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: true
+  early_stopping:
+    stop_training_on_plateau: true
+    min_delta: 1.0e-08
+    patience: 20
+  trainer_devices: 1
+  trainer_accelerator: cpu
+  enable_progress_bar: false
+  steps_per_epoch: null
+  max_epochs: 2
+  seed: 1000
+  use_wandb: false
+  save_ckpt: false
+  save_ckpt_path: null
+  resume_ckpt_path: null
+  wandb:
+    entity: null
+    project: test
+    name: test_run
+    wandb_mode: offline
+    api_key: ''
+    prv_runid: null
+    group: null
+  optimizer_name: Adam
+  optimizer:
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    reduce_lr_on_plateau:
+      threshold: 1.0e-07
+      threshold_mode: rel
+      cooldown: 3
+      patience: 5
+      factor: 0.5
+      min_lr: 1.0e-08

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -53,7 +53,7 @@ class BaseDataset(Dataset):
 
     def __init__(
         self,
-        labels: sio.Labels,
+        labels: Optional[sio.Labels],
         data_config: DictConfig,
         max_stride: int,
         scale: float = 1.0,
@@ -72,8 +72,8 @@ class BaseDataset(Dataset):
         self.scale = scale
         self.apply_aug = apply_aug
         self.max_hw = max_hw
-        self.max_instances = get_max_instances(self.labels)
-        self.lf_idx_list = self._get_lf_idx_list()
+        self.max_instances = get_max_instances(self.labels) if self.labels else None
+        self.lf_idx_list = self._get_lf_idx_list() if self.labels else None
         self.np_chunks = np_chunks
         self.np_chunks_path = np_chunks_path
         self.use_existing_chunks = use_existing_chunks
@@ -183,6 +183,16 @@ class BaseDataset(Dataset):
 
     def __len__(self) -> int:
         """Return the number of samples in the dataset."""
+        if self.use_existing_chunks:
+            chunks_folder = Path(self.np_chunks_path)
+            num_files = len(
+                [
+                    f
+                    for f in chunks_folder.iterdir()
+                    if f.is_file() and f.suffix == ".npz"
+                ]
+            )
+            return num_files
         return len(self.lf_idx_list)
 
     def __getitem__(self, index) -> Dict:
@@ -220,7 +230,7 @@ class BottomUpDataset(BaseDataset):
 
     def __init__(
         self,
-        labels: sio.Labels,
+        labels: Optional[sio.Labels],
         data_config: DictConfig,
         confmap_head_config: DictConfig,
         pafs_head_config: DictConfig,
@@ -339,7 +349,7 @@ class CenteredInstanceDataset(BaseDataset):
 
     def __init__(
         self,
-        labels: sio.Labels,
+        labels: Optional[sio.Labels],
         data_config: DictConfig,
         crop_hw: Tuple[int],
         confmap_head_config: DictConfig,
@@ -365,7 +375,7 @@ class CenteredInstanceDataset(BaseDataset):
         )
         self.crop_hw = crop_hw
         self.confmap_head_config = confmap_head_config
-        self.instance_idx_list = self._get_instance_idx_list()
+        self.instance_idx_list = self._get_instance_idx_list() if self.labels else None
         self.cache_lf = [None, None]
         if not self.use_existing_chunks:
             self._fill_cache()
@@ -477,6 +487,16 @@ class CenteredInstanceDataset(BaseDataset):
 
     def __len__(self) -> int:
         """Return number of instances in the labels object."""
+        if self.use_existing_chunks:
+            chunks_folder = Path(self.np_chunks_path)
+            num_files = len(
+                [
+                    f
+                    for f in chunks_folder.iterdir()
+                    if f.is_file() and f.suffix == ".npz"
+                ]
+            )
+            return num_files
         return len(self.instance_idx_list)
 
     def __getitem__(self, index) -> Dict:
@@ -577,7 +597,7 @@ class CentroidDataset(BaseDataset):
 
     def __init__(
         self,
-        labels: sio.Labels,
+        labels: Optional[sio.Labels],
         data_config: DictConfig,
         confmap_head_config: DictConfig,
         max_stride: int,
@@ -741,7 +761,7 @@ class SingleInstanceDataset(BaseDataset):
 
     def __init__(
         self,
-        labels: sio.Labels,
+        labels: Optional[sio.Labels],
         data_config: DictConfig,
         confmap_head_config: DictConfig,
         max_stride: int,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -49,6 +49,7 @@ from sleap_nn.data.streaming_datasets import (
 )
 from loguru import logger
 from sleap_nn.training.utils import check_memory
+from sleap_nn.inference.utils import get_skeleton_from_config
 
 
 MODEL_WEIGHTS = {
@@ -92,6 +93,12 @@ class ModelTrainer:
         self.config = config
         self.data_pipeline_fw = self.config.data_config.data_pipeline_fw
         self.use_existing_chunks = self.config.data_config.use_existing_chunks
+        self.user_instances_only = (
+            self.config.data_config.user_instances_only
+            if "user_instances_only" in self.config.data_config
+            and self.config.data_config.user_instances_only is not None
+            else True
+        )  # TODO: defaults should be handles in config validation.
 
         # Get ckpt dir path
         self.dir_path = self.config.trainer_config.save_ckpt_path
@@ -130,18 +137,15 @@ class ModelTrainer:
         ):
             self.train_dataset = None
             self.val_dataset = None
+            self.np_chunks_path = (
+                Path(self.config.data_config.np_chunks_path)
+                if self.config.data_config.np_chunks_path is not None
+                else Path(self.dir_path)
+            )
             # Get np chunks path
             self.np_chunks = True if "np_chunks" in self.data_pipeline_fw else False
-            self.train_np_chunks_path = (
-                Path(self.config.data_config.np_chunks_path) / "train_chunks"
-                if self.config.data_config.np_chunks_path is not None
-                else Path(self.dir_path) / "train_chunks"
-            )
-            self.val_np_chunks_path = (
-                Path(self.config.data_config.np_chunks_path) / "val_chunks"
-                if self.config.data_config.np_chunks_path is not None
-                else Path(self.dir_path) / "val_chunks"
-            )
+            self.train_np_chunks_path = Path(self.np_chunks_path) / "train_chunks"
+            self.val_np_chunks_path = Path(self.np_chunks_path) / "val_chunks"
             if self.use_existing_chunks:
                 if not (
                     self.train_np_chunks_path.exists()
@@ -189,94 +193,122 @@ class ModelTrainer:
         # set seed
         torch.manual_seed(self.seed)
 
-        train_labels = sio.load_slp(self.config.data_config.train_labels_path)
-        self.user_instances_only = (
-            self.config.data_config.user_instances_only
-            if "user_instances_only" in self.config.data_config
-            and self.config.data_config.user_instances_only is not None
-            else True
-        )  # TODO: defaults should be handles in config validation.
-        self.skeletons = train_labels.skeletons
-        # save the skeleton in the config
-        self.config["data_config"]["skeletons"] = {}
-        for skl in self.skeletons:
-            if skl.symmetries:
-                symm = [list(s.nodes) for s in skl.symmetries]
-            else:
-                symm = None
-            skl_name = skl.name if skl.name is not None else "skeleton-0"
-            self.config["data_config"]["skeletons"][skl_name] = {
-                "nodes": skl.nodes,
-                "edges": skl.edges,
-                "symmetries": symm,
-            }
-
-        # if edges and part names aren't set in config, get it from `sio.Labels` object.
-        head_config = self.config.model_config.head_configs[self.model_type]
-        for key in head_config:
-            if "part_names" in head_config[key].keys():
-                if head_config[key]["part_names"] is None:
-                    part_names = [x.name for x in self.skeletons[0].nodes]
-                    self.config.model_config.head_configs[self.model_type][key][
-                        "part_names"
-                    ] = part_names
-
-            if "edges" in head_config[key].keys():
-                if head_config[key]["edges"] is None:
-                    edges = [
-                        (x.source.name, x.destination.name)
-                        for x in self.skeletons[0].edges
-                    ]
-                    self.config.model_config.head_configs[self.model_type][key][
-                        "edges"
-                    ] = edges
-
         self.max_stride = self.config.model_config.backbone_config[
             f"{self.backbone_type}"
         ]["max_stride"]
-        self.edge_inds = train_labels.skeletons[0].edge_inds
-
-        self.max_height, self.max_width = get_max_height_width(train_labels)
-        if (
-            self.config.data_config.preprocessing.max_height is None
-            and self.config.data_config.preprocessing.max_width is None
-        ):
-            self.config.data_config.preprocessing.max_height = self.max_height
-            self.config.data_config.preprocessing.max_width = self.max_width
 
         if self.config.data_config.preprocessing.scale is None:
             self.config.data_config.preprocessing.scale = 1.0
 
-        if self.model_type == "centered_instance":
-            # compute crop size
-            self.crop_hw = self.config.data_config.preprocessing.crop_hw
-            if self.crop_hw is None:
+        if self.use_existing_chunks:  # load preprocessing params
+            if self.data_pipeline_fw == "litdata":
+                config_path = Path(self.litdata_chunks_path) / "config.yaml"
+            elif self.data_pipeline_fw == "torch_dataset_np_chunks":
+                config_path = Path(self.np_chunks_path) / "config.yaml"
+            chunks_config = OmegaConf.load(config_path.as_posix())
+            self.skeletons = get_skeleton_from_config(
+                chunks_config.data_config.skeletons
+            )
+            self.edge_inds = self.skeletons[0].edge_inds
+            self.max_height, self.max_width = (
+                chunks_config.data_config.preprocessing.max_height,
+                chunks_config.data_config.preprocessing.max_width,
+            )
+            self.crop_hw = chunks_config.data_config.preprocessing.crop_hw[0]
 
-                min_crop_size = (
-                    self.config.data_config.preprocessing.min_crop_size
-                    if "min_crop_size" in self.config.data_config.preprocessing
-                    else None
-                )
-                crop_size = find_instance_crop_size(
-                    train_labels,
-                    maximum_stride=self.max_stride,
-                    min_crop_size=min_crop_size,
-                    input_scaling=self.config.data_config.preprocessing.scale,
-                )
-                self.crop_hw = crop_size
-                self.config.data_config.preprocessing.crop_hw = (
-                    self.crop_hw,
-                    self.crop_hw,
-                )
-            else:
-                self.crop_hw = self.crop_hw[0]
+        else:
+            train_labels = sio.load_slp(self.config.data_config.train_labels_path)
+
+            self.max_height, self.max_width = get_max_height_width(train_labels)
+            if (
+                self.config.data_config.preprocessing.max_height is None
+                and self.config.data_config.preprocessing.max_width is None
+            ):
+                self.config.data_config.preprocessing.max_height = self.max_height
+                self.config.data_config.preprocessing.max_width = self.max_width
+
+            if self.model_type == "centered_instance":
+                # compute crop size
+                self.crop_hw = self.config.data_config.preprocessing.crop_hw
+                if self.crop_hw is None:
+
+                    min_crop_size = (
+                        self.config.data_config.preprocessing.min_crop_size
+                        if "min_crop_size" in self.config.data_config.preprocessing
+                        else None
+                    )
+                    crop_size = find_instance_crop_size(
+                        train_labels,
+                        maximum_stride=self.max_stride,
+                        min_crop_size=min_crop_size,
+                        input_scaling=self.config.data_config.preprocessing.scale,
+                    )
+                    self.crop_hw = crop_size
+                    self.config.data_config.preprocessing.crop_hw = (
+                        self.crop_hw,
+                        self.crop_hw,
+                    )
+                else:
+                    self.crop_hw = self.crop_hw[0]
+
+            self.skeletons = train_labels.skeletons
+            # save the skeleton in the config
+            self.config["data_config"]["skeletons"] = {}
+            for skl in self.skeletons:
+                if skl.symmetries:
+                    symm = [list(s.nodes) for s in skl.symmetries]
+                else:
+                    symm = None
+                skl_name = skl.name if skl.name is not None else "skeleton-0"
+                self.config["data_config"]["skeletons"][skl_name] = {
+                    "nodes": skl.nodes,
+                    "edges": skl.edges,
+                    "symmetries": symm,
+                }
+
+            # if edges and part names aren't set in config, get it from `sio.Labels` object.
+            head_config = self.config.model_config.head_configs[self.model_type]
+            for key in head_config:
+                if "part_names" in head_config[key].keys():
+                    if head_config[key]["part_names"] is None:
+                        part_names = [x.name for x in self.skeletons[0].nodes]
+                        self.config.model_config.head_configs[self.model_type][key][
+                            "part_names"
+                        ] = part_names
+
+                if "edges" in head_config[key].keys():
+                    if head_config[key]["edges"] is None:
+                        edges = [
+                            (x.source.name, x.destination.name)
+                            for x in self.skeletons[0].edges
+                        ]
+                        self.config.model_config.head_configs[self.model_type][key][
+                            "edges"
+                        ] = edges
+
+            self.edge_inds = train_labels.skeletons[0].edge_inds
 
         OmegaConf.save(config=self.config, f=f"{self.dir_path}/training_config.yaml")
+        # save config to chunks folder
+        if not self.use_existing_chunks and self.data_pipeline_fw in [
+            "litdata",
+            "torch_dataset_np_chunks",
+        ]:
+            if self.data_pipeline_fw == "litdata":
+                save_path = Path(self.litdata_chunks_path) / "config.yaml"
+            elif self.data_pipeline_fw == "torch_dataset_np_chunks":
+                save_path = Path(self.np_chunks_path) / "config.yaml"
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            OmegaConf.save(config=self.config, f=save_path.as_posix())
 
     def _create_data_loaders_torch_dataset(self):
         """Create a torch DataLoader for train, validation and test sets using the data_config."""
-        train_labels = sio.load_slp(self.config.data_config.train_labels_path)
-        val_labels = sio.load_slp(self.config.data_config.val_labels_path)
+        if self.use_existing_chunks:
+            train_labels, val_labels = None, None
+        else:
+            train_labels = sio.load_slp(self.config.data_config.train_labels_path)
+            val_labels = sio.load_slp(self.config.data_config.val_labels_path)
+
         if self.data_pipeline_fw == "torch_dataset":
             train_cache_memory = check_memory(
                 train_labels,

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -751,3 +751,7 @@ def test_reuse_bin_files(config, tmp_path: str):
     )
     trainer2 = ModelTrainer(centroid_config)
     trainer2.train()
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__ + "::test_trainer_torch_dataset"])

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -753,5 +753,69 @@ def test_reuse_bin_files(config, tmp_path: str):
     trainer2.train()
 
 
-if __name__ == "__main__":
-    pytest.main(["-v", __file__ + "::test_trainer_torch_dataset"])
+@pytest.mark.skipif(
+    sys.platform.startswith("li"),
+    reason="Flaky test (The training test runs on Ubuntu for a long time: >6hrs and then fails.)",
+)
+# TODO: Revisit this test later (Failing on ubuntu)
+# torch dataset
+def test_reuse_npz_files(config, tmp_path: str):
+    """Test reusing `.npz` files."""
+    # Centroid model
+    OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset_np_chunks")
+    centroid_config = config.copy()
+    head_config = config.model_config.head_configs.centered_instance
+    OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
+    del centroid_config.model_config.head_configs.centered_instance
+    del centroid_config.model_config.head_configs.centroid["confmaps"].part_names
+
+    OmegaConf.update(
+        centroid_config,
+        "trainer_config.save_ckpt_path",
+        f"{tmp_path}/test_model_trainer/",
+    )
+
+    if (Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt").exists():
+        os.remove(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "best.ckpt"
+            ).as_posix()
+        )
+        os.remove(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "last.ckpt"
+            ).as_posix()
+        )
+        shutil.rmtree(
+            (
+                Path(centroid_config.trainer_config.save_ckpt_path) / "lightning_logs"
+            ).as_posix()
+        )
+
+    OmegaConf.update(centroid_config, "trainer_config.save_ckpt", True)
+    OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
+    OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
+    OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
+    OmegaConf.update(centroid_config, "data_config.delete_chunks_after_training", False)
+    OmegaConf.update(
+        centroid_config,
+        "data_config.np_chunks_path",
+        Path(tmp_path) / "new_chunks",
+    )
+
+    # test reusing bin files
+    trainer1 = ModelTrainer(centroid_config)
+    trainer1.train()
+
+    OmegaConf.update(
+        centroid_config,
+        "data_config.np_chunks_path",
+        (trainer1.np_chunks_path.as_posix()),
+    )
+    OmegaConf.update(
+        centroid_config,
+        "data_config.use_existing_chunks",
+        True,
+    )
+    trainer2 = ModelTrainer(centroid_config)
+    trainer2.train()

--- a/training_config.yaml
+++ b/training_config.yaml
@@ -1,0 +1,117 @@
+data_config:
+  provider: LabelsReader
+  train_labels_path: /Users/divyasesh/Desktop/its_me/sleap-nn/tests/assets/minimal_instance.pkg.slp
+  val_labels_path: /Users/divyasesh/Desktop/its_me/sleap-nn/tests/assets/minimal_instance.pkg.slp
+  test_file_path: null
+  user_instances_only: true
+  data_pipeline_fw: torch_dataset
+  np_chunks_path: null
+  litdata_chunks_path: null
+  use_existing_chunks: false
+  delete_chunks_after_training: true
+  chunk_size: 100
+  preprocessing:
+    is_rgb: false
+    max_width: 384
+    max_height: 384
+    scale: 1.0
+    crop_hw:
+    - 160
+    - 160
+    min_crop_size: null
+  use_augmentations_train: true
+  augmentation_config:
+    intensity:
+      contrast_p: 1.0
+    geometric:
+      rotation: 180.0
+      scale: null
+      translate_width: 0
+      translate_height: 0
+      affine_p: 0.5
+  skeletons:
+    Skeleton-0:
+      nodes:
+      - name: A
+      - name: B
+      edges:
+      - source:
+          name: A
+        destination:
+          name: B
+      symmetries: null
+model_config:
+  init_weights: default
+  pre_trained_weights: null
+  pretrained_backbone_weights: null
+  pretrained_head_weights: null
+  backbone_config:
+    unet:
+      in_channels: 1
+      kernel_size: 3
+      filters: 16
+      filters_rate: 1.5
+      max_stride: 8
+      convs_per_block: 2
+      stacks: 1
+      stem_stride: null
+      middle_block: true
+      up_interpolate: false
+      output_stride: 2
+  head_configs:
+    single_instance: null
+    centroid: null
+    bottomup: null
+    centered_instance:
+      confmaps:
+        part_names:
+        - '0'
+        - '1'
+        anchor_part: 1
+        sigma: 1.5
+        output_stride: 2
+trainer_config:
+  train_data_loader:
+    batch_size: 1
+    shuffle: true
+    num_workers: 2
+  val_data_loader:
+    batch_size: 1
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: true
+  early_stopping:
+    stop_training_on_plateau: true
+    min_delta: 1.0e-08
+    patience: 20
+  trainer_devices: 1
+  trainer_accelerator: cpu
+  enable_progress_bar: false
+  steps_per_epoch: null
+  max_epochs: 2
+  seed: 1000
+  use_wandb: false
+  save_ckpt: false
+  save_ckpt_path: null
+  resume_ckpt_path: null
+  wandb:
+    entity: null
+    project: test
+    name: test_run
+    wandb_mode: offline
+    api_key: ''
+    prv_runid: null
+    group: null
+  optimizer_name: Adam
+  optimizer:
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    reduce_lr_on_plateau:
+      threshold: 1.0e-07
+      threshold_mode: rel
+      cooldown: 3
+      patience: 5
+      factor: 0.5
+      min_lr: 1.0e-08


### PR DESCRIPTION
This PR saves a configuration file in the chunks directory at the time of chunk creation. This helps to we can skip loading the full .slp file when we reuse the chunks and instead load parameters directly from the saved config—significantly speeding up initialization and reducing memory usage.

Related Issue: #171 