### PR TITLE
Fix bug in caching images to disk

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -113,7 +113,7 @@ class BaseDataset(Dataset):
         if self.cache_img is not None:
             if self.cache_img == "memory":
                 self._fill_cache()
-            elif self.cache_img == "disk":
+            elif self.cache_img == "disk" and not self.use_existing_imgs:
                 if self.rank is None or self.rank == 0:
                     self._fill_cache()
                 if is_distributed_initialized():


### PR DESCRIPTION
This PR fixes a bug in caching images to disk when we set `use_existing_imgs` to `True`.