### PR TITLE
Minor bug fixes in training pipeline

### DIFF
--- a/sleap_nn/architectures/convnext.py
+++ b/sleap_nn/architectures/convnext.py
@@ -237,7 +237,7 @@ class ConvNextWrapper(nn.Module):
                 pool_before_convs=False,
                 pooling_stride=2,
                 num_convs=convs_per_block - 1,
-                filters=int(last_block_filters * filters_rate),
+                filters=round(last_block_filters * filters_rate),
                 kernel_size=kernel_size,
                 use_bias=True,
                 batch_norm=False,
@@ -252,10 +252,10 @@ class ConvNextWrapper(nn.Module):
             block_filters = int(last_block_filters)
         else:
             # Keep the block output filters the same
-            block_filters = int(last_block_filters * filters_rate)
+            block_filters = round(last_block_filters * filters_rate)
 
         middle_contract = SimpleConvBlock(
-            in_channels=int(last_block_filters * filters_rate),
+            in_channels=round(last_block_filters * filters_rate),
             pool=False,
             pool_before_convs=False,
             pooling_stride=2,
@@ -279,7 +279,7 @@ class ConvNextWrapper(nn.Module):
             x_in_shape = int(self.arch["channels"][-1])
         else:
             # Keep the block output filters the same
-            x_in_shape = int(self.arch["channels"][-1] * filters_rate)
+            x_in_shape = round(self.arch["channels"][-1] * filters_rate)
 
         self.dec = Decoder(
             x_in_shape=x_in_shape,

--- a/sleap_nn/architectures/encoder_decoder.py
+++ b/sleap_nn/architectures/encoder_decoder.py
@@ -185,7 +185,7 @@ class StemBlock(nn.Module):
 
         for block in range(self.stem_blocks):
             prev_block_filters = in_channels if block == 0 else block_filters
-            block_filters = int(self.filters * (self.filters_rate**block))
+            block_filters = round(self.filters * (self.filters_rate**block))
 
             self.stem_stack.append(
                 SimpleConvBlock(
@@ -271,10 +271,12 @@ class Encoder(nn.Module):
         self.prefix = prefix
 
         self.encoder_stack = nn.ModuleList([])
-        block_filters = int(filters * (filters_rate ** (stem_blocks - 1)))
+        block_filters = round(filters * (filters_rate ** (stem_blocks - 1)))
         for block in range(down_blocks):
             prev_block_filters = -1 if block + self.stem_blocks == 0 else block_filters
-            block_filters = int(filters * (filters_rate ** (block + self.stem_blocks)))
+            block_filters = round(
+                filters * (filters_rate ** (block + self.stem_blocks))
+            )
 
             self.encoder_stack.append(
                 SimpleConvBlock(
@@ -605,13 +607,13 @@ class Decoder(nn.Module):
 
         for block in range(up_blocks):
             prev_block_filters = -1 if block == 0 else block_filters_out
-            block_filters_out = int(
+            block_filters_out = round(
                 filters
                 * (filters_rate ** max(0, down_blocks + self.stem_blocks - 1 - block))
             )
 
             if self.block_contraction:
-                block_filters_out = int(
+                block_filters_out = round(
                     self.filters
                     * (
                         self.filters_rate

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -153,7 +153,7 @@ class Model(nn.Module):
                     in_channels *= self.backbone.filters_rate * (
                         np.log2(head.output_stride) - np.log2(min_output_stride)
                     )
-            self.head_layers.append(head.make_head(x_in=int(in_channels)))
+            self.head_layers.append(head.make_head(x_in=round(in_channels)))
 
     @classmethod
     def from_config(

--- a/sleap_nn/architectures/swint.py
+++ b/sleap_nn/architectures/swint.py
@@ -273,7 +273,7 @@ class SwinTWrapper(nn.Module):
                 pool_before_convs=False,
                 pooling_stride=2,
                 num_convs=convs_per_block - 1,
-                filters=int(last_block_filters * filters_rate),
+                filters=round(last_block_filters * filters_rate),
                 kernel_size=kernel_size,
                 use_bias=True,
                 batch_norm=False,
@@ -288,10 +288,10 @@ class SwinTWrapper(nn.Module):
             block_filters = int(last_block_filters)
         else:
             # Keep the block output filters the same
-            block_filters = int(last_block_filters * filters_rate)
+            block_filters = round(last_block_filters * filters_rate)
 
         middle_contract = SimpleConvBlock(
-            in_channels=int(last_block_filters * filters_rate),
+            in_channels=round(last_block_filters * filters_rate),
             pool=False,
             pool_before_convs=False,
             pooling_stride=2,

--- a/sleap_nn/architectures/unet.py
+++ b/sleap_nn/architectures/unet.py
@@ -101,7 +101,7 @@ class UNet(nn.Module):
         for i in range(self.stacks):
             # Create encoder for this stack
             in_channels = (
-                int(self.filters * (self.filters_rate ** (self.stem_blocks)))
+                round(self.filters * (self.filters_rate ** (self.stem_blocks)))
                 if self.stem_blocks > 0
                 else in_channels
             )
@@ -119,7 +119,7 @@ class UNet(nn.Module):
             # Create middle block separately (not part of encoder stack)
             self.middle_blocks = nn.ModuleList()
             # Get the last block filters from encoder
-            last_block_filters = int(
+            last_block_filters = round(
                 filters * (filters_rate ** (down_blocks + stem_blocks - 1))
             )
             enc_num = len(encoder.encoder_stack)
@@ -151,10 +151,10 @@ class UNet(nn.Module):
                     block_filters = int(last_block_filters)
                 else:
                     # Keep the block output filters the same
-                    block_filters = int(last_block_filters * filters_rate)
+                    block_filters = round(last_block_filters * filters_rate)
 
                 middle_contract = SimpleConvBlock(
-                    in_channels=int(last_block_filters * filters_rate),
+                    in_channels=round(last_block_filters * filters_rate),
                     pool=False,
                     pool_before_convs=False,
                     pooling_stride=2,
@@ -187,12 +187,12 @@ class UNet(nn.Module):
             # Create decoder for this stack
             if self.block_contraction:
                 # Contract the channels with an exponent lower than the last encoder block
-                x_in_shape = int(
+                x_in_shape = round(
                     filters * (filters_rate ** (down_blocks + stem_blocks - 1))
                 )
             else:
                 # Keep the block output filters the same
-                x_in_shape = int(
+                x_in_shape = round(
                     filters * (filters_rate ** (down_blocks + stem_blocks))
                 )
             decoder = Decoder(

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1891,6 +1891,19 @@ def get_train_val_dataloaders(
         and config.trainer_config.train_data_loader.pin_memory is not None
         else True
     )
+    if train_steps_per_epoch is None:
+        train_steps_per_epoch = config.trainer_config.train_steps_per_epoch
+        if train_steps_per_epoch is None:
+            train_steps_per_epoch = get_steps_per_epoch(
+                dataset=train_dataset,
+                batch_size=config.trainer_config.train_data_loader.batch_size,
+            )
+
+    if val_steps_per_epoch is None:
+        val_steps_per_epoch = get_steps_per_epoch(
+            dataset=val_dataset,
+            batch_size=config.trainer_config.val_data_loader.batch_size,
+        )
 
     trainer_devices = config.trainer_config.trainer_devices
     trainer_devices = (
@@ -1912,7 +1925,11 @@ def get_train_val_dataloaders(
     train_data_loader = InfiniteDataLoader(
         dataset=train_dataset,
         sampler=train_sampler,
-        len_dataloader=round(train_steps_per_epoch / trainer_devices),
+        len_dataloader=(
+            round(train_steps_per_epoch / trainer_devices)
+            if trainer_devices >= 1
+            else None
+        ),
         shuffle=(
             config.trainer_config.train_data_loader.shuffle
             if train_sampler is None
@@ -1945,7 +1962,11 @@ def get_train_val_dataloaders(
         dataset=val_dataset,
         shuffle=False if val_sampler is None else None,
         sampler=val_sampler,
-        len_dataloader=round(val_steps_per_epoch / trainer_devices),
+        len_dataloader=(
+            round(val_steps_per_epoch / trainer_devices)
+            if trainer_devices >= 1
+            else None
+        ),
         batch_size=config.trainer_config.val_data_loader.batch_size,
         num_workers=config.trainer_config.val_data_loader.num_workers,
         pin_memory=pin_memory,

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1912,7 +1912,7 @@ def get_train_val_dataloaders(
     train_data_loader = InfiniteDataLoader(
         dataset=train_dataset,
         sampler=train_sampler,
-        len_dataloader=train_steps_per_epoch,
+        len_dataloader=round(train_steps_per_epoch / trainer_devices),
         shuffle=(
             config.trainer_config.train_data_loader.shuffle
             if train_sampler is None
@@ -1945,7 +1945,7 @@ def get_train_val_dataloaders(
         dataset=val_dataset,
         shuffle=False if val_sampler is None else None,
         sampler=val_sampler,
-        len_dataloader=val_steps_per_epoch,
+        len_dataloader=round(val_steps_per_epoch / trainer_devices),
         batch_size=config.trainer_config.val_data_loader.batch_size,
         num_workers=config.trainer_config.val_data_loader.num_workers,
         pin_memory=pin_memory,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -658,14 +658,15 @@ class ModelTrainer:
         ):  # save config if there are no distributed process
 
             if self.config.trainer_config.use_wandb:
-                wandb.init(
-                    dir=self.config.trainer_config.save_ckpt_path,
-                    project=self.config.trainer_config.wandb.project,
-                    entity=self.config.trainer_config.wandb.entity,
-                    name=self.config.trainer_config.wandb.name,
-                    id=self.config.trainer_config.wandb.prv_runid,
-                    group=self.config.trainer_config.wandb.group,
-                )
+                if wandb.run is None:
+                    wandb.init(
+                        dir=self.config.trainer_config.save_ckpt_path,
+                        project=self.config.trainer_config.wandb.project,
+                        entity=self.config.trainer_config.wandb.entity,
+                        name=self.config.trainer_config.wandb.name,
+                        id=self.config.trainer_config.wandb.prv_runid,
+                        group=self.config.trainer_config.wandb.group,
+                    )
                 self.config.trainer_config.wandb.current_run_id = wandb.run.id
                 wandb.config["run_name"] = self.config.trainer_config.wandb.name
                 wandb.config["run_config"] = OmegaConf.to_container(


### PR DESCRIPTION
This PR fixes the following bugs:
- Fix data duplication in multi-GPU training: When using an infinite data loader with multiple GPUs, data was being unnecessarily replicated. This is now resolved by limiting the number of training steps based on the number of available devices.

- Improve filter computation: Use round() instead of int() when computing the number of filters to avoid unintended down-rounding.

- WandB initialization check: Prevent duplicate WandB runs by checking if a run is already initialized before calling wandb.init(). This is particularly useful for compatibility with sweep-based executions.