### PR TITLE
Update in channels for torch with keras weights

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -318,6 +318,26 @@ class ModelTrainer:
                     self.config.trainer_config.save_ckpt_path
                 )
 
+        # check in channels, verify with img channels / ensure_rgb/ ensure_grayscale
+        if self.train_labels[0] is not None:
+            img_channels = self.train_labels[0][0].image.shape[-1]
+            if self.config.data_config.preprocessing.ensure_rgb:
+                img_channels = 3
+            if self.config.data_config.preprocessing.ensure_grayscale:
+                img_channels = 1
+            if (
+                self.config.model_config.backbone_config[
+                    f"{self.backbone_type}"
+                ].in_channels
+                != img_channels
+            ):
+                self.config.model_config.backbone_config[
+                    f"{self.backbone_type}"
+                ].in_channels = img_channels
+                logger.info(
+                    f"Updating backbone in_channels from {self.config.model_config.backbone_config[f'{self.backbone_type}'].in_channels} to {img_channels}"
+                )
+
     def _setup_model_ckpt_dir(self):
         """Create the model ckpt folder."""
         ckpt_path = self.config.trainer_config.save_ckpt_path

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1756,7 +1756,6 @@ def test_legacy_single_instance_predictor(
         data_path=small_robot_minimal.as_posix(),
         make_labels=True,
         integral_refinement="integral",
-        ensure_grayscale=True,
     )
     gt_labels = sio.load_slp(small_robot_minimal)
 

--- a/tests/test_legacy_models.py
+++ b/tests/test_legacy_models.py
@@ -19,6 +19,8 @@ from sleap_nn.legacy_models import (
     load_legacy_model_weights,
     map_legacy_to_pytorch_layers,
     load_legacy_model,
+    get_keras_first_layer_channels,
+    update_backbone_in_channels,
 )
 
 
@@ -1121,3 +1123,219 @@ class TestActivationStatistics:
                     print(
                         f"  {name_l}: loaded(μ={loaded_mean:.4f}, σ={loaded_std:.4f}) vs random(μ={random_mean:.4f}, σ={random_std:.4f})"
                     )
