### PR TITLE
Add option to parse frame ranges for videos

### DIFF
--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -219,8 +219,7 @@ class Predictor(ABC):
         provider: str,
         data_path: str,
         queue_maxsize: int = 8,
-        video_start_idx=None,
-        video_end_idx=None,
+        frames: Optional[list] = None,
     ):
         """Create the data pipeline."""
 
@@ -729,8 +728,7 @@ class TopDownPredictor(Predictor):
         provider: str,
         data_path: str,
         queue_maxsize: int = 8,
-        video_start_idx=None,
-        video_end_idx=None,
+        frames: Optional[list] = None,
     ):
         """Make a data loading pipeline.
 
@@ -739,8 +737,7 @@ class TopDownPredictor(Predictor):
                 Either "LabelsReader" or "VideoReader".
             data_path: (str) Path to `.slp` file or `.mp4` to run inference on.
             queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
-            video_start_idx: (int) Start index of the frames to read. Default: None.
-            video_end_idx: (int) End index of the frames to read. Default: None.
+            frames: (list) List of frames indices. If `None`, all frames in the video are used. Default: None.
 
         Returns:
             This method initiates the reader class (doesn't return a pipeline) and the
@@ -825,10 +822,7 @@ class TopDownPredictor(Predictor):
             }
 
             self.pipeline = provider.from_filename(
-                filename=data_path,
-                queue_maxsize=queue_maxsize,
-                start_idx=video_start_idx,
-                end_idx=video_end_idx,
+                filename=data_path, queue_maxsize=queue_maxsize, frames=frames
             )
             self.videos = [self.pipeline.video]
 
@@ -1091,8 +1085,7 @@ class SingleInstancePredictor(Predictor):
         provider: str,
         data_path: str,
         queue_maxsize: int = 8,
-        video_start_idx=None,
-        video_end_idx=None,
+        frames: Optional[list] = None,
     ):
         """Make a data loading pipeline.
 
@@ -1101,8 +1094,7 @@ class SingleInstancePredictor(Predictor):
                 Either "LabelsReader" or "VideoReader".
             data_path: (str) Path to `.slp` file or `.mp4` to run inference on.
             queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
-            video_start_idx: (int) Start index of the frames to read. Default: None.
-            video_end_idx: (int) End index of the frames to read. Default: None.
+            frames: List of frames indices. If `None`, all frames in the video are used. Default: None.
 
         Returns:
             This method initiates the reader class (doesn't return a pipeline) and the
@@ -1168,10 +1160,7 @@ class SingleInstancePredictor(Predictor):
             }
 
             self.pipeline = provider.from_filename(
-                filename=data_path,
-                queue_maxsize=queue_maxsize,
-                start_idx=video_start_idx,
-                end_idx=video_end_idx,
+                filename=data_path, queue_maxsize=queue_maxsize, frames=frames
             )
 
             self.videos = [self.pipeline.video]
@@ -1466,8 +1455,7 @@ class BottomUpPredictor(Predictor):
         provider: str,
         data_path: str,
         queue_maxsize: int = 8,
