### PR TITLE
Minor bug fixes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -696,7 +696,7 @@ trainer_config:
     - `save_last`: (bool) When True, saves a last.ckpt whenever a checkpoint file gets saved. On a local filesystem, this will be a symbolic link, and otherwise a copy of the checkpoint file. This allows accessing the latest checkpoint in a deterministic manner. **Default**: `None`
 
 ### Hardware Configuration
-- `trainer_devices`: (int) Number of devices to train on (int), which devices to train on (list or str), or "auto" to select automatically. **Default**: `"auto"`
+- `trainer_devices`: (int) Number of devices to train on (int), which devices to train on (list or str), or "auto" to select automatically. If `None`, it's set to "auto". **Default**: `None`
 - `trainer_accelerator`: (str) One of the ("cpu", "gpu", "tpu", "ipu", "auto"). "auto" recognises the machine the model is running on and chooses the appropriate accelerator for the `Trainer` to be connected to. **Default**: `"auto"`
 - `profiler`: (str) Profiler for pytorch Trainer. One of ["advanced", "passthrough", "pytorch", "simple"]. **Default**: `None`
 - `trainer_strategy`: (str) Training strategy, one of ["auto", "ddp", "fsdp", "ddp_find_unused_parameters_false", "ddp_find_unused_parameters_true", ...]. This supports any training strategy that is supported by `lightning.Trainer`. **Default**: `"auto"`

--- a/docs/sample_configs/config_bottomup_convnext.yaml
+++ b/docs/sample_configs/config_bottomup_convnext.yaml
@@ -97,7 +97,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/sample_configs/config_bottomup_unet.yaml
+++ b/docs/sample_configs/config_bottomup_unet.yaml
@@ -96,7 +96,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/sample_configs/config_centroid_swint.yaml
+++ b/docs/sample_configs/config_centroid_swint.yaml
@@ -92,7 +92,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -90,7 +90,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/sample_configs/config_multi_class_bottomup_unet.yaml
+++ b/docs/sample_configs/config_multi_class_bottomup_unet.yaml
@@ -97,7 +97,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/sample_configs/config_single_instance_unet.yaml
+++ b/docs/sample_configs/config_single_instance_unet.yaml
@@ -90,7 +90,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/sample_configs/config_topdown_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet.yaml
@@ -91,7 +91,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -99,7 +99,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/docs/training.md
+++ b/docs/training.md
@@ -156,7 +156,7 @@ trainer_config:
   ckpt_dir: models
   run_name: multi_gpu_training_1
   trainer_accelerator: "auto"
