### PR TITLE
Close videos before creating data loaders

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - python=3.9
   - pytorch-cuda=11.8
   - numpy
-  - sleap-io
+  - sleap-io>=0.2.0
   - pydantic
   - lightning
   - cudnn

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python=3.9
   - numpy
-  - sleap-io
+  - sleap-io>=0.2.0
   - pytorch
   - pydantic
   - lightning

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python=3.9
   - numpy
-  - sleap-io
+  - sleap-io>=0.2.0
   - pydantic
   - lightning
   - pytorch

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -160,6 +160,10 @@ class BaseDataset(Dataset):
             if self.cache_img == "memory":
                 self.cache[lf_idx] = img
 
+        for video in self.labels.videos:
+            if video.is_open:
+                video.close()
+
     def _get_video_idx(self, lf):
         """Return indsample of `lf.video` in `labels.videos`."""
         return self.labels.videos.index(lf.video)

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -160,9 +160,6 @@ class BaseDataset(Dataset):
             if self.cache_img == "memory":
                 self.cache[lf_idx] = img
 
-        for video in self.labels.videos:
-            video.close()
-
     def _get_video_idx(self, lf):
         """Return indsample of `lf.video` in `labels.videos`."""
         return self.labels.videos.index(lf.video)

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -477,11 +477,13 @@ class ModelTrainer:
 
         # If using caching, close the videos to prevent `h5py objects can't be pickled error` when num_workers > 0.
         if "cache_img" in self.data_pipeline_fw:
-            for video in self.train_labels:
-                video.close()
+            for video in self.train_labels.videos:
+                if video.is_open:
+                    video.close()
 
-            for video in self.val_labels:
-                video.close()
+            for video in self.val_labels.videos:
+                if video.is_open:
+                    video.close()
 
         # train
         self.train_data_loader = DataLoader(

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -475,6 +475,14 @@ class ModelTrainer:
             else True
         )
 
+        # If using caching, close the videos to prevent `h5py objects can't be pickled error` when num_workers > 0.
+        if "cache_img" in self.data_pipeline_fw:
+            for video in self.train_labels:
+                video.close()
+
+            for video in self.val_labels:
+                video.close()
+
         # train
         self.train_data_loader = DataLoader(
             dataset=self.train_dataset,


### PR DESCRIPTION
Previously, when num_workers > 0, the open video backends (e.g., HDF5 via h5py) caused multiprocessing to fail since h5py objects cannot be pickled. However, because we're using cached images (preloaded from the labels), the video backend is no longer needed during training. This PR explicitly closes these videos so that we can safely leverage multiprocessing for data loading without triggering serialization errors.