### PR TITLE
Add option to get validation data from train labels

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,6 +15,7 @@ The config file has three main sections:
     - `provider`: (str) Provider class to read the input sleap files. Only "LabelsReader" supported for the training pipeline.
     - `train_labels_path`: (str) Path to training data (`.slp` file)
     - `val_labels_path`: (str) Path to validation data (`.slp` file)
+    - `validation_fraction`: (float) Float between 0 and 1 specifying the fraction of the training set to sample for generating the validation set. The remaining labeled frames will be left in the training set. If the `validation_labels` are already specified, this has no effect. Default: 0.1.
     - `test_file_path`: (str) Path to test dataset (`.slp` file or `.mp4` file). *Note*: This is used only with CLI to get evaluation on test set after training is completed. 
     - `user_instances_only`: (bool) `True` if only user labeled instances should be used for training. If `False`, both user labeled and predicted instances would be used. *Default*: `True`.
     - `data_pipeline_fw`: (str) Framework to create the data loaders. One of [`litdata`, `torch_dataset`, `torch_dataset_cache_img_memory`, `torch_dataset_cache_img_disk`].

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -142,6 +142,10 @@ class DataConfig:
 
     train_labels_path: (str) Path to training data (.slp file)
     val_labels_path: (str) Path to validation data (.slp file)
+    validation_fraction: Float between 0 and 1 specifying the fraction of the
+        training set to sample for generating the validation set. The remaining
+        labeled frames will be left in the training set. If the `validation_labels`
+        are already specified, this has no effect. Default: 0.1.
     test_file_path: (str) Path to test dataset (`.slp` file or `.mp4` file). *Note*: This is used only
         with CLI to get evaluation on test set after training is completed.
     provider: (str) Provider class to read the input sleap files. Only "LabelsReader"
@@ -172,6 +176,7 @@ class DataConfig:
 
     train_labels_path: Optional[str] = None
     val_labels_path: Optional[str] = None  # TODO : revisit MISSING!
+    validation_fraction: int = 0.1
     test_file_path: Optional[str] = None
     provider: str = "LabelsReader"
     user_instances_only: bool = True
@@ -205,6 +210,9 @@ def data_mapper(legacy_config: dict) -> DataConfig:
         ),
         val_labels_path=legacy_config_data.get("labels", {}).get(
             "validation_labels", None
+        ),
+        validation_fraction=legacy_config_data.get("labels", {}).get(
+            "validation_fraction", None
         ),
         test_file_path=legacy_config_data.get("labels", {}).get("test_labels", None),
         preprocessing=PreprocessingConfig(

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -176,7 +176,7 @@ class DataConfig:
 
     train_labels_path: Optional[str] = None
     val_labels_path: Optional[str] = None  # TODO : revisit MISSING!
-    validation_fraction: int = 0.1
+    validation_fraction: float = 0.1
     test_file_path: Optional[str] = None
     provider: str = "LabelsReader"
     user_instances_only: bool = True

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -213,7 +213,7 @@ def get_head_configs(head_cfg):
 def get_data_config(
     train_labels_path: str,
     val_labels_path: str,
-    validation_fraction: int = 0.1,
+    validation_fraction: float = 0.1,
     test_file_path: Optional[str] = None,
     provider: str = "LabelsReader",
     user_instances_only: bool = True,
@@ -606,7 +606,7 @@ def run_training(config: DictConfig):
             provider="LabelsReader",
             peak_threshold=0.2,
             make_labels=True,
-            save_path=Path(trainer.dir_path) / f"preds_{dataset}.slp",
+            save_path=Path(trainer.dir_path) / f"pred_{dataset}.slp",
         )
 
         evaluator = Evaluator(
@@ -663,7 +663,7 @@ def run_training(config: DictConfig):
 def train(
     train_labels_path: str,
     val_labels_path: str,
-    validation_fraction: int = 0.1,
+    validation_fraction: float = 0.1,
     test_file_path: Optional[str] = None,
     provider: str = "LabelsReader",
     user_instances_only: bool = True,

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -51,6 +51,7 @@ def config(sleap_data_dir):
                 "provider": "LabelsReader",
                 "train_labels_path": f"{sleap_data_dir}/minimal_instance.pkg.slp",
                 "val_labels_path": f"{sleap_data_dir}/minimal_instance.pkg.slp",
+                "validation_fraction": 0.1,
                 "test_file_path": None,
                 "user_instances_only": True,
                 "data_pipeline_fw": "torch_dataset",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -160,6 +160,27 @@ def test_train_method(minimal_instance, tmp_path: str):
     assert (Path(tmp_path) / "test_train_method").joinpath("pred_val.slp").exists()
     assert (Path(tmp_path) / "test_train_method").joinpath("pred_test.slp").exists()
 
+    # with no val labels path
+    train(
+        train_labels_path=minimal_instance,
+        val_labels_path=None,
+        validation_fraction=0.1,
+        test_file_path=minimal_instance,
+        max_epochs=1,
+        trainer_accelerator="cpu",
+        head_configs="centered_instance",
+        save_ckpt=True,
+        save_ckpt_path=(Path(tmp_path) / "test_train_method").as_posix(),
+    )
+    folder_created = (Path(tmp_path) / "test_train_method").exists()
+    assert folder_created
+    assert (
+        (Path(tmp_path) / "test_train_method").joinpath("training_config.yaml").exists()
+    )
+    assert (Path(tmp_path) / "test_train_method").joinpath("best.ckpt").exists()
+    assert (Path(tmp_path) / "test_train_method").joinpath("pred_train.slp").exists()
+    assert (Path(tmp_path) / "test_train_method").joinpath("pred_test.slp").exists()
+
     # convnext
     train(
         train_labels_path=minimal_instance,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -84,7 +84,7 @@ def sample_cfg(minimal_instance, tmp_path):
                 "train_data_loader": {
                     "batch_size": 1,
                     "shuffle": True,
-                    "num_workers": 2,
+                    "num_workers": 0,
                 },
                 "val_data_loader": {
                     "batch_size": 1,

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -16,6 +16,7 @@ from sleap_nn.training.lightning_modules import (
     CentroidLightningModule,
     BottomUpLightningModule,
 )
+import sleap_io as sio
 from torch.nn.functional import mse_loss
 import os
 import wandb
@@ -36,6 +37,22 @@ def caplog(caplog: LogCaptureFixture):
     )
     yield caplog
     logger.remove(handler_id)
+
+
+def test_cfg_without_val_labels_path(config, tmp_path, minimal_instance):
+    """Test Model Trainer if no val labels path is provided."""
+    labels = sio.load_slp(minimal_instance)
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_vals_fraction/"
+    )
+    config.data_config.val_labels_path = None
+    trainer = ModelTrainer(config)
+    assert np.all(trainer.train_labels[0].instances[0].numpy()) == np.all(
+        labels[0].instances[0].numpy()
+    )
+    assert np.all(trainer.val_labels[0].instances[0].numpy()) == np.all(
+        labels[0].instances[0].numpy()
+    )
 
 
 def test_create_data_loader_torch_dataset(caplog, config, tmp_path):


### PR DESCRIPTION
This PR adds an option to generate the validation data from train labels if `data_config.val_labels_path` is `None`. The user can specify the fraction of training set to be considered for val dataset in `data_config.validation_fraction`.