### PR TITLE
Move convnext/ swint pretrained weights

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -81,7 +81,6 @@ The model configuration section defines the neural network architecture, includi
 
 ### Model Initialization
 - `init_weights`: (str) Model weights initialization method. "default" uses kaiming uniform initialization and "xavier" uses Xavier initialization method. **Default**: `"default"`
-- `pre_trained_weights`: (str) Pretrained weights file name supported only for ConvNext and SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights","ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"]. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"]. **Default**: `None`
 - `pretrained_backbone_weights`: (str) Path of the `ckpt` file with which the backbone is initialized. If `None`, random init is used. **Default**: `None`
 - `pretrained_head_weights`: (str) Path of the `ckpt` file with which the head layers are initialized. If `None`, random init is used. **Default**: `None`
 
@@ -104,6 +103,7 @@ The model configuration section defines the neural network architecture, includi
 
 #### ConvNeXt Backbone
 - `backbone_config.convnext`:
+  - `pre_trained_weights`: (str) Pretrained weights file name supported only for ConvNext backbones. For ConvNext, one of ["ConvNeXt_Base_Weights","ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"]. **Default**: `None`
   - `arch`: (Default is `Tiny` architecture config. No need to provide if `model_type` is provided)
     - `depths`: (List[int]) Number of layers in each block. **Default**: `[3, 3, 9, 3]`
     - `channels`: (List[int]) Number of channels in each block. **Default**: `[96, 192, 384, 768]`
@@ -120,6 +120,7 @@ The model configuration section defines the neural network architecture, includi
 
 #### Swin Transformer Backbone
 - `backbone_config.swint`:
+  - `pre_trained_weights`: (str) Pretrained weights file name supported only for SwinT backbones. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"]. **Default**: `None`
   - `model_type`: (str) One of the SwinT architecture types: ["tiny", "small", "base"]. **Default**: `"tiny"`
   - `arch`: Dictionary of embed dimension, depths and number of heads in each layer. Default is "Tiny architecture". {'embed': 96, 'depths': [2,2,6,2], 'channels':[3, 6, 12, 24]}. **Default**: `None`
   - `max_stride`: (int) Factor by which input image size is reduced through the layers. This is always `32` for all convnext architectures provided stem_stride is 2. **Default**: `32`
@@ -347,7 +348,6 @@ data_config:
 
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/docs/sample_configs/config_bottomup_convnext.yaml
+++ b/docs/sample_configs/config_bottomup_convnext.yaml
@@ -53,12 +53,12 @@ data_config:
   skeletons: null
 model_config:
   init_weights: xavier
-  pre_trained_weights: null #   pre_trained_weights: ConvNeXt_Tiny_Weights (for convnext)
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:
     unet: null
     convnext:
+      pre_trained_weights: null
       in_channels: 1
       model_type: tiny
       arch: 

--- a/docs/sample_configs/config_bottomup_unet.yaml
+++ b/docs/sample_configs/config_bottomup_unet.yaml
@@ -53,7 +53,6 @@ data_config:
   skeletons: null
 model_config:
   init_weights: xavier
-  pre_trained_weights: null #   pre_trained_weights: ConvNeXt_Tiny_Weights (for convnext)
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/docs/sample_configs/config_centroid_swint.yaml
+++ b/docs/sample_configs/config_centroid_swint.yaml
@@ -53,13 +53,13 @@ data_config:
   skeletons: null
 model_config:
   init_weights: xavier
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:
     unet:
     convnext: null
     swint:
+      pre_trained_weights: null
       in_channels: 1
       model_type: tiny
       arch: 

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -53,7 +53,6 @@ data_config:
   skeletons: null
 model_config:
   init_weights: xavier
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/docs/sample_configs/config_multi_class_bottomup_unet.yaml
+++ b/docs/sample_configs/config_multi_class_bottomup_unet.yaml
@@ -53,7 +53,6 @@ data_config:
   skeletons: null
 model_config:
   init_weights: xavier
