### PR TITLE
Add eff_scale to dataset

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -354,6 +354,7 @@ class BottomUpDataset(BaseDataset):
             max_width=self.max_hw[1],
         )
         sample["instances"] = sample["instances"] * eff_scale
+        sample["eff_scale"] = eff_scale
 
         # resize image
         sample["image"], sample["instances"] = apply_resizer(
@@ -565,6 +566,7 @@ class BottomUpMultiClassDataset(BaseDataset):
             max_width=self.max_hw[1],
         )
         sample["instances"] = sample["instances"] * eff_scale
+        sample["eff_scale"] = eff_scale
 
         # resize image
         sample["image"], sample["instances"] = apply_resizer(
@@ -822,6 +824,7 @@ class CenteredInstanceDataset(BaseDataset):
         sample["video_idx"] = torch.tensor(video_idx, dtype=torch.int32)
         sample["num_instances"] = num_instances
         sample["orig_size"] = torch.Tensor([orig_img_height, orig_img_width])
+        sample["eff_scale"] = eff_scale
 
         # apply augmentation
         if self.apply_aug:
@@ -1080,6 +1083,7 @@ class TopDownCenteredInstanceMultiClassDataset(CenteredInstanceDataset):
         sample["video_idx"] = torch.tensor(video_idx, dtype=torch.int32)
         sample["num_instances"] = num_instances
         sample["orig_size"] = torch.Tensor([orig_img_height, orig_img_width])
+        sample["eff_scale"] = eff_scale
 
         # apply augmentation
         if self.apply_aug:
@@ -1276,6 +1280,7 @@ class CentroidDataset(BaseDataset):
             max_width=self.max_hw[1],
         )
         sample["instances"] = sample["instances"] * eff_scale
+        sample["eff_scale"] = eff_scale
 
         # resize image
         sample["image"], sample["instances"] = apply_resizer(
@@ -1455,6 +1460,7 @@ class SingleInstanceDataset(BaseDataset):
             max_width=self.max_hw[1],
         )
         sample["instances"] = sample["instances"] * eff_scale
+        sample["eff_scale"] = eff_scale
 
         # resize image
         sample["image"], sample["instances"] = apply_resizer(

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -51,6 +51,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
         "num_instances",
         "part_affinity_fields",
         "labels_idx",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -99,6 +100,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
         "num_instances",
         "part_affinity_fields",
         "labels_idx",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -176,6 +178,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
         "num_instances",
         "part_affinity_fields",
         "labels_idx",
+        "eff_scale",
     ]
 
     sample = next(iter(dataset))
@@ -210,6 +213,7 @@ def test_bottomup_dataset(minimal_instance, tmp_path):
         "num_instances",
         "part_affinity_fields",
         "labels_idx",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -268,6 +272,7 @@ def test_bottomup_multiclass_dataset(minimal_instance, tmp_path):
         "labels_idx",
         "track_ids",
         "num_tracks",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -449,6 +454,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -483,6 +489,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -560,6 +567,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
 
     sample = next(iter(dataset))
@@ -639,6 +647,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
 
     sample = next(iter(dataset))
@@ -709,6 +718,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         "labels_idx",
         "track_id",
         "class_vectors",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -915,6 +925,7 @@ def test_centroid_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -948,6 +959,7 @@ def test_centroid_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
     sample = next(iter(dataset))
     assert len(sample.keys()) == len(gt_sample_keys)
@@ -1023,6 +1035,7 @@ def test_centroid_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
 
     sample = next(iter(dataset))
@@ -1084,6 +1097,7 @@ def test_single_instance_dataset(minimal_instance, tmp_path):
         "confidence_maps",
         "orig_size",
         "labels_idx",
+        "eff_scale",
     ]
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
@@ -1117,6 +1131,7 @@ def test_single_instance_dataset(minimal_instance, tmp_path):
         "confidence_maps",
         "orig_size",
         "labels_idx",
+        "eff_scale",
     ]
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):
@@ -1191,6 +1206,7 @@ def test_single_instance_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
+        "eff_scale",
     ]
 
     for gt_key, key in zip(sorted(gt_sample_keys), sorted(sample.keys())):


### PR DESCRIPTION
This PR adds `eff_scale` key to the dataset pipeline which would be useful to run inference on the dataloader samples directly. 