### PR TITLE
Add profiler and strategy parameters

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -164,6 +164,8 @@ The config file has three main sections:
         - `save_last`: (bool) When True, saves a last.ckpt whenever a checkpoint file gets saved. On a local filesystem, this will be a symbolic link, and otherwise a copy of the checkpoint file. This allows accessing the latest checkpoint in a deterministic manner. *Default*: `False`.
     - `trainer_devices`: (int) Number of devices to train on (int), which devices to train on (list or str), or "auto" to select automatically. *Default*: `"auto"`.
     - `trainer_accelerator`: (str) One of the ("cpu", "gpu", "tpu", "ipu", "auto"). "auto" recognises the machine the model is running on and chooses the appropriate accelerator for the `Trainer` to be connected to. *Default*: `"auto"`.
+    - `profiler`: (str) Profiler for pytorch Trainer. One of ["advanced", "passthrough", "pytorch", "simple"]. *Default*: `None`.
+    - `trainer_strategy`: (str) Training strategy, one of ["auto", "ddp", "fsdp", "ddp_find_unused_parameters_false", "ddp_find_unused_parameters_true", ...]. This supports any training strategy that is supported by `lightning.Trainer`. *Default*: `"auto"`.
     - `enable_progress_bar`: (bool) When True, enables printing the logs during training.
     *Default*: `False`.
     - `steps_per_epoch`: (int) Minimum number of iterations in a single epoch. (Useful if model is trained with very few data points). Refer `limit_train_batches` parameter of Torch `Trainer`. If `None`, the number of iterations depends on the number of samples in the train dataset.

--- a/docs/config_bottomup.yaml
+++ b/docs/config_bottomup.yaml
@@ -93,6 +93,8 @@ trainer_config:
     save_last: true
   trainer_devices: 1
   trainer_accelerator: cpu
+  profiler: "simple"
+  trainer_strategy: auto
   enable_progress_bar: false
   steps_per_epoch: null
   max_epochs: 50

--- a/initial_config.yaml
+++ b/initial_config.yaml
@@ -4,7 +4,7 @@ data_config:
   val_labels_path: /Users/divyasesh/Desktop/its_me/sleap-nn/tests/assets/minimal_instance.pkg.slp
   test_file_path: null
   user_instances_only: true
-  data_pipeline_fw: torch_dataset
+  data_pipeline_fw: torch
   np_chunks_path: null
   litdata_chunks_path: null
   use_existing_chunks: false
@@ -115,4 +115,3 @@ trainer_config:
       patience: 5
       factor: 0.5
       min_lr: 1.0e-08
-  profiler: simple_torch

--- a/initial_config.yaml
+++ b/initial_config.yaml
@@ -12,9 +12,9 @@ data_config:
   chunk_size: 100
   preprocessing:
     is_rgb: false
-    max_width: null
-    max_height: null
-    scale: null
+    max_width: 384
+    max_height: 384
+    scale: 1.0
     crop_hw:
     - 160
     - 160
@@ -29,6 +29,17 @@ data_config:
       translate_width: 0
       translate_height: 0
       affine_p: 0.5
+  skeletons:
+    Skeleton-0:
+      nodes:
+      - name: A
+      - name: B
+      edges:
+      - source:
+          name: A
+        destination:
+          name: B
+      symmetries: null
 model_config:
   init_weights: default
   pre_trained_weights: null
@@ -104,3 +115,4 @@ trainer_config:
       patience: 5
       factor: 0.5
       min_lr: 1.0e-08