-  pre_trained_weights: null #   pre_trained_weights: ConvNeXt_Tiny_Weights (for convnext)
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/docs/sample_configs/config_single_instance_unet.yaml
+++ b/docs/sample_configs/config_single_instance_unet.yaml
@@ -53,7 +53,6 @@ data_config:
   skeletons: null
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/docs/sample_configs/config_topdown_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet.yaml
@@ -53,7 +53,6 @@ data_config:
   skeletons: null
 model_config:
   init_weights: xavier
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -53,7 +53,6 @@ data_config:
   skeletons: null
 model_config:
   init_weights: xavier
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -109,6 +109,9 @@ class ConvNextConfig:
     """Convnext configuration for backbone.
 
     Attributes:
+        pre_trained_weights: (str) Pretrained weights file name supported only for
+            ConvNext backbones. For ConvNext, one of ["ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"].
         arch: (Default is Tiny architecture config. No need to provide if model_type is provided)
             depths: (List[int]) Number of layers in each block. *Default*: `[3, 3, 9, 3]`.
             channels: (List[int]) Number of channels in each block. *Default*: `[96, 192, 384, 768]`.
@@ -124,6 +127,12 @@ class ConvNextConfig:
         max_stride: (int) Factor by which input image size is reduced through the layers. This is always `32` for all convnext architectures. *Default*: `32`.
     """
 
+    pre_trained_weights: Optional[str] = field(
+        default=None,
+        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
+            value
+        ),
+    )
     model_type: str = "tiny"  # Options: tiny, small, base, large
     arch: Optional[dict] = None
     stem_patch_kernel: int = 4
@@ -136,12 +145,42 @@ class ConvNextConfig:
     output_stride: int = 1
     max_stride: int = 32
 
+    def validate_pre_trained_weights(self, value):
+        """Validate pre_trained_weights.
+
+        Check:
+        convnext_weights are one of
+        (
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        )
+        """
+        if value is None:
+            return
+
+        convnext_weights = [
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        ]
+
+        if value not in convnext_weights:
+            message = f"Invalid pre-trained weights for ConvNext. Must be one of {convnext_weights}"
+            logger.error(message)
+            raise ValueError(message)
+
 
 @define
 class ConvNextSmallConfig:
     """Convnext configuration for backbone.
 
     Attributes:
+        pre_trained_weights: (str) Pretrained weights file name supported only for
+            ConvNext backbones. For ConvNext, one of ["ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"].
         arch: (Default is Tiny architecture config. No need to provide if model_type
             is provided)
             depths: (List(int)) Number of layers in each block. Default: [3, 3, 9, 3].
@@ -170,6 +209,12 @@ class ConvNextSmallConfig:
             This is always `32` for all convnext architectures.
     """
 
+    pre_trained_weights: Optional[str] = field(
+        default=None,
+        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
+            value
+        ),
+    )
     model_type: str = "small"  # Options: tiny, small, base, large
     arch: Optional[dict] = None
     stem_patch_kernel: int = 4
@@ -182,12 +227,42 @@ class ConvNextSmallConfig:
     output_stride: int = 1
     max_stride: int = 32
 
+    def validate_pre_trained_weights(self, value):
+        """Validate pre_trained_weights.
+
+        Check:
+        convnext_weights are one of
+        (
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        )
+        """
+        if value is None:
+            return
+
+        convnext_weights = [
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        ]
+
+        if value not in convnext_weights:
+            message = f"Invalid pre-trained weights for ConvNext. Must be one of {convnext_weights}"
+            logger.error(message)
+            raise ValueError(message)
+
 
 @define
 class ConvNextBaseConfig:
     """Convnext configuration for backbone.
 
     Attributes:
+        pre_trained_weights: (str) Pretrained weights file name supported only for
+            ConvNext backbones. For ConvNext, one of ["ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"].
         arch: (Default is Tiny architecture config. No need to provide if model_type
             is provided)
             depths: (List(int)) Number of layers in each block. Default: [3, 3, 9, 3].
@@ -216,6 +291,12 @@ class ConvNextBaseConfig:
             This is always `32` for all convnext architectures.
     """
 
+    pre_trained_weights: Optional[str] = field(
+        default=None,
+        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
+            value
+        ),
+    )
     model_type: str = "base"  # Options: tiny, small, base, large
     arch: Optional[dict] = None
     stem_patch_kernel: int = 4
@@ -228,12 +309,42 @@ class ConvNextBaseConfig:
     output_stride: int = 1
     max_stride: int = 32
 
+    def validate_pre_trained_weights(self, value):
+        """Validate pre_trained_weights.
+
+        Check:
+        convnext_weights are one of
+        (
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        )
+        """
+        if value is None:
+            return
+
+        convnext_weights = [
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        ]
+
+        if value not in convnext_weights:
+            message = f"Invalid pre-trained weights for ConvNext. Must be one of {convnext_weights}"
+            logger.error(message)
+            raise ValueError(message)
+
 
 @define
 class ConvNextLargeConfig:
     """Convnext configuration for backbone.
 
     Attributes:
+        pre_trained_weights: (str) Pretrained weights file name supported only for
+            ConvNext backbones. For ConvNext, one of ["ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"].
         arch: (Default is Tiny architecture config. No need to provide if model_type
             is provided)
             depths: (List(int)) Number of layers in each block. Default: [3, 3, 9, 3].
@@ -262,6 +373,12 @@ class ConvNextLargeConfig:
             This is always `32` for all convnext architectures.
     """
 