-        video_start_idx=None,
-        video_end_idx=None,
+        frames: Optional[list] = None,
     ):
         """Make a data loading pipeline.
 
@@ -1476,8 +1464,7 @@ class BottomUpPredictor(Predictor):
                 Either "LabelsReader" or "VideoReader".
             data_path: (str) Path to `.slp` file or `.mp4` to run inference on.
             queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
-            video_start_idx: (int) Start index of the frames to read. Default: None.
-            video_end_idx: (int) End index of the frames to read. Default: None.
+            frames: List of frames indices. If `None`, all frames in the video are used. Default: None.
 
         Returns:
             This method initiates the reader class (doesn't return a pipeline) and the
@@ -1541,10 +1528,7 @@ class BottomUpPredictor(Predictor):
             }
 
             self.pipeline = provider.from_filename(
-                filename=data_path,
-                queue_maxsize=queue_maxsize,
-                start_idx=video_start_idx,
-                end_idx=video_end_idx,
+                filename=data_path, queue_maxsize=queue_maxsize, frames=frames
             )
 
             self.videos = [self.pipeline.video]
@@ -1658,8 +1642,7 @@ def run_inference(
     provider: Optional[str] = None,
     batch_size: int = 4,
     queue_maxsize: int = 8,
-    videoreader_start_idx: Optional[int] = None,
-    videoreader_end_idx: Optional[int] = None,
+    frames: Optional[list] = None,
     crop_size: Optional[int] = None,
     peak_threshold: Union[float, List[float]] = 0.2,
     ##
@@ -1718,8 +1701,7 @@ def run_inference(
                 Either "LabelsReader" or "VideoReader". Default: None.
         batch_size: (int) Number of samples per batch. Default: 4.
         queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
-        videoreader_start_idx: (int) Start index of the frames to read. Default: None.
-        videoreader_end_idx: (int) End index of the frames to read. Default: None.
+        frames: (list) List of frames indices. If `None`, all frames in the video are used. Default: None.
         crop_size: (int) Crop size. If not provided, the crop size from training_config.yaml is used.
                 Default: None.
         peak_threshold: (float) Minimum confidence threshold. Peaks with values below
@@ -1819,8 +1801,7 @@ def run_inference(
 
     if provider == "VideoReader":
         preprocess_config["video_queue_maxsize"] = queue_maxsize
-        preprocess_config["videoreader_start_idx"] = videoreader_start_idx
-        preprocess_config["videoreader_end_idx"] = videoreader_end_idx
+        preprocess_config["frames"] = frames
 
     # initializes the inference model
     predictor = Predictor.from_model_paths(
@@ -1869,9 +1850,7 @@ def run_inference(
 
     # initialize make_pipeline function
 
-    predictor.make_pipeline(
-        provider, data_path, queue_maxsize, videoreader_start_idx, videoreader_end_idx
-    )
+    predictor.make_pipeline(provider, data_path, queue_maxsize, frames)
 
     # run predict
     output = predictor.predict(

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -1,7 +1,7 @@
 """Entry point for running inference."""
 
 import argparse
-from typing import Optional
+from typing import Optional, List
 from loguru import logger
 from sleap_nn.inference.predictors import run_inference
 
@@ -124,16 +124,15 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         help=("Maximum size of the frame buffer queue."),
     )
     parser.add_argument(
-        "--videoreader_start_idx",
-        type=int,
-        default=None,
-        help=("Start index of the frames to read."),
-    )
-    parser.add_argument(
-        "--videoreader_end_idx",
-        type=int,
-        default=None,
-        help=("End index of the frames to read."),
+        "--frames",
+        type=str,
+        default="",
+        help=(
+            "List of frames to predict when running on a video. Can be specified as a "
+            "comma separated list (e.g. 1,2,3) or a range separated by hyphen (e.g., "
+            "1-3, for 1,2,3). If not provided, defaults to predicting on the entire "
+            "video."
+        ),
     )
     parser.add_argument(
         "--crop_size",
@@ -282,6 +281,26 @@ def _make_cli_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def frame_list(frame_str: str) -> Optional[List[int]]:
+    """Converts 'n-m' string to list of ints.
+
+    Args:
+        frame_str: string representing range
+
+    Returns:
+        List of ints, or None if string does not represent valid range.
+    """
+
+    # Handle ranges of frames. Must be of the form "1-200" (or "1,-200")
+    if "-" in frame_str:
+        min_max = frame_str.split("-")
+        min_frame = int(min_max[0].rstrip(","))
+        max_frame = int(min_max[1])
+        return list(range(min_frame, max_frame + 1))
+
+    return [int(x) for x in frame_str.split(",")] if len(frame_str) else None
+
+
 def main(args: Optional[list] = None):
     """Entrypoint for sleap-nn CLI for running inference.
 
@@ -294,6 +313,9 @@ def main(args: Optional[list] = None):
     args, _ = parser.parse_known_args(args)
     logger.info("Args:")
     logger.info(vars(args))