-  trainer_devices: "auto"
+  trainer_devices: "auto" # or null
   trainer_strategy: "auto"
 ```
 

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -651,7 +651,7 @@ def get_trainer_config(
     num_workers: int = 0,
     ckpt_save_top_k: int = 1,
     ckpt_save_last: Optional[bool] = None,
-    trainer_num_devices: Union[str, int] = "auto",
+    trainer_num_devices: Optional[Union[str, int]] = None,
     trainer_accelerator: str = "auto",
     enable_progress_bar: bool = True,
     min_train_steps_per_epoch: int = 200,
@@ -709,7 +709,7 @@ def get_trainer_config(
             the checkpoint file. This allows accessing the latest checkpoint in a deterministic
             manner. Default: False.
         trainer_num_devices: Number of devices to train on (int), which devices to train
-            on (list or str), or "auto" to select automatically. Default: "auto".
+            on (list or str), or "auto" to select automatically. If `None`, it's set to "auto". Default: None.
         trainer_accelerator: One of the ("cpu", "gpu", "tpu", "ipu", "auto"). "auto" recognises
             the machine the model is running on and chooses the appropriate accelerator for
             the `Trainer` to be connected to. Default: "auto".

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -1214,4 +1214,11 @@ def model_mapper(legacy_config: dict) -> ModelConfig:
 
     head_cfg = HeadConfig(**head_cfg_args)
 
-    return ModelConfig(backbone_config=backbone_cfg, head_configs=head_cfg)
+    trained_weights_path = legacy_config_model.get("base_checkpoint", None)
+
+    return ModelConfig(
+        backbone_config=backbone_cfg,
+        head_configs=head_cfg,
+        pretrained_backbone_weights=trained_weights_path,
+        pretrained_head_weights=trained_weights_path,
+    )

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -205,7 +205,7 @@ class TrainerConfig:
         train_data_loader: (Note: Any parameters from Torch's DataLoader could be used.)
         val_data_loader: (Similar to train_data_loader)
         model_ckpt: (Note: Any parameters from Lightning's ModelCheckpoint could be used.)
-        trainer_devices: (int) Number of devices to train on (int), which devices to train on (list or str), or "auto" to select automatically. *Default*: `"auto"`.
+        trainer_devices: (int) Number of devices to train on (int), which devices to train on (list or str), or "auto" to select automatically. If `None`, it's set to "auto". *Default*: `None`.
         trainer_accelerator: (str) One of the ("cpu", "gpu", "tpu", "ipu", "auto"). "auto" recognises the machine the model is running on and chooses the appropriate accelerator for the Trainer to be connected to. *Default*: `"auto"`.
         profiler: (str) Profiler for pytorch Trainer. One of ["advanced", "passthrough", "pytorch", "simple"]. *Default*: `None`.
         trainer_strategy: (str) Training strategy, one of ["auto", "ddp", "fsdp", "ddp_find_unused_parameters_false", "ddp_find_unused_parameters_true", ...]. This supports any training strategy that is supported by `lightning.Trainer`. *Default*: `"auto"`.
@@ -233,7 +233,7 @@ class TrainerConfig:
     val_data_loader: DataLoaderConfig = field(factory=DataLoaderConfig)
     model_ckpt: ModelCkptConfig = field(factory=ModelCkptConfig)
     trainer_devices: Optional[Any] = field(
-        default="auto",
+        default=None,
         validator=lambda inst, attr, val: TrainerConfig.validate_trainer_devices(val),
     )
     trainer_accelerator: str = "auto"

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -235,12 +235,6 @@ class BaseDataset(Dataset):
                     if img is not None:  # Memory cache
                         self.cache[key] = img
 
-        # Close videos after all processing is done
-        for label in self.labels:
-            for video in label.videos:
-                if video.is_open:
-                    video.close()
-
     def _get_video_idx(self, lf, labels_idx):
         """Return indsample of `lf.video` in `labels.videos`."""
         return self.labels[labels_idx].videos.index(lf.video)

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -139,7 +139,7 @@ def train(
     num_workers: int = 0,
     ckpt_save_top_k: int = 1,
     ckpt_save_last: Optional[bool] = None,
-    trainer_num_devices: Union[str, int] = "auto",
+    trainer_num_devices: Optional[Union[str, int]] = None,
     trainer_accelerator: str = "auto",
     enable_progress_bar: bool = True,
     min_train_steps_per_epoch: int = 200,
@@ -300,7 +300,7 @@ def train(
             the checkpoint file. This allows accessing the latest checkpoint in a deterministic
             manner. Default: None.
         trainer_num_devices: Number of devices to train on (int), which devices to train
-            on (list or str), or "auto" to select automatically. Default: "auto".
+            on (list or str), or "auto" to select automatically. If `None`, it's set to "auto". Default: None.
         trainer_accelerator: One of the ("cpu", "gpu", "tpu", "ipu", "auto"). "auto" recognises
             the machine the model is running on and chooses the appropriate accelerator for
             the `Trainer` to be connected to. Default: "auto".

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -295,6 +295,8 @@ class ModelTrainer:
             self.config.trainer_config.ckpt_dir = ckpt_dir
         run_name = self.config.trainer_config.run_name
         if run_name is None:
+            sum_train_lfs = sum([len(train_label) for train_label in self.train_labels])
+            sum_val_lfs = sum([len(val_label) for val_label in self.val_labels])
             trainer_devices = (
                 self.config.trainer_config.trainer_devices
                 if self.config.trainer_config.trainer_devices is not None
@@ -310,13 +312,11 @@ class ModelTrainer:
                 else:
                     trainer_devices = 1
             if trainer_devices > 1:
-                run_name = (
-                    f"{self.model_type}.n={len(self.train_labels)+len(self.val_labels)}"
-                )
+                run_name = f"{self.model_type}.n={sum_train_lfs+sum_val_lfs}"
             else:
                 run_name = (
                     datetime.now().strftime("%y%m%d_%H%M%S")
-                    + f".{self.model_type}.n={len(self.train_labels)+len(self.val_labels)}"
+                    + f".{self.model_type}.n={sum_train_lfs+sum_val_lfs}"
                 )
 
         # If checkpoint path already exists, add suffix to prevent overwriting

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
@@ -112,7 +112,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
@@ -112,7 +112,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
@@ -106,7 +106,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
@@ -106,7 +106,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices: null
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
@@ -102,7 +102,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
@@ -102,7 +102,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
@@ -112,7 +112,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
@@ -112,7 +112,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -115,7 +115,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
@@ -115,7 +115,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices: null
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
@@ -105,7 +105,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
@@ -105,7 +105,7 @@ trainer_config:
   model_ckpt:
     save_top_k: 1
     save_last: false
-  trainer_devices: auto
+  trainer_devices:
   trainer_accelerator: auto
   profiler: null
   trainer_strategy: auto

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -282,7 +282,7 @@ def test_trainer_mapper():
     assert config.visualize_preds_during_training is True
 
     # Test for default values (unspecified by legacy config)
-    assert config.trainer_devices == "auto"
+    assert config.trainer_devices is None
     assert config.trainer_accelerator == "auto"
     assert config.enable_progress_bar is True
     assert config.min_train_steps_per_epoch == 200

--- a/tests/config/test_training_job_config.py
+++ b/tests/config/test_training_job_config.py
@@ -157,7 +157,7 @@ def test_load_bottomup_multiclass_training_config_from_file(
     assert config.trainer_config.max_epochs == 200
     assert config.trainer_config.optimizer_name == "Adam"
     assert config.trainer_config.optimizer.lr == 0.0001
-    assert config.trainer_config.trainer_devices == "auto"  # Default value
+    assert config.trainer_config.trainer_devices is None  # Default value
     assert config.trainer_config.trainer_accelerator == "auto"  # Default value
     assert config.trainer_config.enable_progress_bar is True  # Default value
     assert config.trainer_config.train_data_loader.batch_size == 4  # From the JSON file
@@ -182,7 +182,7 @@ def test_load_bottomup_multiclass_training_config_from_file(
     assert config.trainer_config.max_epochs == 200
     assert config.trainer_config.optimizer_name == "Adam"
     assert config.trainer_config.optimizer.lr == 0.0001
-    assert config.trainer_config.trainer_devices == "auto"  # Default value
+    assert config.trainer_config.trainer_devices is None  # Default value
     assert config.trainer_config.trainer_accelerator == "auto"  # Default value
     assert config.trainer_config.enable_progress_bar is True  # Default value
     assert config.trainer_config.train_data_loader.batch_size == 4  # From the JSON file


### PR DESCRIPTION
In this PR, we introduce the following changes:

- Update the default value of `trainer_config.trainer_devices`.

- Fix the default run name logic: it now uses the number of labeled frames (instead of the number of label objects).