### PR TITLE
Fix skeletons structure in config

### DIFF
--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -175,7 +175,7 @@ class DataConfig:
     preprocessing: PreprocessingConfig = field(factory=PreprocessingConfig)
     use_augmentations_train: bool = False
     augmentation_config: Optional[AugmentationConfig] = None
-    skeletons: Optional[dict] = None
+    skeletons: Optional[list] = None
 
 
 def data_mapper(legacy_config: dict) -> DataConfig:
@@ -198,10 +198,15 @@ def data_mapper(legacy_config: dict) -> DataConfig:
 
     # get skeleton(s)
     json_skeletons = legacy_config_data.get("labels", {}).get("skeletons", None)
-    skeletons_dict = None
+    skeletons_list = None
     if json_skeletons is not None:
+        skeletons_list = []
         skeletons = SkeletonDecoder().decode(json_skeletons)
-        skeletons_dict = yaml.safe_load(SkeletonYAMLEncoder().encode(skeletons))
+        skeletons = yaml.safe_load(SkeletonYAMLEncoder().encode(skeletons))
+        for skl_name in skeletons.keys():
+            skl = skeletons[skl_name]
+            skl["name"] = skl_name
+            skeletons_list.append(skl)
 
     data_cfg_args = {}
     preprocessing_args = {}
@@ -433,7 +438,7 @@ def data_mapper(legacy_config: dict) -> DataConfig:
     data_cfg_args["use_augmentations_train"] = (
         True if any(intensity_args.values()) or any(geometric_args.values()) else False
     )
-    data_cfg_args["skeletons"] = skeletons_dict
+    data_cfg_args["skeletons"] = skeletons_list
 
     return DataConfig(**data_cfg_args)
 

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1882,9 +1882,8 @@ def get_train_val_datasets(
         )
 
     elif model_type == "centroid":
-        skeleton_name = list(config.data_config.skeletons.keys())[0]
         nodes = [
-            x["name"] for x in config.data_config.skeletons[f"{skeleton_name}"]["nodes"]
+            x["name"] for x in config.data_config.skeletons[0]["nodes"]
         ]
         anchor_part = config.model_config.head_configs.centroid.confmaps.anchor_part
         anchor_ind = nodes.index(anchor_part) if anchor_part is not None else None

--- a/sleap_nn/inference/utils.py
+++ b/sleap_nn/inference/utils.py
@@ -17,9 +17,9 @@ def get_skeleton_from_config(skeleton_config: OmegaConf):
 
     """
     skeletons = []
-    for name, skel_cfg in skeleton_config.items():
+    for skel_cfg in skeleton_config:
 
-        skel = sio.Skeleton(nodes=[n["name"] for n in skel_cfg.nodes], name=name)
+        skel = sio.Skeleton(nodes=[n["name"] for n in skel_cfg.nodes], name=skel_cfg.name)
         skel.add_edges(
             [(e["source"]["name"], e["destination"]["name"]) for e in skel_cfg.edges]
         )

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -235,9 +235,15 @@ class ModelTrainer:
             ]
 
         # save skeleton to config
-        self.config["data_config"]["skeletons"] = yaml.safe_load(
+        skeleton_yaml = yaml.safe_load(
             SkeletonYAMLEncoder().encode(self.skeletons)
         )
+        skeleton_names = skeleton_yaml.keys()
+        self.config["data_config"]["skeletons"] = []
+        for skeleton_name in skeleton_names:
+            skl = skeleton_yaml[skeleton_name]
+            skl["name"] = skeleton_name
+            self.config["data_config"]["skeletons"].append(skl)
 
         # if edges and part names aren't set in head configs, get it from labels object.
         head_config = self.config.model_config.head_configs[self.model_type]

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
@@ -51,16 +51,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
@@ -51,16 +51,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
@@ -53,16 +53,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
@@ -53,16 +53,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
@@ -51,16 +51,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
@@ -51,16 +51,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
@@ -51,16 +51,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-3:
-      nodes:
-      - name: thorax
-      - name: head
-      edges:
-      - source:
-          name: thorax
-        destination:
-          name: head
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
@@ -51,16 +51,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -53,16 +53,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-3:
-      nodes:
-      - name: thorax
-      - name: head
-      edges:
-      - source:
-          name: thorax
-        destination:
-          name: head
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
@@ -53,16 +53,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
@@ -52,16 +52,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
@@ -52,16 +52,16 @@ data_config:
       - 0.05
       mixup_p: 0.0
   skeletons:
-    Skeleton-0:
-      nodes:
-      - name: A
-      - name: B
-      edges:
-      - source:
-          name: A
-        destination:
-          name: B
-      symmetries: []
+  - nodes:
+    - name: A
+    - name: B
+    edges:
+    - source:
+        name: A
+      destination:
+        name: B
+    symmetries: []
+    name: Skeleton-0
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/tests/config/test_training_job_config.py
+++ b/tests/config/test_training_job_config.py
@@ -231,8 +231,9 @@ def test_load_centered_instance_training_config_from_file(
     ]
     assert config.model_config.head_configs.centered_instance.confmaps.sigma == 1.5
 
-    assert len(config.data_config.skeletons["Skeleton-0"]["nodes"]) == 2
-    assert len(config.data_config.skeletons["Skeleton-0"]["edges"]) == 1
+    assert len(config.data_config.skeletons[0]["nodes"]) == 2
+    assert len(config.data_config.skeletons[0]["edges"]) == 1
+    assert config.data_config.skeletons[0]["name"] == "Skeleton-0"
 
 
 def test_load_centered_instance_with_scaling_config_from_file(
@@ -291,8 +292,9 @@ def test_load_single_instance_training_config_from_file(
     assert single.confmaps.part_names == ["A", "B"]
     assert single.confmaps.sigma == 5.0
     assert single.confmaps.output_stride == 4
-    assert len(config.data_config.skeletons["Skeleton-0"]["nodes"]) == 2
-    assert len(config.data_config.skeletons["Skeleton-0"]["edges"]) == 1
+    assert len(config.data_config.skeletons[0]["nodes"]) == 2
+    assert len(config.data_config.skeletons[0]["edges"]) == 1
+    assert config.data_config.skeletons[0]["name"] == "Skeleton-0"
 
 
 def test_load_topdown_training_config_from_file(topdown_training_config_path):


### PR DESCRIPTION
This PR refactors the structure of `data_config.skeletons` to resolve issues with using skeleton names as dictionary keys. Previously, `data_config.skeletons` were in a dictionary format where each key represented a skeleton name. However, since `sio.Skeletons` does not require skeletons to have a name (i.e., names can be `None`), this caused errors because `None` cannot be a valid dictionary key.

To address this, `data_config.skeletons` is now defined as a list of skeleton entries. Each entry in the list includes a new `name` field to optionally specify the skeleton name.

