### PR TITLE
Fix wandb logging

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -658,7 +658,14 @@ class ModelTrainer:
         ):  # save config if there are no distributed process
 
             if self.config.trainer_config.use_wandb:
-                wandb.init(dir=self.config.trainer_config.save_ckpt_path)
+                wandb.init(
+                    dir=self.config.trainer_config.save_ckpt_path,
+                    project=self.config.trainer_config.wandb.project,
+                    entity=self.config.trainer_config.wandb.entity,
+                    name=self.config.trainer_config.wandb.name,
+                    id=self.config.trainer_config.wandb.prv_runid,
+                    group=self.config.trainer_config.wandb.group,
+                )
                 self.config.trainer_config.wandb.current_run_id = wandb.run.id
                 wandb.config["run_name"] = self.config.trainer_config.wandb.name
                 wandb.config["run_config"] = OmegaConf.to_container(


### PR DESCRIPTION
This PR fixes an issue with wandb logging by ensuring that the provided wandb configuration is correctly passed to `wandb.init()` call.









Ask ChatGPT
