### PR TITLE
Save train, val, test predictions after training

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -518,6 +518,11 @@ def test_main(sample_cfg):
     )
     assert Path(sample_cfg.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
     assert (
+        Path(sample_cfg.trainer_config.save_ckpt_path)
+        .joinpath("pred_train.slp")
+        .exists()
+    )
+    assert (
         Path(sample_cfg.trainer_config.save_ckpt_path).joinpath("pred_val.slp").exists()
     )
     assert (


### PR DESCRIPTION
Previously, after training, predictions were saved only for the full labels file in `train_labels_path` when `val_labels_path` wasn't provided. This PR updates the logic to save predictions from the training and validation (and test if `test_path` is provided) datasets individually.