### PR TITLE
Add more features to Tracker

### DIFF
--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -1786,8 +1786,9 @@ def run_inference(
     device: str = "auto",
     tracking: bool = False,
     tracking_window_size: int = 5,
-    tracking_instance_score_threshold: float = 0.0,
+    min_new_track_points: int = 0,
     candidates_method: str = "fixed_window",
+    min_match_points: int = 0,
     features: str = "keypoints",
     scoring_method: str = "oks",
     scoring_reduction: str = "mean",
@@ -1881,12 +1882,13 @@ def run_inference(
         tracking: (bool) If True, runs tracking on the predicted instances.
         tracking_window_size: Number of frames to look for in the candidate instances to match
                 with the current detections. Default: 5.
-        tracking_instance_score_threshold: Instance score threshold for creating new tracks.
-            Default: 0.0.
+        min_new_track_points: We won't spawn a new track for an instance with
+            fewer than this many points. Default: 0.
         candidates_method: Either of `fixed_window` or `local_queues`. In fixed window
             method, candidates from the last `window_size` frames. In local queues,
             last `window_size` instances for each track ID is considered for matching
             against the current detection. Default: `fixed_window`.
+        min_match_points: Minimum non-NaN points for match candidates. Default: 0.
         features: Feature representation for the candidates to update current detections.
             One of [`keypoints`, `centroids`, `bboxes`, `image`]. Default: `keypoints`.
         scoring_method: Method to compute association score between features from the
@@ -1954,8 +1956,9 @@ def run_inference(
             tracked_frames = run_tracker(
                 untracked_frames=frames,
                 window_size=tracking_window_size,
-                instance_score_threshold=tracking_instance_score_threshold,
+                min_new_track_points=min_new_track_points,
                 candidates_method=candidates_method,
+                min_match_points=min_match_points,
                 features=features,
                 scoring_method=scoring_method,
                 scoring_reduction=scoring_reduction,
@@ -2016,8 +2019,9 @@ def run_inference(
         if tracking:
             predictor.tracker = Tracker.from_config(
                 candidates_method=candidates_method,
+                min_match_points=min_match_points,
                 window_size=tracking_window_size,
-                instance_score_threshold=tracking_instance_score_threshold,
+                min_new_track_points=min_new_track_points,
                 features=features,
                 scoring_method=scoring_method,
                 scoring_reduction=scoring_reduction,

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -222,10 +222,12 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--tracking_instance_score_threshold",
-        type=float,
-        default=0.0,
-        help=("Instance score threshold for creating new tracks."),
+        "--min_new_track_points",
+        type=int,
+        default=0,
+        help=(
+            "We won't spawn a new track for an instance with fewer than this many points."
+        ),
     )
     parser.add_argument(
         "--candidates_method",
@@ -237,6 +239,12 @@ def _make_cli_parser() -> argparse.ArgumentParser:
             "last `window_size` instances for each track ID is considered for matching"
             "against the current detection."
         ),
+    )
+    parser.add_argument(
+        "--min_match_points",
+        type=int,
+        default=0,
+        help=("Minimum non-NaN points for match candidates."),
     )
     parser.add_argument(
         "--features",

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -264,7 +264,17 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         help=(
             "Method to aggregate and reduce multiple scores if there are"
             "several detections associated with the same track. One of [`mean`, `max`,"
-            "`weighted`]."
+            "`robust_quantile`]."
+        ),
+    )
+    parser.add_argument(
+        "--robust_best_instance",
+        type=float,
+        default=1.0,
+        help=(
+            "If the value is between 0 and 1 (excluded), use a robust quantile similarity score for the"
+            "track. If the value is 1, use the max similarity (non-robust)."
+            "For selecting a robust score, 0.95 is a good value."
         ),
     )
     parser.add_argument(
@@ -314,6 +324,16 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         help=(
             "Number of pyramid scale levels to consider. This is different"
             "from the scale parameter, which determines the initial image scaling."
+        ),
+    )
+
+    parser.add_argument(
+        "--post_connect_single_breaks",
+        action="store_true",
+        default=False,
+        help=(
+            "If True and `max_tracks` is not None with local queues candidate method,"
+            "connects track breaks when exactly one track is lost and exactly one new track is spawned in the frame."
         ),
     )
 

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1142,6 +1142,9 @@ def test_bottomup_predictor(
         max_instances=6,
         peak_threshold=0.03,
         tracking=True,
+        candidates_method="local_queues",
+        max_tracks=6,
+        post_connect_single_breaks=True,
         device="cpu",
     )
 
@@ -1213,3 +1216,24 @@ def test_bottomup_predictor(
     )
 
     assert np.all(np.abs(backbone_ckpt - model_weights) < 1e-6)
+
+
+def test_tracking_only_pipeline(
+    minimal_instance_centroid_ckpt, minimal_instance_ckpt, centered_instance_video
+):
+    """Test tracking-only pipeline."""
+    labels = run_inference(
+        model_paths=[minimal_instance_centroid_ckpt, minimal_instance_ckpt],
+        data_path=centered_instance_video.as_posix(),
+        make_labels=True,
+        max_instances=2,
+        peak_threshold=0.1,
+        frames=[x for x in range(0, 10)],
+        integral_refinement="integral",
+        post_connect_single_breaks=True,
+    )
+    labels.save("preds.slp")
+
+    tracked_labels = run_inference(data_path="preds.slp", tracking=True)
+
+    assert len(tracked_labels.tracks) == 2

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -879,7 +879,7 @@ def test_single_instance_predictor(
             data_path="./tests/assets/centered_pair_small.mp4",
             make_labels=True,
             device="cpu",
-            peak_threshold=0.3,
+            peak_threshold=0.0,
         )
         assert isinstance(pred_labels, sio.Labels)
         assert len(pred_labels) == 1100


### PR DESCRIPTION
This PR enhances the tracking pipeline with the following features:

- Support for track-only mode (skip generating predictions and use existing predicted instances).

- New arguments:

    - min_match_points: minimum non-NaN keypoints required to consider as candidates.

    - min_new_track_points: minimum non-nan keypoints required to initialize a new track.

- Adds post_connect_single_breaks(): stitches together tracks that have exactly one missing and one new track across consecutive frames.

- Adds robust quantile as an additional scoring reduction method (alongside max and mean).

