### PR TITLE
Ensure only rank-0 handles writing files in ddp training

### DIFF
--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -1,3 +1,36 @@
 """Main module for sleap_nn package."""
 
+import os
+from loguru import logger
+
+# Get RANK for distributed training
+GLOBAL_RANK = int(os.environ.get("RANK", -1))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
+
+
+# Configure loguru for distributed training
+def _should_log(record):
+    """Filter function to control logging based on rank."""
+    # Always log ERROR acrossall ranks
+    if record["level"].no >= logger.level("ERROR").no:
+        return True
+
+    # Log infor only on rank 0
+    if GLOBAL_RANK in [0, -1] and record["level"].no >= logger.level("INFO").no:
+        return True
+
+    return False
+
+
+# Remove default handler and add custom one
+logger.remove()
+
+# Add logger with the custom filter
+logger.add(
+    lambda msg: print(msg, end=""),
+    level="DEBUG",
+    filter=_should_log,
+    format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {name}:{function}:{line} | {message}",
+)
+
 __version__ = "0.0.1"

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -18,6 +18,7 @@ from sleap_nn.config.get_config import (
     get_model_config,
     get_data_config,
 )
+from sleap_nn import GLOBAL_RANK
 
 
 def run_training(config: DictConfig):
@@ -34,7 +35,7 @@ def run_training(config: DictConfig):
     logger.info("Finished training at:", finish_timestamp)
     logger.info(f"Total training time: {total_elapsed} secs")
 
-    if trainer.trainer.global_rank == 0:
+    if GLOBAL_RANK in [0, -1]:
         # run inference on val dataset
         if config.trainer_config.save_ckpt:
             data_paths = {}

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -303,6 +303,7 @@ class LightningModel(L.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
     def on_validation_epoch_start(self):
@@ -319,6 +320,7 @@ class LightningModel(L.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
     def training_step(self, batch, batch_idx):
@@ -554,9 +556,16 @@ class SingleInstanceLightningModule(LightningModel):
                     on_step=True,
                     on_epoch=True,
                     logger=True,
+                    sync_dist=True,
                 )
         self.log(
-            "train_loss", loss, prog_bar=True, on_step=True, on_epoch=True, logger=True
+            "train_loss",
+            loss,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            logger=True,
+            sync_dist=True,
         )
         return loss
 
@@ -586,6 +595,7 @@ class SingleInstanceLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
         self.log(
             "val_loss",
@@ -594,6 +604,7 @@ class SingleInstanceLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
 
@@ -758,10 +769,17 @@ class TopDownCenteredInstanceLightningModule(LightningModel):
                     on_step=True,
                     on_epoch=True,
                     logger=True,
+                    sync_dist=True,
                 )
 
         self.log(
-            "train_loss", loss, prog_bar=True, on_step=True, on_epoch=True, logger=True
+            "train_loss",
+            loss,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            logger=True,
+            sync_dist=True,
         )
         return loss
 
@@ -791,6 +809,7 @@ class TopDownCenteredInstanceLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
         self.log(
             "val_loss",
@@ -799,6 +818,7 @@ class TopDownCenteredInstanceLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
 
@@ -937,7 +957,13 @@ class CentroidLightningModule(LightningModel):
         y_preds = self.model(X)["CentroidConfmapsHead"]
         loss = nn.MSELoss()(y_preds, y)
         self.log(
-            "train_loss", loss, prog_bar=True, on_step=True, on_epoch=True, logger=True
+            "train_loss",
+            loss,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            logger=True,
+            sync_dist=True,
         )
         return loss
 
@@ -957,6 +983,7 @@ class CentroidLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
         self.log(
             "val_loss",
@@ -965,6 +992,7 @@ class CentroidLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
 
@@ -1171,7 +1199,13 @@ class BottomUpLightningModule(LightningModel):
         }
         loss = sum([s * losses[t] for s, t in zip(self.loss_weights, losses)])
         self.log(
-            "train_loss", loss, prog_bar=True, on_step=True, on_epoch=True, logger=True
+            "train_loss",
+            loss,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            logger=True,
+            sync_dist=True,
         )
         return loss
 
@@ -1222,6 +1256,7 @@ class BottomUpLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
         self.log(
             "val_loss",
@@ -1230,6 +1265,7 @@ class BottomUpLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
 
@@ -1421,7 +1457,13 @@ class BottomUpMultiClassLightningModule(LightningModel):
         }
         loss = sum([s * losses[t] for s, t in zip(self.loss_weights, losses)])
         self.log(
-            "train_loss", loss, prog_bar=True, on_step=True, on_epoch=True, logger=True
+            "train_loss",
+            loss,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            logger=True,
+            sync_dist=True,
         )
         return loss
 
@@ -1463,6 +1505,7 @@ class BottomUpMultiClassLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
         self.log(
             "val_loss",
@@ -1471,6 +1514,7 @@ class BottomUpMultiClassLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
 
@@ -1647,10 +1691,17 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
                     on_step=True,
                     on_epoch=True,
                     logger=True,
+                    sync_dist=True,
                 )
 
         self.log(
-            "train_loss", loss, prog_bar=True, on_step=True, on_epoch=True, logger=True
+            "train_loss",
+            loss,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            logger=True,
+            sync_dist=True,
         )
         return loss
 
@@ -1691,6 +1742,7 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
         self.log(
             "val_loss",
@@ -1699,4 +1751,5 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             on_step=True,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )


### PR DESCRIPTION
This PR updates the training loop to guard disk writes and logging so they are executed only by the global rank-0 process in DDP, eliminating redundant file creation and repeated log entries from other ranks.

Related issue: #253 