### PR TITLE
Fix caching when imgs path already exist

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -111,10 +111,11 @@ class BaseDataset(Dataset):
         self.cache = {}
 
         if self.cache_img is not None:
-            if self.rank is None or self.rank == 0:
-                self._fill_cache()
-            if is_distributed_initialized():
-                dist.barrier()
+            if self.cache_img == "memory" or not self.use_existing_imgs:
+                if self.rank is None or self.rank == 0:
+                    self._fill_cache()
+                if is_distributed_initialized():
+                    dist.barrier()
 
     def _get_lf_idx_list(self) -> List[Tuple[int]]:
         """Return list of indices of labelled frames."""


### PR DESCRIPTION
Currently, the `_fill_cache()` method is called even when `use_existing_imgs` is True. This is fixed in this PR by running the fill cache method only when the caching method is `memory` or when `use_existing_imgs` is False.