+    pre_trained_weights: Optional[str] = field(
+        default=None,
+        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
+            value
+        ),
+    )
     model_type: str = "large"  # Options: tiny, small, base, large
     arch: Optional[dict] = None
     stem_patch_kernel: int = 4
@@ -274,12 +391,41 @@ class ConvNextLargeConfig:
     output_stride: int = 1
     max_stride: int = 32
 
+    def validate_pre_trained_weights(self, value):
+        """Validate pre_trained_weights.
+
+        Check:
+        convnext_weights are one of
+        (
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        )
+        """
+        if value is None:
+            return
+
+        convnext_weights = [
+            "ConvNeXt_Base_Weights",
+            "ConvNeXt_Tiny_Weights",
+            "ConvNeXt_Small_Weights",
+            "ConvNeXt_Large_Weights",
+        ]
+
+        if value not in convnext_weights:
+            message = f"Invalid pre-trained weights for ConvNext. Must be one of {convnext_weights}"
+            logger.error(message)
+            raise ValueError(message)
+
 
 @define
 class SwinTConfig:
     """SwinT configuration (tiny) for backbone.
 
     Attributes:
+        pre_trained_weights: (str) Pretrained weights file name supported only for
+            SwinT backbones. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].
         model_type: (str) One of the SwinT architecture types: ["tiny", "small", "base"]. *Default*: `"tiny"`.
         arch: Dictionary of embed dimension, depths and number of heads in each layer. Default is "Tiny architecture". {'embed': 96, 'depths': [2,2,6,2], 'channels':[3, 6, 12, 24]}. *Default*: `None`.
         max_stride: (int) Factor by which input image size is reduced through the layers. This is always `32` for all swint architectures. *Default*: `32`.
@@ -294,6 +440,12 @@ class SwinTConfig:
         output_stride: (int) The stride of the output confidence maps relative to the input image. This is the reciprocal of the resolution, e.g., an output stride of 2 results in confidence maps that are 0.5x the size of the input. Increasing this value can considerably speed up model performance and decrease memory requirements, at the cost of decreased spatial resolution. *Default*: `1`.
     """
 
