### PR TITLE
Minor fixes to tracking

### DIFF
--- a/sleap_nn/tracking/candidates/fixed_window.py
+++ b/sleap_nn/tracking/candidates/fixed_window.py
@@ -133,7 +133,7 @@ class FixedWindowCandidates:
 
         """
         add_to_queue = True
-        if np.any(row_inds) and np.any(col_inds):
+        if row_inds is not None and col_inds is not None:
 
             for idx, (row, col) in enumerate(zip(row_inds, col_inds)):
                 current_instances.track_ids[row] = self.current_tracks[col]

--- a/sleap_nn/tracking/candidates/fixed_window.py
+++ b/sleap_nn/tracking/candidates/fixed_window.py
@@ -19,7 +19,7 @@ class FixedWindowCandidates:
         instance_score_threshold: Instance score threshold for creating new tracks.
             Default: 0.0.
         tracker_queue: Deque object that stores the past `window_size` tracked instances.
-        current_tracks: List of track IDs that are being tracked.
+        all_tracks: List of track IDs that are created.
     """
 
     def __init__(self, window_size: int = 5, instance_score_threshold: float = 0.0):
@@ -27,7 +27,18 @@ class FixedWindowCandidates:
         self.window_size = window_size
         self.instance_score_threshold = instance_score_threshold
         self.tracker_queue = deque(maxlen=self.window_size)
-        self.current_tracks = []
+        self.all_tracks = []
+
+    @property
+    def current_tracks(self):
+        """Get track IDs of items currently in tracker queue."""
+        if not len(self.tracker_queue):
+            return []
+        else:
+            curr_tracks = set()
+            for item in self.tracker_queue:
+                curr_tracks.update(item.track_ids)
+            return list(curr_tracks)
 
     def get_track_instances(
         self,
@@ -77,10 +88,10 @@ class FixedWindowCandidates:
 
     def get_new_track_id(self) -> int:
         """Return a new track_id."""
-        if not self.current_tracks:
+        if not self.all_tracks:
             new_track_id = 0
         else:
-            new_track_id = max(self.current_tracks) + 1
+            new_track_id = max(self.all_tracks) + 1
         return new_track_id
 
     def add_new_tracks(
@@ -97,7 +108,7 @@ class FixedWindowCandidates:
                 new_tracks_id = self.get_new_track_id()
                 current_instances.track_ids[i] = new_tracks_id
                 current_instances.tracking_scores[i] = 1.0
-                self.current_tracks.append(new_tracks_id)
+                self.all_tracks.append(new_tracks_id)
 
         if add_to_queue and is_new_track:
             self.tracker_queue.append(current_instances)
@@ -125,7 +136,7 @@ class FixedWindowCandidates:
         if np.any(row_inds) and np.any(col_inds):
 
             for idx, (row, col) in enumerate(zip(row_inds, col_inds)):
-                current_instances.track_ids[row] = col
+                current_instances.track_ids[row] = self.current_tracks[col]
                 current_instances.tracking_scores[row] = tracking_scores[idx]
 
             # update tracks to queue

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -349,16 +349,13 @@ class Tracker:
         )
 
         for f_idx, f in enumerate(current_instances_features):
-            for track_id in self.candidate.current_tracks:
-                oks = [
+            for t_idx, track_id in enumerate(self.candidate.current_tracks):
+                scores_trackid = [
                     scoring_method(f, x.feature)
                     for x in candidates_feature_dict[track_id]
                 ]
-                if len(oks):
-                    oks = scoring_reduction(oks)  # scoring reduction
-                else:
-                    oks = 0.0
-                scores[f_idx][track_id] = oks
+                score_trackid = scoring_reduction(scores_trackid)  # scoring reduction
+                scores[f_idx][t_idx] = score_trackid
 
         return scores
 

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -39,8 +39,7 @@ def get_keypoints(pred_instance: Union[sio.PredictedInstance, np.ndarray]):
     """Return keypoints as np.array from the `PredictedInstance` object."""
     if isinstance(pred_instance, np.ndarray):
         return pred_instance
-    pred_inst = np.nan_to_num(pred_instance.numpy(), nan=0.0, posinf=0.0, neginf=0.0)
-    return pred_inst
+    return pred_instance.numpy()
 
 
 def get_centroid(pred_instance: Union[sio.PredictedInstance, np.ndarray]):


### PR DESCRIPTION
This PR addresses a few bugs in the tracking module:

Fixed window tracking: Only tracks that are active within the current window should be considered. Previously, all tracks created up to that point were used, which could lead to incorrect matches.

Local queues (per SLEAP tracking logic): When the `max_tracks` limit is reached, unmatched instances should be assigned track = None. These instances are excluded from the final labeled frame.

