### PR TITLE
Add pck to voc metrics

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -668,7 +668,8 @@ class Evaluator:
     def evaluate(self):
         """Return the evaluation metrics."""
         metrics = {}
-        metrics["voc_metrics"] = self.voc_metrics()
+        metrics["voc_metrics"] = self.voc_metrics(match_score_by="oks")
+        metrics["voc_metrics"].update(self.voc_metrics(match_score_by="pck"))
         metrics["mOKS"] = self.mOKS()
         metrics["distance_metrics"] = self.distance_metrics()
         metrics["pck_metrics"] = self.pck_metrics()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -524,6 +524,18 @@ def test_evaluator_main(
     result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     assert Path(f"{tmp_path}/metrics_test.npz").exists()
 
+    metrics = np.load(f"{tmp_path}/metrics_test.npz", allow_pickle=True)
+    assert "voc_metrics" in metrics
+    assert "mOKS" in metrics
+    assert "distance_metrics" in metrics
+    assert "pck_metrics" in metrics
+    assert "visibility_metrics" in metrics
+    voc_metrics = metrics["voc_metrics"].item()
+    assert "pck_voc.mAP" in voc_metrics
+    assert "pck_voc.mAR" in voc_metrics
+    assert "oks_voc.mAP" in voc_metrics
+    assert "oks_voc.mAR" in voc_metrics
+
 
 # def test_evaluator_logging_empty_frame_pairs(capsys, minimal_instance):
 #     """Test that the Evaluator logs an error when there are no matching frame pairs."""


### PR DESCRIPTION
Previously, `Evaluator.evaluate()` returned VOC metrics only using `OKS` as the matching score. This PR extends the evaluation to include both `OKS`- and `PCK`-based matches, and returns metrics for both in the VOC output.