### PR TITLE
Fix seeding in training workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# uv lock files
+uv.lock
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/docs/config.md
+++ b/docs/config.md
@@ -108,7 +108,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: <ckpt_dir>
@@ -728,7 +728,7 @@ trainer_config:
 - `visualize_preds_during_training`: (bool) If set to `True`, sample predictions (keypoints + confidence maps) are saved to `viz` folder in the ckpt dir and in wandb table. **Default**: `False`
 - `keep_viz`: (bool) If set to `True`, the `viz` folder containing training visualizations will be kept after training completes. If `False`, the folder will be deleted. This parameter only has an effect when `visualize_preds_during_training` is `True`. **Default**: `False`
 - `max_epochs`: (int) Maximum number of epochs to run. **Default**: `10`
-- `seed`: (int) Seed value for the current experiment. **Default**: `0`
+- `seed`: (int) Seed value for the current experiment. If None, no seeding is applied. **Default**: `None`
 - `use_wandb`: (bool) True to enable wandb logging. **Default**: `False`
 - `save_ckpt`: (bool) True to enable checkpointing. **Default**: `False`
 - `ckpt_dir`: (str) Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`

--- a/docs/sample_configs/config_bottomup_convnext.yaml
+++ b/docs/sample_configs/config_bottomup_convnext.yaml
@@ -108,7 +108,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 40
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_bottomup_unet.yaml
+++ b/docs/sample_configs/config_bottomup_unet.yaml
@@ -107,7 +107,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 40
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_centroid_swint.yaml
+++ b/docs/sample_configs/config_centroid_swint.yaml
@@ -103,7 +103,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 30
-  seed: 0
+  seed:
   use_wandb: true
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -101,7 +101,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 30
-  seed: 0
+  seed:
   use_wandb: true
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_multi_class_bottomup_unet.yaml
+++ b/docs/sample_configs/config_multi_class_bottomup_unet.yaml
@@ -108,7 +108,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 40
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_single_instance_unet.yaml
+++ b/docs/sample_configs/config_single_instance_unet.yaml
@@ -101,7 +101,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_topdown_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet.yaml
@@ -102,7 +102,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 30
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -110,7 +110,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 30
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/training.md
+++ b/docs/training.md
@@ -219,7 +219,8 @@ ckpt_dir: models
 ```
 
 !!! note "Training steps in multi-gpu setting"
