### PR TITLE
Add `keep-viz` parameter

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -172,6 +172,7 @@ The config file has three main sections:
     - `min_train_steps_per_epoch`: (int) Minimum number of iterations in a single epoch. (Useful if model is trained with very few data points). Refer `limit_train_batches` parameter of Torch `Trainer`. *Default*: `200`.
     - `train_steps_per_epoch`: (int) Number of minibatches (steps) to train for in an epoch. If set to `None`, this is set to the number of batches in the training data or `min_train_steps_per_epoch`, whichever is largest. *Default*: `None`.
     - `visualize_preds_during_training`: (bool) If set to `True`, sample predictions (keypoints + confidence maps) are saved to `viz` folder in the ckpt dir and in wandb table. *Default*: `False`.
+    - `keep_viz`: (bool) If set to `True`, the `viz` folder containing training visualizations will be kept after training completes. If `False`, the folder will be deleted. This parameter only has an effect when `visualize_preds_during_training` is `True`. *Default*: `False`.
     - `max_epochs`: (int) Maximum number of epochs to run. *Default*: `10`.
     - `seed`: (int) Seed value for the current experiment. *Default*: `0`.
     - `use_wandb`: (bool) True to enable wandb logging. *Default*: `False`.

--- a/docs/config_bottomup_convnext.yaml
+++ b/docs/config_bottomup_convnext.yaml
@@ -109,6 +109,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 40
   seed: 0
   use_wandb: false

--- a/docs/config_bottomup_unet.yaml
+++ b/docs/config_bottomup_unet.yaml
@@ -109,6 +109,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 40
   seed: 0
   use_wandb: false

--- a/docs/config_centroid_swint.yaml
+++ b/docs/config_centroid_swint.yaml
@@ -104,6 +104,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 30
   seed: 0
   use_wandb: true

--- a/docs/config_centroid_unet.yaml
+++ b/docs/config_centroid_unet.yaml
@@ -103,6 +103,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 30
   seed: 0
   use_wandb: true

--- a/docs/config_multi_class_bottomup_unet.yaml
+++ b/docs/config_multi_class_bottomup_unet.yaml
@@ -110,6 +110,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 40
   seed: 0
   use_wandb: false

--- a/docs/config_single_instance_unet.yaml
+++ b/docs/config_single_instance_unet.yaml
@@ -102,6 +102,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 200
   seed: 0
   use_wandb: false

--- a/docs/config_topdown_centered_instance_unet.yaml
+++ b/docs/config_topdown_centered_instance_unet.yaml
@@ -106,6 +106,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 30
   seed: 0
   use_wandb: false

--- a/docs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -114,6 +114,7 @@ trainer_config:
   min_train_steps_per_epoch: 200
   train_steps_per_epoch:
   visualize_preds_during_training: true
+  keep_viz: false
   max_epochs: 30
   seed: 0
   use_wandb: false

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -374,8 +374,7 @@ def trainer_mapper(legacy_config: dict) -> TrainerConfig:
 
     # Handle legacy delete_viz_images parameter
     if legacy_config_outputs.get("keep_viz_images", None) is not None:
