### PR TITLE
Ensure caching of images to disk in rank:0

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -111,7 +111,9 @@ class BaseDataset(Dataset):
         self.cache = {}
 
         if self.cache_img is not None:
-            if self.cache_img == "memory" or not self.use_existing_imgs:
+            if self.cache_img == "memory":
+                self._fill_cache()
+            elif self.cache_img == "disk":
                 if self.rank is None or self.rank == 0:
                     self._fill_cache()
                 if is_distributed_initialized():
@@ -415,6 +417,7 @@ class CenteredInstanceDataset(BaseDataset):
             cache_img=cache_img,
             cache_img_path=cache_img_path,
             use_existing_imgs=use_existing_imgs,
+            rank=rank,
         )
         self.crop_hw = crop_hw
         self.confmap_head_config = confmap_head_config
@@ -648,6 +651,7 @@ class CentroidDataset(BaseDataset):
             cache_img=cache_img,
             cache_img_path=cache_img_path,
             use_existing_imgs=use_existing_imgs,
+            rank=rank,
         )
         self.confmap_head_config = confmap_head_config
 
@@ -810,6 +814,7 @@ class SingleInstanceDataset(BaseDataset):
             cache_img=cache_img,
             cache_img_path=cache_img_path,
             use_existing_imgs=use_existing_imgs,
+            rank=rank,
         )
         self.confmap_head_config = confmap_head_config
 

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -338,6 +338,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.train_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
             self.val_dataset = BottomUpDataset(
                 labels=self.val_labels,
@@ -353,6 +354,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.val_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
 
         elif self.model_type == "centered_instance":
@@ -370,6 +372,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.train_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
             self.val_dataset = CenteredInstanceDataset(
                 labels=self.val_labels,
@@ -385,6 +388,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.val_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
 
         elif self.model_type == "centroid":
@@ -401,6 +405,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.train_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
             self.val_dataset = CentroidDataset(
                 labels=self.val_labels,
@@ -415,6 +420,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.val_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
 
         elif self.model_type == "single_instance":
@@ -431,6 +437,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.train_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
             self.val_dataset = SingleInstanceDataset(
                 labels=self.val_labels,
@@ -445,6 +452,7 @@ class ModelTrainer:
                 cache_img=self.cache_img,
                 cache_img_path=self.val_cache_img_path,
                 use_existing_imgs=self.use_existing_imgs,
+                rank=self.trainer.global_rank if self.trainer is not None else None,
             )
 
         else:


### PR DESCRIPTION
This PR fixes a bug with the dataset pipeline, where caching to disk si repeated across the different processes created in different GPUs in a multi-gpu training setup. Here, we ensure that _fill_cache() method is called only when rank is 0 or None (when trainer hasn't been initialized yet).