### PR TITLE
Fix compute filters in unet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "psutil",
     "opencv-python",
     "hydra-core",
+    "jupyter",
+    "jupyterlab",
     "pyzmq"
 ]
 dynamic = ["version", "readme"]

--- a/sleap_nn/architectures/unet.py
+++ b/sleap_nn/architectures/unet.py
@@ -135,7 +135,9 @@ class UNet(nn.Module):
                         pool_before_convs=False,
                         pooling_stride=2,
                         num_convs=convs_per_block - 1,
-                        filters=int(last_block_filters * filters_rate),
+                        filters=int(
+                            filters * (filters_rate ** (down_blocks + stem_blocks))
+                        ),
                         kernel_size=kernel_size,
                         use_bias=True,
                         batch_norm=False,
@@ -151,10 +153,14 @@ class UNet(nn.Module):
                     block_filters = int(last_block_filters)
                 else:
                     # Keep the block output filters the same
-                    block_filters = int(last_block_filters * filters_rate)
+                    block_filters = int(
+                        filters * (filters_rate ** (down_blocks + stem_blocks))
+                    )
 
                 middle_contract = SimpleConvBlock(
-                    in_channels=int(last_block_filters * filters_rate),
+                    in_channels=int(
+                        filters * (filters_rate ** (down_blocks + stem_blocks))
+                    ),
                     pool=False,
                     pool_before_convs=False,
                     pooling_stride=2,


### PR DESCRIPTION
This PR fixes a bug in how filters are computed for the UNet backbone. Previously, the calculation differed slightly from SLEAP due to rounding errors, which caused a layer mismatch when running inference with legacy SLEAP model weights. This update aligns the filter computation with SLEAP’s implementation, ensuring compatibility with models trained in the tensorflow framework.

Related Issue: #309