### PR TITLE
More robust help injection in CLI

### DIFF
--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -493,9 +493,23 @@ def add_help(name: str = "sleap_help"):
         def wrapper(*args, **kwargs):
             joined = " ".join(sys.argv[1:])
             if "hydra/help=" not in joined and "hydra.help." not in joined:
-                sys.argv.insert(1, f"hydra/help={name}")
-            return fn(*args, **kwargs)
+                if "--" in sys.argv:
+                    dashdash = sys.argv.index("--")
+                    sys.argv.insert(dashdash, f"hydra/help={name}")
+                else:
+                    dashdash = len(sys.argv)
 
+                beginning_of_overrides_section = -1
+                for idx, arg in enumerate(sys.argv[1:dashdash], start=1):
+                    if not arg.startswith("-") and idx < dashdash and ("=" in arg or arg.startswith("+")):
+                        beginning_of_overrides_section = idx
+                        break
+                if beginning_of_overrides_section != -1:
+                    sys.argv.insert(beginning_of_overrides_section, f"hydra/help={name}")
+                else:
+                    sys.argv.insert(dashdash, f"hydra/help={name}")
+            # breakpoint()
+            return fn(*args, **kwargs)
         return wrapper
 
     return outer

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -495,7 +495,6 @@ def add_help(name: str = "sleap_help"):
             if "hydra/help=" not in joined and "hydra.help." not in joined:
                 if "--" in sys.argv:
                     dashdash = sys.argv.index("--")
-                    sys.argv.insert(dashdash, f"hydra/help={name}")
                 else:
                     dashdash = len(sys.argv)
 

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -501,15 +501,22 @@ def add_help(name: str = "sleap_help"):
 
                 beginning_of_overrides_section = -1
                 for idx, arg in enumerate(sys.argv[1:dashdash], start=1):
-                    if not arg.startswith("-") and idx < dashdash and ("=" in arg or arg.startswith("+")):
+                    if (
+                        not arg.startswith("-")
+                        and idx < dashdash
+                        and ("=" in arg or arg.startswith("+"))
+                    ):
                         beginning_of_overrides_section = idx
                         break
                 if beginning_of_overrides_section != -1:
-                    sys.argv.insert(beginning_of_overrides_section, f"hydra/help={name}")
+                    sys.argv.insert(
+                        beginning_of_overrides_section, f"hydra/help={name}"
+                    )
                 else:
                     sys.argv.insert(dashdash, f"hydra/help={name}")
             # breakpoint()
             return fn(*args, **kwargs)
