### PR TITLE
Fix Inference on SuggestionFrames

### DIFF
--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -241,7 +241,9 @@ class LabelsReader(Thread):
             for suggestion in self.labels.suggestions:
                 lf = self.labels.find(suggestion.video, suggestion.frame_idx)
                 if len(lf) == 0 or not lf[0].has_user_instances:
-                    new_lf = sio.LabeledFrame(video=suggestion.video, frame_idx=suggestion.frame_idx)
+                    new_lf = sio.LabeledFrame(
+                        video=suggestion.video, frame_idx=suggestion.frame_idx
+                    )
                     self.filtered_lfs.append(new_lf)
 
         else:


### PR DESCRIPTION
This PR solves the following bug: When a user runs inference on unlabeled suggested frame, `sleap-nn` raises an exception where `self.labels.find(...)` has an empty list when filtering out unlabeled suggested. The PR fixes the bug by initializing a new `LabeledFrame` object with the given video and frame index and modify the condition to check an empty list instead of indexing. 