+    pre_trained_weights: Optional[str] = field(
+        default=None,
+        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
+            value
+        ),
+    )
     model_type: str = field(
         default="tiny",
         validator=lambda instance, attr, value: instance.validate_model_type(value),
@@ -321,12 +473,37 @@ class SwinTConfig:
             logger.error(message)
             raise ValueError(message)
 
+    def validate_pre_trained_weights(self, value):
+        """Validate pre_trained_weights.
+
+        Check:
+        swint_weights are one of
+        (
+            "Swin_T_Weights",
+            "Swin_S_Weights",
+            "Swin_B_Weights"
+        )
+        """
+        if value is None:
+            return
+
+        swint_weights = ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"]
+
+        if value not in swint_weights:
+            message = (
+                f"Invalid pre-trained weights for SwinT. Must be one of {swint_weights}"
+            )
+            logger.error(message)
+            raise ValueError(message)
+
 
 @define
 class SwinTSmallConfig:
     """SwinT configuration (small) for backbone.
 
     Attributes:
+        pre_trained_weights: (str) Pretrained weights file name supported only for
+            SwinT backbones. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].
         model_type: (str) One of the SwinT architecture types: ["tiny", "small", "base"]. *Default*: `"small"`.
         arch: Dictionary of embed dimension, depths and number of heads in each layer. Default is "Tiny architecture". {'embed': 96, 'depths': [2,2,6,2], 'channels':[3, 6, 12, 24]}. *Default*: `None`.
         max_stride: (int) Factor by which input image size is reduced through the layers. This is always `32` for all swint architectures. *Default*: `32`.
@@ -341,6 +518,12 @@ class SwinTSmallConfig:
         output_stride: (int) The stride of the output confidence maps relative to the input image. This is the reciprocal of the resolution, e.g., an output stride of 2 results in confidence maps that are 0.5x the size of the input. Increasing this value can considerably speed up model performance and decrease memory requirements, at the cost of decreased spatial resolution. *Default*: `1`.
     """
 
+    pre_trained_weights: Optional[str] = field(
+        default=None,
+        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
+            value
+        ),
+    )
     model_type: str = field(
         default="small",
         validator=lambda instance, attr, value: instance.validate_model_type(value),
@@ -368,12 +551,37 @@ class SwinTSmallConfig:
             logger.error(message)
             raise ValueError(message)
 
+    def validate_pre_trained_weights(self, value):
+        """Validate pre_trained_weights.
+
+        Check:
+        swint_weights are one of
+        (
+            "Swin_T_Weights",
+            "Swin_S_Weights",
+            "Swin_B_Weights"
+        )
+        """
+        if value is None:
+            return
+
+        swint_weights = ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"]
+
+        if value not in swint_weights:
+            message = (
+                f"Invalid pre-trained weights for SwinT. Must be one of {swint_weights}"
+            )
+            logger.error(message)
+            raise ValueError(message)
+
 
 @define
 class SwinTBaseConfig:
     """SwinT configuration for backbone.
 
     Attributes:
+        pre_trained_weights: (str) Pretrained weights file name supported only for
+            SwinT backbones. For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].
         model_type: (str) One of the SwinT architecture types: ["tiny", "small", "base"]. *Default*: `"base"`.
         arch: Dictionary of embed dimension, depths and number of heads in each layer. Default is "Tiny architecture". {'embed': 96, 'depths': [2,2,6,2], 'channels':[3, 6, 12, 24]}. *Default*: `None`.
         max_stride: (int) Factor by which input image size is reduced through the layers. This is always `32` for all swint architectures. *Default*: `32`.
@@ -389,6 +597,12 @@ class SwinTBaseConfig:
 
     """
 
+    pre_trained_weights: Optional[str] = field(
+        default=None,
+        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
+            value
+        ),
+    )
     model_type: str = field(
         default="base",
         validator=lambda instance, attr, value: instance.validate_model_type(value),
@@ -413,6 +627,29 @@ class SwinTBaseConfig:
         valid_types = ["tiny", "small", "base"]
         if value not in valid_types:
             message = f"Invalid model_type. Must be one of {valid_types}"
+            logger.error(message)
+            raise ValueError(message)
+
+    def validate_pre_trained_weights(self, value):
+        """Validate pre_trained_weights.
+
+        Check:
+        swint_weights are one of
+        (
+            "Swin_T_Weights",
+            "Swin_S_Weights",
+            "Swin_B_Weights"
+        )
+        """
+        if value is None:
+            return
+
+        swint_weights = ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"]
+
+        if value not in swint_weights:
+            message = (
+                f"Invalid pre-trained weights for SwinT. Must be one of {swint_weights}"
+            )
             logger.error(message)
             raise ValueError(message)
 
@@ -730,10 +967,6 @@ class ModelConfig:
     Attributes:
         init_weights: (str) model weights initialization method. "default" uses kaiming
             uniform initialization and "xavier" uses Xavier initialization method.
-        pre_trained_weights: (str) Pretrained weights file name supported only for
-            ConvNext and SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights",
-            "ConvNeXt_Tiny_Weights", "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"].
-            For SwinT, one of ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"].
         pretrained_backbone_weights: Path of the `ckpt` file with which the backbone
             is initialized. If `None`, random init is used.
         pretrained_head_weights: Path of the `ckpt` file with which the head layers