+
         return wrapper
 
     return outer

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -641,11 +641,6 @@ def test_main(sample_cfg):
         main(invalid_cfg)
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("li")
-    and not torch.cuda.is_available(),  # self-hosted GPUs have linux os but cuda is available, so will do test
-    reason="Flaky test (The training test runs on Ubuntu for a long time: >6hrs and then fails.)",
-)
 def test_main_cli(sample_cfg, tmp_path):
     # Test that train cli handles empty argument gracefully
     cmd = [

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -641,6 +641,11 @@ def test_main(sample_cfg):
         main(invalid_cfg)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("li")
+    and not torch.cuda.is_available(),  # self-hosted GPUs have linux os but cuda is available, so will do test
+    reason="Flaky test (The training test runs on Ubuntu for a long time: >6hrs and then fails.)",
+)
 def test_main_cli(sample_cfg, tmp_path):
     # Test that train cli handles empty argument gracefully
     cmd = [

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -640,7 +640,8 @@ def test_main(sample_cfg):
     with pytest.raises(SystemExit):
         main(invalid_cfg)
 
-def test_main_cli(sample_cfg, tmp_path): 
+
+def test_main_cli(sample_cfg, tmp_path):
     # Test that train cli handles empty argument gracefully
     cmd = [
         "uv",
@@ -654,7 +655,7 @@ def test_main_cli(sample_cfg, tmp_path):
     )
     # Exit code should be 2
     assert result.returncode == 2
-    assert "No model config found" in result.stdout # Should tell user what is wrong
+    assert "No model config found" in result.stdout  # Should tell user what is wrong
     assert "--help" in result.stdout  # should suggest using --help
 
     cmd = [
@@ -671,7 +672,7 @@ def test_main_cli(sample_cfg, tmp_path):
     # Exit code should be 0
     assert result.returncode == 0
     assert "Usage" in result.stdout  # Should show usage information
-    assert "sleap.ai" in result.stdout # should point user to read the documents
+    assert "sleap.ai" in result.stdout  # should point user to read the documents
 
     # Now to test overrides and defaults
     OmegaConf.save(sample_cfg, (Path(tmp_path) / "test_config.yaml").as_posix())
@@ -683,7 +684,7 @@ def test_main_cli(sample_cfg, tmp_path):
         "--config-dir",
         f"{tmp_path}",
         "--config-name",
-        "test_config"
+        "test_config",
     ]
     result = subprocess.run(
         cmd,
@@ -694,8 +695,8 @@ def test_main_cli(sample_cfg, tmp_path):
     assert result.returncode == 0
     # Try to parse the output back into the yaml, truncate the beginning (starts with "data_config")
     # Only keep stdout starting from "data_config"
-    stripped_out = result.stdout[result.stdout.find("data_config"):].strip()
-    stripped_out = stripped_out[:stripped_out.find(" | INFO") - 19]
+    stripped_out = result.stdout[result.stdout.find("data_config") :].strip()
+    stripped_out = stripped_out[: stripped_out.find(" | INFO") - 19]
     output = OmegaConf.create(stripped_out)
     assert output == sample_cfg
 
@@ -711,7 +712,7 @@ def test_main_cli(sample_cfg, tmp_path):
         "--config-name",
         "test_config",
         "trainer_config.max_epochs=2",
-        "data_config.preprocessing.scale=1.2"
+        "data_config.preprocessing.scale=1.2",
     ]
     result = subprocess.run(
         cmd,
@@ -720,7 +721,7 @@ def test_main_cli(sample_cfg, tmp_path):
     )
     # Exit code should be 0
     assert result.returncode == 0
-    stripped_out = result.stdout[result.stdout.find("data_config"):].strip()
-    stripped_out = stripped_out[:stripped_out.find(" | INFO") - 19]
+    stripped_out = result.stdout[result.stdout.find("data_config") :].strip()
+    stripped_out = stripped_out[: stripped_out.find(" | INFO") - 19]
     output = OmegaConf.create(stripped_out)
     assert output == sample_cfg

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,3 +1,4 @@
+import subprocess
 from omegaconf import DictConfig, OmegaConf
 from pathlib import Path
 import copy
@@ -638,3 +639,88 @@ def test_main(sample_cfg):
     invalid_cfg.model_config = None
     with pytest.raises(SystemExit):
         main(invalid_cfg)
+
+def test_main_cli(sample_cfg, tmp_path): 
+    # Test that train cli handles empty argument gracefully
+    cmd = [
+        "uv",
+        "run",
+        "sleap-nn-train",
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+    # Exit code should be 2
+    assert result.returncode == 2
+    assert "No model config found" in result.stdout # Should tell user what is wrong
+    assert "--help" in result.stdout  # should suggest using --help
+
+    cmd = [
+        "uv",
+        "run",
+        "sleap-nn-train",
+        "--help",
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+    # Exit code should be 0
+    assert result.returncode == 0
+    assert "Usage" in result.stdout  # Should show usage information
+    assert "sleap.ai" in result.stdout # should point user to read the documents
+
+    # Now to test overrides and defaults
+    OmegaConf.save(sample_cfg, (Path(tmp_path) / "test_config.yaml").as_posix())
+
+    cmd = [
+        "uv",
+        "run",
+        "sleap-nn-train",
+        "--config-dir",
+        f"{tmp_path}",
+        "--config-name",
+        "test_config"
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+    # Exit code should be 0
+    assert result.returncode == 0
+    # Try to parse the output back into the yaml, truncate the beginning (starts with "data_config")
+    # Only keep stdout starting from "data_config"
+    stripped_out = result.stdout[result.stdout.find("data_config"):].strip()
+    stripped_out = stripped_out[:stripped_out.find(" | INFO") - 19]
+    output = OmegaConf.create(stripped_out)
+    assert output == sample_cfg
+
+    # config override should work
+    sample_cfg.trainer_config.max_epochs = 2
+    sample_cfg.data_config.preprocessing.scale = 1.2
+    cmd = [
+        "uv",
+        "run",
+        "sleap-nn-train",
+        "--config-dir",
+        f"{tmp_path}",
+        "--config-name",
+        "test_config",
+        "trainer_config.max_epochs=2",
+        "data_config.preprocessing.scale=1.2"
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+    # Exit code should be 0
+    assert result.returncode == 0
+    stripped_out = result.stdout[result.stdout.find("data_config"):].strip()
+    stripped_out = stripped_out[:stripped_out.find(" | INFO") - 19]
+    output = OmegaConf.create(stripped_out)
+    assert output == sample_cfg


### PR DESCRIPTION
Currently `sleap-nn-train` does not take commandline overrides because of a bug with how hydra handles overrides, this PR solves it. 