### PR TITLE
Add online hard keypoint mining

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -206,3 +206,21 @@ The config file has three main sections:
         - `min_delta`: (float) Minimum change in the monitored quantity to qualify as an improvement, i.e. an absolute change of less than or equal to min_delta, will count as no improvement. *Default*: `0.0`.
         - `patience`: (int) Number of checks with no improvement after which training will be stopped. Under the default configuration, one check happens after every training epoch. *Default*: `1`.
     - `zmq`: (dict) Dict with keys ["publish_adddress", "controller_address"]. `publish_address` specifies the address and port to which the training logs (loss values) should be sent to. `controller_address` specifies the address and port to listen to to stop the training (specific to SLEAP GUI). *Default*: `None`.
+    - `online_hard_keypoint_mining`
+        - `online_mining`: (bool) If True, online hard keypoint mining (OHKM) will be enabled. When
+            this is enabled, the loss is computed per keypoint (or edge for PAFs) and
+            sorted from lowest (easy) to highest (hard). The hard keypoint loss will be
+            scaled to have a higher weight in the total loss, encouraging the training
+            to focus on tricky body parts that are more difficult to learn.
+            If False, no mining will be performed and all keypoints will be weighted
+            equally in the loss. *Default*: `False`.
+        - `hard_to_easy_ratio`: (float) The minimum ratio of the individual keypoint loss with
+            respect to the lowest keypoint loss in order to be considered as "hard".
+            This helps to switch focus on across groups of keypoints during training. *Default*: `2.0`.
+        - `min_hard_keypoints`: (int) The minimum number of keypoints that will be considered as
+            "hard", even if they are not below the `hard_to_easy_ratio`. *Default*: `2`.
+        - `max_hard_keypoints`: (int) The maximum number of hard keypoints to apply scaling to.
+            This can help when there are few very easy keypoints which may skew the
+            ratio and result in loss scaling being applied to most keypoints, which can
+            reduce the impact of hard mining altogether.
+        - `loss_scale`: (float) Factor to scale the hard keypoint losses by. *Default*: `5.0`.

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -20,6 +20,7 @@ from sleap_nn.config.trainer_config import (
     TrainerConfig,
     ModelCkptConfig,
     WandBConfig,
+    HardKeypointMiningConfig,
     OptimizerConfig,
 )
 from sleap_nn.config.training_job_config import TrainingJobConfig
@@ -449,6 +450,11 @@ def get_trainer_config(
     early_stopping: bool = False,
     early_stopping_min_delta: float = 0.0,
     early_stopping_patience: int = 1,
+    online_mining: bool = False,
+    hard_to_easy_ratio: float = 2.0,
+    min_hard_keypoints: int = 2,
+    max_hard_keypoints: Optional[int] = None,
+    loss_scale: float = 5.0,
 ):
     """Train a pose-estimation model with SLEAP-NN framework.
 
@@ -516,6 +522,23 @@ def get_trainer_config(
         early_stopping_patience: Number of checks with no improvement after which training
             will be stopped. Under the default configuration, one check happens after every
             training epoch. Default: 1.
+        online_mining: If True, online hard keypoint mining (OHKM) will be enabled. When
+            this is enabled, the loss is computed per keypoint (or edge for PAFs) and
+            sorted from lowest (easy) to highest (hard). The hard keypoint loss will be
+            scaled to have a higher weight in the total loss, encouraging the training
+            to focus on tricky body parts that are more difficult to learn.
+            If False, no mining will be performed and all keypoints will be weighted
+            equally in the loss.
+        hard_to_easy_ratio: The minimum ratio of the individual keypoint loss with
+            respect to the lowest keypoint loss in order to be considered as "hard".
+            This helps to switch focus on across groups of keypoints during training.
+        min_hard_keypoints: The minimum number of keypoints that will be considered as
+            "hard", even if they are not below the `hard_to_easy_ratio`.
+        max_hard_keypoints: The maximum number of hard keypoints to apply scaling to.
+            This can help when there are few very easy keypoints which may skew the
+            ratio and result in loss scaling being applied to most keypoints, which can
+            reduce the impact of hard mining altogether.
+        loss_scale: Factor to scale the hard keypoint losses by.
     """
     # constrict trainer config
     train_dataloader_cfg = DataLoaderConfig(
@@ -582,6 +605,13 @@ def get_trainer_config(
             min_delta=early_stopping_min_delta,
             patience=early_stopping_patience,
             stop_training_on_plateau=early_stopping,
+        ),
+        online_hard_keypoint_mining=HardKeypointMiningConfig(
+            online_mining=online_mining,
+            hard_to_easy_ratio=hard_to_easy_ratio,
+            min_hard_keypoints=min_hard_keypoints,
+            max_hard_keypoints=max_hard_keypoints,
+            loss_scale=loss_scale,
         ),
     )
     return trainer_config
