### PR TITLE
Enable tracking on user-labeled instances

### DIFF
--- a/sleap_nn/tracking/candidates/fixed_window.py
+++ b/sleap_nn/tracking/candidates/fixed_window.py
@@ -53,7 +53,6 @@ class FixedWindowCandidates:
             track_ids=[None] * len(untracked_instances),
             tracking_scores=[None] * len(untracked_instances),
             features=feature_list,
-            instance_scores=[instance.score for instance in untracked_instances],
             frame_idx=frame_idx,
             image=image,
         )
@@ -80,7 +79,6 @@ class FixedWindowCandidates:
                     src_predicted_instance=t.src_instances[track_idx],
                     frame_idx=t.frame_idx,
                     tracking_score=t.tracking_scores[track_idx],
-                    instance_score=t.instance_scores[track_idx],
                     shifted_keypoints=None,
                 )
                 output.append(tracked_instance_feature)

--- a/sleap_nn/tracking/candidates/local_queues.py
+++ b/sleap_nn/tracking/candidates/local_queues.py
@@ -56,7 +56,6 @@ class LocalQueueCandidates:
                 src_instance_idx=ind,
                 track_id=None,
                 feature=feat,
-                instance_score=instance.score,
                 frame_idx=frame_idx,
                 image=image,
             )
@@ -82,7 +81,6 @@ class LocalQueueCandidates:
                 src_predicted_instance=t.src_instance,
                 frame_idx=t.frame_idx,
                 tracking_score=t.tracking_score,
-                instance_score=t.instance_score,
                 shifted_keypoints=None,
             )
             output.append(tracked_instance_feature)

--- a/sleap_nn/tracking/track_instance.py
+++ b/sleap_nn/tracking/track_instance.py
@@ -12,7 +12,6 @@ class TrackInstances:
 
     src_instances: List[sio.PredictedInstance]
     features: List[np.array]
-    instance_scores: List[float] = None
     track_ids: Optional[List[int]] = None
     tracking_scores: Optional[List[float]] = None
     frame_idx: Optional[float] = None
@@ -26,7 +25,6 @@ class TrackInstanceLocalQueue:
     src_instance: sio.PredictedInstance
     src_instance_idx: int
     feature: np.array
-    instance_score: float = None
     track_id: Optional[int] = None
     tracking_score: Optional[float] = None
     frame_idx: Optional[float] = None
@@ -46,5 +44,4 @@ class TrackedInstanceFeature:
     src_predicted_instance: sio.PredictedInstance
     frame_idx: int
     tracking_score: float
-    instance_score: float
     shifted_keypoints: np.ndarray = None

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -560,7 +560,6 @@ class FlowShiftTracker(Tracker):
                             src_predicted_instance=ref_candidate.src_instance,
                             frame_idx=fidx,
                             tracking_score=ref_candidate.tracking_score,
-                            instance_score=ref_candidate.instance_score,
                             shifted_keypoints=pts,
                         )
                     )
@@ -596,7 +595,6 @@ class FlowShiftTracker(Tracker):
                             src_predicted_instance=ref_candidate.src_instances[idx],
                             frame_idx=ref_candidate.frame_idx,
                             tracking_score=ref_candidate.tracking_scores[idx],
-                            instance_score=ref_candidate.instance_scores[idx],
                             shifted_keypoints=pts,
                         )
                     )
@@ -771,13 +769,25 @@ def run_tracker(
     )
     tracked_lfs = []
     for lf in untracked_frames:
-        print(lf.instances)
-        tracked_instances = tracker.track(
-            untracked_instances=lf.instances, frame_idx=lf.frame_idx, image=lf.image
+        # prefer user instances over predicted instance
+        instances = []
+        if lf.has_user_instances:
+            instances_to_track = lf.user_instances
+            if lf.has_predicted_instances:
+                instances = lf.predicted_instances
+        else:
+            instances_to_track = lf.predicted_instances
+
+        instances.extend(
+            tracker.track(
+                untracked_instances=instances_to_track,
+                frame_idx=lf.frame_idx,
+                image=lf.image,
+            )
         )
         tracked_lfs.append(
             sio.LabeledFrame(
-                video=lf.video, frame_idx=lf.frame_idx, instances=tracked_instances
+                video=lf.video, frame_idx=lf.frame_idx, instances=instances
             )
         )
 


### PR DESCRIPTION
This PR adds support for tracking user-labeled instances. Previously, the tracking pipeline only supported predicted instances. With this update, users can now run the tracking pipeline on manually labeled instances. If both user-labeled and predicted instances are present in a frame, the tracker will prioritize user-labeled instances.