-        # Invert the logic: delete_viz_images=True means keep_viz=False
-        trainer_cfg_args["keep_viz"] = not legacy_config_outputs["keep_viz_images"]
+        trainer_cfg_args["keep_viz"] = legacy_config_outputs["keep_viz_images"]
 
     if legacy_config_optimization.get("epochs", None) is not None:
         trainer_cfg_args["max_epochs"] = legacy_config_optimization["epochs"]

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -471,6 +471,7 @@ def get_trainer_config(
     min_train_steps_per_epoch: int = 200,
     train_steps_per_epoch: Optional[int] = None,
     visualize_preds_during_training: bool = False,
+    keep_viz: bool = False,
     max_epochs: int = 10,
     seed: int = 0,
     use_wandb: bool = False,
@@ -534,6 +535,8 @@ def get_trainer_config(
             whichever is largest. Default: `None`.
         visualize_preds_during_training: If set to `True`, sample predictions (keypoints  + confidence maps)
             are saved to `viz` folder in the ckpt dir and in wandb table.
+        keep_viz: If set to `True`, the `viz` folder will be kept after training. If `False`, the `viz` folder
+            will be deleted after training. Only applies when `visualize_preds_during_training` is `True`.
         max_epochs: Maximum number of epochs to run. Default: 100.
         seed: Seed value for the current experiment. default: 1000.
         save_ckpt: True to enable checkpointing. Default: False.
@@ -637,6 +640,7 @@ def get_trainer_config(
         min_train_steps_per_epoch=min_train_steps_per_epoch,
         train_steps_per_epoch=train_steps_per_epoch,
         visualize_preds_during_training=visualize_preds_during_training,
+        keep_viz=keep_viz,
         max_epochs=max_epochs,
         seed=seed,
         use_wandb=use_wandb,
@@ -785,6 +789,7 @@ def train(
     min_train_steps_per_epoch: int = 200,
     train_steps_per_epoch: Optional[int] = None,
     visualize_preds_during_training: bool = False,
+    keep_viz: bool = False,
     max_epochs: int = 10,
     seed: int = 0,
     use_wandb: bool = False,
@@ -955,6 +960,7 @@ def train(
             whichever is largest. Default: `None`.
         visualize_preds_during_training: If set to `True`, sample predictions (keypoints  + confidence maps)
             are saved to `viz` folder in the ckpt dir and in wandb table.
+        keep_viz: If set to `True`, the `viz` folder containing training visualizations will be kept after training completes. If `False`, the folder will be deleted. This parameter only has an effect when `visualize_preds_during_training` is `True`. Default: `False`.
         max_epochs: Maximum number of epochs to run. Default: 10.
         seed: Seed value for the current experiment. default: 0.
         save_ckpt: True to enable checkpointing. Default: False.
@@ -1057,6 +1063,7 @@ def train(
         min_train_steps_per_epoch=min_train_steps_per_epoch,
         train_steps_per_epoch=train_steps_per_epoch,
         visualize_preds_during_training=visualize_preds_during_training,
+        keep_viz=keep_viz,
         max_epochs=max_epochs,
         seed=seed,
         use_wandb=use_wandb,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -690,3 +690,13 @@ class ModelTrainer:
                 and self.config.data_config.delete_cache_imgs_after_training
             ):
                 self._delete_cache_imgs()
+
+            # delete viz folder if requested
+            if (
+                self.config.trainer_config.visualize_preds_during_training
+                and not self.config.trainer_config.keep_viz
+            ):
+                viz_dir = Path(self.config.trainer_config.save_ckpt_path) / "viz"
+                if viz_dir.exists():
+                    logger.info(f"Deleting viz folder at {viz_dir}...")
+                    shutil.rmtree(viz_dir, ignore_errors=True)

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -278,7 +278,7 @@ def test_trainer_mapper():
     assert config.optimizer_name == "Adam"
     assert config.optimizer.lr == 0.001
     assert config.model_ckpt.save_last is None
-    assert config.visualize_preds_during_training is False
+    assert config.visualize_preds_during_training is True
 
     # Test for default values (unspecified by legacy config)
     assert config.trainer_devices == "auto"

--- a/tests/config/test_training_job_config.py
+++ b/tests/config/test_training_job_config.py
@@ -308,6 +308,9 @@ def test_load_topdown_training_config_from_file(topdown_training_config_path):
     assert config.model_config.backbone_config.unet.max_stride == 16
     assert config.model_config.backbone_config.unet.output_stride == 2
 
+    assert not config.trainer_config.keep_viz
+    assert not config.trainer_config.visualize_preds_during_training
+
     # Test topdown head config
     topdown = config.model_config.head_configs.multi_class_topdown
     assert topdown.confmaps.part_names == ["head", "thorax"]

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -126,6 +126,7 @@ def config(sleap_nn_data_dir):
                 "train_steps_per_epoch": None,
                 "max_epochs": 2,
                 "seed": 1000,
+                "keep_viz": True,
                 "use_wandb": False,
                 "save_ckpt": False,
                 "save_ckpt_path": "",


### PR DESCRIPTION
This PR adds `keep_viz` parameter to the config which if set to `False` deletes the `viz` folder created once the training is complete.