### PR TITLE
Fix bugs with zmq config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -206,4 +206,7 @@ The config file has three main sections:
         - `stop_training_on_plateau`: (bool) True if early stopping should be enabled. *Default*: `False`.
         - `min_delta`: (float) Minimum change in the monitored quantity to qualify as an improvement, i.e. an absolute change of less than or equal to min_delta, will count as no improvement. *Default*: `0.0`.
         - `patience`: (int) Number of checks with no improvement after which training will be stopped. Under the default configuration, one check happens after every training epoch. *Default*: `1`.
-    - `zmq`: (dict) Dict with keys ["publish_adddress", "controller_address"]. `publish_address` specifies the address and port to which the training logs (loss values) should be sent to. `controller_address` specifies the address and port to listen to to stop the training (specific to SLEAP GUI). *Default*: `None`.
+    - `zmq`
+        - `publish_address`: (str) Specifies the address and port to which the training logs (loss values) should be sent to. 
+        - `controller_address`: (str) Specifies the address and port to listen to to stop the training (specific to SLEAP GUI). *Default*: `None`.
+        - `controller_polling_timeout`: (int) Polling timeout in microseconds specified as an integer. This controls how long the poller should wait to receive a response and should be set to a small value to minimize the impact on training speed.

--- a/docs/config_bottomup.yaml
+++ b/docs/config_bottomup.yaml
@@ -157,9 +157,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address:
     publish_address:
+    controller_address:
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/docs/config_centroid.yaml
+++ b/docs/config_centroid.yaml
@@ -136,9 +136,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address:
     publish_address:
+    controller_address:
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/docs/config_single_instance.yaml
+++ b/docs/config_single_instance.yaml
@@ -127,9 +127,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address:
     publish_address:
+    controller_address:
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/docs/config_topdown_centered_instance.yaml
+++ b/docs/config_topdown_centered_instance.yaml
@@ -131,9 +131,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address:
     publish_address:
+    controller_address:
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -161,7 +161,7 @@ class EarlyStoppingConfig:
     stop_training_on_plateau: bool = False
 
 
-@attr.s(auto_attribs=True)
+@define
 class ZMQConfig:
     """Configuration of ZeroMQ-based monitoring of the training.
 

--- a/tests/assets/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/initial_config.yaml
@@ -134,9 +134,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address: null
     publish_address: null
+    controller_address: null
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/minimal_instance_bottomup/training_config.yaml
@@ -148,9 +148,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address: null
     publish_address: null
+    controller_address: null
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/minimal_instance_centered_instance/initial_config.yaml
@@ -131,9 +131,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address: null
     publish_address: null
+    controller_address: null
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/minimal_instance_centered_instance/training_config.yaml
@@ -143,9 +143,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address: null
     publish_address: null
+    controller_address: null
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/minimal_instance_centroid/initial_config.yaml
@@ -128,9 +128,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address: null
     publish_address: null
+    controller_address: null
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/minimal_instance_centroid/training_config.yaml
@@ -138,9 +138,9 @@ trainer_config:
     patience: 10
     stop_training_on_plateau: true
   zmq:
-    publish_adddress: null
-    controller_address: null
     publish_address: null
+    controller_address: null
+    controller_polling_timeout: 10
 name: ''
 description: ''
 sleap_nn_version: 0.0.1


### PR DESCRIPTION
This PR fixes minor bugs related to handling ZMQ-specific parameters. Previously, these parameters were managed as a dictionary, but they have now been refactored into a dedicated attrs class for consistency with other nested config parameters. We also add a new parameter to allow specifying the controller polling timeout.