### PR TITLE
Save labels with centroid inference

### DIFF
--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -127,8 +127,8 @@ def test_topdown_predictor(
     )
     assert len(pred_labels) == 1
     assert (
-        pred_labels[0]["centroids"].shape[-2] <= max_instances
-    )  # centroids (1,1,max_instances,2)
+        pred_labels[0]["centroid"].shape[-2] <= max_instances
+    )  # centroids (1,max_instances,2)
 
     # Provider = VideoReader
     # centroid + centered-instance model inference

--- a/tests/inference/test_topdown.py
+++ b/tests/inference/test_topdown.py
@@ -200,7 +200,7 @@ def test_find_instance_peaks_groundtruth(
     output = topdown_inf_layer(ex)[0]
 
     assert "pred_instance_peaks" in output.keys()
-    assert output["pred_instance_peaks"].shape == (1, 2, 2, 2)
+    assert output["pred_instance_peaks"].shape == (2, 2, 2)
     assert output["pred_peak_values"].shape == (2, 2)
 
 


### PR DESCRIPTION
This PR fixes label saving during centroid inference when using ground-truth labels. The `FindInstancePeaksGroundtruth` class returns ground-truth instances based on predicted centroids, but there were bugs preventing these predictions from being saved to .slp files. This PR resolves those issues and ensures predictions can now be correctly saved.