### PR TITLE
Fix minor bugs

### DIFF
--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -153,7 +153,7 @@ class Model(nn.Module):
                     in_channels *= self.backbone.filters_rate * (
                         np.log2(head.output_stride) - np.log2(min_output_stride)
                     )
-            self.head_layers.append(head.make_head(x_in=int(in_channels)))
+            self.head_layers.append(head.make_head(x_in=round(in_channels)))
 
     @classmethod
     def from_config(

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1892,6 +1892,20 @@ def get_train_val_dataloaders(
         else True
     )
 
+    if train_steps_per_epoch is None:
+        train_steps_per_epoch = config.trainer_config.train_steps_per_epoch
+        if train_steps_per_epoch is None:
+            train_steps_per_epoch = get_steps_per_epoch(
+                dataset=train_dataset,
+                batch_size=config.trainer_config.train_data_loader.batch_size,
+            )
+
+    if val_steps_per_epoch is None:
+        val_steps_per_epoch = get_steps_per_epoch(
+            dataset=val_dataset,
+            batch_size=config.trainer_config.val_data_loader.batch_size,
+        )
+
     trainer_devices = config.trainer_config.trainer_devices
     trainer_devices = (
         trainer_devices
@@ -1912,7 +1926,11 @@ def get_train_val_dataloaders(
     train_data_loader = InfiniteDataLoader(
         dataset=train_dataset,
         sampler=train_sampler,
-        len_dataloader=train_steps_per_epoch,
+        len_dataloader=(
+            round(train_steps_per_epoch / trainer_devices)
+            if trainer_devices >= 1
+            else None
+        ),
         shuffle=(
             config.trainer_config.train_data_loader.shuffle
             if train_sampler is None
@@ -1945,7 +1963,11 @@ def get_train_val_dataloaders(
         dataset=val_dataset,
         shuffle=False if val_sampler is None else None,
         sampler=val_sampler,
-        len_dataloader=val_steps_per_epoch,
+        len_dataloader=(
+            round(val_steps_per_epoch / trainer_devices)
+            if trainer_devices >= 1
+            else None
+        ),
         batch_size=config.trainer_config.val_data_loader.batch_size,
         num_workers=config.trainer_config.val_data_loader.num_workers,
         pin_memory=pin_memory,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -658,14 +658,15 @@ class ModelTrainer:
         ):  # save config if there are no distributed process
 
             if self.config.trainer_config.use_wandb:
-                wandb.init(
-                    dir=self.config.trainer_config.save_ckpt_path,
-                    project=self.config.trainer_config.wandb.project,
-                    entity=self.config.trainer_config.wandb.entity,
-                    name=self.config.trainer_config.wandb.name,
-                    id=self.config.trainer_config.wandb.prv_runid,
-                    group=self.config.trainer_config.wandb.group,
-                )
+                if wandb.run is None:
+                    wandb.init(
+                        dir=self.config.trainer_config.save_ckpt_path,
+                        project=self.config.trainer_config.wandb.project,
+                        entity=self.config.trainer_config.wandb.entity,
+                        name=self.config.trainer_config.wandb.name,
+                        id=self.config.trainer_config.wandb.prv_runid,
+                        group=self.config.trainer_config.wandb.group,
+                    )
                 self.config.trainer_config.wandb.current_run_id = wandb.run.id
                 wandb.config["run_name"] = self.config.trainer_config.wandb.name
                 wandb.config["run_config"] = OmegaConf.to_container(


### PR DESCRIPTION
This PR fixes the following bugs:

- Fix data duplication in multi-GPU training: When using an infinite data loader with multiple GPUs, data was being unnecessarily replicated. This is now resolved by limiting the number of training steps based on the number of available devices.

- Improve filter computation: Use round() instead of int() when computing the number of filters to avoid unintended down-rounding.

- WandB initialization check: Prevent duplicate WandB runs by checking if a run is already initialized before calling wandb.init(). This is particularly useful for compatibility with sweep-based executions.