### PR TITLE
Minor updates to config parameters

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -96,7 +96,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: your_model_name
+  ckpt_dir: <ckpt_dir>
+  run_name: <run_name>
   optimizer_name: Adam
   optimizer:
     lr: 0.0001
@@ -202,7 +203,7 @@ data_config:
 
 ### Data Pipeline Framework
 - `data_pipeline_fw`: (str) Framework to create the data loaders. One of [`torch_dataset`, `torch_dataset_cache_img_memory`, `torch_dataset_cache_img_disk`]. **Default**: `"torch_dataset"`. (Note: When using `torch_dataset`, `num_workers` in `trainer_config` should be set to 0 as multiprocessing doesn't work with pickling video backends.)
-- `cache_img_path`: (str) Path to save `.jpg` images created with `torch_dataset_cache_img_disk` data pipeline framework. If `None`, the path provided in `trainer_config.save_ckpt` is used. The `train_imgs` and `val_imgs` dirs are created inside this path. **Default**: `None`
+- `cache_img_path`: (str) Path to save `.jpg` images created with `torch_dataset_cache_img_disk` data pipeline framework. If `None`, the path `<trainer_config.ckpt_dir>/<trainer_config.run_name>` is used. The `train_imgs` and `val_imgs` dirs are created inside this path. **Default**: `None`
 - `use_existing_imgs`: (bool) Use existing train and val images/ chunks in the `cache_img_path` for `torch_dataset_cache_img_disk` frameworks. If `True`, the `cache_img_path` should have `train_imgs` and `val_imgs` dirs. **Default**: `False`
 - `delete_cache_imgs_after_training`: (bool) If `False`, the images (torch_dataset_cache_img_disk) are retained after training. Else, the files are deleted. **Default**: `True`
 
@@ -710,7 +711,8 @@ trainer_config:
 - `seed`: (int) Seed value for the current experiment. **Default**: `0`
 - `use_wandb`: (bool) True to enable wandb logging. **Default**: `False`
 - `save_ckpt`: (bool) True to enable checkpointing. **Default**: `False`
-- `save_ckpt_path`: (str) Directory path to save the training config and checkpoint files. **Default**: `None`
+- `ckpt_dir`: (str) Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
+- `run_name`: (str) Name of the current run. The ckpts will be created in `<ckpt_dir>/<run_name>`. If `None`, a run name is generated with `<timestamp>_<head_name>`. **Default**: `None`
 - `resume_ckpt_path`: (str) Path to `.ckpt` file from which training is resumed. **Default**: `None`
 
 ### Optimizer Configuration

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,7 +28,7 @@ data_config:
     ensure_rgb: false
     ensure_grayscale: false
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:
@@ -213,8 +213,8 @@ data_config:
     - `max_height`: (int) Maximum height the image should be padded to. If not provided, the original image size will be retained. **Default**: `None`
     - `max_width`: (int) Maximum width the image should be padded to. If not provided, the original image size will be retained. **Default**: `None`
     - `scale`: (float) Factor to resize the image dimensions by, specified as a float. **Default**: `1.0`
-    - `crop_hw`: (Tuple[int]) Crop height and width of each instance (h, w) for centered-instance model. If `None`, this would be automatically computed based on the largest instance in the `sio.Labels` file. **Default**: `None`
-    - `min_crop_size`: (int) Minimum crop size to be used if `crop_hw` is `None`. **Default**: `100`
+    - `crop_size`: (int) Crop size of each instance for centered-instance model. If `None`, this would be automatically computed based on the largest instance in the `sio.Labels` file. **Default**: `None`
+    - `min_crop_size`: (int) Minimum crop size to be used if `crop_size` is `None`. **Default**: `100`
 
 #### Example: Common Preprocessing Configurations
 
@@ -225,7 +225,7 @@ data_config:
     ensure_rgb: false
     ensure_grayscale: false
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
 ```
 
@@ -236,7 +236,7 @@ data_config:
     ensure_rgb: true
     ensure_grayscale: false
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
 ```
 
@@ -247,7 +247,7 @@ data_config:
     ensure_rgb: false
     ensure_grayscale: false
     scale: 1.0
-    crop_hw: [256, 256]  # Fixed 256x256 crop
+    crop_size: 256  # Fixed 256x256 crop
     min_crop_size: 100
 ```
 
@@ -260,7 +260,7 @@ data_config:
     scale: 1.0
     max_height: 512
     max_width: 512
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
 ```
 

--- a/docs/sample_configs/config_bottomup_convnext.yaml
+++ b/docs/sample_configs/config_bottomup_convnext.yaml
@@ -110,7 +110,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   optimizer_name: Adam
   optimizer:

--- a/docs/sample_configs/config_bottomup_convnext.yaml
+++ b/docs/sample_configs/config_bottomup_convnext.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_bottomup_unet.yaml
+++ b/docs/sample_configs/config_bottomup_unet.yaml
@@ -109,7 +109,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   optimizer_name: Adam
   optimizer:

--- a/docs/sample_configs/config_bottomup_unet.yaml
+++ b/docs/sample_configs/config_bottomup_unet.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_centroid_swint.yaml
+++ b/docs/sample_configs/config_centroid_swint.yaml
@@ -105,7 +105,8 @@ trainer_config:
   seed: 0
   use_wandb: true
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   wandb: # sample wandb config
     entity:

--- a/docs/sample_configs/config_centroid_swint.yaml
+++ b/docs/sample_configs/config_centroid_swint.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -103,7 +103,8 @@ trainer_config:
   seed: 0
   use_wandb: true
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   wandb: # sample wandb config
     entity:

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_multi_class_bottomup_unet.yaml
+++ b/docs/sample_configs/config_multi_class_bottomup_unet.yaml
@@ -110,7 +110,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   optimizer_name: Adam
   optimizer:

--- a/docs/sample_configs/config_multi_class_bottomup_unet.yaml
+++ b/docs/sample_configs/config_multi_class_bottomup_unet.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_single_instance_unet.yaml
+++ b/docs/sample_configs/config_single_instance_unet.yaml
@@ -103,7 +103,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   optimizer_name: Adam
   optimizer:

--- a/docs/sample_configs/config_single_instance_unet.yaml
+++ b/docs/sample_configs/config_single_instance_unet.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_topdown_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw:
+    crop_size:
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_topdown_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet.yaml
@@ -104,7 +104,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   optimizer_name: Adam
   optimizer:

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw:
+    crop_size:
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -112,7 +112,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path:
+  ckpt_dir:
+  run_name:
   resume_ckpt_path: null
   optimizer_name: Adam
   optimizer:

--- a/docs/step_by_step_tutorial.md
+++ b/docs/step_by_step_tutorial.md
@@ -92,7 +92,8 @@ trainer_config:
   max_epochs: 200
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: your_model_name
+  ckpt_dir: <ckpt_dir>
+  run_name: <run_name>
   optimizer_name: Adam
   optimizer:
     lr: 0.0001
@@ -222,8 +223,8 @@ The `trainer_config` section controls the training process, including key hyperp
 
 - **Epochs and Checkpoints:**  
     - Set `max_epochs` to control how many epochs to train for.
-    - Use `save_ckpt_path` to specify where model checkpoints are saved. If not set, a default path will be created using a timestamp and model type.
-    - For multi-GPU training, always set a static `save_ckpt_path` so all workers write to the same location.
+    - Use `ckpt_dir` and `run_name` to specify where model checkpoints are saved. If not set, a default folder in the working dir will be created using a timestamp and model type.
+    - For multi-GPU training, always set a static `run_name` so all workers write to the same location.
 
 - **Device and Accelerator:**  
     - `trainer_accelerator` can be `"cpu"`, `"cuda"`, `"mps"`, or `"auto"`.  
@@ -258,7 +259,8 @@ trainer_config:
   max_epochs: 200
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: my_model_ckpt_dir
+  ckpt_dir: my_model_ckpt_dir
+  run_name: my_run_1
   optimizer_name: Adam
   optimizer:
     lr: 0.0001

--- a/docs/step_by_step_tutorial.md
+++ b/docs/step_by_step_tutorial.md
@@ -31,7 +31,7 @@ data_config:
     ensure_rgb: false
     ensure_grayscale: false
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:
@@ -149,7 +149,7 @@ data_config:
     ensure_rgb: false
     ensure_grayscale: false
     scale: 1.0
-    crop_hw: null # only for centered-instance model
+    crop_size: null # only for centered-instance model
     min_crop_size: 100 # only for centered-instance model
   use_augmentations_train: true
   augmentation_config:

--- a/docs/training.md
+++ b/docs/training.md
@@ -153,7 +153,8 @@ sleap-nn train \
 To automatically configure the accelerator and number of devices, set:
 ```yaml
 trainer_config:
-  save_ckpt_path: multi_gpu_training
+  ckpt_dir: models
+  run_name: multi_gpu_training_1
   trainer_accelerator: "auto"
   trainer_devices: "auto"
   trainer_strategy: "auto"
@@ -162,7 +163,8 @@ trainer_config:
 To set the number of gpus to be used and the accelerator:
 ```yaml
 trainer_config:
-  save_ckpt_path: multi_gpu_training
+ckpt_dir: models
+  run_name: multi_gpu_training_1
   trainer_accelerator: "gpu"
   trainer_devices: 4
   trainer_strategy: "ddp"

--- a/example_notebooks/training_demo.py
+++ b/example_notebooks/training_demo.py
@@ -36,6 +36,7 @@ def _():
     import matplotlib.pyplot as plt
     import seaborn as sns
     from torchvision import transforms
+    from pathlib import Path
 
     from omegaconf import OmegaConf
 
@@ -292,7 +293,7 @@ def _(get_trainer_config, model_type):
         learning_rate=1e-4,
         save_ckpt=True,
         max_epochs=10,
-        save_ckpt_path=f"{model_type.value}_training",
+        run_name=f"{model_type.value}_training",
         lr_scheduler="reduce_lr_on_plateau",
     )
     return (trainer_config,)
