### PR TITLE
Add length parameter to InfiniteDataLoader

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -545,6 +545,11 @@ class ModelTrainer:
             train_steps_per_epoch = self.config.trainer_config.min_train_steps_per_epoch
         self.config.trainer_config.train_steps_per_epoch = train_steps_per_epoch
 
+        val_steps_per_epoch = get_steps_per_epoch(
+            dataset=val_dataset,
+            batch_size=self.config.trainer_config.val_data_loader.batch_size,
+        )
+
         # create lightning.Trainer instance.
         self.trainer = L.Trainer(
             callbacks=callbacks,
@@ -563,10 +568,12 @@ class ModelTrainer:
         # setup dataloaders
         # need to set up dataloaders after Trainer is initialized (for ddp). DistributedSampler depends on the rank
         train_dataloader, val_dataloader = get_train_val_dataloaders(
-            train_dataset,
-            val_dataset,
-            self.config,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            config=self.config,
             rank=self.trainer.global_rank if self.trainer is not None else None,
+            train_steps_per_epoch=self.config.trainer_config.train_steps_per_epoch,
+            val_steps_per_epoch=val_steps_per_epoch,
         )
 
         if (

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -807,9 +807,14 @@ def test_infinite_dataloader(minimal_instance, tmp_path):
 
     assert len(list(iter(dataset))) == 1
 
-    dl = iter(InfiniteDataLoader(dataset=dataset, batch_size=1, num_workers=0))
+    dl = InfiniteDataLoader(dataset=dataset, batch_size=1, num_workers=0)
+    loader = iter(dl)
 
     for _ in range(10):
-        _ = next(dl)
+        _ = next(loader)
 
     assert get_steps_per_epoch(dataset=dataset, batch_size=1) == 1
+    assert len(dl) == 1
+
+    dl = InfiniteDataLoader(dataset=dataset, batch_size=1, len_dataloader=15)
+    assert len(dl) == 15

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -101,7 +101,7 @@ def sample_cfg(minimal_instance, tmp_path):
                 "trainer_devices": 1,
                 "trainer_accelerator": "cpu",
                 "enable_progress_bar": False,
-                "min_train_steps_per_epoch": 200,
+                "min_train_steps_per_epoch": 20,
                 "train_steps_per_epoch": None,
                 "max_epochs": 2,
                 "seed": 1000,


### PR DESCRIPTION
This PR fixes the InfiniteDataLoader implementation. Lightning's Trainer does not rely on the dataloader's __iter__ for controlling the number of training steps per epoch—instead, it uses len(dataloader) to determine how many batches to draw. If __len__ returns the number of batches in the dataset (as it does by default in the Ultralytics based implementation), the dataloader will stop after one pass through the dataset, even if more steps per epoch are expected. This PR updates the __len__ to return the desired number of steps per epoch, allowing the infinite dataloader to be compatible with Lightning's limit_train_batches and ensuring proper cycling through the dataset across epochs.