@@ -748,62 +981,11 @@ class ModelConfig:
     """
 
     init_weights: str = "default"
-    pre_trained_weights: Optional[str] = field(
-        default=None,
-        validator=lambda instance, attr, value: instance.validate_pre_trained_weights(
-            value
-        ),
-    )
     pretrained_backbone_weights: Optional[str] = None
     pretrained_head_weights: Optional[str] = None
     backbone_config: BackboneConfig = field(factory=BackboneConfig)
     head_configs: HeadConfig = field(factory=HeadConfig)
     total_params: Optional[int] = None
-
-    def validate_pre_trained_weights(self, value):
-        """Validate pre_trained_weights.
-
-        Check:
-        convnext_weights are one of
-        (
-            "ConvNeXt_Base_Weights",
-            "ConvNeXt_Tiny_Weights",
-            "ConvNeXt_Small_Weights",
-            "ConvNeXt_Large_Weights",
-        )
-        swint_weights are one of
-        (
-            "Swin_T_Weights",
-            "Swin_S_Weights",
-            "Swin_B_Weights"
-        )
-        unet weights is None
-        """
-        if value is None:
-            return
-
-        convnext_weights = [
-            "ConvNeXt_Base_Weights",
-            "ConvNeXt_Tiny_Weights",
-            "ConvNeXt_Small_Weights",
-            "ConvNeXt_Large_Weights",
-        ]
-        swint_weights = ["Swin_T_Weights", "Swin_S_Weights", "Swin_B_Weights"]
-
-        if self.backbone_config.convnext is not None:
-            if value not in convnext_weights:
-                message = f"Invalid pre-trained weights for ConvNext. Must be one of {convnext_weights}"
-                logger.error(message)
-                raise ValueError(message)
-        elif self.backbone_config.swint is not None:
-            if value not in swint_weights:
-                message = f"Invalid pre-trained weights for SwinT. Must be one of {swint_weights}"
-                logger.error(message)
-                raise ValueError(message)
-        elif self.backbone_config.unet is not None:
-            message = "UNet does not support pre-trained weights."
-            logger.error(message)
-            raise ValueError(message)
 
 
 def model_mapper(legacy_config: dict) -> ModelConfig:

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -377,7 +377,6 @@ def get_data_config(
 
 def get_model_config(
     init_weight: str = "default",
-    pre_trained_weights: Optional[str] = None,
     pretrained_backbone_weights: Optional[str] = None,
     pretrained_head_weights: Optional[str] = None,
     backbone_config: Union[str, Dict[str, Any]] = "unet",
@@ -391,10 +390,6 @@ def get_model_config(
     Args:
         init_weight: model weights initialization method. "default" uses kaiming uniform
             initialization and "xavier" uses Xavier initialization method. Default: "default".
-        pre_trained_weights: Pretrained weights file name supported only for ConvNext and
-            SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights","ConvNeXt_Tiny_Weights",
-            "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"]. For SwinT, one of ["Swin_T_Weights",
-            "Swin_S_Weights", "Swin_B_Weights"]. Default: None.
         pretrained_backbone_weights: Path of the `ckpt` file with which the backbone is
             initialized. If `None`, random init is used. Default: None.
         pretrained_head_weights: Path of the `ckpt` file with which the head layers are
@@ -450,7 +445,6 @@ def get_model_config(
     head_configs = get_head_configs(head_cfg=head_configs)
     model_config = ModelConfig(
         init_weights=init_weight,
-        pre_trained_weights=pre_trained_weights,
         pretrained_backbone_weights=pretrained_backbone_weights,
         pretrained_head_weights=pretrained_head_weights,
         backbone_config=backbone_config,
@@ -776,7 +770,6 @@ def train(
     intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
     geometry_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
     init_weight: str = "default",
-    pre_trained_weights: Optional[str] = None,
     pretrained_backbone_weights: Optional[str] = None,
     pretrained_head_weights: Optional[str] = None,
     backbone_config: Union[str, Dict[str, Any]] = "unet",
@@ -882,10 +875,6 @@ def train(
                     }
         init_weight: model weights initialization method. "default" uses kaiming uniform
             initialization and "xavier" uses Xavier initialization method. Default: "default".
-        pre_trained_weights: Pretrained weights file name supported only for ConvNext and
-            SwinT backbones. For ConvNext, one of ["ConvNeXt_Base_Weights","ConvNeXt_Tiny_Weights",
-            "ConvNeXt_Small_Weights", "ConvNeXt_Large_Weights"]. For SwinT, one of ["Swin_T_Weights",
-            "Swin_S_Weights", "Swin_B_Weights"]. Default: None.
         pretrained_backbone_weights: Path of the `ckpt` file with which the backbone is
             initialized. If `None`, random init is used. Default: None.
         pretrained_head_weights: Path of the `ckpt` file with which the head layers are
@@ -1047,7 +1036,6 @@ def train(
 
     model_config = get_model_config(
         init_weight=init_weight,
-        pre_trained_weights=pre_trained_weights,
         pretrained_backbone_weights=pretrained_backbone_weights,
         pretrained_head_weights=pretrained_head_weights,
         backbone_config=backbone_config,

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
@@ -63,7 +63,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
@@ -63,7 +63,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
@@ -65,7 +65,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
@@ -65,7 +65,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
@@ -63,7 +63,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
@@ -63,7 +63,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
@@ -63,7 +63,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
@@ -63,7 +63,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -65,7 +65,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
@@ -65,7 +65,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
@@ -64,7 +64,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
@@ -64,7 +64,6 @@ data_config:
       symmetries: []
 model_config:
   init_weights: default
-  pre_trained_weights: null
   pretrained_backbone_weights: null
   pretrained_head_weights: null
   backbone_config:

--- a/tests/config/test_model_config.py
+++ b/tests/config/test_model_config.py
@@ -50,7 +50,6 @@ def default_config():
     """Fixture for a default ModelConfig instance."""
     return ModelConfig(
         init_weights="default",
-        pre_trained_weights=None,
         backbone_config=BackboneConfig(),
         head_configs=HeadConfig(),
     )
@@ -59,29 +58,28 @@ def default_config():
 def test_default_initialization(default_config):
     """Test default initialization of ModelConfig."""
     assert default_config.init_weights == "default"
-    assert default_config.pre_trained_weights == None
 
 
 def test_invalid_pre_trained_weights(caplog):
     """Test validation failure with an invalid pre_trained_weights."""
-    with pytest.raises(ValueError):
-        ModelConfig(
-            pre_trained_weights="here",
-            backbone_config=BackboneConfig(unet=UNetConfig()),
-        )
-    assert "UNet" in caplog.text
 
     with pytest.raises(ValueError):
         ModelConfig(
-            pre_trained_weights="here",
-            backbone_config=BackboneConfig(convnext=ConvNextConfig()),
+            backbone_config=BackboneConfig(
+                convnext=ConvNextConfig(
+                    pre_trained_weights="here",
+                )
+            ),
         )
     assert "Invalid pre-trained" in caplog.text
 
     with pytest.raises(ValueError):
         ModelConfig(
-            pre_trained_weights="here",
-            backbone_config=BackboneConfig(swint=SwinTConfig()),
+            backbone_config=BackboneConfig(
+                swint=SwinTConfig(
+                    pre_trained_weights="here",
+                )
+            ),
         )
     assert "Invalid pre-trained" in caplog.text
 
@@ -91,7 +89,6 @@ def test_update_config(default_config):
     config = OmegaConf.structured(
         ModelConfig(
             init_weights="default",
-            pre_trained_weights=None,
             backbone_config=BackboneConfig(unet=UNetConfig()),
             head_configs=HeadConfig(),
         )

--- a/tests/config/test_training_job_config.py
+++ b/tests/config/test_training_job_config.py
@@ -66,7 +66,6 @@ def sample_config():
         ),
         "model_config": ModelConfig(
             init_weights="default",
-            pre_trained_weights=None,
             backbone_config="unet",
         ),
         "trainer_config": TrainerConfig(early_stopping=EarlyStoppingConfig()),

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -77,7 +77,6 @@ def config(sleap_nn_data_dir):
             },
             "model_config": {
                 "init_weights": "default",
-                "pre_trained_weights": None,
                 "pretrained_backbone_weights": None,
                 "pretrained_head_weights": None,
                 "backbone_config": {

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -44,7 +44,6 @@ def sample_cfg(minimal_instance, tmp_path):
             },
             "model_config": {
                 "init_weights": "default",
-                "pre_trained_weights": None,
                 "pretrained_backbone_weights": None,
                 "pretrained_head_weights": None,
                 "backbone_config": {

--- a/tests/training/test_lightning_modules.py
+++ b/tests/training/test_lightning_modules.py
@@ -76,9 +76,6 @@ def test_topdown_centered_instance_model(config, tmp_path: str):
     assert abs(loss - mse_loss(preds, input_cm)) < 1e-3
 
     # convnext with pretrained weights
-    OmegaConf.update(
-        config, "model_config.pre_trained_weights", "ConvNeXt_Tiny_Weights"
-    )
     OmegaConf.update(config, "data_config.preprocessing.ensure_rgb", True)
     OmegaConf.update(config, "model_config.backbone_config.unet", None)
     OmegaConf.update(
@@ -97,6 +94,11 @@ def test_topdown_centered_instance_model(config, tmp_path: str):
             "output_stride": 2,
             "max_stride": 32,
         },
+    )
+    OmegaConf.update(
+        config,
+        "model_config.backbone_config.convnext.pre_trained_weights",
+        "ConvNeXt_Tiny_Weights",
     )
     model = TopDownCenteredInstanceLightningModule(
         config=config,


### PR DESCRIPTION
Currently, the `model_config` includes a `pretrained_weights` parameter that is only relevant for the Swin Transformer and ConvNeXt architectures. This PR moves the `pretrained_weights` setting into the dedicated convnext and swint config sections. 
Relevant issue: [#154](https://github.com/talmolab/sleap-nn/issues/154).