### PR TITLE
Add control flags to run inference on select LabeledFrames

### DIFF
--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -331,10 +331,11 @@ class LabelsReader(Thread):
                     lf.instances = lf.user_instances
                     self.filtered_lfs.append(lf)
 
-        # Filter to only suggested instances
+        # Filter to only unlabeled suggested instances
         elif self.only_suggested_frames:
             self.filtered_lfs = []
-            for lf in self.labels.suggestions:
+            for suggestion in self.labels.suggestions:
+                lf = self.labels.find(suggestion.video, suggestion.frame_idx)[0]
                 if lf is None or not lf.has_user_instances:
                     self.filtered_lfs.append(lf)
 

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -220,6 +220,8 @@ class Predictor(ABC):
         data_path: str,
         queue_maxsize: int = 8,
         frames: Optional[list] = None,
+        only_labeled_frames: bool = False,
+        only_suggested_frames: bool = False,
     ):
         """Create the data pipeline."""
 
@@ -729,6 +731,8 @@ class TopDownPredictor(Predictor):
         data_path: str,
         queue_maxsize: int = 8,
         frames: Optional[list] = None,
+        only_labeled_frames: bool = False,
+        only_suggested_frames: bool = False,
     ):
         """Make a data loading pipeline.
 
@@ -738,6 +742,8 @@ class TopDownPredictor(Predictor):
             data_path: (str) Path to `.slp` file or `.mp4` to run inference on.
             queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
             frames: (list) List of frames indices. If `None`, all frames in the video are used. Default: None.
+            only_labeled_frames: (bool) `True` if inference should be run only on user-labeled frames. Default: `False`.
+            only_suggested_frames: (bool) `True` if inference should be run only on unlabeled suggested frames. Default: `False`.
 
         Returns:
             This method initiates the reader class (doesn't return a pipeline) and the
@@ -785,6 +791,8 @@ class TopDownPredictor(Predictor):
                 filename=data_path,
                 queue_maxsize=queue_maxsize,
                 instances_key=self.instances_key,
+                only_labeled_frames=only_labeled_frames,
+                only_suggested_frames=only_suggested_frames,
             )
             self.videos = self.pipeline.labels.videos
 
@@ -1086,6 +1094,8 @@ class SingleInstancePredictor(Predictor):
         data_path: str,
         queue_maxsize: int = 8,
         frames: Optional[list] = None,
+        only_labeled_frames: bool = False,
+        only_suggested_frames: bool = False,
     ):
         """Make a data loading pipeline.
 
@@ -1095,6 +1105,8 @@ class SingleInstancePredictor(Predictor):
             data_path: (str) Path to `.slp` file or `.mp4` to run inference on.
             queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
             frames: List of frames indices. If `None`, all frames in the video are used. Default: None.
