### PR TITLE
Add testpypi index to toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,12 @@ name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true
+
 [tool.black]
 line-length = 88
 


### PR DESCRIPTION
This PR adds testspypi index to `pyproject.toml` to enable publishing to testpypi with uv