@@ -648,7 +649,12 @@ def _(
 
     pred_labels = run_inference(
         data_path=path_to_val_slp_file,
-        model_paths=[sleap_nn_cfg.trainer_config.save_ckpt_path],
+        model_paths=[
+            (
+                Path(sleap_nn_cfg.trainer_config.ckpt_dir)
+                / sleap_nn_cfg.trainer_config.run_name
+            ).as_posix()
+        ],
         output_path=f"predictions_{model_type.value}.slp",
     )
     return (pred_labels,)

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -23,8 +23,8 @@ class PreprocessingConfig:
         max_height: (int) Maximum height the image should be padded to. If not provided, the original image size will be retained. *Default*: `None`.
         max_width: (int) Maximum width the image should be padded to. If not provided, the original image size will be retained. *Default*: `None`.
         scale: (float) Factor to resize the image dimensions by, specified as a float. *Default*: `1.0`.
-        crop_hw: (Tuple[int]) Crop height and width of each instance (h, w) for centered-instance model. If `None`, this would be automatically computed based on the largest instance in the `sio.Labels` file. *Default*: `None`.
-        min_crop_size: (int) Minimum crop size to be used if `crop_hw` is `None`. *Default*: `100`.
+        crop_size: (int) Crop size of each instance for centered-instance model. If `None`, this would be automatically computed based on the largest instance in the `sio.Labels` file. *Default*: `None`.
+        min_crop_size: (int) Minimum crop size to be used if `crop_size` is `None`. *Default*: `100`.
     """
 
     ensure_rgb: bool = False
@@ -34,7 +34,7 @@ class PreprocessingConfig:
     scale: float = field(
         default=1.0, validator=lambda instance, attr, value: instance.validate_scale()
     )
-    crop_hw: Optional[Tuple[int, int]] = None
+    crop_size: Optional[int] = None
     min_crop_size: Optional[int] = 100  # to help app work in case of error
 
     def validate_scale(self):
@@ -273,7 +273,7 @@ def data_mapper(legacy_config: dict) -> DataConfig:
         is not None
     ):
         size = legacy_config_data["instance_cropping"]["crop_size"]
-        preprocessing_args["crop_hw"] = (size, size)
+        preprocessing_args["crop_size"] = size
 
     # augmentation
     if (

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -662,7 +662,8 @@ def get_trainer_config(
     seed: int = 0,
     use_wandb: bool = False,
     save_ckpt: bool = False,
-    save_ckpt_path: Optional[str] = None,
+    ckpt_dir: Optional[str] = None,
+    run_name: Optional[str] = None,
     resume_ckpt_path: Optional[str] = None,
     wandb_entity: Optional[str] = None,
     wandb_project: Optional[str] = None,
@@ -726,9 +727,8 @@ def get_trainer_config(
         max_epochs: Maximum number of epochs to run. Default: 100.
         seed: Seed value for the current experiment. default: 1000.
         save_ckpt: True to enable checkpointing. Default: False.
-        save_ckpt_path: Directory path to save the training config and checkpoint files.
-            If `None` and `save_ckpt` is `True`, then the current working dir is used as
-            the ckpt path. Default: None
+        ckpt_dir: Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
+        run_name: Name of the current run. The ckpts will be created in `<ckpt_dir>/<run_name>`. If `None`, a run name is generated with `<timestamp>_<head_name>`. Default: None.
         resume_ckpt_path: Path to `.ckpt` file from which training is resumed. Default: None.
         use_wandb: True to enable wandb logging. Default: False.
         wandb_entity: Entity of wandb project. Default: None.
@@ -840,7 +840,8 @@ def get_trainer_config(
             group=wandb_group_name,
         ),
         save_ckpt=save_ckpt,
-        save_ckpt_path=save_ckpt_path,
+        ckpt_dir=ckpt_dir,
+        run_name=run_name,
         resume_ckpt_path=resume_ckpt_path,
         optimizer_name=optimizer,
         optimizer=OptimizerConfig(lr=learning_rate, amsgrad=amsgrad),

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -467,7 +467,7 @@ def get_data_config(
     scale: float = 1.0,
     max_height: Optional[int] = None,
     max_width: Optional[int] = None,
-    crop_hw: Optional[Tuple[int, int]] = None,
+    crop_size: Optional[int] = None,
     min_crop_size: Optional[int] = 100,
     use_augmentations_train: bool = False,
     intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
@@ -511,10 +511,10 @@ def get_data_config(
             original image size will be retained. Default: None.
         max_width: Maximum width the image should be padded to. If not provided, the
             original image size will be retained. Default: None.
-        crop_hw: Crop height and width of each instance (h, w) for centered-instance model.
+        crop_size: Crop size of each instance for centered-instance model.
             If `None`, this would be automatically computed based on the largest instance
             in the `sio.Labels` file. Default: None.
-        min_crop_size: Minimum crop size to be used if `crop_hw` is `None`. Default: 100.
+        min_crop_size: Minimum crop size to be used if `crop_size` is `None`. Default: 100.
         use_augmentations_train: True if the data augmentation should be applied to the
             training data, else False. Default: False.
         intensity_aug: One of ["uniform_noise", "gaussian_noise", "contrast", "brightness"]
@@ -538,7 +538,7 @@ def get_data_config(
         max_height=max_height,
         max_width=max_width,
         scale=scale,
-        crop_hw=crop_hw,
+        crop_size=crop_size,
         min_crop_size=min_crop_size,
     )
     augmentation_config = None

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -231,7 +231,7 @@ class TrainerConfig:
     train_data_loader: DataLoaderConfig = field(factory=DataLoaderConfig)
     val_data_loader: DataLoaderConfig = field(factory=DataLoaderConfig)
     model_ckpt: ModelCkptConfig = field(factory=ModelCkptConfig)
-    trainer_devices: Any = field(
+    trainer_devices: Optional[Any] = field(
         default="auto",
         validator=lambda inst, attr, val: TrainerConfig.validate_trainer_devices(val),
     )
@@ -274,6 +274,8 @@ class TrainerConfig:
     @staticmethod
     def validate_trainer_devices(value):
         """Validate the value of trainer_devices."""
+        if value is None:
+            return
         if isinstance(value, int) and value >= 0:
             return
         if isinstance(value, list) and all(
@@ -282,7 +284,7 @@ class TrainerConfig:
             return
         if isinstance(value, str) and value == "auto":
             return
-        message = "trainer_devices must be an integer >= 0, a list of integers >= 0, or the string 'auto'."
+        message = "trainer_devices must be an integer >= 0, or the string 'auto'."
         logger.error(message)
         raise ValueError(message)
 

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -218,7 +218,8 @@ class TrainerConfig:
         seed: (int) Seed value for the current experiment. *Default*: `0`.
         use_wandb: (bool) True to enable wandb logging. *Default*: `False`.
         save_ckpt: (bool) True to enable checkpointing. *Default*: `False`.
-        save_ckpt_path: (str) Directory path to save the training config and checkpoint files. *Default*: `None`.
+        ckpt_dir: (str) Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
+        run_name: (str) Name of the current run. The ckpts will be created in `<ckpt_dir>/<run_name>`. If `None`, a run name is generated with `<timestamp>_<head_name>`. *Default*: `None`.
         resume_ckpt_path: (str) Path to `.ckpt` file from which training is resumed. *Default*: `None`.
         wandb: (Only if use_wandb is True, else skip this)
         optimizer_name: (str) Optimizer to be used. One of ["Adam", "AdamW"]. *Default*: `"Adam"`.
@@ -247,7 +248,8 @@ class TrainerConfig:
     seed: int = 0
     use_wandb: bool = False
     save_ckpt: bool = False
-    save_ckpt_path: Optional[str] = None
+    ckpt_dir: str = "."
+    run_name: Optional[str] = None
     resume_ckpt_path: Optional[str] = None
     wandb: WandBConfig = field(factory=WandBConfig)
     optimizer_name: str = field(
@@ -392,9 +394,10 @@ def trainer_mapper(legacy_config: dict) -> TrainerConfig:
         ]
 
     trainer_cfg_args["save_ckpt"] = True
-    trainer_cfg_args["save_ckpt_path"] = (
-        Path(legacy_config_outputs.get("runs_folder", ".")) / run_name
+    trainer_cfg_args["ckpt_dir"] = (
+        Path(legacy_config_outputs.get("runs_folder", "."))
     ).as_posix()
+    trainer_cfg_args["run_name"] = run_name
     trainer_cfg_args["resume_ckpt_path"] = resume_ckpt_path
 
     trainer_cfg_args["optimizer_name"] = re.sub(

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -82,8 +82,8 @@ class Predictor(ABC):
             apply_pad_to_stride) should be applied on the frames read in the video reader.
             Default: True.
         preprocess_config: Preprocessing config with keys: [`scale`,
-            `ensure_rgb`, `ensure_grayscale`, `scale`, `max_height`, `max_width`, `crop_hw`]. Default: {"scale": 1.0,
-            "ensure_rgb": False, "ensure_grayscale": False, "max_height": None, "max_width": None, "crop_hw": None}
+            `ensure_rgb`, `ensure_grayscale`, `scale`, `max_height`, `max_width`, `crop_size`]. Default: {"scale": 1.0,
+            "ensure_rgb": False, "ensure_grayscale": False, "max_height": None, "max_width": None, "crop_size": None}
         pipeline: If provider is LabelsReader, pipeline is a `DataLoader` object. If provider
             is VideoReader, pipeline is an instance of `sleap_nn.data.providers.VideoReader`
             class. Default: None.
@@ -101,7 +101,7 @@ class Predictor(ABC):
         "scale": 1.0,
         "ensure_rgb": False,
         "ensure_grayscale": False,
-        "crop_hw": None,
+        "crop_size": None,
         "max_height": None,
         "max_width": None,
     }
@@ -608,7 +608,10 @@ class TopDownPredictor(Predictor):
         if self.centroid_config is None:
             centroid_crop_layer = CentroidCrop(
                 use_gt_centroids=True,
-                crop_hw=self.preprocess_config.crop_hw,
+                crop_hw=(
+                    self.preprocess_config.crop_size,
+                    self.preprocess_config.crop_size,
+                ),
                 anchor_ind=anchor_ind,
                 return_crops=return_crops,
             )
@@ -629,7 +632,10 @@ class TopDownPredictor(Predictor):
                 max_instances=self.max_instances,
                 max_stride=max_stride,
                 input_scale=self.centroid_config.data_config.preprocessing.scale,
-                crop_hw=self.preprocess_config.crop_hw,
+                crop_hw=(
+                    self.preprocess_config.crop_size,
+                    self.preprocess_config.crop_size,
+                ),
                 use_gt_centroids=False,
             )
 
@@ -1013,10 +1019,10 @@ class TopDownPredictor(Predictor):
                 else preprocess_config["max_width"]
             )
 
-        preprocess_config["crop_hw"] = (
-            confmap_config.data_config.preprocessing.crop_hw
-            if preprocess_config["crop_hw"] is None and confmap_config is not None
-            else preprocess_config["crop_hw"]
+        preprocess_config["crop_size"] = (
+            confmap_config.data_config.preprocessing.crop_size
+            if preprocess_config["crop_size"] is None and confmap_config is not None
+            else preprocess_config["crop_size"]
         )
 
         # create an instance of TopDownPredictor class
@@ -2568,7 +2574,10 @@ class TopDownMultiClassPredictor(Predictor):
         if self.centroid_config is None:
             centroid_crop_layer = CentroidCrop(
                 use_gt_centroids=True,
-                crop_hw=self.preprocess_config.crop_hw,
+                crop_hw=(
+                    self.preprocess_config.crop_size,
+                    self.preprocess_config.crop_size,
+                ),
                 anchor_ind=anchor_ind,
                 return_crops=return_crops,
             )
@@ -2589,7 +2598,10 @@ class TopDownMultiClassPredictor(Predictor):
                 max_instances=self.max_instances,
                 max_stride=max_stride,
                 input_scale=self.centroid_config.data_config.preprocessing.scale,
-                crop_hw=self.preprocess_config.crop_hw,
+                crop_hw=(
+                    self.preprocess_config.crop_size,
+                    self.preprocess_config.crop_size,
+                ),
                 use_gt_centroids=False,
             )
 
@@ -2992,10 +3004,10 @@ class TopDownMultiClassPredictor(Predictor):
                 else preprocess_config["max_width"]
             )
 
-        preprocess_config["crop_hw"] = (
-            confmap_config.data_config.preprocessing.crop_hw
-            if preprocess_config["crop_hw"] is None and confmap_config is not None
-            else preprocess_config["crop_hw"]
+        preprocess_config["crop_size"] = (
+            confmap_config.data_config.preprocessing.crop_size
+            if preprocess_config["crop_size"] is None and confmap_config is not None
+            else preprocess_config["crop_size"]
         )
 
         # create an instance of TopDownPredictor class

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -229,7 +229,7 @@ def run_inference(
     preprocess_config = {  # if not given, then use from training config
         "ensure_rgb": ensure_rgb,
         "ensure_grayscale": ensure_grayscale,
-        "crop_hw": (crop_size, crop_size) if crop_size is not None else None,
+        "crop_size": crop_size,
         "max_width": max_width,
         "max_height": max_height,
         "scale": input_scale,

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -117,7 +117,7 @@ def train(
     scale: float = 1.0,
     max_height: Optional[int] = None,
     max_width: Optional[int] = None,
-    crop_hw: Optional[Tuple[int, int]] = None,
+    crop_size: Optional[int] = None,
     min_crop_size: Optional[int] = 100,
     use_augmentations_train: bool = False,
     intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
@@ -206,10 +206,10 @@ def train(
             original image size will be retained. Default: None.
         max_width: Maximum width the image should be padded to. If not provided, the
             original image size will be retained. Default: None.
-        crop_hw: Crop height and width of each instance (h, w) for centered-instance model.
+        crop_size: Crop size of each instance for centered-instance model.
             If `None`, this would be automatically computed based on the largest instance
             in the `sio.Labels` file. Default: None.
-        min_crop_size: Minimum crop size to be used if `crop_hw` is `None`. Default: 100.
+        min_crop_size: Minimum crop size to be used if `crop_size` is `None`. Default: 100.
         use_augmentations_train: True if the data augmentation should be applied to the
             training data, else False. Default: False.
         intensity_aug: One of ["uniform_noise", "gaussian_noise", "contrast", "brightness"]
@@ -380,7 +380,7 @@ def train(
         scale=scale,
         max_height=max_height,
         max_width=max_width,
-        crop_hw=crop_hw,
+        crop_size=crop_size,
         min_crop_size=min_crop_size,
         use_augmentations_train=use_augmentations_train,
         intensity_aug=intensity_aug,

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
@@ -125,7 +125,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minmal_instance_bottomup
+  ckpt_dir: .
+  run_name: minmal_instance_bottomup
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: 384
     max_width: 384
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
@@ -125,7 +125,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minmal_instance_bottomup
+  ckpt_dir: .
+  run_name: minmal_instance_bottomup
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
@@ -15,9 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw:
-    - 96
-    - 96
+    crop_size: 96
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
@@ -119,7 +119,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_centered_instance
+  ckpt_dir: .
+  run_name: minimal_instance_centered_instance
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
@@ -119,7 +119,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_centered_instance
+  ckpt_dir: .
+  run_name: minimal_instance_centered_instance
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
@@ -15,9 +15,7 @@ data_config:
     max_height: 384
     max_width: 384
     scale: 1.0
-    crop_hw:
-    - 96
-    - 96
+    crop_size: 96
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
@@ -115,7 +115,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_centroid
+  ckpt_dir: .
+  run_name: minimal_instance_centroid
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: 384
     max_width: 384
     scale: 1.0
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
@@ -115,7 +115,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_centroid
+  ckpt_dir: .
+  run_name: minimal_instance_centroid
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 0.5
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
@@ -125,7 +125,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_multiclass_bottomup
+  ckpt_dir: .
+  run_name: minimal_instance_multiclass_bottomup
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
@@ -15,7 +15,7 @@ data_config:
     max_height: 384
     max_width: 384
     scale: 0.5
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
@@ -125,7 +125,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_multiclass_bottomup
+  ckpt_dir: .
+  run_name: minimal_instance_multiclass_bottomup
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -15,9 +15,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 1.0
-    crop_hw:
-    - 128
-    - 128
+    crop_size: 128
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -128,7 +128,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_multiclass_topdown
+  ckpt_dir: .
+  run_name: minimal_instance_multiclass_topdown
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
@@ -15,9 +15,7 @@ data_config:
     max_height: 384
     max_width: 384
     scale: 1.0
-    crop_hw:
-    - 128
-    - 128
+    crop_size: 128
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
@@ -128,7 +128,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_multiclass_topdown
+  ckpt_dir: .
+  run_name: minimal_instance_multiclass_topdown
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
@@ -16,7 +16,7 @@ data_config:
     max_height: null
     max_width: null
     scale: 0.5
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
@@ -118,7 +118,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_single_instance
+  ckpt_dir: .
+  run_name: minimal_instance_single_instance
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
@@ -16,7 +16,7 @@ data_config:
     max_height: 320
     max_width: 560
     scale: 0.5
-    crop_hw: null
+    crop_size: null
     min_crop_size: 100
   use_augmentations_train: true
   augmentation_config:

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
@@ -118,7 +118,8 @@ trainer_config:
   seed: 0
   use_wandb: false
   save_ckpt: true
-  save_ckpt_path: minimal_instance_single_instance
+  ckpt_dir: .
+  run_name: minimal_instance_single_instance
   resume_ckpt_path: null
   wandb:
     entity: null

--- a/tests/config/test_data_config.py
+++ b/tests/config/test_data_config.py
@@ -177,7 +177,7 @@ def test_data_mapper():
     assert config.preprocessing.max_height == 256
     assert config.preprocessing.max_width == 256
     assert config.preprocessing.scale == 0.5
-    assert config.preprocessing.crop_hw is None
+    assert config.preprocessing.crop_size is None
     assert config.preprocessing.min_crop_size == 100
 
     # Test augmentation config

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -209,7 +209,8 @@ def test_trainer_config(caplog):
     assert conf_structured.lr_scheduler is None
     assert conf_structured.early_stopping is None
     assert conf_structured.use_wandb is False
-    assert conf_structured.save_ckpt_path is None
+    assert conf_structured.ckpt_dir == "."
+    assert conf_structured.run_name is None
 
     # Test customization
     custom_conf = TrainerConfig(

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -409,7 +409,7 @@ def test_bottomup_multiclass_dataset(minimal_instance, tmp_path):
 
 def test_centered_instance_dataset(minimal_instance, tmp_path):
     """Test the CenteredInstanceDataset."""
-    crop_hw = (160, 160)
+    crop_size = 160
     base_topdown_data_config = OmegaConf.create(
         {
             "user_instances_only": True,
@@ -431,7 +431,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=1.0,
         confmap_head_config=confmap_head,
-        crop_hw=crop_hw,
+        crop_size=crop_size,
         labels=[
             sio.load_slp(minimal_instance),
             sio.load_slp(minimal_instance),
@@ -471,7 +471,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=1.0,
         confmap_head_config=confmap_head,
-        crop_hw=crop_hw,
+        crop_size=crop_size,
         labels=[sio.load_slp(minimal_instance)],
         cache_img="memory",
         apply_aug=base_topdown_data_config.use_augmentations_train,
@@ -551,7 +551,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         ensure_rgb=True,
         ensure_grayscale=False,
         confmap_head_config=confmap_head,
-        crop_hw=(100, 100),
+        crop_size=100,
         labels=[sio.load_slp(minimal_instance)],
         apply_aug=base_topdown_data_config.use_augmentations_train,
     )
@@ -629,7 +629,7 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=2.0,
         confmap_head_config=confmap_head,
-        crop_hw=(100, 100),
+        crop_size=100,
         labels=[sio.load_slp(minimal_instance)],
         apply_aug=base_topdown_data_config.use_augmentations_train,
         intensity_aug=base_topdown_data_config.augmentation_config.intensity,
@@ -670,7 +670,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
             tracks += 1
     tracked_labels.update()
 
-    crop_hw = (160, 160)
+    crop_size = 160
     base_topdown_data_config = OmegaConf.create(
         {
             "user_instances_only": True,
@@ -693,7 +693,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=1.0,
         confmap_head_config=confmap_head,
-        crop_hw=crop_hw,
+        crop_size=crop_size,
         labels=[
             tracked_labels,
             tracked_labels,
@@ -736,7 +736,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=1.0,
         confmap_head_config=confmap_head,
-        crop_hw=crop_hw,
+        crop_size=crop_size,
         labels=[tracked_labels],
         cache_img="memory",
         apply_aug=base_topdown_data_config.use_augmentations_train,
@@ -803,7 +803,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         ensure_rgb=True,
         ensure_grayscale=False,
         confmap_head_config=confmap_head,
-        crop_hw=(100, 100),
+        crop_size=100,
         labels=[tracked_labels],
         apply_aug=base_topdown_data_config.use_augmentations_train,
     )
@@ -867,7 +867,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=2.0,
         confmap_head_config=confmap_head,
-        crop_hw=(100, 100),
+        crop_size=100,
         labels=[tracked_labels],
         apply_aug=base_topdown_data_config.use_augmentations_train,
         intensity_aug=["uniform_noise", "gaussian_noise"],

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -58,7 +58,7 @@ def config(sleap_nn_data_dir):
                     "max_width": None,
                     "max_height": None,
                     "scale": 1.0,
-                    "crop_hw": [160, 160],
+                    "crop_size": 160,
                     "min_crop_size": None,
                 },
                 "use_augmentations_train": True,

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -142,7 +142,8 @@ def config(sleap_nn_data_dir):
                 "keep_viz": True,
                 "use_wandb": False,
                 "save_ckpt": False,
-                "save_ckpt_path": "",
+                "ckpt_dir": ".",
+                "run_name": None,
                 "resume_ckpt_path": None,
                 "wandb": {
                     "entity": None,

--- a/tests/inference/test_bottomup.py
+++ b/tests/inference/test_bottomup.py
@@ -24,9 +24,8 @@ def test_bottomup_inference_model(
     train_config = OmegaConf.load(
         f"{minimal_instance_bottomup_ckpt}/training_config.yaml"
     )
-    OmegaConf.update(
-        train_config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
-    )
+    OmegaConf.update(train_config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(train_config, "trainer_config.run_name", "test_model_trainer")
     OmegaConf.update(
         train_config,
         "data_config.train_labels_path",
@@ -117,9 +116,8 @@ def test_multiclass_bottomup_inference_model(
     train_config = OmegaConf.load(
         f"{minimal_instance_multi_class_bottomup_ckpt}/training_config.yaml"
     )
-    OmegaConf.update(
-        train_config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
-    )
+    OmegaConf.update(train_config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(train_config, "trainer_config.run_name", "test_model_trainer")
     OmegaConf.update(
         train_config,
         "data_config.train_labels_path",

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -37,7 +37,7 @@ def test_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": None,
         "ensure_grayscale": None,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -63,7 +63,7 @@ def test_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": False,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -106,7 +106,7 @@ def test_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": True,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -214,7 +214,7 @@ def test_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": False,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -322,7 +322,7 @@ def test_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": True,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -433,7 +433,7 @@ def test_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": False,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -544,7 +544,7 @@ def test_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": True,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -597,7 +597,7 @@ def test_multiclass_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": None,
         "ensure_grayscale": None,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -619,7 +619,7 @@ def test_multiclass_topdown_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": False,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -809,7 +809,7 @@ def test_single_instance_predictor(
     preprocess_config = {
         "ensure_rgb": None,
         "ensure_grayscale": None,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -846,7 +846,7 @@ def test_bottomup_predictor(
     preprocess_config = {
         "ensure_rgb": None,
         "ensure_grayscale": None,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -869,7 +869,7 @@ def test_bottomup_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": True,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
     }
@@ -918,7 +918,7 @@ def test_multi_class_bottomup_predictor(
     preprocess_config = {
         "ensure_rgb": None,
         "ensure_grayscale": None,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
         "scale": None,
@@ -941,7 +941,7 @@ def test_multi_class_bottomup_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": True,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def sample_config(tmp_path, minimal_instance):
                     "max_width": None,
                     "max_height": None,
                     "scale": 1.0,
-                    "crop_hw": [160, 160],
+                    "crop_size": 160,
                     "min_crop_size": None,
                 },
                 "use_augmentations_train": True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,7 +104,8 @@ def sample_config(tmp_path, minimal_instance):
                 "seed": 42,
                 "use_wandb": False,
                 "save_ckpt": True,
-                "save_ckpt_path": str(tmp_path / "test_ckpt"),
+                "ckpt_dir": str(tmp_path),
+                "run_name": "test_ckpt",
                 "resume_ckpt_path": None,
             },
         }
@@ -128,8 +129,13 @@ def test_train_command(sample_config, tmp_path):
     result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     print(result.stdout)
     print(result.stderr)
-    assert Path(f"{sample_config.trainer_config.save_ckpt_path}").exists()
-    assert Path(f"{sample_config.trainer_config.save_ckpt_path}/best.ckpt").exists()
+    assert (
+        Path(f"{sample_config.trainer_config.ckpt_dir}")
+        / sample_config.trainer_config.run_name
+    ).exists()
+    assert Path(
+        f"{sample_config.trainer_config.ckpt_dir}/{sample_config.trainer_config.run_name}/best.ckpt"
+    ).exists()
 
 
 def test_track_command(

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -590,7 +590,7 @@ def test_single_instance_predictor(
     preprocess_config = {
         "ensure_rgb": False,
         "ensure_grayscale": True,
-        "crop_hw": None,
+        "crop_size": None,
         "max_width": None,
         "max_height": None,
     }

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -110,7 +110,8 @@ def sample_cfg(minimal_instance, tmp_path):
                 "seed": 1000,
                 "use_wandb": False,
                 "save_ckpt": True,
-                "save_ckpt_path": (Path(tmp_path) / "test_cli_main").as_posix(),
+                "ckpt_dir": Path(tmp_path).as_posix(),
+                "run_name": "test_cli_main",
                 "resume_ckpt_path": None,
                 "wandb": {
                     "entity": None,
@@ -154,7 +155,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         trainer_accelerator="cpu" if torch.mps.is_available() else "auto",
         head_configs="centered_instance",
         save_ckpt=True,
-        save_ckpt_path=(Path(tmp_path) / "test_train_method").as_posix(),
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_train_method",
         online_mining=True,
         min_train_steps_per_epoch=5,
     )
@@ -178,7 +180,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         trainer_accelerator="cpu" if torch.mps.is_available() else "auto",
         head_configs="centered_instance",
         save_ckpt=True,
-        save_ckpt_path=(Path(tmp_path) / "test_train_method").as_posix(),
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_train_method",
         min_train_steps_per_epoch=1,
     )
     folder_created = (Path(tmp_path) / "test_train_method-1").exists()
@@ -205,7 +208,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         backbone_config="convnext",
         head_configs="centered_instance",
         save_ckpt=True,
-        save_ckpt_path=(Path(tmp_path) / "test_convnext").as_posix(),
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_convnext",
         min_train_steps_per_epoch=1,
     )
     folder_created = (Path(tmp_path) / "test_convnext").exists()
@@ -226,7 +230,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         backbone_config="swint",
         head_configs="centered_instance",
         save_ckpt=True,
-        save_ckpt_path=(Path(tmp_path) / "test_swint").as_posix(),
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_swint",
         min_train_steps_per_epoch=1,
     )
     folder_created = (Path(tmp_path) / "test_swint").exists()
@@ -247,7 +252,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         backbone_config="swint",
         head_configs="centered_instance",
         save_ckpt=True,
-        save_ckpt_path=(Path(tmp_path) / "test_swint").as_posix(),
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_swint",
         min_train_steps_per_epoch=1,
     )
     folder_created = (Path(tmp_path) / "test_swint-1").exists()
@@ -275,7 +281,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             intensity_aug="intensity",
             geometry_aug=["rotation", "scale"],
             save_ckpt=True,
-            save_ckpt_path=f"{tmp_path}/test_aug",
+            ckpt_dir=Path(tmp_path).as_posix(),
+            run_name="test_aug",
             min_train_steps_per_epoch=1,
         )
 
@@ -291,7 +298,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             intensity_aug="uniform_noise",
             geometry_aug="rotate",
             save_ckpt=True,
-            save_ckpt_path=f"{tmp_path}/test_aug",
+            ckpt_dir=Path(tmp_path).as_posix(),
+            run_name="test_aug",
             min_train_steps_per_epoch=1,
         )
 
@@ -306,7 +314,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         intensity_aug=["uniform_noise", "gaussian_noise", "contrast"],
         geometry_aug=["rotation", "scale"],
         save_ckpt=True,
-        save_ckpt_path=f"{tmp_path}/test_aug",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_aug",
         min_train_steps_per_epoch=1,
     )
 
@@ -328,7 +337,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         intensity_aug="brightness",
         geometry_aug=["translate", "erase_scale", "mixup"],
         save_ckpt=True,
-        save_ckpt_path=f"{tmp_path}/test_aug",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_aug",
         min_train_steps_per_epoch=1,
     )
 
@@ -355,7 +365,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         },
         geometry_aug={"rotation_max": 180.0, "rotation_min": -180.0, "affine_p": 1.0},
         save_ckpt=True,
-        save_ckpt_path=f"{tmp_path}/test_aug",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_aug",
         min_train_steps_per_epoch=1,
     )
 
@@ -375,7 +386,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             trainer_num_devices=1,
             head_configs="centroid",
             save_ckpt=True,
-            save_ckpt_path=f"{tmp_path}/test_aug",
+            ckpt_dir=Path(tmp_path).as_posix(),
+            run_name="test_aug",
             min_train_steps_per_epoch=1,
         )
 
@@ -402,7 +414,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         trainer_accelerator="cpu" if torch.mps.is_available() else "auto",
         head_configs="centroid",
         save_ckpt=False,
-        save_ckpt_path=f"{tmp_path}/test_custom_backbone",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_custom_backbone",
         min_train_steps_per_epoch=1,
     )
     config = OmegaConf.load(f"{tmp_path}/test_custom_backbone/training_config.yaml")
@@ -419,7 +432,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             trainer_num_devices=1,
             head_configs="center",
             save_ckpt=True,
-            save_ckpt_path=f"{tmp_path}/test_aug",
+            ckpt_dir=Path(tmp_path).as_posix(),
+            run_name="test_aug",
             min_train_steps_per_epoch=1,
         )
 
@@ -443,7 +457,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             },
         },
         save_ckpt=False,
-        save_ckpt_path=f"{tmp_path}/test_centroid",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_centroid",
         min_train_steps_per_epoch=1,
     )
     config = OmegaConf.load(f"{tmp_path}/test_centroid/training_config.yaml")
@@ -458,7 +473,8 @@ def test_train_method(minimal_instance, tmp_path: str):
     #     head_configs="single_instance",
     #     save_ckpt=True,
     #     trainer_num_devices=1,
-    #     save_ckpt_path=f"{tmp_path}/test_single_instabce",
+    #     ckpt_dir=Path(tmp_path).as_posix(),
+    #     run_name="test_single_instabce",
     #     lr_scheduler="reduce_lr_on_plateau",
     # )
     # config = OmegaConf.load(f"{tmp_path}/test_single_instabce/training_config.yaml")
@@ -473,7 +489,8 @@ def test_train_method(minimal_instance, tmp_path: str):
         trainer_num_devices=1,
         head_configs="bottomup",
         save_ckpt=True,
-        save_ckpt_path=f"{tmp_path}/test_bottomup",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_bottomup",
         lr_scheduler="reduce_lr_on_plateau",
         min_train_steps_per_epoch=1,
     )
@@ -499,7 +516,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             }
         },
         save_ckpt=True,
-        save_ckpt_path=f"{tmp_path}/test_custom_head",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_custom_head",
         lr_scheduler="step_lr",
         min_train_steps_per_epoch=1,
     )
@@ -531,7 +549,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             }
         },
         save_ckpt=False,
-        save_ckpt_path=f"{tmp_path}/test_scheduler",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_scheduler",
         lr_scheduler={
             "step_lr": {"step_size": 10, "gamma": 0.1},
         },
@@ -553,7 +572,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             }
         },
         save_ckpt=False,
-        save_ckpt_path=f"{tmp_path}/test_reducelr_scheduler",
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_reducelr_scheduler",
         lr_scheduler={
             "reduce_lr_on_plateau": {
                 "threshold": 1e-5,
@@ -579,7 +599,8 @@ def test_train_method(minimal_instance, tmp_path: str):
             trainer_num_devices=1,
             head_configs="centered_instance",
             save_ckpt=False,
-            save_ckpt_path=f"{tmp_path}/test_invalid_sch",
+            ckpt_dir=Path(tmp_path).as_posix(),
+            run_name="test_invalid_sch",
             lr_scheduler="red_lr",
             min_train_steps_per_epoch=1,
         )
@@ -597,26 +618,35 @@ def test_main(sample_cfg):
         sample_cfg.trainer_config.trainer_accelerator = "auto"
     main(sample_cfg)
 
-    folder_created = Path(sample_cfg.trainer_config.save_ckpt_path).exists()
+    folder_created = (
+        Path(sample_cfg.trainer_config.ckpt_dir) / sample_cfg.trainer_config.run_name
+    ).exists()
     assert folder_created
     assert (
-        Path(sample_cfg.trainer_config.save_ckpt_path)
+        (Path(sample_cfg.trainer_config.ckpt_dir) / sample_cfg.trainer_config.run_name)
         .joinpath("training_config.yaml")
         .exists()
     )
-    assert Path(sample_cfg.trainer_config.save_ckpt_path).joinpath("best.ckpt").exists()
     assert (
-        Path(sample_cfg.trainer_config.save_ckpt_path)
+        (Path(sample_cfg.trainer_config.ckpt_dir) / sample_cfg.trainer_config.run_name)
+        .joinpath("best.ckpt")
+        .exists()
+    )
+    assert (
+        (Path(sample_cfg.trainer_config.ckpt_dir) / sample_cfg.trainer_config.run_name)
         .joinpath("pred_train_0.slp")
         .exists()
     )
     assert (
-        Path(sample_cfg.trainer_config.save_ckpt_path)
+        (Path(sample_cfg.trainer_config.ckpt_dir) / sample_cfg.trainer_config.run_name)
         .joinpath("pred_val_0.slp")
         .exists()
     )
     assert (
-        not Path(sample_cfg.trainer_config.save_ckpt_path)
+        not (
+            Path(sample_cfg.trainer_config.ckpt_dir)
+            / sample_cfg.trainer_config.run_name
+        )
         .joinpath("pred_test.slp")
         .exists()
     )
@@ -625,10 +655,14 @@ def test_main(sample_cfg):
     sample_cfg.data_config.test_file_path = sample_cfg.data_config.train_labels_path[0]
     main(sample_cfg)
 
-    folder_created = Path(f"{sample_cfg.trainer_config.save_ckpt_path}-1").exists()
+    folder_created = Path(
+        f"{sample_cfg.trainer_config.ckpt_dir}/{sample_cfg.trainer_config.run_name}-1"
+    ).exists()
     assert folder_created
     assert (
-        Path(f"{sample_cfg.trainer_config.save_ckpt_path}-1")
+        Path(
+            f"{sample_cfg.trainer_config.ckpt_dir}/{sample_cfg.trainer_config.run_name}-1"
+        )
         .joinpath("pred_test.slp")
         .exists()
     )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -27,7 +27,7 @@ def sample_cfg(minimal_instance, tmp_path):
                     "max_width": None,
                     "max_height": None,
                     "scale": 1.0,
-                    "crop_hw": [160, 160],
+                    "crop_size": 160,
                     "min_crop_size": None,
                 },
                 "use_augmentations_train": True,

--- a/tests/training/test_lightning_modules.py
+++ b/tests/training/test_lightning_modules.py
@@ -58,10 +58,9 @@ def test_topdown_centered_instance_model(
         trainer_accelerator="cpu" if torch.mps.is_available() else "auto",
         optimizer="AdamW",
     )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
     OmegaConf.update(
-        config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_topdown_centered_instance_model_1/",
+        config, "trainer_config.run_name", "test_topdown_centered_instance_model_1"
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
 
@@ -115,10 +114,9 @@ def test_topdown_centered_instance_model(
     model = LightningModel.get_lightning_model_from_config(
         config=model_trainer.config
     )  # passing model trainer config modifies the in_channels according to the pretrained model weights
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
     OmegaConf.update(
-        config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_topdown_centered_instance_model_2/",
+        config, "trainer_config.run_name", "test_topdown_centered_instance_model_2"
     )
     train_dataset, val_dataset = get_train_val_datasets(
         train_labels=model_trainer.train_labels,
@@ -162,9 +160,8 @@ def test_centroid_model(config, tmp_path: str):
         head_configs=config.model_config.head_configs,
     )
 
-    OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_centroid_model_1/"
-    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(config, "trainer_config.run_name", "test_centroid_model_1")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer.get_model_trainer_from_config(config)
     train_dataset, val_dataset = get_train_val_datasets(
@@ -191,9 +188,8 @@ def test_centroid_model(config, tmp_path: str):
     # torch dataset
     model = LightningModel.get_lightning_model_from_config(config=config)
 
-    OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_centroid_model_2/"
-    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(config, "trainer_config.run_name", "test_centroid_model_2")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
 
     model_trainer = ModelTrainer.get_model_trainer_from_config(config)
@@ -227,12 +223,8 @@ def test_single_instance_model(config, tmp_path: str):
     del config.model_config.head_configs.single_instance.confmaps.anchor_part
 
     OmegaConf.update(config, "model_config.init_weights", "xavier")
-
-    OmegaConf.update(
-        config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_single_instance_model_1/",
-    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(config, "trainer_config.run_name", "test_single_instance_model_1")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer.get_model_trainer_from_config(config)
     train_dataset, val_dataset = get_train_val_datasets(
@@ -278,11 +270,8 @@ def test_single_instance_model(config, tmp_path: str):
     assert abs(loss - mse_loss(preds, input_["confidence_maps"].squeeze(dim=1))) < 1e-3
 
     # torch dataset
-    OmegaConf.update(
-        config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_single_instance_model_2/",
-    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(config, "trainer_config.run_name", "test_single_instance_model_2")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer.get_model_trainer_from_config(config)
     train_dataset, val_dataset = get_train_val_datasets(
@@ -339,9 +328,8 @@ def test_bottomup_model(config, tmp_path: str):
     config.model_config.head_configs.bottomup["pafs"] = paf
     config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
 
-    OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_bottomup_model_1/"
-    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(config, "trainer_config.run_name", "test_bottomup_model_1")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer.get_model_trainer_from_config(config)
     train_dataset, val_dataset = get_train_val_datasets(
@@ -380,9 +368,8 @@ def test_bottomup_model(config, tmp_path: str):
     config.model_config.head_configs.bottomup["pafs"] = paf
     config.model_config.head_configs.bottomup.confmaps.loss_weight = 1.0
 
-    OmegaConf.update(
-        config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_bottomup_model_2/"
-    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(config, "trainer_config.run_name", "test_bottomup_model_2")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer.get_model_trainer_from_config(config)
     train_dataset, val_dataset = get_train_val_datasets(
@@ -434,10 +421,9 @@ def test_multi_class_bottomup_model(config, tmp_path: str, minimal_instance):
     config.model_config.head_configs.multi_class_bottomup["class_maps"] = class_maps
     config.model_config.head_configs.multi_class_bottomup.confmaps.loss_weight = 1.0
 
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
     OmegaConf.update(
-        config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_multi_class_bottomup_model_1/",
+        config, "trainer_config.run_name", "test_multi_class_bottomup_model_1"
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     model_trainer = ModelTrainer.get_model_trainer_from_config(
@@ -495,10 +481,11 @@ def test_mutli_class_topdown_centered(config, tmp_path: str, minimal_instance):
     )
 
     model = LightningModel.get_lightning_model_from_config(config=model_trainer.config)
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
     OmegaConf.update(
         config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_topdown_centered_instance_multiclass_model_1/",
+        "trainer_config.run_name",
+        "test_topdown_centered_instance_multiclass_model_1",
     )
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
 
@@ -531,11 +518,8 @@ def test_incorrect_model_type(config, caplog, tmp_path: str):
 
     OmegaConf.update(config, "model_config.init_weights", "xavier")
 
-    OmegaConf.update(
-        config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_single_instance_model_1/",
-    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(config, "trainer_config.run_name", "test_single_instance_model_1")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
     with pytest.raises(Exception):
         _ = LightningModel.get_lightning_model_from_config(config)
@@ -549,10 +533,9 @@ def test_load_trained_ckpts(config, tmp_path, minimal_instance_centered_instance
     else:
         OmegaConf.update(config, "trainer_config.trainer_accelerator", "cpu")
 
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
     OmegaConf.update(
-        config,
-        "trainer_config.save_ckpt_path",
-        f"{tmp_path}/test_model_trainer_load_trained_ckpts/",
+        config, "trainer_config.run_name", "test_model_trainer_load_trained_ckpts"
     )
     OmegaConf.update(config, "trainer_config.save_ckpt", True)
     OmegaConf.update(config, "trainer_config.use_wandb", True)

--- a/tests/training/test_lightning_modules.py
+++ b/tests/training/test_lightning_modules.py
@@ -556,7 +556,7 @@ def test_load_trained_ckpts(config, tmp_path, minimal_instance_centered_instance
     )
     OmegaConf.update(config, "trainer_config.save_ckpt", True)
     OmegaConf.update(config, "trainer_config.use_wandb", True)
-    OmegaConf.update(config, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config, "data_config.preprocessing.crop_size", None)
     OmegaConf.update(config, "data_config.preprocessing.min_crop_size", 100)
     OmegaConf.update(
         config,

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -74,9 +74,9 @@ def test_setup_data_loaders_torch_dataset(caplog, config, tmp_path, minimal_inst
     OmegaConf.update(
         config, "trainer_config.save_ckpt_path", f"{tmp_path}/test_model_trainer/"
     )
-    # without explicitly providing crop_hw
+    # without explicitly providing crop_size
     config_copy = config.copy()
-    OmegaConf.update(config_copy, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config_copy, "data_config.preprocessing.crop_size", None)
     OmegaConf.update(config_copy, "trainer_config.train_data_loader.num_workers", 0)
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
     OmegaConf.update(config_copy, "data_config.data_pipeline_fw", "torch_dataset")
@@ -98,7 +98,7 @@ def test_setup_data_loaders_torch_dataset(caplog, config, tmp_path, minimal_inst
 
     ## with memory caching
     config_copy = config.copy()
-    OmegaConf.update(config_copy, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config_copy, "data_config.preprocessing.crop_size", None)
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
     OmegaConf.update(
         config_copy, "data_config.data_pipeline_fw", "torch_dataset_cache_img_memory"
@@ -121,7 +121,7 @@ def test_setup_data_loaders_torch_dataset(caplog, config, tmp_path, minimal_inst
 
     ## with caching imgs on disk
     config_copy = config.copy()
-    OmegaConf.update(config_copy, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(config_copy, "data_config.preprocessing.crop_size", None)
     OmegaConf.update(config_copy, "data_config.preprocessing.min_crop_size", 100)
     OmegaConf.update(
         config_copy, "data_config.data_pipeline_fw", "torch_dataset_cache_img_disk"
@@ -292,7 +292,7 @@ def test_model_trainer_centered_instance(caplog, config, tmp_path: str):
     OmegaConf.update(
         training_cfg, "trainer_config.visualize_preds_during_training", True
     )
-    OmegaConf.update(training_cfg, "data_config.preprocessing.crop_hw", None)
+    OmegaConf.update(training_cfg, "data_config.preprocessing.crop_size", None)
     OmegaConf.update(training_cfg, "data_config.preprocessing.min_crop_size", 100)
     OmegaConf.update(training_cfg, "trainer_config.lr_scheduler.step_lr.step_size", 10)
     OmegaConf.update(training_cfg, "trainer_config.lr_scheduler.step_lr.gamma", 0.5)
@@ -345,7 +345,7 @@ def test_model_trainer_centered_instance(caplog, config, tmp_path: str):
     assert training_config.model_config.total_params is not None
     assert training_config.trainer_config.wandb.api_key == ""
     assert training_config.data_config.skeletons
-    assert training_config.data_config.preprocessing.crop_hw == (104, 104)
+    assert training_config.data_config.preprocessing.crop_size == 104
 
     checkpoint = torch.load(
         Path(model_trainer.config.trainer_config.save_ckpt_path).joinpath("last.ckpt"),


### PR DESCRIPTION
This PR updates a few config parameters to align with SLEAP conventions:

- `crop_hw` → `crop_size`: simplifies the config by using a single integer instead of a list.

- `save_ckpt_pth` → `save_ckpt_dir` + `run_name`: checkpoint paths are now organized under <save_ckpt_dir>/<run_name>, with a new folder created for each run.