+
+
+class TestChannelDetection:
+    """Test channel detection and backbone configuration updates."""
+
+    def test_get_keras_first_layer_channels(self, tmp_path):
+        """Test extracting input channels from Keras model."""
+        # Create a mock Keras model file with known structure
+        h5_path = tmp_path / "test_model.h5"
+
+        with h5py.File(h5_path, "w") as f:
+            # Create model_weights group
+            model_weights = f.create_group("model_weights")
+
+            # Create first layer with 3 input channels (using UNet naming pattern)
+            first_layer = model_weights.create_group("stack0_enc0_conv0")
+            kernel_data = np.random.randn(3, 3, 3, 32)  # (H, W, C_in, C_out)
+            first_layer.create_dataset("stack0_enc0_conv0/kernel:0", data=kernel_data)
+            first_layer.create_dataset(
+                "stack0_enc0_conv0/bias:0", data=np.random.randn(32)
+            )
+
+            # Create second layer
+            second_layer = model_weights.create_group("stack0_enc0_conv1")
+            kernel_data = np.random.randn(3, 3, 32, 64)  # (H, W, C_in, C_out)
+            second_layer.create_dataset("stack0_enc0_conv1/kernel:0", data=kernel_data)
+            second_layer.create_dataset(
+                "stack0_enc0_conv1/bias:0", data=np.random.randn(64)
+            )
+
+        # Test channel extraction
+        channels = get_keras_first_layer_channels(str(h5_path))
+        assert channels == 3
+
+    def test_get_keras_first_layer_channels_single_channel(self, tmp_path):
+        """Test extracting input channels from single-channel Keras model."""
+        h5_path = tmp_path / "test_model.h5"
+
+        with h5py.File(h5_path, "w") as f:
+            model_weights = f.create_group("model_weights")
+            first_layer = model_weights.create_group("first_conv")
+            kernel_data = np.random.randn(3, 3, 1, 32)  # (H, W, C_in, C_out)
+            first_layer.create_dataset("first_conv/kernel:0", data=kernel_data)
+            first_layer.create_dataset("first_conv/bias:0", data=np.random.randn(32))
+
+        channels = get_keras_first_layer_channels(str(h5_path))
+        assert channels == 1
+
+    def test_get_keras_first_layer_channels_no_kernel(self, tmp_path):
+        """Test handling of model without kernel weights."""
+        h5_path = tmp_path / "test_model.h5"
+
+        with h5py.File(h5_path, "w") as f:
+            model_weights = f.create_group("model_weights")
+            # Only bias weights, no kernel
+            first_layer = model_weights.create_group("first_conv")
+            first_layer.create_dataset("first_conv/bias:0", data=np.random.randn(32))
+
+        channels = get_keras_first_layer_channels(str(h5_path))
+        assert channels is None
+
+    def test_get_keras_first_layer_channels_different_patterns(self, tmp_path):
+        """Test extracting input channels with different naming patterns."""
+        # Test 1: ConvNext pattern
+        h5_path = tmp_path / "convnext_model.h5"
+        with h5py.File(h5_path, "w") as f:
+            model_weights = f.create_group("model_weights")
+            # ConvNext first layer
+            first_layer = model_weights.create_group("features.0.0")
+            kernel_data = np.random.randn(4, 4, 3, 96)  # (H, W, C_in, C_out)
+            first_layer.create_dataset("features.0.0/kernel:0", data=kernel_data)
+            first_layer.create_dataset("features.0.0/bias:0", data=np.random.randn(96))
+
+            # Later layer
+            second_layer = model_weights.create_group("features.1.0")
+            kernel_data = np.random.randn(3, 3, 96, 192)  # (H, W, C_in, C_out)
+            second_layer.create_dataset("features.1.0/kernel:0", data=kernel_data)
+            second_layer.create_dataset(
+                "features.1.0/bias:0", data=np.random.randn(192)
+            )
+
+        channels = get_keras_first_layer_channels(str(h5_path))
+        assert channels == 3
+
+        # Test 2: Stem block pattern
+        h5_path = tmp_path / "stem_model.h5"
+        with h5py.File(h5_path, "w") as f:
+            model_weights = f.create_group("model_weights")
+            # Stem block first layer
+            first_layer = model_weights.create_group("stem0")
+            kernel_data = np.random.randn(7, 7, 1, 64)  # (H, W, C_in, C_out)
+            first_layer.create_dataset("stem0/kernel:0", data=kernel_data)
+            first_layer.create_dataset("stem0/bias:0", data=np.random.randn(64))
+
+            # Later layer
+            second_layer = model_weights.create_group("encoder_block1")
+            kernel_data = np.random.randn(3, 3, 64, 128)  # (H, W, C_in, C_out)
+            second_layer.create_dataset("encoder_block1/kernel:0", data=kernel_data)
+            second_layer.create_dataset(
+                "encoder_block1/bias:0", data=np.random.randn(128)
+            )
+
+        channels = get_keras_first_layer_channels(str(h5_path))
+        assert channels == 1
+
+        # Test 3: Custom naming with fallback
+        h5_path = tmp_path / "custom_model.h5"
+        with h5py.File(h5_path, "w") as f:
+            model_weights = f.create_group("model_weights")
+            # Custom named first layer
+            first_layer = model_weights.create_group("my_custom_input_layer")
+            kernel_data = np.random.randn(3, 3, 3, 32)  # (H, W, C_in, C_out)
+            first_layer.create_dataset(
+                "my_custom_input_layer/kernel:0", data=kernel_data
+            )
+            first_layer.create_dataset(
+                "my_custom_input_layer/bias:0", data=np.random.randn(32)
+            )
+
+            # Later layer with more channels
+            second_layer = model_weights.create_group("my_custom_output_layer")
+            kernel_data = np.random.randn(3, 3, 32, 64)  # (H, W, C_in, C_out)
+            second_layer.create_dataset(
+                "my_custom_output_layer/kernel:0", data=kernel_data
+            )
+            second_layer.create_dataset(
+                "my_custom_output_layer/bias:0", data=np.random.randn(64)
+            )
+
+        channels = get_keras_first_layer_channels(str(h5_path))
+        assert channels == 3
+
+    def test_update_backbone_in_channels(self):
+        """Test updating backbone configuration in_channels."""
+        from omegaconf import DictConfig
+
+        # Create a mock backbone config
+        backbone_config = DictConfig(
+            {"in_channels": 1, "filters": 32, "kernel_size": 3}
+        )
+
+        # Test updating when channels are different
+        update_backbone_in_channels(backbone_config, 3)
+        assert backbone_config.in_channels == 3
+
+        # Test not updating when channels are the same
+        update_backbone_in_channels(backbone_config, 3)
+        assert backbone_config.in_channels == 3  # Should remain unchanged
+
+        # Test not updating when channels are 1 (default)
+        backbone_config.in_channels = 1
+        update_backbone_in_channels(backbone_config, 1)
+        assert backbone_config.in_channels == 1
+
+    def test_create_model_with_channel_detection(self, tmp_path):
+        """Test that model creation uses channel detection when h5 file exists."""
+        # Create a mock config file
+        config_path = tmp_path / "training_config.json"
+        config_data = {
+            "model_config": {
+                "backbone_config": {
+                    "unet": {
+                        "in_channels": 1,  # Default
+                        "filters": 32,
+                        "kernel_size": 3,
+                        "filters_rate": 1.5,
+                        "max_stride": 16,
+                        "stem_stride": None,
+                        "middle_block": True,
+                        "up_interpolate": True,
+                        "stacks": 1,
+                        "convs_per_block": 2,
+                        "output_stride": 1,
+                    }
+                },
+                "head_configs": {
+                    "centroid": {
+                        "confmaps": {
+                            "anchor_part": None,
+                            "sigma": 5.0,
+                            "output_stride": 1,
+                        }
+                    }
+                },
+            }
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        # Create a mock h5 file with 3 channels
+        h5_path = tmp_path / "best_model.h5"
+        with h5py.File(h5_path, "w") as f:
+            model_weights = f.create_group("model_weights")
+            first_layer = model_weights.create_group("first_conv")
+            kernel_data = np.random.randn(3, 3, 3, 32)  # 3 input channels
+            first_layer.create_dataset("first_conv/kernel:0", data=kernel_data)
+            first_layer.create_dataset("first_conv/bias:0", data=np.random.randn(32))
+
+        # Mock the TrainingJobConfig.load_sleap_config to return our config
+        from unittest.mock import patch
+        from omegaconf import DictConfig
+
+        def mock_load_config(path):
+            return DictConfig(config_data)
+
+        with patch(
+            "sleap_nn.legacy_models.TrainingJobConfig.load_sleap_config",
+            side_effect=mock_load_config,
+        ):
+            # This should update the backbone config to use 3 channels
+            model = create_model_from_legacy_config(str(tmp_path))
+
+            # Check that the model was created with the updated config
+            # The backbone should have 3 input channels
+            assert model.backbone.in_channels == 3


### PR DESCRIPTION
This PR addresses issue #258 by adding compatibility when converting Keras model weights to PyTorch. 

- We now read the input channel dimension first from the Keras .h5 weights file and update the corresponding `in_channels` parameter in the converted PyTorch model before loading the weights of other layers.

- We also add a validation step in the `ModelTrainer` class to check if the input image shape (after preprocessing) matches `in_channels` in the config. If there is a mismatch, the config is automatically updated to reflect the correct number of input channels depending on the image shape.
