### PR TITLE
Add support to run inference on specific video in a .slp file

### DIFF
--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -252,9 +252,22 @@ class VideoReader(Thread):
         filename: str,
         queue_maxsize: int,
         frames: Optional[list] = None,
+        dataset: Optional[str] = None,
+        input_format: str = "channels_last",
     ):
         """Create VideoReader from a .slp filename."""
-        video = sio.load_video(filename)
+        video = sio.load_video(filename, dataset=dataset, input_format=input_format)
+        frame_buffer = Queue(maxsize=queue_maxsize)
+        return cls(video, frame_buffer, frames)
+
+    @classmethod
+    def from_video(
+        cls,
+        video: sio.Video,
+        queue_maxsize: int,
+        frames: Optional[list] = None,
+    ):
+        """Create VideoReader from a video object."""
         frame_buffer = Queue(maxsize=queue_maxsize)
         return cls(video, frame_buffer, frames)
 

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -100,15 +100,6 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--provider",
-        type=str,
-        default=None,
-        help=(
-            "Provider class to read the input sleap files."
-            "Either 'LabelsReader' or 'VideoReader'"
-        ),
-    )
-    parser.add_argument(
         "--only_labeled_frames",
         action="store_true",
         default=False,
@@ -128,6 +119,35 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--video_index",
+        type=int,
+        default=None,
+        help=(
+            "Integer index of video in .slp file to predict on. To be used with an .slp"
+            " path as an alternative to specifying the video path."
+        ),
+    )
+    parser.add_argument(
+        "--video_dataset", type=str, default=None, help="The dataset for HDF5 videos."
+    )
+    parser.add_argument(
+        "--video_input_format",
+        type=str,
+        default="channels_last",
+        help="The input_format for HDF5 videos.",
+    )
+    parser.add_argument(
+        "--frames",
+        type=str,
+        default="",
+        help=(
+            "List of frames to predict when running on a video. Can be specified as a "
+            "comma separated list (e.g. 1,2,3) or a range separated by hyphen (e.g., "
+            "1-3, for 1,2,3). If not provided, defaults to predicting on the entire "
+            "video."
+        ),
+    )
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=4,
@@ -141,17 +161,6 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         type=int,
         default=8,
         help=("Maximum size of the frame buffer queue."),
