### PR TITLE
Remove `nested` tensors to support `mps` for BottomUp models

### DIFF
--- a/sleap_nn/inference/paf_grouping.py
+++ b/sleap_nn/inference/paf_grouping.py
@@ -180,10 +180,10 @@ def make_line_subs(
 
     X = torch.cat(
         (src_peaks[:, 0].unsqueeze(dim=-1), dst_peaks[:, 0].unsqueeze(dim=-1)), dim=-1
-    ).to(torch.float64)
+    ).to(torch.float32)
     Y = torch.cat(
         (src_peaks[:, 1].unsqueeze(dim=-1), dst_peaks[:, 1].unsqueeze(dim=-1)), dim=-1
-    ).to(torch.float64)
+    ).to(torch.float32)
     samples = torch.tensor([0, 1], device=X.device).repeat(n_candidates, 1)
     samples_new = torch.linspace(0, 1, steps=n_line_points, device=X.device).repeat(
         n_candidates, 1
@@ -494,11 +494,7 @@ def score_paf_lines_batch(
         batch_edge_peak_inds.append(edge_peak_inds_sample)
         batch_line_scores.append(line_scores_sample)
 
-    return (
-        torch.nested.nested_tensor(batch_edge_inds),
-        torch.nested.nested_tensor(batch_edge_peak_inds),
-        torch.nested.nested_tensor(batch_line_scores),
-    )
+    return batch_edge_inds, batch_edge_peak_inds, batch_line_scores
 
 
 def match_candidates_sample(
@@ -674,7 +670,7 @@ def match_candidates_batch(
     match_dst_peak_inds = []
     match_line_scores = []
 
-    for sample in range(edge_inds.size(0)):
+    for sample in range(len(edge_inds)):
         edge_inds_sample = edge_inds[sample]
         edge_peak_inds_sample = edge_peak_inds[sample]
         line_scores_sample = line_scores[sample]
@@ -698,12 +694,7 @@ def match_candidates_batch(
         match_dst_peak_inds.append(match_dst_peak_inds_sample)
         match_line_scores.append(match_line_scores_sample)
 
-    return (
-        torch.nested.nested_tensor(match_edge_inds),
-        torch.nested.nested_tensor(match_src_peak_inds),
-        torch.nested.nested_tensor(match_dst_peak_inds),
-        torch.nested.nested_tensor(match_line_scores),
-    )
+    return match_edge_inds, match_src_peak_inds, match_dst_peak_inds, match_line_scores
 
 
 def assign_connections_to_instances(
@@ -1115,7 +1106,7 @@ def group_instances_batch(
 
     See also: match_candidates_batch, group_instances_sample
     """
-    n_samples = peaks.size(0)
+    n_samples = len(peaks)
     predicted_instances_batch = []
     predicted_peak_scores_batch = []
     predicted_instance_scores_batch = []
@@ -1147,9 +1138,9 @@ def group_instances_batch(
         )
 
     return (
-        torch.nested.nested_tensor(predicted_instances_batch),
-        torch.nested.nested_tensor(predicted_peak_scores_batch),
-        torch.nested.nested_tensor(predicted_instance_scores_batch),
+        predicted_instances_batch,
+        predicted_peak_scores_batch,
+        predicted_instance_scores_batch,
     )
 
 

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -666,10 +666,10 @@ class BottomUpLightningModule(BaseLightningModule):
         ex["image"] = ex["image"].unsqueeze(dim=0)
         output = self.bottomup_inf_layer(ex)[0]
         img = output["image"][0, 0].cpu().numpy()
-        pafs = output["pred_part_affinity_fields"]  # (h, w, 2*edges)
+        pafs = output["pred_part_affinity_fields"].cpu().numpy()  # (h, w, 2*edges)
         fig = plot_pafs(
             img=img,
-            pafs=pafs,
+            pafs=pafs[0],
             plot_title=f"@ Epoch: {self.trainer.current_epoch}",
         )
         return fig

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -980,7 +980,7 @@ class ModelTrainer:
                         plot_fn=lambda: self.model.visualize_pafs_example(
                             next(train_viz_pipeline1)
                         ),
-                        prefix="train_pafs_magnitude",
+                        prefix="train.pafs_magnitude",
                     )
                 )
                 callbacks.append(
@@ -989,7 +989,7 @@ class ModelTrainer:
                         plot_fn=lambda: self.model.visualize_pafs_example(
                             next(val_viz_pipeline1)
                         ),
-                        prefix="validation_pafs_magnitude",
+                        prefix="validation.pafs_magnitude",
                     )
                 )
 
@@ -1001,11 +1001,6 @@ class ModelTrainer:
                         is_bottomup=(self.model_type == "bottomup"),
                     )
                 )
-
-        if self.model_type == "bottomup":
-            if torch.backends.mps.is_available() and torch.backends.mps.is_built():
-                # Explicitly avoid using MPS
-                self.config.trainer_config.trainer_accelerator = "cpu"
 
         self.trainer = L.Trainer(
             callbacks=callbacks,

--- a/sleap_nn/training/utils.py
+++ b/sleap_nn/training/utils.py
@@ -45,7 +45,7 @@ def plot_pafs(
 
     pafs = pafs.reshape((pafs.shape[0], pafs.shape[1], -1, 2))  # (h, w, edges, 2)
     pafs_mag = np.sqrt(pafs[..., 0] ** 2 + pafs[..., 1] ** 2)
-    pafs_mag = np.squeeze(pafs_mag.max(axis=-1))
+    pafs_mag = pafs_mag.max(axis=-1)
 
     fig, ax = plt.subplots()
     ax.axis("off")

--- a/tests/inference/test_bottomup.py
+++ b/tests/inference/test_bottomup.py
@@ -69,7 +69,7 @@ def test_bottomup_inference_model(
 
     output = inference_layer(ex)[0]
     assert "pred_confmaps" not in output.keys()
-    assert output["pred_instance_peaks"].is_nested
+    assert isinstance(output["pred_instance_peaks"], list)
     assert tuple(output["pred_instance_peaks"][0].shape)[1:] == (2, 2)
     assert tuple(output["pred_peak_values"][0].shape)[1:] == (2,)
 
@@ -99,7 +99,7 @@ def test_bottomup_inference_model(
     output = inference_layer(ex)[0]
     assert tuple(output["pred_confmaps"].shape) == (1, 2, 192, 192)
     assert tuple(output["pred_part_affinity_fields"].shape) == (1, 96, 96, 2)
-    assert output["pred_instance_peaks"].is_nested
+    assert isinstance(output["pred_instance_peaks"], list)
     assert output["peaks"][0].shape[-1] == 2
     assert tuple(output["pred_instance_peaks"][0].shape)[1:] == (2, 2)
     assert tuple(output["pred_peak_values"][0].shape)[1:] == (2,)

--- a/tests/inference/test_utils.py
+++ b/tests/inference/test_utils.py
@@ -24,13 +24,13 @@ def test_get_skeleton_from_config(minimal_instance, minimal_instance_ckpt):
 def test_interp1d():
     """Test function for `interp()` function."""
     x = torch.linspace(0, 10, steps=10)
-    y = torch.randint(10, 30, (10,), dtype=torch.float64)
+    y = torch.randint(10, 30, (10,), dtype=torch.float32)
     xq = torch.linspace(0, 10, steps=20)
     yq = interp1d(x, y, xq)
     assert yq.shape == (20,)
 
     x = torch.linspace(0, 10, steps=10).repeat(5, 1)
-    y = torch.randint(10, 30, (5, 10), dtype=torch.float64)
+    y = torch.randint(10, 30, (5, 10), dtype=torch.float32)
     xq = torch.linspace(0, 10, steps=20).repeat(5, 1)
     yq = interp1d(x, y, xq)
     assert yq.shape == (5, 20)


### PR DESCRIPTION
This PR removes the dependency on `torch.nested` tensors from the BottomUp training and inference pipeline. Previously, due to lack of support for nested tensors on the MPS device, we had to default to using the CPU for BottomUp models. During inference, however, we process each sample individually (e.g., in `inference/paf_grouping.py`), so batching is not essential. This change replaces nested tensors with standard Python lists during inference, enabling compatibility with MPS while simplifying the data handling.