### PR TITLE
Add helpful CLI message to `sleap-nn-train`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,17 @@ dependencies = [
 dynamic = ["version", "readme"]
 
 [tool.setuptools]
-packages = ["sleap_nn"]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["sleap_nn*"] 
 
 [tool.setuptools.dynamic]
 version = {attr = "sleap_nn.__version__"}
 readme = {file = ["README.md"]}
+
+[tool.setuptools.package-data]
+sleap_nn = ["config/**/*.yaml"]
 
 [project.optional-dependencies]
 torch = [

--- a/sleap_nn/config/hydra/__init__.py
+++ b/sleap_nn/config/hydra/__init__.py
@@ -1,0 +1,2 @@
+# sleap_nn/config/hydra/__init__.py
+# Marks this directory as a Python package so Hydra can import configs.

--- a/sleap_nn/config/hydra/help/training_help.yaml
+++ b/sleap_nn/config/hydra/help/training_help.yaml
@@ -1,0 +1,32 @@
+# sleap_nn/config/hydra/help/training_help.yaml
+app_name: sleap-nn-train
+
+header: |-
+  sleap-nn-train — Train SLEAP models from a config YAML file.
+
+template: |-
+  ${hydra.help.header}
+
+  Usage:
+    sleap-nn-train --config-dir <dir> --config-name <name> [overrides]
+
+  Common overrides:
+    trainer_config.max_epochs=100
+    trainer_config.batch_size=32
+
+  Example: 
+    To start a training from scratch: 
+      sleap-nn-train --config-dir . --config-name myrun
+    To start a training from a checkpoint for maximum 20 more epochs without changing config file: 
+      sleap-nn-train --config-dir . --config-name myrun \
+        trainer_config.resume_ckpt_path=<path/to/ckpt> \
+        trainer_config.max_epochs=20
+
+  Tips:
+    - Use -m/--multirun for sweeps; outputs go under hydra.sweep.dir.
+    - For more detailed flags (completion, multirun internals), use --hydra-help.
+
+  ${hydra.help.footer}
+
+footer: |-
+  For a detailed list of all available config options, please refer to the documentation at [https://nn.sleap.ai/dev/config/].

--- a/sleap_nn/config/training.yaml
+++ b/sleap_nn/config/training.yaml
@@ -6,5 +6,5 @@ defaults:
 # You can leave the rest empty so Hydra has a struct to work with.
 # This prevents `{}` from being passed down.
 model_config: {}
-trainer: {}
-data: {}
+trainer_config: {}
+data_config: {}

--- a/sleap_nn/config/training.yaml
+++ b/sleap_nn/config/training.yaml
@@ -1,0 +1,10 @@
+# Root config for sleap-nn-train
+defaults:
+  - _self_
+  - override hydra/help: training_help
+
+# You can leave the rest empty so Hydra has a struct to work with.
+# This prevents `{}` from being passed down.
+model_config: {}
+trainer: {}
+data: {}

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -448,6 +448,10 @@ def train(
 @hydra.main(version_base=None, config_path='config', config_name="training")
 def main(cfg: DictConfig):
     """Train SLEAP-NN model using CLI."""
+    if not cfg.trainer_config:
+        # set save_ckpt_path to current working dir if not specified
+        print("No trainer config found! Use `sleap-nn-train --help` for more information.")
+        raise SystemExit(2)
     logger.info("Input config:")
     logger.info("\n" + OmegaConf.to_yaml(cfg))
     run_training(cfg)

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -445,7 +445,7 @@ def train(
     run_training(omegaconf_config.copy())
 
 
-@hydra.main(version_base=None, config_path=None, config_name=None)
+@hydra.main(version_base=None, config_path='config', config_name="training")
 def main(cfg: DictConfig):
     """Train SLEAP-NN model using CLI."""
     logger.info("Input config:")

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,5 +1,6 @@
 from omegaconf import DictConfig, OmegaConf
 from pathlib import Path
+import copy
 import sys
 import torch
 import pytest
@@ -626,3 +627,9 @@ def test_main(sample_cfg):
         .joinpath("pred_test.slp")
         .exists()
     )
+
+    # test main exits with invalid config (missing trainer_config)
+    invalid_cfg = copy.deepcopy(sample_cfg)
+    invalid_cfg.trainer_config = None
+    with pytest.raises(SystemExit):
+        main(invalid_cfg)


### PR DESCRIPTION
Add helpful error message and more robust input handling to `sleap-nn-train` CLI: 

Before: 
 
<img width="648" height="342" alt="Screenshot 76" src="https://github.com/user-attachments/assets/9ccb09db-cb9e-491f-ae9d-f745f7e305e0" />
<img width="964" height="476" alt="Screenshot 75" src="https://github.com/user-attachments/assets/c59049a4-1201-4814-80e6-ef3b921669a3" />

After: 
<img width="1025" height="468" alt="Screenshot 77" src="https://github.com/user-attachments/assets/9b66389a-858c-4ae3-b9e3-a00885618999" />
