### PR TITLE
Remove Permanent File Creations After Testing Locally

### DIFF
--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -78,6 +78,7 @@ def test_topdown_predictor(
         video_index=0,
         frames=[0],
         make_labels=True,
+        output_path=tmp_path,
         device="cpu",
         max_instances=6,
         peak_threshold=0.0,
@@ -135,6 +136,7 @@ def test_topdown_predictor(
         ],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=[0.0, 0.0],
         device="cpu",
@@ -170,6 +172,7 @@ def test_topdown_predictor(
         ],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         device="cpu",
         peak_threshold=[0.0, 0.0],
@@ -190,6 +193,7 @@ def test_topdown_predictor(
         ],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         device="cpu",
         frames=[1100, 1101, 1102, 1103],
@@ -207,6 +211,7 @@ def test_topdown_predictor(
             model_paths=[minimal_instance_centered_instance_ckpt],
             data_path=centered_instance_video.as_posix(),
             make_labels=True,
+            output_path=tmp_path,
             max_instances=6,
             device="cpu",
             frames=[x for x in range(100)],
@@ -223,6 +228,7 @@ def test_topdown_predictor(
         ],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=2,
         post_connect_single_breaks=True,
         max_tracks=None,
@@ -248,6 +254,7 @@ def test_topdown_predictor(
             ],
             data_path=centered_instance_video.as_posix(),
             make_labels=True,
+            output_path=tmp_path,
             max_instances=None,
             post_connect_single_breaks=True,
             max_tracks=None,
@@ -318,6 +325,7 @@ def test_multiclass_topdown_predictor(
         video_index=0,
         frames=[0],
         make_labels=True,
+        output_path=tmp_path,
         device="cpu",
         peak_threshold=0.0,
         integral_refinement=None,
@@ -376,6 +384,7 @@ def test_multiclass_topdown_predictor(
         ],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=[0.0, 0.0],
         device="cpu",
@@ -397,6 +406,7 @@ def test_multiclass_topdown_predictor(
         ],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         device="cpu",
         peak_threshold=[0.0, 0.0],
@@ -419,6 +429,7 @@ def test_multiclass_topdown_predictor(
         ],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         integral_refinement=None,
         device="cpu",
@@ -436,6 +447,7 @@ def test_multiclass_topdown_predictor(
             model_paths=[minimal_instance_multi_class_topdown_ckpt],
             data_path=centered_instance_video.as_posix(),
             make_labels=True,
+            output_path=tmp_path,
             max_instances=6,
             device="cpu",
             frames=[x for x in range(100)],
@@ -449,6 +461,7 @@ def test_single_instance_predictor(
     small_robot_minimal_video,
     small_robot_minimal,
     minimal_instance_single_instance_ckpt,
+    tmp_path,
 ):
     """Test SingleInstancePredictor module."""
     # provider as LabelsReader
@@ -459,6 +472,7 @@ def test_single_instance_predictor(
         model_paths=[minimal_instance_single_instance_ckpt],
         data_path=small_robot_minimal.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         device="cpu",
         peak_threshold=0.1,
@@ -506,6 +520,7 @@ def test_single_instance_predictor(
         frames=[0],
         device="cpu",
         make_labels=True,
+        output_path=tmp_path,
         peak_threshold=0.1,
         integral_refinement=None,
     )
@@ -534,6 +549,7 @@ def test_single_instance_predictor(
         model_paths=[minimal_instance_single_instance_ckpt],
         data_path=small_robot_minimal_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         device="cpu",
         peak_threshold=0.1,
         integral_refinement=None,
@@ -586,6 +602,7 @@ def test_bottomup_predictor(
     minimal_instance_bottomup_ckpt,
     minimal_instance_centered_instance_ckpt,
     centered_instance_video,
+    tmp_path,
 ):
     """Test BottomUpPredictor module."""
     # provider as LabelsReader
@@ -595,6 +612,7 @@ def test_bottomup_predictor(
         model_paths=[minimal_instance_bottomup_ckpt],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.05,
         device="cpu",
@@ -643,6 +661,7 @@ def test_bottomup_predictor(
         video_index=0,
         frames=[0],
         make_labels=True,
+        output_path=tmp_path,
         device="cpu",
         integral_refinement=None,
     )
@@ -654,6 +673,7 @@ def test_bottomup_predictor(
         model_paths=[minimal_instance_bottomup_ckpt],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=1.0,
         device="cpu",
@@ -668,6 +688,7 @@ def test_bottomup_predictor(
         model_paths=[minimal_instance_bottomup_ckpt],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.05,
         frames=[x for x in range(100)],
@@ -703,6 +724,7 @@ def test_bottomup_predictor(
         model_paths=[minimal_instance_bottomup_ckpt],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.05,
         tracking=True,
@@ -727,6 +749,7 @@ def test_multi_class_bottomup_predictor(
     minimal_instance,
     minimal_instance_multi_class_bottomup_ckpt,
     minimal_instance_multi_class_topdown_ckpt,
+    tmp_path,
 ):
     """Test BottomUpPredictor module."""
     # provider as LabelsReader
@@ -736,6 +759,7 @@ def test_multi_class_bottomup_predictor(
         model_paths=[minimal_instance_multi_class_bottomup_ckpt],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.03,
         device="cpu",
@@ -789,6 +813,7 @@ def test_multi_class_bottomup_predictor(
         video_index=0,
         frames=[0],
         make_labels=True,
+        output_path=tmp_path,
         device="cpu",
         integral_refinement=None,
     )
@@ -801,6 +826,7 @@ def test_multi_class_bottomup_predictor(
         model_paths=[minimal_instance_multi_class_bottomup_ckpt],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.03,
         frames=[x for x in range(100)],
@@ -837,6 +863,7 @@ def test_tracking_only_pipeline(
     minimal_instance_centroid_ckpt,
     minimal_instance_centered_instance_ckpt,
     centered_instance_video,
+    tmp_path,
 ):
     """Test tracking-only pipeline."""
     labels = run_inference(
@@ -846,16 +873,17 @@ def test_tracking_only_pipeline(
         ],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=2,
         peak_threshold=0.1,
         frames=[x for x in range(0, 10)],
         integral_refinement="integral",
         post_connect_single_breaks=True,
     )
-    labels.save("preds.slp")
+    labels.save(f"{tmp_path}/preds.slp")
 
     tracked_labels = run_inference(
-        data_path="preds.slp",
+        data_path=f"{tmp_path}/preds.slp",
         tracking=True,
         post_connect_single_breaks=True,
         max_instances=2,
@@ -877,12 +905,14 @@ def test_legacy_topdown_predictor(
     minimal_instance,
     sleap_centroid_model_path,
     sleap_centered_instance_model_path,
+    tmp_path,
 ):
     """Test legacy topdown predictor."""
     pred_labels = run_inference(
         model_paths=[sleap_centroid_model_path, sleap_centered_instance_model_path],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         integral_refinement="integral",
         max_instances=2,
     )
@@ -917,14 +947,14 @@ def test_legacy_topdown_predictor(
 
 
 def test_legacy_bottomup_predictor(
-    minimal_instance,
-    sleap_bottomup_model_path,
+    minimal_instance, sleap_bottomup_model_path, tmp_path
 ):
     """Test legacy bottomup predictor."""
     pred_labels = run_inference(
         model_paths=[sleap_bottomup_model_path],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         integral_refinement="integral",
     )
     gt_labels = sio.load_slp(minimal_instance)
@@ -958,14 +988,14 @@ def test_legacy_bottomup_predictor(
 
 
 def test_legacy_single_instance_predictor(
-    small_robot_minimal,
-    sleap_single_instance_model_path,
+    small_robot_minimal, sleap_single_instance_model_path, tmp_path
 ):
     """Test legacy single instance predictor."""
     pred_labels = run_inference(
         model_paths=[sleap_single_instance_model_path],
         data_path=small_robot_minimal.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         integral_refinement="integral",
     )
     gt_labels = sio.load_slp(small_robot_minimal)
@@ -974,12 +1004,14 @@ def test_legacy_single_instance_predictor(
 def test_legacy_multiclass_bottomup_predictor(
     minimal_instance,
     sleap_bottomup_multiclass_model_path,
+    tmp_path,
 ):
     """Test legacy multiclass bottomup predictor."""
     pred_labels = run_inference(
         model_paths=[sleap_bottomup_multiclass_model_path],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         integral_refinement="integral",
     )
     gt_labels = sio.load_slp(minimal_instance)
@@ -989,12 +1021,14 @@ def test_legacy_multiclass_topdown_predictor(
     minimal_instance,
     sleap_centroid_model_path,
     sleap_topdown_multiclass_model_path,
+    tmp_path,
 ):
     """Test legacy multiclass topdown predictor."""
     pred_labels = run_inference(
         model_paths=[sleap_centroid_model_path, sleap_topdown_multiclass_model_path],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         integral_refinement="integral",
         max_instances=2,
     )

--- a/tests/tracking/candidates/test_fixed_window.py
+++ b/tests/tracking/candidates/test_fixed_window.py
@@ -6,11 +6,14 @@ from sleap_nn.tracking.candidates.fixed_window import FixedWindowCandidates
 from sleap_nn.tracking.tracker import Tracker
 
 
-def get_pred_instances(minimal_instance_centered_instance_ckpt, minimal_instance, n=10):
+def get_pred_instances(
+    minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path, n=10
+):
     result_labels = run_inference(
         model_paths=[minimal_instance_centered_instance_ckpt],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.0,
         integral_refinement="integral",
@@ -24,11 +27,14 @@ def get_pred_instances(minimal_instance_centered_instance_ckpt, minimal_instance
 
 
 def test_fixed_window_candidates(
-    minimal_instance_centered_instance_ckpt, minimal_instance
+    minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
 ):
 
     pred_instances = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance, 2
+        minimal_instance_centered_instance_ckpt,
+        minimal_instance,
+        n=2,
+        tmp_path=tmp_path,
     )
     tracker = Tracker.from_config()
     track_instances = tracker.get_features(pred_instances, 0)

--- a/tests/tracking/candidates/test_local_queues.py
+++ b/tests/tracking/candidates/test_local_queues.py
@@ -6,11 +6,14 @@ from sleap_nn.tracking.candidates.local_queues import LocalQueueCandidates
 from sleap_nn.tracking.tracker import Tracker
 
 
-def get_pred_instances(minimal_instance_centered_instance_ckpt, minimal_instance, n=10):
+def get_pred_instances(
+    minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path, n=10
+):
     result_labels = run_inference(
         model_paths=[minimal_instance_centered_instance_ckpt],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.0,
         integral_refinement="integral",
@@ -24,11 +27,14 @@ def get_pred_instances(minimal_instance_centered_instance_ckpt, minimal_instance
 
 
 def test_local_queues_candidates(
-    minimal_instance_centered_instance_ckpt, minimal_instance
+    minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
 ):
 
     pred_instances = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance, 2
+        minimal_instance_centered_instance_ckpt,
+        minimal_instance,
+        n=2,
+        tmp_path=tmp_path,
     )
     tracker = Tracker.from_config(candidates_method="local_queues")
     track_instances = tracker.get_features(pred_instances, 0)

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -26,12 +26,15 @@ def caplog(caplog: LogCaptureFixture):
     logger.remove(handler_id)
 
 
-def get_pred_instances(minimal_instance_centered_instance_ckpt, minimal_instance):
+def get_pred_instances(
+    minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
+):
     """Get `sio.PredictedInstance` objects from Predictor class."""
     result_labels = run_inference(
         model_paths=[minimal_instance_centered_instance_ckpt],
         data_path=minimal_instance.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=6,
         peak_threshold=0.0,
         integral_refinement="integral",
@@ -44,12 +47,14 @@ def get_pred_instances(minimal_instance_centered_instance_ckpt, minimal_instance
     return pred_instances, imgs
 
 
-def test_tracker(caplog, minimal_instance_centered_instance_ckpt, minimal_instance):
+def test_tracker(
+    caplog, minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
+):
     """Test `Tracker` module."""
     # Test for the first two instances
     # no new tracks should be created
     pred_instances, _ = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     tracker = Tracker.from_config(
         min_new_track_points=3
@@ -67,7 +72,7 @@ def test_tracker(caplog, minimal_instance_centered_instance_ckpt, minimal_instan
     # pose as feature, oks scoring method, avg score reduction, hungarian matching
     # Test for the first two instances (tracks assigned to each of the new instances)
     pred_instances, _ = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     tracker = Tracker.from_config(candidates_method="fixed_window")
     for p in pred_instances:
@@ -87,7 +92,7 @@ def test_tracker(caplog, minimal_instance_centered_instance_ckpt, minimal_instan
     # pose as feature, oks scoring method, max score reduction, hungarian matching
     # Test for the first two instances (tracks assigned to each of the new instances)
     pred_instances, _ = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     tracker = Tracker.from_config(candidates_method="local_queues")
     for p in pred_instances:
@@ -105,7 +110,7 @@ def test_tracker(caplog, minimal_instance_centered_instance_ckpt, minimal_instan
     # Test indv. functions for fixed window
     # with 2 existing tracks in the queue
     pred_instances, _ = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     tracker = Tracker.from_config(
         candidates_method="fixed_window",
@@ -115,7 +120,7 @@ def test_tracker(caplog, minimal_instance_centered_instance_ckpt, minimal_instan
     _ = tracker.track(pred_instances, 0)
 
     pred_instances, _ = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     # Test points as feature
     track_instances = tracker.get_features(pred_instances, 0, None)
@@ -164,7 +169,7 @@ def test_tracker(caplog, minimal_instance_centered_instance_ckpt, minimal_instan
     # Test local queue tracker
     # with existing tracks
     pred_instances, _ = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     tracker = Tracker.from_config(
         candidates_method="local_queues",
@@ -254,12 +259,14 @@ def test_tracker(caplog, minimal_instance_centered_instance_ckpt, minimal_instan
     assert "Invalid `track_matching_method` argument." in caplog.text
 
 
-def test_flowshifttracker(minimal_instance_centered_instance_ckpt, minimal_instance):
+def test_flowshifttracker(
+    minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
+):
     """Tests for `FlowShiftTracker` class."""
     # Test Fixed-window method: pose as feature, oks scoring method
     # Test for the first two instances (tracks assigned to each of the new instances)
     pred_instances, imgs = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     tracker = Tracker.from_config(
         candidates_method="fixed_window",
@@ -293,7 +300,7 @@ def test_flowshifttracker(minimal_instance_centered_instance_ckpt, minimal_insta
     # Test Local queue method: pose as feature, oks scoring method
     # Test for the first two instances (tracks assigned to each of the new instances)
     pred_instances, imgs = get_pred_instances(
-        minimal_instance_centered_instance_ckpt, minimal_instance
+        minimal_instance_centered_instance_ckpt, minimal_instance, tmp_path
     )
     tracker = Tracker.from_config(
         candidates_method="local_queues",
@@ -349,6 +356,7 @@ def test_run_tracker(
     minimal_instance_centered_instance_ckpt,
     centered_instance_video,
     minimal_instance,
+    tmp_path,
 ):
     """Tests for run_tracker."""
     labels = run_inference(
@@ -358,6 +366,7 @@ def test_run_tracker(
         ],
         data_path=centered_instance_video.as_posix(),
         make_labels=True,
+        output_path=tmp_path,
         max_instances=2,
         peak_threshold=0.1,
         frames=[x for x in range(0, 10)],
@@ -387,6 +396,7 @@ def test_run_tracker(
             ],
             data_path=centered_instance_video.as_posix(),
             make_labels=True,
+            output_path=tmp_path,
             max_instances=2,
             peak_threshold=0.1,
             frames=[x for x in range(0, 10)],

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -232,7 +232,9 @@ def test_model_trainer_centered_instance(caplog, config, tmp_path: str):
     OmegaConf.update(
         config, "data_config.data_pipeline_fw", "torch_dataset_cache_img_memory"
     )
-    OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_trainer"
+    )
     OmegaConf.update(config, "trainer_config.profiler", None)
 
     ## invalid profiler: raise exception
@@ -505,7 +507,9 @@ def test_zmq_callbacks(config, tmp_path: str):
     OmegaConf.update(
         config, "data_config.data_pipeline_fw", "torch_dataset_cache_img_memory"
     )
-    OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_zmq_callbacks"
+    )
     OmegaConf.update(
         config, "trainer_config.zmq.publish_address", "tcp://127.0.0.1:9510"
     )
@@ -767,13 +771,15 @@ def test_model_trainer_multi_classtopdown(config, tmp_path, minimal_instance, ca
     reason="Flaky test (The training test runs on Ubuntu for a long time: >6hrs and then fails.)",
 )
 # TODO: Revisit this test later (Failing on ubuntu)
-def test_resume_training(config):
+def test_resume_training(config, tmp_path):
     if torch.mps.is_available():
         config.trainer_config.trainer_accelerator = "cpu"
     else:
         config.trainer_config.trainer_accelerator = "auto"
     # train a model for 2 epochs:
-    OmegaConf.update(config, "trainer_config.save_ckpt_path", None)
+    OmegaConf.update(
+        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_resume_trainer"
+    )
     OmegaConf.update(config, "trainer_config.save_ckpt", True)
     trainer = ModelTrainer.get_model_trainer_from_config(config)
     trainer.train()
@@ -791,7 +797,9 @@ def test_resume_training(config):
     prv_runid = training_config.trainer_config.wandb.current_run_id
     OmegaConf.update(config_copy, "trainer_config.wandb.prv_runid", prv_runid)
     OmegaConf.update(config_copy, "data_config.data_pipeline_fw", "torch_dataset")
-    OmegaConf.update(config_copy, "trainer_config.save_ckpt_path", None)
+    OmegaConf.update(
+        config_copy, "trainer_config.save_ckpt_path", f"{tmp_path}/test_resume_trainer"
+    )
     OmegaConf.update(config_copy, "trainer_config.save_ckpt", True)
     trainer = ModelTrainer.get_model_trainer_from_config(config_copy)
     trainer.train()

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -1054,6 +1054,7 @@ def test_loading_pretrained_weights(
     minimal_instance,
     caplog,
     minimal_instance_centered_instance_ckpt,
+    tmp_path,
 ):
     """Test loading pretrained weights for model initialization."""
     # with keras (.h5 weights)
@@ -1069,6 +1070,7 @@ def test_loading_pretrained_weights(
     sleap_nn_config.trainer_config.trainer_accelerator = "cpu"
     sleap_nn_config.data_config.preprocessing.ensure_rgb = True
     sleap_nn_config.trainer_config.max_epochs = 2
+    sleap_nn_config.trainer_config.save_ckpt_path = f"{tmp_path}/test_loading_weights"
 
     trainer = ModelTrainer.get_model_trainer_from_config(
         config=sleap_nn_config,
@@ -1095,6 +1097,7 @@ def test_loading_pretrained_weights(
     sleap_nn_config.data_config.preprocessing.ensure_rgb = True
     sleap_nn_config.trainer_config.max_epochs = 2
     sleap_nn_config.trainer_config.trainer_accelerator = "cpu"
+    sleap_nn_config.trainer_config.save_ckpt_path = f"{tmp_path}/test_loading_weights"
     trainer = ModelTrainer.get_model_trainer_from_config(
         config=sleap_nn_config,
         train_labels=[sio.load_slp(minimal_instance)],


### PR DESCRIPTION
This PR removes permanent file creations after running `pytest  tests`, preventing the cumulative directories in the repository directory.