### PR TITLE
Fix bugs in training pipeline

### DIFF
--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -210,7 +210,11 @@ class LightningModel(L.LightningModule):
             if self.pretrained_backbone_weights.endswith(".ckpt"):
                 ckpt = torch.load(
                     self.pretrained_backbone_weights,
-                    map_location=self.trainer_accelerator,
+                    map_location=(
+                        self.trainer_accelerator
+                        if not self.trainer_accelerator == "gpu"
+                        else "cuda"
+                    ),
                     weights_only=False,
                 )
                 ckpt["state_dict"] = {
@@ -239,7 +243,11 @@ class LightningModel(L.LightningModule):
             if self.pretrained_head_weights.endswith(".ckpt"):
                 ckpt = torch.load(
                     self.pretrained_head_weights,
-                    map_location=self.trainer_accelerator,
+                    map_location=(
+                        self.trainer_accelerator
+                        if not self.trainer_accelerator == "gpu"
+                        else "cuda"
+                    ),
                     weights_only=False,
                 )
                 ckpt["state_dict"] = {

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -388,12 +388,7 @@ class ModelTrainer:
             if self.config.model_config.pretrained_backbone_weights.endswith(".ckpt"):
                 pretrained_backbone_ckpt = torch.load(
                     self.config.model_config.pretrained_backbone_weights,
-                    map_location=(
-                        self.config.trainer_config.trainer_accelerator
-                        if self.config.trainer_config.trainer_accelerator is not None
-                        or self.config.trainer_config.trainer_accelerator != "auto"
-                        else "cpu"
-                    ),
+                    map_location="cpu",  # this will be loaded on cpu as it's just used to get the input channels
                     weights_only=False,
                 )
                 input_channels = list(pretrained_backbone_ckpt["state_dict"].values())[


### PR DESCRIPTION
This PR fixes the following bugs:

- `torch.load()` in `lightning_modules.py` failed when using "gpu" as the device for map location, it should use "cuda" / "mps" / "cpu". Related Issue: #321 

- Fixes a bug in computing the length of the dataloader. (If there's only one sample, the code failed to return 1)

- Resolved a compatibility issue where MediaVideo backends did not work with the threading model used for caching. (Removing the thread-based approach for now)