+            only_labeled_frames: (bool) `True` if inference should be run only on user-labeled frames. Default: `False`.
+            only_suggested_frames: (bool) `True` if inference should be run only on unlabeled suggested frames. Default: `False`.
 
         Returns:
             This method initiates the reader class (doesn't return a pipeline) and the
@@ -1132,6 +1144,8 @@ class SingleInstancePredictor(Predictor):
             self.pipeline = provider.from_filename(
                 filename=data_path,
                 queue_maxsize=queue_maxsize,
+                only_labeled_frames=only_labeled_frames,
+                only_suggested_frames=only_suggested_frames,
             )
             self.videos = self.pipeline.labels.videos
 
@@ -1456,6 +1470,8 @@ class BottomUpPredictor(Predictor):
         data_path: str,
         queue_maxsize: int = 8,
         frames: Optional[list] = None,
+        only_labeled_frames: bool = False,
+        only_suggested_frames: bool = False,
     ):
         """Make a data loading pipeline.
 
@@ -1465,6 +1481,8 @@ class BottomUpPredictor(Predictor):
             data_path: (str) Path to `.slp` file or `.mp4` to run inference on.
             queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
             frames: List of frames indices. If `None`, all frames in the video are used. Default: None.
+            only_labeled_frames: (bool) `True` if inference should be run only on user-labeled frames. Default: `False`.
+            only_suggested_frames: (bool) `True` if inference should be run only on unlabeled suggested frames. Default: `False`.
 
         Returns:
             This method initiates the reader class (doesn't return a pipeline) and the
@@ -1500,6 +1518,8 @@ class BottomUpPredictor(Predictor):
             self.pipeline = provider.from_filename(
                 filename=data_path,
                 queue_maxsize=queue_maxsize,
+                only_labeled_frames=only_labeled_frames,
+                only_suggested_frames=only_suggested_frames,
             )
             self.videos = self.pipeline.labels.videos
 
@@ -1640,6 +1660,8 @@ def run_inference(
     is_rgb: bool = False,
     anchor_part: Optional[str] = None,
     provider: Optional[str] = None,
+    only_labeled_frames: bool = False,
+    only_suggested_frames: bool = False,
     batch_size: int = 4,
     queue_maxsize: int = 8,
     frames: Optional[list] = None,
@@ -1699,6 +1721,8 @@ def run_inference(
                 provided, the anchor part in the `training_config.yaml` is used.
         provider: (str) Provider class to read the input sleap files.
                 Either "LabelsReader" or "VideoReader". Default: None.
+        only_labeled_frames: (bool) `True` if inference should be run only on user-labeled frames. Default: `False`.
+        only_suggested_frames: (bool) `True` if inference should be run only on unlabeled suggested frames. Default: `False`.
         batch_size: (int) Number of samples per batch. Default: 4.
         queue_maxsize: (int) Maximum size of the frame buffer queue. Default: 8.
         frames: (list) List of frames indices. If `None`, all frames in the video are used. Default: None.
@@ -1850,7 +1874,14 @@ def run_inference(
 
     # initialize make_pipeline function
 
-    predictor.make_pipeline(provider, data_path, queue_maxsize, frames)
+    predictor.make_pipeline(
+        provider,
+        data_path,
+        queue_maxsize,
+        frames,
+        only_labeled_frames,
+        only_suggested_frames,
+    )
 
     # run predict
     output = predictor.predict(

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -109,6 +109,25 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--only_labeled_frames",
+        action="store_true",
+        default=False,
+        help=(
+            "Only run inference on user labeled frames when running on labels dataset. "
+            "This is useful for generating predictions to compare against ground truth."
+        ),
+    )
+    parser.add_argument(
+        "--only_suggested_frames",
+        action="store_true",
+        default=False,
+        help=(
+            "Only run inference on unlabeled suggested frames when running on labels "
+            "dataset. This is useful for generating predictions for initialization "
+            "during labeling."
+        ),
+    )
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=4,

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -124,22 +124,6 @@ def test_labelsreader_provider(minimal_instance):
     queue = Queue(maxsize=4)
     reader = LabelsReader(labels=new_labels, frame_buffer=queue, instances_key=False)
     assert reader.max_height_and_width == (384, 384)
-    reader.start()
-    batch_size = 1
-    try:
-        data = []
-        for i in range(batch_size):
-            frame = reader.frame_buffer.get()
-            if frame["image"] is None:
-                break
-            data.append(frame)
-        assert len(data) == batch_size
-        assert data[0]["image"].shape == (1, 1, 384, 384)
-        assert "instances" not in data[0]
-    except:
-        raise
-    finally:
-        reader.join()
     assert reader.total_len() == 2
 
     # test only user labelled instance
@@ -173,22 +157,67 @@ def test_labelsreader_provider(minimal_instance):
         only_labeled_frames=True,
     )
     assert reader.max_height_and_width == (384, 384)
-    reader.start()
-    batch_size = 1
-    try:
-        data = []
-        for i in range(batch_size):
-            frame = reader.frame_buffer.get()
-            if frame["image"] is None:
-                break
-            data.append(frame)
-        assert len(data) == batch_size
-        assert data[0]["image"].shape == (1, 1, 384, 384)
-        assert "instances" not in data[0]
-    except:
-        raise
-    finally:
-        reader.join()
+    assert reader.total_len() == 1
+
+    # test for suggested frames (no suggested frames)
+    labels_2 = sio.Labels(
+        videos=labels.videos,
+        skeletons=labels.skeletons,
+        labeled_frames=[
+            sio.LabeledFrame(
+                video=labels.videos[0],
+                frame_idx=1,
+                instances=[
+                    sio.PredictedInstance.from_numpy(
+                        points_data=np.array([[1.0, 2.0], [2.0, 3.0]]),
+                        skeleton=labels.skeletons[0],
+                        point_scores=[0.1],
+                        score=1.0,
+                    )
+                ],
+            )
+        ],
+    )
+    assert len(labels_2) == 1
+    queue = Queue(maxsize=4)
+    reader = LabelsReader(
+        labels=labels_2,
+        frame_buffer=queue,
+        instances_key=False,
+        only_suggested_frames=True,
+    )
+    assert reader.max_height_and_width == (384, 384)
+    assert reader.total_len() == 0
+
+    # test for suggested frames (1 suggested frames)
+    labels_2 = sio.Labels(
+        videos=labels.videos,
+        skeletons=labels.skeletons,
+        labeled_frames=[
+            sio.LabeledFrame(
+                video=labels.videos[0],
+                frame_idx=1,
+                instances=[
+                    sio.PredictedInstance.from_numpy(
+                        points_data=np.array([[1.0, 2.0], [2.0, 3.0]]),
+                        skeleton=labels.skeletons[0],
+                        point_scores=[0.1],
+                        score=1.0,
+                    )
+                ],
+            )
+        ],
+    )
+    labels_2.suggestions.append(sio.SuggestionFrame(labels.videos[0], frame_idx=1))
+    assert len(labels_2) == 1
+    queue = Queue(maxsize=4)
+    reader = LabelsReader(
+        labels=labels_2,
+        frame_buffer=queue,
+        instances_key=False,
+        only_suggested_frames=True,
+    )
+    assert reader.max_height_and_width == (384, 384)
     assert reader.total_len() == 1
 
     # with instances key


### PR DESCRIPTION
This PR adds the following CLI flags to control which frames should be used for inference.

- `--only-labelled`: Run inference only on frames with user-labeled instances.

- `--only-suggested`: Run inference only on frames marked as suggestions (e.g., unlabeled targets).