+  profiler: simple_torch

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -168,6 +168,8 @@ class TrainerConfig:
         model_ckpt: (Note: Any parameters from Lightning's ModelCheckpoint could be used.)
         trainer_devices: (int) Number of devices to train on (int), which devices to train on (list or str), or "auto" to select automatically.
         trainer_accelerator: (str) One of the ("cpu", "gpu", "tpu", "ipu", "auto"). "auto" recognises the machine the model is running on and chooses the appropriate accelerator for the Trainer to be connected to.
+        profiler: (str) Profiler for pytorch Trainer. One of ["advanced", "passthrough", "pytorch", "simple"].
+        trainer_strategy: (str) Training strategy, one of ["auto", "ddp", "fsdp", "ddp_find_unused_parameters_false", "ddp_find_unused_parameters_true", ...]. This supports any training strategy that is supported by `lightning.Trainer`.
         enable_progress_bar: (bool) When True, enables printing the logs during training.
         steps_per_epoch: (int) Minimum number of iterations in a single epoch. (Useful if model is trained with very few data points). Refer limit_train_batches parameter of Torch Trainer. If None, the number of iterations depends on the number of samples in the train dataset.
         max_epochs: (int) Maxinum number of epochs to run.
@@ -191,6 +193,8 @@ class TrainerConfig:
         validator=lambda inst, attr, val: TrainerConfig.validate_trainer_devices(val),
     )
     trainer_accelerator: str = "auto"
+    profiler: Optional[str] = None
+    trainer_strategy: str = "auto"
     enable_progress_bar: bool = True
     steps_per_epoch: Optional[int] = None
     max_epochs: int = 10

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -1,10 +1,6 @@
 """This module is to train a sleap-nn model using Lightning."""
 
 from pathlib import Path
-import numpy as np
-from typing import Optional, List
-import time
-from torch import nn
 import os
 import psutil
 import shutil
@@ -17,6 +13,13 @@ import litdata as ld
 import wandb
 from lightning.pytorch.loggers import WandbLogger, CSVLogger
 from lightning.pytorch.callbacks import ModelCheckpoint, EarlyStopping