-    )
-    parser.add_argument(
-        "--frames",
-        type=str,
-        default="",
-        help=(
-            "List of frames to predict when running on a video. Can be specified as a "
-            "comma separated list (e.g. 1,2,3) or a range separated by hyphen (e.g., "
-            "1-3, for 1,2,3). If not provided, defaults to predicting on the entire "
-            "video."
-        ),
     )
     parser.add_argument(
         "--crop_size",

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -603,7 +603,6 @@ def run_training(config: DictConfig):
         pred_labels = predict(
             data_path=labels_path,
             model_paths=[trainer.dir_path],
-            provider="LabelsReader",
             peak_threshold=0.2,
             make_labels=True,
             output_path=Path(trainer.dir_path) / f"pred_{dataset}.slp",
@@ -634,11 +633,6 @@ def run_training(config: DictConfig):
             pred_labels = predict(
                 data_path=config.data_config.test_file_path,
                 model_paths=[trainer.dir_path],
-                provider=(
-                    "LabelsReader"
-                    if config.data_config.test_file_path.endswith(".slp")
-                    else "VideoReader"
-                ),
                 peak_threshold=0.2,
                 make_labels=True,
                 output_path=Path(trainer.dir_path) / "pred_test.slp",

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -53,9 +53,7 @@ def test_videoreader_provider(centered_instance_video, minimal_instance):
 
     # test with from_video method
     labels = sio.load_slp(minimal_instance)
-    video = sio.load_video(labels.videos[0])
-    queue = Queue(maxsize=4)
-    reader = VideoReader.from_video(video=video, frame_buffer=queue, frames=[0])
+    reader = VideoReader.from_video(video=labels.videos[0], queue_maxsize=4, frames=[0])
     assert reader.max_height_and_width == (384, 384)
     reader.start()
     batch_size = 1

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -28,7 +28,7 @@ def test_providers(minimal_instance):
     assert l.max_height_and_width == (384, 384)
 
 
-def test_videoreader_provider(centered_instance_video):
+def test_videoreader_provider(centered_instance_video, minimal_instance):
     """Test VideoReader class."""
     video = sio.load_video(centered_instance_video)
     queue = Queue(maxsize=4)
@@ -50,6 +50,29 @@ def test_videoreader_provider(centered_instance_video):
     finally:
         reader.join()
     assert reader.total_len() == 4
+
+    # test with from_video method
+    labels = sio.load_slp(minimal_instance)
+    video = sio.load_video(labels.videos[0])
+    queue = Queue(maxsize=4)
+    reader = VideoReader.from_video(video=video, frame_buffer=queue, frames=[0])
+    assert reader.max_height_and_width == (384, 384)
+    reader.start()
+    batch_size = 1
+    try:
+        data = []
+        for i in range(batch_size):
+            frame = reader.frame_buffer.get()
+            if frame["image"] is None:
+                break
+            data.append(frame)
+        assert len(data) == batch_size
+        assert data[0]["image"].shape == (1, 1, 384, 384)
+    except:
+        raise
+    finally:
+        reader.join()
+    assert reader.total_len() == 1
 
     # check graceful stop (video has 1100 frames)
     reader = VideoReader.from_filename(

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -94,3 +94,51 @@ def test_predict_main(
     pred = sio.load_slp((Path(tmp_path) / "minimal_inst_preds.slp").as_posix())
 
     assert len(pred) == 3
+
+    # test with video
+    main(
+        [
+            "--data_path",
+            "./tests/assets/centered_pair_small.mp4",
+            "--model_paths",
+            f"{minimal_instance_centroid_ckpt}",
+            "--model_paths",
+            f"{minimal_instance_ckpt}",
+            "-o",
+            f"{tmp_path}/minimal_inst_preds.slp",
+            "--frames",
+            "0-3",
+            "--peak_threshold",
+            f"{0.0}",
+        ]
+    )
+    assert (Path(tmp_path) / "minimal_inst_preds.slp").exists()
+
+    pred = sio.load_slp((Path(tmp_path) / "minimal_inst_preds.slp").as_posix())
+
+    assert len(pred) == 4
+
+    # test with video index
+    main(
+        [
+            "--data_path",
+            f"{minimal_instance}",
+            "--model_paths",
+            f"{minimal_instance_centroid_ckpt}",
+            "--model_paths",
+            f"{minimal_instance_ckpt}",
+            "-o",
+            f"{tmp_path}/minimal_inst_preds.slp",
+            "--video_index",
+            "0",
+            "--frames",
+            "0",
+            "--peak_threshold",
+            f"{0.0}",
+        ]
+    )
+    assert (Path(tmp_path) / "minimal_inst_preds.slp").exists()
+
+    pred = sio.load_slp((Path(tmp_path) / "minimal_inst_preds.slp").as_posix())
+
+    assert len(pred) == 1

--- a/tests/tracking/candidates/test_fixed_window.py
+++ b/tests/tracking/candidates/test_fixed_window.py
@@ -10,7 +10,6 @@ def get_pred_instances(minimal_instance_ckpt, n=10):
     result_labels = run_inference(
         model_paths=[minimal_instance_ckpt],
         data_path="./tests/assets/minimal_instance.pkg.slp",
-        provider="LabelsReader",
         make_labels=True,
         max_instances=6,
         peak_threshold=0.0,

--- a/tests/tracking/candidates/test_local_queues.py
+++ b/tests/tracking/candidates/test_local_queues.py
@@ -10,7 +10,6 @@ def get_pred_instances(minimal_instance_ckpt, n=10):
     result_labels = run_inference(
         model_paths=[minimal_instance_ckpt],
         data_path="./tests/assets/minimal_instance.pkg.slp",
-        provider="LabelsReader",
         make_labels=True,
         max_instances=6,
         peak_threshold=0.0,

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -30,7 +30,6 @@ def get_pred_instances(minimal_instance_ckpt):
     result_labels = run_inference(
         model_paths=[minimal_instance_ckpt],
         data_path="./tests/assets/minimal_instance.pkg.slp",
-        provider="LabelsReader",
         make_labels=True,
         max_instances=6,
         peak_threshold=0.0,


### PR DESCRIPTION
This PR adds the option to inference on specific video when the user provides a `.slp` file to run inference on.

- `--video-index`: Index of the video in the project file.

- `--video-dataset`: Name or path of the video dataset (e.g., video0/video).