@@ -703,6 +733,11 @@ def train(
     early_stopping: bool = False,
     early_stopping_min_delta: float = 0.0,
     early_stopping_patience: int = 1,
+    online_mining: bool = False,
+    hard_to_easy_ratio: float = 2.0,
+    min_hard_keypoints: int = 2,
+    max_hard_keypoints: Optional[int] = None,
+    loss_scale: float = 5.0,
 ):
     """Train a pose-estimation model with SLEAP-NN framework.
 
@@ -882,6 +917,23 @@ def train(
         early_stopping_patience: Number of checks with no improvement after which training
             will be stopped. Under the default configuration, one check happens after every
             training epoch. Default: 1.
+        online_mining: If True, online hard keypoint mining (OHKM) will be enabled. When
+            this is enabled, the loss is computed per keypoint (or edge for PAFs) and
+            sorted from lowest (easy) to highest (hard). The hard keypoint loss will be
+            scaled to have a higher weight in the total loss, encouraging the training
+            to focus on tricky body parts that are more difficult to learn.
+            If False, no mining will be performed and all keypoints will be weighted
+            equally in the loss.
+        hard_to_easy_ratio: The minimum ratio of the individual keypoint loss with
+            respect to the lowest keypoint loss in order to be considered as "hard".
+            This helps to switch focus on across groups of keypoints during training.
+        min_hard_keypoints: The minimum number of keypoints that will be considered as
+            "hard", even if they are not below the `hard_to_easy_ratio`.
+        max_hard_keypoints: The maximum number of hard keypoints to apply scaling to.
+            This can help when there are few very easy keypoints which may skew the
+            ratio and result in loss scaling being applied to most keypoints, which can
+            reduce the impact of hard mining altogether.
+        loss_scale: Factor to scale the hard keypoint losses by.
     """
     data_config = get_data_config(
         train_labels_path=train_labels_path,
@@ -946,6 +998,11 @@ def train(
         early_stopping=early_stopping,
         early_stopping_min_delta=early_stopping_min_delta,
         early_stopping_patience=early_stopping_patience,
+        online_mining=online_mining,
+        hard_to_easy_ratio=hard_to_easy_ratio,
+        min_hard_keypoints=min_hard_keypoints,
+        max_hard_keypoints=max_hard_keypoints,
+        loss_scale=loss_scale,
     )
 
     # create omegaconf object

--- a/sleap_nn/training/losses.py
+++ b/sleap_nn/training/losses.py
@@ -1,0 +1,60 @@
+"""Custom loss functions."""
+
+import torch
+from typing import Optional
+
+
+def compute_ohkm_loss(
+    y_gt: torch.Tensor,
+    y_pr: torch.Tensor,
+    hard_to_easy_ratio: float = 2.0,
+    min_hard_keypoints: int = 2,
+    max_hard_keypoints: Optional[int] = None,
+    loss_scale: float = 5.0,
+) -> torch.Tensor:
+    """Compute the online hard keypoint mining loss."""
+    if max_hard_keypoints is None:
+        max_hard_keypoints = -1
+    # Compute elementwise squared difference.
+    loss = (y_pr - y_gt) ** 2
+
+    # Store initial shape for normalization.
+    batch_shape = loss.shape
+
+    # Reduce over everything but channels axis.
+    l = torch.sum(loss, dim=(0, 2, 3))
+
+    # Compute the loss for the "easy" keypoint.
+    best_loss = torch.min(l)
+
+    # Find the number of hard keypoints.
+    is_hard_keypoint = (l / best_loss) >= hard_to_easy_ratio
+    n_hard_keypoints = torch.sum(is_hard_keypoint.to(torch.int32))
+
+    # Work out the actual final number of keypoints to consider as hard.
+    if max_hard_keypoints < 0:
+        max_hard_keypoints = l.shape[0]
+    else:
+        max_hard_keypoints = min(
+            max_hard_keypoints,
+            l.shape[0],
+        )
+    k = min(
+        max(
+            n_hard_keypoints,
+            min_hard_keypoints,
+        ),
+        max_hard_keypoints,
+    )
+
+    # Pull out the top hard values.
+    k_vals, k_inds = torch.topk(l, k=k, largest=True, sorted=False)
+
+    # Apply weights.
+    k_loss = k_vals * loss_scale
+
+    # Reduce over all channels.
+    n_elements = batch_shape[0] * batch_shape[2] * batch_shape[3] * k
+    k_loss = torch.sum(k_loss) / n_elements
+
+    return k_loss

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -257,6 +257,13 @@ def test_trainer_mapper():
                 "plateau_min_delta": 1e-06,
                 "plateau_patience": 10,
             },
