### PR TITLE
Change zmq address to port arguments

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -137,8 +137,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 
 name: 'your_experiment_name'
@@ -857,8 +857,8 @@ trainer_config:
 
 ### ZMQ Configuration
 - `zmq`:
-    - `publish_address`: (str) The address (e.g., `tcp://127.0.0.1:9000`) where training logs (such as loss values) will be published in real time (used primarily with the SLEAP GUI). Set to `None` to disable log publishing. **Default**: `None`
-    - `controller_address`: (str) The address and port to listen for external stop/pause commands (used primarily with the SLEAP GUI). Set to `None` to disable remote control. **Default**: `None`
+    - `publish_port`: (int) Port (e.g., `tcp://127.0.0.1:<publish_port>`) where training logs (such as loss values) will be published in real time (used primarily with the SLEAP GUI). Set to `None` to disable log publishing. **Default**: `None`
+    - `controller_port`: (int) Port (e.g., `tcp://127.0.0.1:<controller_port>`) to listen for external stop/pause commands (used primarily with the SLEAP GUI). Set to `None` to disable remote control. **Default**: `None`
     - `controller_polling_timeout`: (int) Polling timeout in microseconds specified as an integer. This controls how long the poller should wait to receive a response and should be set to a small value to minimize the impact on training speed. **Default**: `10`
 
 

--- a/docs/sample_configs/config_bottomup_convnext.yaml
+++ b/docs/sample_configs/config_bottomup_convnext.yaml
@@ -138,8 +138,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/docs/sample_configs/config_bottomup_unet.yaml
+++ b/docs/sample_configs/config_bottomup_unet.yaml
@@ -137,8 +137,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/docs/sample_configs/config_centroid_swint.yaml
+++ b/docs/sample_configs/config_centroid_swint.yaml
@@ -141,8 +141,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -139,8 +139,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/docs/sample_configs/config_multi_class_bottomup_unet.yaml
+++ b/docs/sample_configs/config_multi_class_bottomup_unet.yaml
@@ -138,8 +138,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/docs/sample_configs/config_single_instance_unet.yaml
+++ b/docs/sample_configs/config_single_instance_unet.yaml
@@ -131,8 +131,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/docs/sample_configs/config_topdown_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet.yaml
@@ -132,8 +132,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -140,8 +140,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -685,8 +685,8 @@ def get_trainer_config(
     min_hard_keypoints: int = 2,
     max_hard_keypoints: Optional[int] = None,
     loss_scale: float = 5.0,
-    zmq_publish_address: Optional[str] = None,
-    zmq_controller_address: Optional[str] = None,
+    zmq_publish_port: Optional[int] = None,
+    zmq_controller_port: Optional[int] = None,
     zmq_controller_timeout: int = 10,
 ):
     """Train a pose-estimation model with SLEAP-NN framework.
@@ -777,8 +777,8 @@ def get_trainer_config(
             ratio and result in loss scaling being applied to most keypoints, which can
             reduce the impact of hard mining altogether.
         loss_scale: Factor to scale the hard keypoint losses by for oks.
-        zmq_publish_address: (str) Specifies the address and port to which the training logs (loss values) should be sent to.
-        zmq_controller_address: (str) Specifies the address and port to listen to to stop the training (specific to SLEAP GUI).
+        zmq_publish_port: (int) Specifies the port to which the training logs (loss values) should be sent to.
+        zmq_controller_port: (int) Specifies the port to listen to to stop the training (specific to SLEAP GUI).
         zmq_controller_timeout: (int) Polling timeout in microseconds specified as an integer. This controls how long the poller
             should wait to receive a response and should be set to a small value to minimize the impact on training speed.
     """
@@ -861,9 +861,9 @@ def get_trainer_config(
             loss_scale=loss_scale,
         ),
         zmq=ZMQConfig(
-            controller_address=zmq_controller_address,
+            controller_port=zmq_controller_port,
             controller_polling_timeout=zmq_controller_timeout,
-            publish_address=zmq_publish_address,
+            publish_port=zmq_publish_port,
         ),
     )
     return trainer_config

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -187,14 +187,14 @@ class ZMQConfig:
     """Configuration of ZeroMQ-based monitoring of the training.
 
     Attributes:
-        controller_address: IP address/hostname and port number of the endpoint to listen for command messages from. For TCP-based endpoints, this must be in the form of "tcp://{ip_address}:{port_number}". Defaults to None. *Default*: `None`.
+        controller_port: Port number of the endpoint to listen for command messages from. "tcp://tcp://127.0.0.1:{port_number}". Set to `None` to disable log publishing. *Default*: `None`.
         controller_polling_timeout: Polling timeout in microseconds specified as an integer. This controls how long the poller should wait to receive a response and should be set to a small value to minimize the impact on training speed. *Default*: `10`.
-        publish_address: IP address/hostname and port number of the endpoint to publish updates to. For TCP-based endpoints, this must be in the form of "tcp://{ip_address}:{port_number}". Sample: "tcp://127.0.0.1:9001". Defaults to None. *Default*: `None`.
+        publish_port: Port number of the endpoint to publish updates to. "tcp://tcp://127.0.0.1:{port_number}". Set to `None` to disable log publishing. *Default*: `None`.
     """
 