+
+    if args.frames:
+        args.frames = frame_list(args.frames)
 
     _ = run_inference(**vars(args))
 

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -290,7 +290,6 @@ def frame_list(frame_str: str) -> Optional[List[int]]:
     Returns:
         List of ints, or None if string does not represent valid range.
     """
-
     # Handle ranges of frames. Must be of the form "1-200" (or "1,-200")
     if "-" in frame_str:
         min_max = frame_str.split("-")

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -354,7 +354,10 @@ class Tracker:
                     scoring_method(f, x.feature)
                     for x in candidates_feature_dict[track_id]
                 ]
-                oks = scoring_reduction(oks)  # scoring reduction
+                if len(oks):
+                    oks = scoring_reduction(oks)  # scoring reduction
+                else:
+                    oks = 0.0
                 scores[f_idx][track_id] = oks
 
         return scores

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -39,7 +39,8 @@ def get_keypoints(pred_instance: Union[sio.PredictedInstance, np.ndarray]):
     """Return keypoints as np.array from the `PredictedInstance` object."""
     if isinstance(pred_instance, np.ndarray):
         return pred_instance
-    return pred_instance.numpy()
+    pred_inst = np.nan_to_num(pred_instance.numpy(), nan=0.0, posinf=0.0, neginf=0.0)
+    return pred_inst
 
 
 def get_centroid(pred_instance: Union[sio.PredictedInstance, np.ndarray]):

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -33,7 +33,7 @@ def test_videoreader_provider(centered_instance_video):
     """Test VideoReader class."""
     video = sio.load_video(centered_instance_video)
     queue = Queue(maxsize=4)
-    reader = VideoReader(video=video, frame_buffer=queue, start_idx=None, end_idx=4)
+    reader = VideoReader(video=video, frame_buffer=queue, frames=[0, 1, 2, 3])
     assert reader.max_height_and_width == (384, 384)
     reader.start()
     batch_size = 4
@@ -56,8 +56,7 @@ def test_videoreader_provider(centered_instance_video):
     reader = VideoReader.from_filename(
         filename=centered_instance_video,
         queue_maxsize=4,
-        start_idx=1099,
-        end_idx=1104,
+        frames=[1099, 1100, 1101, 1102, 1103],
     )
     reader.start()
     batch_size = 4
@@ -74,27 +73,6 @@ def test_videoreader_provider(centered_instance_video):
         raise
     finally:
         reader.join()
-
-    # end not specified
-    queue = Queue(maxsize=4)
-    reader = VideoReader(video=video, frame_buffer=queue, start_idx=1094, end_idx=None)
-    assert reader.max_height_and_width == (384, 384)
-    reader.start()
-    batch_size = 4
-    try:
-        data = []
-        for i in range(batch_size):
-            frame = reader.frame_buffer.get()
-            if frame["image"] is None:
-                break
-            data.append(frame)
-        assert len(data) == batch_size
-        assert data[0]["image"].shape == (1, 1, 384, 384)
-    except:
-        raise
-    finally:
-        reader.join()
-    assert reader.total_len() == 6
 
 
 def test_labelsreader_provider(minimal_instance):

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -140,8 +140,7 @@ def test_topdown_predictor(
         max_instances=6,
         peak_threshold=[0.0, 0.0],
         integral_refinement="integral",
-        videoreader_start_idx=0,
-        videoreader_end_idx=100,
+        frames=[x for x in range(100)],
     )
 
     assert isinstance(pred_labels, sio.Labels)
@@ -169,8 +168,7 @@ def test_topdown_predictor(
         provider="VideoReader",
         make_labels=True,
         max_instances=6,
-        videoreader_start_idx=1100,
-        videoreader_end_idx=1103,
+        frames=[1100, 1101, 1102, 1103],
         peak_threshold=0.1,
     )
 
@@ -186,8 +184,7 @@ def test_topdown_predictor(
             provider="VideoReader",
             make_labels=True,
             max_instances=6,
-            videoreader_start_idx=0,
-            videoreader_end_idx=100,
+            frames=[x for x in range(100)],
             peak_threshold=0.1,
         )
     assert "Error when reading video frame." in caplog.text
@@ -200,8 +197,7 @@ def test_topdown_predictor(
         make_labels=True,
         max_instances=2,
         peak_threshold=0.1,
-        videoreader_start_idx=0,
-        videoreader_end_idx=20,
+        frames=[x for x in range(20)],
         tracking=True,
     )
 
@@ -774,7 +770,7 @@ def test_single_instance_predictor(
             provider="VideoReader",
             make_labels=False,
             peak_threshold=0.3,
-            videoreader_end_idx=100,
+            frames=[x for x in range(100)],
         )
         assert isinstance(preds, list)
         assert len(preds) == 25
@@ -987,8 +983,7 @@ def test_bottomup_predictor(
         make_labels=True,
         max_instances=6,
         peak_threshold=0.03,
-        videoreader_start_idx=0,
-        videoreader_end_idx=100,
+        frames=[x for x in range(100)],
     )
 
     assert isinstance(pred_labels, sio.Labels)
@@ -1003,8 +998,7 @@ def test_bottomup_predictor(
         make_labels=False,
         max_instances=6,
         peak_threshold=0.03,
-        videoreader_start_idx=0,
-        videoreader_end_idx=100,
+        frames=[x for x in range(100)],
     )
     assert isinstance(preds, list)
     assert len(preds) == 25

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -4,7 +4,10 @@ from sleap_nn.predict import main
 
 
 def test_predict_main(
-    minimal_instance, minimal_instance_ckpt, minimal_instance_centroid_ckpt, tmp_path
+    minimal_instance,
+    minimal_instance_ckpt,
+    minimal_instance_centroid_ckpt,
+    tmp_path,
 ):
     # test for centered instance + saving slp file
     main(
@@ -15,8 +18,6 @@ def test_predict_main(
             f"{minimal_instance_ckpt}",
             "-o",
             f"{tmp_path}/minimal_inst_preds.slp",
-            "--frames",
-            "0-5",
         ]
     )
     assert (Path(tmp_path) / "minimal_inst_preds.slp").exists()
@@ -47,3 +48,49 @@ def test_predict_main(
     pred = sio.load_slp((Path(tmp_path) / "minimal_inst_topdown_preds.slp").as_posix())
 
     assert len(gt) == len(pred)
+
+    # test with video
+    main(
+        [
+            "--data_path",
+            "./tests/assets/centered_pair_small.mp4",
+            "--model_paths",
+            f"{minimal_instance_centroid_ckpt}",
+            "--model_paths",
+            f"{minimal_instance_ckpt}",
+            "-o",
+            f"{tmp_path}/minimal_inst_preds.slp",
+            "--frames",
+            "0-5",
+            "--peak_threshold",
+            f"{0.0}",
+        ]
+    )
+    assert (Path(tmp_path) / "minimal_inst_preds.slp").exists()
+
+    pred = sio.load_slp((Path(tmp_path) / "minimal_inst_preds.slp").as_posix())
+
+    assert len(pred) == 6
+
+    # test with video
+    main(
+        [
+            "--data_path",
+            "./tests/assets/centered_pair_small.mp4",
+            "--model_paths",
+            f"{minimal_instance_centroid_ckpt}",
+            "--model_paths",
+            f"{minimal_instance_ckpt}",
+            "-o",
+            f"{tmp_path}/minimal_inst_preds.slp",
+            "--frames",
+            "0,1,2",
+            "--peak_threshold",
+            f"{0.0}",
+        ]
+    )
+    assert (Path(tmp_path) / "minimal_inst_preds.slp").exists()
+
+    pred = sio.load_slp((Path(tmp_path) / "minimal_inst_preds.slp").as_posix())
+
+    assert len(pred) == 3

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -15,6 +15,8 @@ def test_predict_main(
             f"{minimal_instance_ckpt}",
             "-o",
             f"{tmp_path}/minimal_inst_preds.slp",
+            "--frames",
+            "0-5",
         ]
     )
     assert (Path(tmp_path) / "minimal_inst_preds.slp").exists()


### PR DESCRIPTION
This PR adds option to accept a frame range, e.g., `--frames 10-100` in the CLI. This replaces the current `--videoreader_start_idx` and `--videoreader_end_idx` parameters, aligning with the frame range notation used in the SLEAP GUI. The frame range is converted to a list before passing to `sleap_nn.inference.predictors.run_inference()`.