+            "hard_keypoint_mining": {
+                "online_mining": False,
+                "hard_to_easy_ratio": 2.0,
+                "min_hard_keypoints": 2,
+                "max_hard_keypoints": None,
+                "loss_scale": 5.0,
+            },
         },
         "outputs": {"save_outputs": True, "save_visualizations": True, "zmq": {}},
     }
@@ -297,3 +304,8 @@ def test_trainer_mapper():
     assert config.early_stopping.patience == 10
     assert config.early_stopping.min_delta == 1e-6
     assert config.early_stopping.stop_training_on_plateau is True
+    assert config.online_hard_keypoint_mining.online_mining is False
+    assert config.online_hard_keypoint_mining.hard_to_easy_ratio == 2.0
+    assert config.online_hard_keypoint_mining.min_hard_keypoints == 2
+    assert config.online_hard_keypoint_mining.max_hard_keypoints is None
+    assert config.online_hard_keypoint_mining.loss_scale == 5.0

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -169,6 +169,13 @@ def config(sleap_data_dir):
                         "min_lr": 1e-08,
                     },
                 },
+                "online_hard_keypoint_mining": {
+                    "online_mining": False,
+                    "hard_to_easy_ratio": 2.0,
+                    "min_hard_keypoints": 2,
+                    "max_hard_keypoints": None,
+                    "loss_scale": 5.0,
+                },
             },
         }
     )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -150,6 +150,7 @@ def test_train_method(minimal_instance, tmp_path: str):
         head_configs="centered_instance",
         save_ckpt=True,
         save_ckpt_path=(Path(tmp_path) / "test_train_method").as_posix(),
+        online_mining=True,
     )
     folder_created = (Path(tmp_path) / "test_train_method").exists()
     assert folder_created

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -654,6 +654,11 @@ def test_trainer_torch_dataset(caplog, config, tmp_path: str):
     OmegaConf.update(
         config_early_stopping, "trainer_config.early_stopping.min_delta", 1e-1
     )
+    OmegaConf.update(
+        config_early_stopping,
+        "trainer_config.online_hard_keypoint_mining.online_mining",
+        True,
+    )
     OmegaConf.update(config_early_stopping, "trainer_config.early_stopping.patience", 1)
     OmegaConf.update(config_early_stopping, "trainer_config.max_epochs", 10)
     OmegaConf.update(
@@ -756,6 +761,9 @@ def test_trainer_torch_dataset_bottomup(config):
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.step_size", 10)
     OmegaConf.update(config, "trainer_config.lr_scheduler.step_lr.gamma", 0.5)
     OmegaConf.update(config, "trainer_config.enable_progress_bar", True)
+    OmegaConf.update(
+        config, "trainer_config.online_hard_keypoint_mining.online_mining", True
+    )
 
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     head_config = config.model_config.head_configs.centered_instance


### PR DESCRIPTION
This PR introduces Online Hard Keypoint Mining (OHKM) for training. When enabled, the loss is computed separately for each keypoint (or each edge for PAFs) and ranked from easiest to hardest based on the loss. The hardest keypoints receive higher weighting in the total loss, enabling the model to focus more on hard body parts.