+from lightning.pytorch.profilers import (
+    SimpleProfiler,
+    AdvancedProfiler,
+    XLAProfiler,
+    PyTorchProfiler,
+    PassThroughProfiler,
+)
 from torchvision.models.swin_transformer import (
     Swin_T_Weights,
     Swin_S_Weights,
@@ -93,12 +96,9 @@ class ModelTrainer:
         self.config = config
         self.data_pipeline_fw = self.config.data_config.data_pipeline_fw
         self.use_existing_chunks = self.config.data_config.use_existing_chunks
-        self.user_instances_only = (
-            self.config.data_config.user_instances_only
-            if "user_instances_only" in self.config.data_config
-            and self.config.data_config.user_instances_only is not None
-            else True
-        )  # TODO: defaults should be handles in config validation.
+        self.user_instances_only = OmegaConf.select(
+            self.config, "data_config.user_instances_only", default=True
+        )
 
         # Get ckpt dir path
         self.dir_path = self.config.trainer_config.save_ckpt_path
@@ -805,6 +805,27 @@ class ModelTrainer:
             logger.error(message)
             raise ValueError(message)
 
+        profilers = {
+            "advanced": AdvancedProfiler(),
+            "passthrough": PassThroughProfiler(),
+            "pytorch": PyTorchProfiler(),
+            "simple": SimpleProfiler(),
+        }
+        cfg_profiler = OmegaConf.select(
+            self.config, "trainer_config.profiler", default=None
+        )
+        if cfg_profiler is not None:
+            if cfg_profiler in profilers:
+                profiler = profilers[cfg_profiler] if cfg_profiler is not None else None
+            else:
+                message = f"{cfg_profiler} is not a valid option. Please choose one of {list(profilers.keys())}"
+                logger.error(message)
+                raise ValueError(message)
+
+        strategy = OmegaConf.select(
+            self.config, "trainer_config.trainer_strategy", default="auto"
+        )
+
         self.trainer = L.Trainer(
             callbacks=callbacks,
             logger=training_loggers,
@@ -814,12 +835,8 @@ class ModelTrainer:
             accelerator=self.config.trainer_config.trainer_accelerator,
             enable_progress_bar=self.config.trainer_config.enable_progress_bar,
             limit_train_batches=self.steps_per_epoch,
-            strategy=(
-                "ddp_find_unused_parameters_false"
-                if isinstance(self.config.trainer_config.trainer_devices, int)
-                and self.config.trainer_config.trainer_devices > 1
-                else "auto"
-            ),
+            strategy=strategy,
+            profiler=profiler,
         )
 
         try:

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -814,6 +814,7 @@ class ModelTrainer:
         cfg_profiler = OmegaConf.select(
             self.config, "trainer_config.profiler", default=None
         )
+        profiler = None
         if cfg_profiler is not None:
             if cfg_profiler in profilers:
                 profiler = profilers[cfg_profiler] if cfg_profiler is not None else None

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -817,7 +817,7 @@ class ModelTrainer:
         profiler = None
         if cfg_profiler is not None:
             if cfg_profiler in profilers:
-                profiler = profilers[cfg_profiler] if cfg_profiler is not None else None
+                profiler = profilers[cfg_profiler]
             else:
                 message = f"{cfg_profiler} is not a valid option. Please choose one of {list(profilers.keys())}"
                 logger.error(message)

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -353,7 +353,17 @@ def test_trainer_torch_dataset(caplog, config, tmp_path: str):
     model_trainer = ModelTrainer(config)
     assert model_trainer.dir_path == "."
 
+    ### invalid profiler
+    OmegaConf.update(config, "trainer_config.profiler", "simple_torch")
+    with pytest.raises(ValueError):
+        model_trainer = ModelTrainer(
+            config,
+        )
+        model_trainer.train()
+    assert f"simple_torch is not a valid option" in caplog.text
+
     ##### test for reusing np chunks path
+    OmegaConf.update(config, "trainer_config.profiler", "simple")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset_np_chunks")
     OmegaConf.update(config, "data_config.np_chunks_path", tmp_path)
     OmegaConf.update(config, "data_config.use_existing_chunks", True)
@@ -795,6 +805,7 @@ def test_reuse_npz_files(config, tmp_path: str):
     OmegaConf.update(centroid_config, "trainer_config.save_ckpt", True)
     OmegaConf.update(centroid_config, "trainer_config.use_wandb", False)
     OmegaConf.update(centroid_config, "trainer_config.max_epochs", 1)
+    OmegaConf.update(centroid_config, "trainer_config.profiler", "simple")
     OmegaConf.update(centroid_config, "trainer_config.steps_per_epoch", 10)
     OmegaConf.update(centroid_config, "data_config.delete_chunks_after_training", False)
     OmegaConf.update(

--- a/training_config.yaml
+++ b/training_config.yaml
@@ -4,7 +4,7 @@ data_config:
   val_labels_path: /Users/divyasesh/Desktop/its_me/sleap-nn/tests/assets/minimal_instance.pkg.slp
   test_file_path: null
   user_instances_only: true
-  data_pipeline_fw: torch_dataset
+  data_pipeline_fw: torch
   np_chunks_path: null
   litdata_chunks_path: null
   use_existing_chunks: false
@@ -116,4 +116,3 @@ trainer_config:
       patience: 5
       factor: 0.5
       min_lr: 1.0e-08
-  profiler: simple_torch

--- a/training_config.yaml
+++ b/training_config.yaml
@@ -70,6 +70,7 @@ model_config:
         anchor_part: 1
         sigma: 1.5
         output_stride: 2
+  total_params: 131376
 trainer_config:
   train_data_loader:
     batch_size: 1
@@ -115,3 +116,4 @@ trainer_config:
       patience: 5
       factor: 0.5
       min_lr: 1.0e-08
+  profiler: simple_torch


### PR DESCRIPTION
This PR adds two new parameters to the `trainer_config`: `profiler` and `strategy` where `profiler` is used to specify different profilers for `lightning.Trainer`, and `strategy` specifies the training strategy to be used.