### PR TITLE
Auto-select GPUs

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -895,11 +895,12 @@ class ModelTrainer:
             and self.config.trainer_config.trainer_devices < torch.cuda.device_count()
             and self.config.trainer_config.trainer_device_indices is None
         ):
-            devices = list(
-                np.argsort(get_gpu_memory())[::-1][
+            devices = [
+                int(x)
+                for x in np.argsort(get_gpu_memory())[::-1][
                     : self.config.trainer_config.trainer_devices
                 ]
-            )
+            ]
 
         # create lightning.Trainer instance.
         self.trainer = L.Trainer(

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -42,6 +42,7 @@ from sleap_nn.config.utils import (
 )
 from sleap_nn.training.lightning_modules import LightningModel
 from sleap_nn.config.utils import check_output_strides
+from sleap_nn.training.utils import get_gpu_memory
 from sleap_nn.config.training_job_config import verify_training_cfg
 from sleap_nn.training.callbacks import (
     ProgressReporterZMQ,
@@ -876,21 +877,34 @@ class ModelTrainer:
                 logger.error(message)
                 raise ValueError(message)
 
+        devices = (
+            OmegaConf.select(
+                self.config, "trainer_config.trainer_device_indices", default=None
+            )
+            if OmegaConf.select(
+                self.config, "trainer_config.trainer_device_indices", default=None
+            )
+            is not None
+            else self.config.trainer_config.trainer_devices
+        )
+
+        # if trainer devices is set to less than the number of available GPUs, use the least used GPUs
+        if (
+            torch.cuda.is_available()
+            and isinstance(self.config.trainer_config.trainer_devices, int)
+            and self.config.trainer_config.trainer_devices < torch.cuda.device_count()
+            and self.config.trainer_config.trainer_device_indices is None
+        ):
+            devices = np.argsort(get_gpu_memory())[
+                : self.config.trainer_config.trainer_devices
+            ]
+
         # create lightning.Trainer instance.
         self.trainer = L.Trainer(
             callbacks=callbacks,
             logger=loggers,
             enable_checkpointing=self.config.trainer_config.save_ckpt,
-            devices=(
-                OmegaConf.select(
-                    self.config, "trainer_config.trainer_device_indices", default=None
-                )
-                if OmegaConf.select(
-                    self.config, "trainer_config.trainer_device_indices", default=None
-                )
-                is not None
-                else self.config.trainer_config.trainer_devices
-            ),
+            devices=devices,
             max_epochs=self.config.trainer_config.max_epochs,
             accelerator=self.config.trainer_config.trainer_accelerator,
             enable_progress_bar=self.config.trainer_config.enable_progress_bar,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -895,9 +895,11 @@ class ModelTrainer:
             and self.config.trainer_config.trainer_devices < torch.cuda.device_count()
             and self.config.trainer_config.trainer_device_indices is None
         ):
-            devices = np.argsort(get_gpu_memory())[
-                : self.config.trainer_config.trainer_devices
-            ]
+            devices = list(
+                np.argsort(get_gpu_memory())[::-1][
+                    : self.config.trainer_config.trainer_devices
+                ]
+            )
 
         # create lightning.Trainer instance.
         self.trainer = L.Trainer(

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -887,10 +887,12 @@ class ModelTrainer:
             is not None
             else self.config.trainer_config.trainer_devices
         )
+        logger.info(f"Trainer devices: {devices}")
 
         # if trainer devices is set to less than the number of available GPUs, use the least used GPUs
         if (
             torch.cuda.is_available()
+            and self.config.trainer_config.trainer_accelerator != "cpu"
             and isinstance(self.config.trainer_config.trainer_devices, int)
             and self.config.trainer_config.trainer_devices < torch.cuda.device_count()
             and self.config.trainer_config.trainer_device_indices is None
@@ -901,6 +903,7 @@ class ModelTrainer:
                     : self.config.trainer_config.trainer_devices
                 ]
             ]
+            logger.info(f"Using GPUs with most available memory: {devices}")
 
         # create lightning.Trainer instance.
         self.trainer = L.Trainer(


### PR DESCRIPTION
This PR adds functionality to automatically select GPUs with the most available memory when the number of training devices specified by the user is less than the total GPUs available. In this case, we query the memory utilization of each GPU, sort them by free memory, and allocate the devices with the highest availability.