-    In a multi-gpu training setup, the effective steps during training would be `config.trainer_config.trainer_steps_per_epoch` / `config.trainer_config.trainer_devices`. 
+    - In a multi-gpu training setup, the effective steps during training would be `config.trainer_config.trainer_steps_per_epoch` / `config.trainer_config.trainer_devices`. 
+    - If validation labels are not provided in a multi-GPU training setup, we now ensure deterministic splitting of labels into train/val sets by seeding with 42 (when no seed is given). This prevents each GPU worker from producing a different split. To generate a different train-val split, set a custom seed via `config.trainer_config.seed`.
 !!! note "Multi-node training"
     Multi-node trainings have not been validated and should be considered experimental.
 

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -660,7 +660,7 @@ def get_trainer_config(
     visualize_preds_during_training: bool = False,
     keep_viz: bool = False,
     max_epochs: int = 10,
-    seed: int = 0,
+    seed: Optional[int] = None,
     use_wandb: bool = False,
     save_ckpt: bool = False,
     ckpt_dir: Optional[str] = None,
@@ -726,7 +726,7 @@ def get_trainer_config(
         keep_viz: If set to `True`, the `viz` folder will be kept after training. If `False`, the `viz` folder
             will be deleted after training. Only applies when `visualize_preds_during_training` is `True`.
         max_epochs: Maximum number of epochs to run. Default: 100.
-        seed: Seed value for the current experiment. default: 1000.
+        seed: Seed value for the current experiment. If None, no seeding is applied. Default: None.
         save_ckpt: True to enable checkpointing. Default: False.
         ckpt_dir: Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
         run_name: Name of the current run. The ckpts will be created in `<ckpt_dir>/<run_name>`. If `None`, a run name is generated with `<timestamp>_<head_name>`. Default: None.

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -216,7 +216,7 @@ class TrainerConfig:
         visualize_preds_during_training: (bool) If set to `True`, sample predictions (keypoints + confidence maps) are saved to `viz` folder in the ckpt dir and in wandb table. *Default*: `False`.
         keep_viz: (bool) If set to `True`, the `viz` folder will be kept after training. If `False`, the `viz` folder will be deleted after training. Only applies when `visualize_preds_during_training` is `True`. *Default*: `False`.
         max_epochs: (int) Maximum number of epochs to run. *Default*: `10`.
-        seed: (int) Seed value for the current experiment. *Default*: `0`.
+        seed: (int) Seed value for the current experiment. If None, no seeding is applied. *Default*: `0`.
         use_wandb: (bool) True to enable wandb logging. *Default*: `False`.
         save_ckpt: (bool) True to enable checkpointing. *Default*: `False`.
         ckpt_dir: (str) Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
@@ -247,7 +247,7 @@ class TrainerConfig:
     visualize_preds_during_training: bool = False
     keep_viz: bool = False
     max_epochs: int = 10
-    seed: int = 0
+    seed: Optional[int] = None
     use_wandb: bool = False
     save_ckpt: bool = False
     ckpt_dir: Optional[str] = "."

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -148,7 +148,7 @@ def train(
     visualize_preds_during_training: bool = False,
     keep_viz: bool = False,
     max_epochs: int = 10,
-    seed: int = 0,
+    seed: Optional[int] = None,
     use_wandb: bool = False,
     save_ckpt: bool = False,
     ckpt_dir: Optional[str] = None,
@@ -316,7 +316,7 @@ def train(
             are saved to `viz` folder in the ckpt dir and in wandb table.
         keep_viz: If set to `True`, the `viz` folder containing training visualizations will be kept after training completes. If `False`, the folder will be deleted. This parameter only has an effect when `visualize_preds_during_training` is `True`. Default: `False`.
         max_epochs: Maximum number of epochs to run. Default: 10.
-        seed: Seed value for the current experiment. default: 0.
+        seed: Seed value for the current experiment. If None, no seeding is applied. Default: None.
         save_ckpt: True to enable checkpointing. Default: False.
         ckpt_dir: Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
         run_name: Name of the current run. The ckpts will be created in `<ckpt_dir>/<run_name>`. If `None`, a run name is generated with `<timestamp>_<head_name>`. **Default**: `None`

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/initial_config.yaml
@@ -123,7 +123,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 10
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_bottomup/training_config.yaml
@@ -123,7 +123,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 10
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/initial_config.yaml
@@ -117,7 +117,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 10
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centered_instance/training_config.yaml
@@ -117,7 +117,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 10
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/initial_config.yaml
@@ -113,7 +113,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 30
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_centroid/training_config.yaml
@@ -113,7 +113,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 30
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/initial_config.yaml
@@ -123,7 +123,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 200
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_bottomup/training_config.yaml
@@ -123,7 +123,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 200
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -126,7 +126,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 200
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/training_config.yaml
@@ -126,7 +126,7 @@ trainer_config:
   visualize_preds_during_training: false
   keep_viz: false
   max_epochs: 200
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/initial_config.yaml
@@ -116,7 +116,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: true
   max_epochs: 100
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_single_instance/training_config.yaml
@@ -116,7 +116,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: true
   max_epochs: 100
-  seed: 0
+  seed:
   use_wandb: false
   save_ckpt: true
   ckpt_dir: .

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -287,7 +287,7 @@ def test_trainer_mapper():
     assert config.trainer_accelerator == "auto"
     assert config.enable_progress_bar is True
     assert config.min_train_steps_per_epoch == 200
-    assert config.seed is 0
+    assert config.seed is None
     assert config.use_wandb is False
     assert config.save_ckpt is True
     assert config.resume_ckpt_path is None


### PR DESCRIPTION
This PR fixes seeding in the training pipeline. Previously, the seed parameter in the config was defined but never applied. We now explicitly set the seed when provided. In multi-GPU setups, if validation labels are missing, we default the seed to 42 during train/val splitting to ensure all workers use the same split.