### PR TITLE
Fix `@oneof` Validation and Add Support for None for train_labels_path

### DIFF
--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -154,7 +154,7 @@ class DataConfig:
     """Data configuration.
 
     Attributes:
-        train_labels_path: (List[str]) List of paths to training data (`.slp` file(s)). *Default*: `[]`.
+        train_labels_path: (List[str]) List of paths to training data (`.slp` file(s)). *Default*: `None`.
         val_labels_path: (List[str]) List of paths to validation data (`.slp` file(s)). *Default*: `None`.
         validation_fraction: (float) Float between 0 and 1 specifying the fraction of the training set to sample for generating the validation set. The remaining labeled frames will be left in the training set. If the `validation_labels` are already specified, this has no effect. *Default*: `0.1`.
         test_file_path: (str) Path to test dataset (`.slp` file or `.mp4` file). *Note*: This is used only with CLI to get evaluation on test set after training is completed. *Default*: `None`.
@@ -170,7 +170,7 @@ class DataConfig:
         skeletons: skeleton configuration for the `.slp` file. This will be pulled from the train dataset and saved to the `training_config.yaml`
     """
 
-    train_labels_path: List[str] = []
+    train_labels_path: Optional[List[str]] = None
     val_labels_path: Optional[List[str]] = None  # TODO : revisit MISSING!
     validation_fraction: float = 0.1
     test_file_path: Optional[str] = None

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -452,8 +452,8 @@ def get_head_configs(head_cfg: Union[str, Dict[str, Any]]):
 
 
 def get_data_config(
-    train_labels_path: List[str],
-    val_labels_path: List[str] = [],
+    train_labels_path: Optional[List[str]] = None,
+    val_labels_path: Optional[List[str]] = None,
     validation_fraction: float = 0.1,
     test_file_path: Optional[str] = None,
     provider: str = "LabelsReader",
@@ -479,8 +479,8 @@ def get_data_config(
     and starts training by passing this config to the `ModelTrainer` class.
 
     Args:
-        train_labels_path: List of paths to training data (`.slp` file).
-        val_labels_path: List of paths to validation data (`.slp` file).
+        train_labels_path: List of paths to training data (`.slp` file). Default: `None`
+        val_labels_path: List of paths to validation data (`.slp` file). Default: `None`
         validation_fraction: Float between 0 and 1 specifying the fraction of the
             training set to sample for generating the validation set. The remaining
             labeled frames will be left in the training set. If the `validation_labels`

--- a/sleap_nn/config/training_job_config.py
+++ b/sleap_nn/config/training_job_config.py
@@ -116,4 +116,7 @@ def verify_training_cfg(cfg: DictConfig) -> DictConfig:
     schema = OmegaConf.structured(TrainingJobConfig())
     config = OmegaConf.merge(schema, cfg)
     OmegaConf.to_container(config, resolve=True, throw_on_missing=True)
+
+    # Verify configs with @oneof class is valid
+    _ = OmegaConf.to_object(config)
     return config

--- a/sleap_nn/config/training_job_config.py
+++ b/sleap_nn/config/training_job_config.py
@@ -119,4 +119,25 @@ def verify_training_cfg(cfg: DictConfig) -> DictConfig:
 
     # Verify configs with @oneof class is valid
     _ = OmegaConf.to_object(config)
+
+    # Verify required fields are set
+    check_must_be_set(config)
     return config
+
+
+def check_must_be_set(config: DictConfig) -> None:
+    """Check that all required fields are set in the BackboneConfig and HeadConfig."""
+    backbone_config = config.model_config.backbone_config
+    head_config = config.model_config.head_configs
+
+    backbone_attributes = [k for k, v in backbone_config.items() if v is not None]
+
+    head_config_attributes = [k for k, v in head_config.items() if v is not None]
+
+    if len(backbone_attributes) == 0:
+        message = "BackboneConfig: At least one attribute of this class must be set."
+        raise ValueError(message)
+
+    if len(head_config_attributes) == 0:
+        message = "HeadConfig: At least one attribute of this class must be set."
+        raise ValueError(message)

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -91,15 +91,19 @@ def oneof(attrs_cls, must_be_set: bool = False):
             attrib for attrib in attribs if getattr(self, attrib.name) is not None
         ]
 
+        class_name = self.__class__.__name__
+
         if len(attribs_with_value) > 1:
             # Raise error if more than one attribute is set.
-            message = "Only one attribute of this class can be set (not None)."
+            message = (
+                f"{class_name}: Only one attribute of this class can be set (not None)."
+            )
             logger.error(message)
             raise ValueError(message)
 
         if len(attribs_with_value) == 0 and must_be_set:
             # Raise error if none are set.
-            message = "At least one attribute of this class must be set."
+            message = f"{class_name}: At least one attribute of this class must be set."
             logger.error(message)
             raise ValueError(message)
 
@@ -111,17 +115,22 @@ def oneof(attrs_cls, must_be_set: bool = False):
         attribs_with_value = [
             attrib for attrib in attribs if getattr(self, attrib.name) is not None
         ]
+        class_name = self.__class__.__name__
 
         if len(attribs_with_value) > 1:
             # Raise error if more than one attribute is set.
-            message = "Only one attribute of this class can be set (not None)."
+            message = (
+                f"{class_name}: Only one attribute of this class can be set (not None)."
+            )
             logger.error(message)
             raise ValueError(message)
 
         if len(attribs_with_value) == 0:
             if must_be_set:
                 # Raise error if none are set.
-                message = "At least one attribute of this class must be set."
+                message = (
+                    f"{class_name}: At least one attribute of this class must be set."
+                )
                 logger.error(message)
                 raise ValueError(message)
             else:

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -97,8 +97,8 @@ def run_training(config: DictConfig):
 
 
 def train(
-    train_labels_path: List[str],
-    val_labels_path: List[str] = [],
+    train_labels_path: Optional[List[str]] = None,
+    val_labels_path: Optional[List[str]] = None,
     validation_fraction: float = 0.1,
     test_file_path: Optional[str] = None,
     provider: str = "LabelsReader",
@@ -169,8 +169,8 @@ def train(
     and starts training by passing this config to the `ModelTrainer` class.
 
     Args:
-        train_labels_path: List of paths to training data (`.slp` file).
-        val_labels_path: List of paths to validation data (`.slp` file).
+        train_labels_path: List of paths to training data (`.slp` file). Default: `None`
+        val_labels_path: List of paths to validation data (`.slp` file). Default: `None`
         validation_fraction: Float between 0 and 1 specifying the fraction of the
             training set to sample for generating the validation set. The remaining
             labeled frames will be left in the training set. If the `validation_labels`

--- a/tests/config/test_model_config.py
+++ b/tests/config/test_model_config.py
@@ -165,3 +165,25 @@ def test_model_mapper():
     ]
     assert config.head_configs.single_instance.confmaps.sigma == 3.0
     assert config.head_configs.single_instance.confmaps.output_stride == 2
+
+
+def test_model_oneof_failure_model_config(caplog):
+    """Test validation failure with oneof fields."""
+    with pytest.raises(ValueError):
+        ModelConfig(
+            backbone_config=BackboneConfig(
+                unet=UNetConfig(),
+                swint=SwinTConfig(),
+            )
+        )
+    assert "Only one attribute of this class can be set (not None).\n" in caplog.text
+
+
+def test_model_oneof_failure_head_config(caplog):
+    """Test validation failure with oneof fields."""
+    with pytest.raises(ValueError):
+        HeadConfig(
+            single_instance=SingleInstanceConfig(),
+            centroid=CentroidConfig(),
+        )
+    assert "Only one attribute of this class can be set (not None).\n" in caplog.text

--- a/tests/config/test_training_job_config.py
+++ b/tests/config/test_training_job_config.py
@@ -150,7 +150,7 @@ def test_load_bottomup_multiclass_training_config_from_file(
         "female",
         "male",
     ]
-    assert config.data_config.train_labels_path == []
+    assert config.data_config.train_labels_path is None
     assert config.data_config.val_labels_path is None
     assert config.model_config.backbone_config.unet.filters == 8
     assert config.model_config.backbone_config.unet.max_stride == 16
@@ -175,7 +175,7 @@ def test_load_bottomup_multiclass_training_config_from_file(
     config = TrainingJobConfig.load_sleap_config_from_json(slp_cfg_json)
 
     # Assertions to check if the output matches expected values
-    assert config.data_config.train_labels_path == []
+    assert config.data_config.train_labels_path is None
     assert config.data_config.val_labels_path is None
     assert config.model_config.backbone_config.unet.filters == 8
     assert config.model_config.backbone_config.unet.max_stride == 16
@@ -202,7 +202,7 @@ def test_load_bottomup_training_config_from_file(bottomup_training_config_path):
     config = TrainingJobConfig.load_sleap_config(json_file_path)
 
     # Assertions to check if the output matches expected values
-    assert config.data_config.train_labels_path == []
+    assert config.data_config.train_labels_path is None
     assert config.data_config.val_labels_path is None
     assert config.model_config.backbone_config.unet.filters == 16
     assert config.model_config.backbone_config.unet.max_stride == 8
@@ -223,7 +223,7 @@ def test_load_centered_instance_training_config_from_file(
     config = TrainingJobConfig.load_sleap_config(json_file_path)
 
     # Assertions to check if the output matches expected values
-    assert config.data_config.train_labels_path == []
+    assert config.data_config.train_labels_path is None
     assert config.data_config.val_labels_path is None
     assert config.model_config.head_configs.centered_instance.confmaps.part_names == [
         "A",

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -908,6 +908,28 @@ def test_backbone_oneof_validation_error(config, caplog):
     assert "BackboneConfig" in caplog.text
 
 
+def test_backbone_oneof_validation_error_no_backbone(config, caplog):
+    # Test that an error is raised when no backbone field is set
+    config_no_backbone = config.copy()
+    OmegaConf.update(
+        config_no_backbone,
+        "model_config.backbone_config.unet",
+        None,
+    )
+    OmegaConf.update(
+        config_no_backbone,
+        "model_config.backbone_config.convnext",
+        None,
+    )
+    OmegaConf.update(
+        config_no_backbone,
+        "model_config.backbone_config.swint",
+        None,
+    )
+    with pytest.raises(ValueError):
+        ModelTrainer.get_model_trainer_from_config(config_no_backbone)
+
+
 def test_head_configs_oneof_validation_error(config, caplog):
     # Test that an error is raised when a oneof field is not set
     config_two_head_configs = config.copy()
@@ -920,3 +942,30 @@ def test_head_configs_oneof_validation_error(config, caplog):
         ModelTrainer.get_model_trainer_from_config(config_two_head_configs)
     assert "Only one attribute" in caplog.text
     assert "HeadConfig" in caplog.text
+
+
+def test_head_config_oneof_validation_error_no_head(config, caplog):
+    # Test that an error is raised when no head field is set
+    config_no_head = config.copy()
+    OmegaConf.update(
+        config_no_head,
+        "model_config.head_configs.single_instance",
+        None,
+    )
+    OmegaConf.update(
+        config_no_head,
+        "model_config.head_configs.centroid",
+        None,
+    )
+    OmegaConf.update(
+        config_no_head,
+        "model_config.head_configs.centered_instance",
+        None,
+    )
+    OmegaConf.update(
+        config_no_head,
+        "model_config.head_configs.bottomup",
+        None,
+    )
+    with pytest.raises(ValueError):
+        ModelTrainer.get_model_trainer_from_config(config_no_head)

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -905,6 +905,7 @@ def test_backbone_oneof_validation_error(config, caplog):
     with pytest.raises(ValueError):
         ModelTrainer.get_model_trainer_from_config(config_unet_and_convnext)
     assert "Only one attribute" in caplog.text
+    assert "BackboneConfig" in caplog.text
 
 
 def test_head_configs_oneof_validation_error(config, caplog):
@@ -918,3 +919,4 @@ def test_head_configs_oneof_validation_error(config, caplog):
     with pytest.raises(ValueError):
         ModelTrainer.get_model_trainer_from_config(config_two_head_configs)
     assert "Only one attribute" in caplog.text
+    assert "HeadConfig" in caplog.text

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -956,6 +956,7 @@ def test_keep_viz_behavior(config, tmp_path, minimal_instance):
     viz_path = Path(trainer.config.trainer_config.save_ckpt_path) / "viz"
     assert not viz_path.exists(), "viz folder should be deleted when keep_viz=False"
 
+
 def test_backbone_oneof_validation_error(config, caplog):
     # Test that an error is raised when a oneof field is not set
     config_unet_and_convnext = config.copy()
@@ -1031,6 +1032,7 @@ def test_head_config_oneof_validation_error_no_head(config, caplog):
     )
     with pytest.raises(ValueError):
         ModelTrainer.get_model_trainer_from_config(config_no_head)
+
 
 @pytest.mark.skipif(
     sys.platform.startswith("li")

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -22,6 +22,7 @@ from sleap_nn.training.lightning_modules import (
     BottomUpLightningModule,
     BottomUpMultiClassLightningModule,
 )
+from sleap_nn.config.model_config import ConvNextConfig, SingleInstanceConfig
 import sleap_io as sio
 from torch.nn.functional import mse_loss
 import os
@@ -891,3 +892,29 @@ def test_keep_viz_behavior(config, tmp_path, minimal_instance):
     trainer.train()
     viz_path = Path(trainer.config.trainer_config.save_ckpt_path) / "viz"
     assert not viz_path.exists(), "viz folder should be deleted when keep_viz=False"
+
+
+def test_backbone_oneof_validation_error(config, caplog):
+    # Test that an error is raised when a oneof field is not set
+    config_unet_and_convnext = config.copy()
+    OmegaConf.update(
+        config_unet_and_convnext,
+        "model_config.backbone_config.convnext",
+        ConvNextConfig(),
+    )
+    with pytest.raises(ValueError):
+        ModelTrainer.get_model_trainer_from_config(config_unet_and_convnext)
+    assert "Only one attribute" in caplog.text
+
+
+def test_head_configs_oneof_validation_error(config, caplog):
+    # Test that an error is raised when a oneof field is not set
+    config_two_head_configs = config.copy()
+    OmegaConf.update(
+        config_two_head_configs,
+        "model_config.head_configs.single_instance",
+        SingleInstanceConfig(),
+    )
+    with pytest.raises(ValueError):
+        ModelTrainer.get_model_trainer_from_config(config_two_head_configs)
+    assert "Only one attribute" in caplog.text


### PR DESCRIPTION
This PR fixes two issues: 
1. Classes with `@oneof` decorator is not raising a `ValueError` when more than one attributes are set. When verifying and loading configs, OmegaConf does not instantiate the attrs classes because it only creates and updates a `DictConfig` schema. Therefore, the `@oneof` validations in the `__init__` for each class would never run. To fix this, I added `OmegaConf.to_object()` function to represent the config into a database backed by the attrs classes. 
2. Allow optional label paths in config. `train_labels_path` and `val_labels_path` would now accept `None` values. 