### PR TITLE
Fix trainer config mappings and add option to load config from json str

### DIFF
--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -283,6 +283,15 @@ def trainer_mapper(legacy_config: dict) -> TrainerConfig:
         if resume_ckpt_path is not None
         else None
     )
+    run_name = legacy_config_outputs.get("run_name", None)
+    run_name = run_name if run_name is not None else f"training_{time.time()}"
+    run_name_prefix = legacy_config_outputs.get("run_name_prefix", "")
+    run_name_suffix = legacy_config_outputs.get("run_name_suffix", "")
+    run_name = (
+        run_name_prefix
+        if run_name_prefix is not None
+        else "" + run_name + run_name_suffix if run_name_prefix is not None else ""
+    )
     return TrainerConfig(
         train_data_loader=DataLoaderConfig(
             batch_size=legacy_config_optimization.get("batch_size", 1),
@@ -303,8 +312,7 @@ def trainer_mapper(legacy_config: dict) -> TrainerConfig:
         max_epochs=legacy_config_optimization.get("epochs", 10),
         save_ckpt=True,
         save_ckpt_path=(
-            Path(legacy_config_outputs.get("runs_folder", "."))
-            / legacy_config_outputs.get("run_name", f"training_{time.time()}")
+            Path(legacy_config_outputs.get("runs_folder", ".")) / run_name
         ).as_posix(),
         optimizer_name=re.sub(
             r"^[a-z]",

--- a/sleap_nn/config/training_job_config.py
+++ b/sleap_nn/config/training_job_config.py
@@ -104,9 +104,22 @@ class TrainingJobConfig:
         with open(json_file_path, "r") as f:
             old_config = json.load(f)
 
-        data_config = data_mapper(old_config)
-        model_config = model_mapper(old_config)
-        trainer_config = trainer_mapper(old_config)
+        return cls.load_sleap_config_from_json(old_config)
+
+    @classmethod
+    def load_sleap_config_from_json(cls, json_str: str) -> OmegaConf:
+        """Load a SLEAP configuration from a JSON string and convert it to OmegaConf.
+
+        Args:
+            cls: The class to instantiate with the loaded configuration.
+            json_str: JSON-formatted string containing the SLEAP configuration.
+
+        Returns:
+            An OmegaConf instance with the loaded configuration.
+        """
+        data_config = data_mapper(json_str)
+        model_config = model_mapper(json_str)
+        trainer_config = trainer_mapper(json_str)
 
         config = cls(
             data_config=data_config,

--- a/tests/config/test_training_job_config.py
+++ b/tests/config/test_training_job_config.py
@@ -166,6 +166,31 @@ def test_load_bottomup_multiclass_training_config_from_file(
         config.trainer_config.early_stopping.stop_training_on_plateau is True
     )  # From the JSON file
 
+    # Test by loading with JSON-formatted string
+    with open(json_file_path, "r") as f:
+        slp_cfg_json = json.load(f)
+
+    config = TrainingJobConfig.load_sleap_config_from_json(slp_cfg_json)
+
+    # Assertions to check if the output matches expected values
+    assert config.data_config.train_labels_path == []
+    assert config.data_config.val_labels_path == []
+    assert config.model_config.backbone_config.unet.filters == 8
+    assert config.model_config.backbone_config.unet.max_stride == 16
+    assert config.trainer_config.max_epochs == 200
+    assert config.trainer_config.optimizer_name == "Adam"
+    assert config.trainer_config.optimizer.lr == 0.0001
+    assert config.trainer_config.trainer_devices == "auto"  # Default value
+    assert config.trainer_config.trainer_accelerator == "auto"  # Default value
+    assert config.trainer_config.enable_progress_bar is True  # Default value
+    assert config.trainer_config.train_data_loader.batch_size == 4  # From the JSON file
+    assert (
+        config.trainer_config.lr_scheduler.reduce_lr_on_plateau is not None
+    )  # From the JSON file
+    assert (
+        config.trainer_config.early_stopping.stop_training_on_plateau is True
+    )  # From the JSON file
+
 
 def test_load_bottomup_training_config_from_file(bottomup_training_config_path):
     """Test the load_sleap_config function with a sample bottomup configuration from a JSON file."""


### PR DESCRIPTION
This PR improves the handling of `save_ckpt_path` when mapping from a SLEAP config by correctly incorporating the configured prefix and suffix params. It also adds a new `load_sleap_config_from_json` class method to TrainingJobConfig, enabling conversion from a SLEAP JSON-formatted string directly, without requiring a file path.