-    controller_address: Optional[str] = None
+    controller_port: Optional[int] = None
     controller_polling_timeout: int = 10
-    publish_address: Optional[str] = None
+    publish_port: Optional[int] = None
 
 
 @define
@@ -559,14 +559,14 @@ def trainer_mapper(legacy_config: dict) -> TrainerConfig:
         legacy_config_outputs.get("zmq", {}).get("subscribe_to_controller", None)
         is not None
     ):
-        zmq_cfg_args["controller_address"] = legacy_config_outputs["zmq"][
-            "controller_address"
-        ]
+        zmq_cfg_args["controller_port"] = int(
+            legacy_config_outputs["zmq"]["controller_address"].split(":")[-1]
+        )
 
     if legacy_config_outputs.get("zmq", {}).get("publish_updates", None) is not None:
-        zmq_cfg_args["publish_address"] = legacy_config_outputs["zmq"][
-            "publish_address"
-        ]
+        zmq_cfg_args["publish_port"] = int(
+            legacy_config_outputs["zmq"]["publish_address"].split(":")[-1]
+        )
 
     if (
         legacy_config_outputs.get("zmq", {}).get("controller_polling_timeout", None)

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -173,8 +173,8 @@ def train(
     min_hard_keypoints: int = 2,
     max_hard_keypoints: Optional[int] = None,
     loss_scale: float = 5.0,
-    zmq_publish_address: Optional[str] = None,
-    zmq_controller_address: Optional[str] = None,
+    zmq_publish_port: Optional[int] = None,
+    zmq_controller_port: Optional[int] = None,
     zmq_controller_timeout: int = 10,
 ):
     """Train a pose-estimation model with SLEAP-NN framework.
@@ -367,8 +367,8 @@ def train(
             ratio and result in loss scaling being applied to most keypoints, which can
             reduce the impact of hard mining altogether.
         loss_scale: Factor to scale the hard keypoint losses by for oks.
-        zmq_publish_address: (str) Specifies the address and port to which the training logs (loss values) should be sent to.
-        zmq_controller_address: (str) Specifies the address and port to listen to to stop the training (specific to SLEAP GUI).
+        zmq_publish_port: (int) Specifies the port to which the training logs (loss values) should be sent to.
+        zmq_controller_port: (int) Specifies the port to listen to to stop the training (specific to SLEAP GUI).
         zmq_controller_timeout: (int) Polling timeout in microseconds specified as an integer. This controls how long the poller
             should wait to receive a response and should be set to a small value to minimize the impact on training speed.
     """
@@ -443,8 +443,8 @@ def train(
         min_hard_keypoints=min_hard_keypoints,
         max_hard_keypoints=max_hard_keypoints,
         loss_scale=loss_scale,
-        zmq_publish_address=zmq_publish_address,
-        zmq_controller_address=zmq_controller_address,
+        zmq_publish_port=zmq_publish_port,
+        zmq_controller_port=zmq_controller_port,
         zmq_controller_timeout=zmq_controller_timeout,
     )
 

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -680,15 +680,15 @@ class ModelTrainer:
             self.config.trainer_config.wandb.api_key = ""
 
         # zmq callbacks
-        controller_address = OmegaConf.select(
-            self.config, "trainer_config.zmq.controller_address", default=None
-        )
-        publish_address = OmegaConf.select(
-            self.config, "trainer_config.zmq.publish_address", default=None
-        )
-        if controller_address is not None:
+        if self.config.trainer_config.zmq.controller_port is not None:
+            controller_address = "tcp://127.0.0.1:" + str(
+                self.config.trainer_config.zmq.controller_port
+            )
             callbacks.append(TrainingControllerZMQ(address=controller_address))
-        if publish_address is not None:
+        if self.config.trainer_config.zmq.publish_port is not None:
+            publish_address = "tcp://127.0.0.1:" + str(
+                self.config.trainer_config.zmq.publish_port
+            )
             callbacks.append(ProgressReporterZMQ(address=publish_address))
 
         # viz callbacks

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
@@ -162,9 +162,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
@@ -162,9 +162,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
@@ -156,9 +156,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
@@ -156,9 +156,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
@@ -152,9 +152,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
@@ -152,9 +152,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
@@ -162,9 +162,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
@@ -162,9 +162,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -165,9 +165,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
@@ -165,9 +165,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
@@ -155,9 +155,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
@@ -155,9 +155,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -568,12 +568,8 @@ def test_zmq_callbacks(config, tmp_path: str):
     )
     OmegaConf.update(config, "trainer_config.run_name", "test_zmq_callbacks")
     OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
-    OmegaConf.update(
-        config, "trainer_config.zmq.publish_address", "tcp://127.0.0.1:9510"
-    )
-    OmegaConf.update(
-        config, "trainer_config.zmq.controller_address", "tcp://127.0.0.1:9004"
-    )
+    OmegaConf.update(config, "trainer_config.zmq.publish_port", "9510")
+    OmegaConf.update(config, "trainer_config.zmq.controller_port", "9004")
     OmegaConf.update(config, "trainer_config.max_epochs", 1)
 
     model_trainer = ModelTrainer.get_model_trainer_from_config(config)


### PR DESCRIPTION
This PR updates the ZMQ arguments to use port numbers instead of full addresses.