### PR TITLE
Modify uv installation docs for cuda support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,49 +10,13 @@ Neural network backend for training and inference for animal pose estimation.
 
 This is the deep learning engine that powers [SLEAP](https://sleap.ai) (Social LEAP Estimates Animal Poses), providing neural network architectures for multi-instance animal pose estimation and tracking. Built on PyTorch, SLEAP-NN offers an end-to-end training workflow, supporting multiple model types (Single Instance, Top-Down, Bottom-Up, Multi-Class), and seamless integration with SLEAP's GUI and command-line tools.
 
+Need a quick start? Refer to our [Quick Start guide](https://nn.sleap.ai/latest/#quick-start) in the docs.
+
 ## Documentation
 
 **📚 [Documentation](https://nn.sleap.ai)** - Comprehensive guides and API reference
 
-## Quick Start
-
-Let's start SLEAPiNNg !!! 🐭🐭
-
-> For detailed information on setting up config, training/ inference workflows, please refer to our [docs](https://nn.sleap.ai).
-
-#### 1. Install uv
-Install [`uv`](https://github.com/astral-sh/uv) first - a fast Python package manager:
-```bash
-# macOS/Linux
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-#### 2. Set Up Your Configuration
-
-Create a `config.yaml` file for your experiment.
-
-> Use a sample config from [`docs/sample_configs`](https://github.com/talmolab/sleap-nn/tree/main/docs/sample_configs).
-
-#### 3. Train a model
-
-> Download sample training data from [here](https://storage.googleapis.com/sleap-data/datasets/BermanFlies/random_split1/train.pkg.slp) and validation data from [here](https://storage.googleapis.com/sleap-data/datasets/BermanFlies/random_split1/val.pkg.slp) for quick experimentation.
-
-```bash
-uvx sleap-nn[torch-cpu] train --config-name config.yaml --config-dir /path/to/config_dir/ "data_config.train_labels_path=[labels.pkg.slp]"
-```
-
-#### 4. Run inference on the trained model
-
-To run inference:
-```bash
-uvx sleap-nn[torch-cpu] track --data-path video.mp4 --model-paths model_ckpt_dir/
-```
-
-
-### For development setup
+## For development setup
 
 1. **Clone the sleap-nn repo**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,14 @@
 Let's start SLEAPiNNg !!! 🐭🐭
 
 !!! info "Prerequisite: uv installation"
-    Install [`uv`](https://github.com/astral-sh/uv), a fast Python package manager for modern projects. See the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/) for instructions.
+    Install [`uv`](https://github.com/astral-sh/uv), a fast Python package manager for modern projects:
+    ```bash
+    # macOS/Linux
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    
+    # Windows
+    powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+    ```
 
 ### Step - 1 : Set Up Your Configuration
 
@@ -32,28 +39,55 @@ Create a `config.yaml` file for your experiment. Use a sample config from [`docs
 
 ### Step - 2 : Train a Model
 
-We use `uvx` here which automatically installs sleap-nn from PyPI with all dependencies and runs the command in a single step. Check out [`Installation.md`](installation.md) for different installation options.
+We use `uvx` here which automatically installs sleap-nn from PyPI with all dependencies and runs the command in a single step. `uvx` automatically installs sleap-nn and runs your command inside a temporary virtual environment (venv). This means each run is fully isolated and leaves no trace on your system—perfect for trying out sleap-nn without any permanent installation. Check out [Installation docs](installation.md) for different installation options. 
 
 > **Quick Start Data:** Download sample training data from [here](https://storage.googleapis.com/sleap-data/datasets/BermanFlies/random_split1/train.pkg.slp) and validation data from [here](https://storage.googleapis.com/sleap-data/datasets/BermanFlies/random_split1/val.pkg.slp) for quick experimentation.
 
-```bash
-uvx "sleap-nn[torch-cpu]" train --config-name config.yaml --config-dir /path/to/config_dir/ "data_config.train_labels_path=[train.pkg.slp]" "data_config.val_labels_path=[val.pkg.slp]"
-```
-
-!!! tip "GPU Acceleration"
-    For faster training, use `torch-cuda118` or `torch-cuda128` instead of `torch-cpu`:
+=== "Windows/Linux (CUDA)"
     ```bash
-    uvx "sleap-nn[torch-cuda118]" train --config-name config.yaml --config-dir /path/to/config_dir/ "data_config.train_labels_path=[train.pkg.slp]" "data_config.val_labels_path=[val.pkg.slp]
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-nn train --config-name config.yaml --config-dir /path/to/config_dir/ "data_config.train_labels_path=[train.pkg.slp]" "data_config.val_labels_path=[val.pkg.slp]"
     ```
+
+=== "Windows/Linux (CPU)"
+    ```bash
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu sleap-nn train --config-name config.yaml --config-dir /path/to/config_dir/ "data_config.train_labels_path=[train.pkg.slp]" "data_config.val_labels_path=[val.pkg.slp]"
+    ```
+
+=== "macOS"
+    ```bash
+    uvx sleap-nn[torch] train --config-name config.yaml --config-dir /path/to/config_dir/ "data_config.train_labels_path=[train.pkg.slp]" "data_config.val_labels_path=[val.pkg.slp]"
+    ```
+
+!!! info
+    - For more information on which CUDA version to use for your system, see the [PyTorch installation guide](https://pytorch.org/get-started/locally/).  
+      The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
+    - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
 
 
 ### Step - 3 : Run Inference on the Trained Model
 
 To run inference:
 
-```bash
-uvx "sleap-nn[torch-cpu]" track --data_path video.mp4 --model_paths model_ckpt_dir/
-```
+=== "Windows/Linux (CUDA)"
+    ```bash
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-nn track --data-path video.mp4 --model-paths model_ckpt_dir/
+    ```
+
+=== "Windows/Linux (CPU)"
+    ```bash
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu sleap-nn track --data-path video.mp4 --model-paths model_ckpt_dir/
+    ```
+
+=== "macOS"
+    ```bash
+    uvx sleap-nn[torch] track --data-path video.mp4 --model-paths model_ckpt_dir/
+    ```
+
+!!! info
+    - For more information on which CUDA version to use for your system, see the [PyTorch installation guide](https://pytorch.org/get-started/locally/).  
+      The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
+    - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
+
 
 !!! warning "Model Paths"
     `--model-paths` should be set to `<config.trainer_config.config_dir>/<config.trainer_config.run_name>`. Make sure the model checkpoint directory contains both `best.ckpt` (or legacy sleap `best_model.h5` - only UNet backbone is supported) and `training_config.yaml` (or legacy sleap `training_config.json` - only UNet backbone is supported) files. The inference will fail without these files.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,9 +3,53 @@
 **Prerequisites:** Python 3.11+ (required for all installation methods)
 
 !!! tip "Choose Your Installation Method"
+    - **[Installation as a system-wide tool with uv](#installation-as-a-system-wide-tool-with-uv)**: Use `uv tool install` to install sleap-nn globally as a CLI tool
     - **[Installation with uvx](#installation-with-uvx)**: Use `uvx` for one-off commands (no installation needed)
+    - **[Installation with uv pip](#installation-with-uv-pip)**: Use `uv pip` to install from pypi in a uv virtual env.
     - **[Installation with pip](#installation-with-pip)**: Use `pip` to install from pypi in a conda env. (Recommended to use with a conda env)
     - **[Installation from source](#development-setup-with-uv)**: Use `uv sync` to install from source (for developmental purposes)
+
+---
+
+## Installation as a system-wide tool with uv
+
+`uv tool install` installs sleap-nn globally as a system-wide CLI tool, making `sleap-nn` commands available from anywhere in your terminal.
+
+!!! note "Install uv"
+    Install [`uv`](https://github.com/astral-sh/uv) - a fast Python package manager:
+    ```bash
+    # macOS/Linux
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    
+    # Windows
+    powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+    ```
+
+### Platform-Specific Installation
+
+=== "Windows/Linux (CUDA)"
+    ```bash
+    # CUDA 12.8
+    uv tool install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128
+
+    # CUDA 11.8
+    uv tool install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu118
+    ```
+
+=== "Windows/Linux (CPU)"
+    ```bash
+    uv tool install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu
+    ```
+
+=== "macOS"
+    ```bash
+    uv tool install sleap-nn[torch]
+    ```
+
+!!! info
+    - For more information on which CUDA version to use for your system, see the [PyTorch installation guide](https://pytorch.org/get-started/locally/).  
+      The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
+    - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
 
 ---
 
@@ -13,8 +57,8 @@
 
 `uvx` automatically installs sleap-nn and runs your command inside a temporary virtual environment (venv). This means each run is fully isolated and leaves no trace on your system—perfect for trying out sleap-nn without any permanent installation.
 
-!!! warning "First Time Setup"
-    Install [`uv`](https://github.com/astral-sh/uv) first - a fast Python package manager:
+!!! note "Install uv"
+    Install [`uv`](https://github.com/astral-sh/uv) - a fast Python package manager:
     ```bash
     # macOS/Linux
     curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -25,23 +69,28 @@
 
 ### Platform-Specific Commands
 
-=== "Windows/Linux (CUDA 11.8)"
+=== "Windows/Linux (CUDA)"
     ```bash
-    uvx "sleap-nn[torch-cuda118]" train --config-name myconfig --config-dir /path/to/config_dir/
-    uvx "sleap-nn[torch-cuda118]" track --data_path video.mp4 --model_paths models/
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-nn train --config-name myconfig --config-dir /path/to/config_dir/
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-nn track --data_path video.mp4 --model_paths models/
     ```
 
-=== "Windows/Linux (CUDA 12.8)"
+=== "Windows/Linux (CPU)"
     ```bash
-    uvx "sleap-nn[torch-cuda128]" train --config-name myconfig --config-dir /path/to/config_dir/
-    uvx "sleap-nn[torch-cuda128]" track --data_path video.mp4 --model_paths models/
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu sleap-nn train --config-name myconfig --config-dir /path/to/config_dir/
+    uvx --from "sleap-nn[torch]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu sleap-nn track --data_path video.mp4 --model_paths models/
     ```
 
-=== "macOS/CPU Only"
+=== "macOS"
     ```bash
-    uvx "sleap-nn[torch-cpu]" train --config-name myconfig --config-dir /path/to/config_dir/
-    uvx "sleap-nn[torch-cpu]" track --data_path video.mp4 --model_paths models/
+    uvx "sleap-nn[torch]" train --config-name myconfig --config-dir /path/to/config_dir/
+    uvx "sleap-nn[torch]" track --data_path video.mp4 --model_paths models/
     ```
+
+!!! note
+    - For more information on which CUDA version to use for your system, see the [PyTorch installation guide](https://pytorch.org/get-started/locally/).  
+      The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
+    - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
 
 !!! tip "How uvx Works"
     - **Automatic Installation**: Downloads and installs sleap-nn with dependencies
@@ -50,31 +99,89 @@
     - **Uses recent pkgs**: Uses the latest version from PyPI
 
 !!! note "uvx Installation"
-    Because `uvx` installs packages fresh on every run, it's ideal for quick tests or use in remote environments. For regular use, you could also install with `pip` or setting up a development environment with `uv sync` to avoid repeated downloads.
+    Because `uvx` installs packages fresh on every run, it's ideal for quick tests or use in remote environments. For regular use, you could install with [`uv tool install`](#installation-as-a-system-wide-tool-with-uv) or setting up a development environment with [`uv sync`](#installation-from-source) to avoid repeated downloads.
+
+---
+
+## Installation with uv pip
+
+This method creates a dedicated project environment using uv's modern Python project management. It initializes a new project with `uv init`, creates an isolated virtual environment with `uv venv`, and installs sleap-nn using `uv pip`.
+
+!!! note "Install and set-up uv"
+    Step-1: Install [`uv`](https://github.com/astral-sh/uv) - a fast Python package manager:
+    ```bash
+    # macOS/Linux
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    
+    # Windows
+    powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+    ```
+
+    Step-2: Move to your project directory and initialize the virtual env.
+    ```bash
+    uv init
+    uv venv
+    ```
+
+### Platform-Specific Installation
+
+=== "Windows/Linux (CUDA)"
+    ```bash
+    # CUDA 12.8
+    uv pip install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128
+
+    # CUDA 11.8
+    uv pip install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu118
+    ```
+
+=== "Windows/Linux (CPU)"
+    ```bash
+    uv pip install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu
+    ```
+
+=== "macOS"
+    ```bash
+    uv pip install sleap-nn[torch]
+    ```
+
+!!! info
+    - For more information on which CUDA version to use for your system, see the [PyTorch installation guide](https://pytorch.org/get-started/locally/).  
+      The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
+    - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
 
 ---
 
 ## Installation with pip
 
+We recommend creating a dedicated environment with [conda](https://docs.conda.io/en/latest/miniconda.html) or [mamba/miniforge](https://github.com/conda-forge/miniforge) before installing `sleap-nn` with pip. This helps avoid dependency conflicts and keeps your Python setup clean. After installing Miniconda or Miniforge, create and activate an environment, then run the pip install commands below inside the activated environment.
+
+
 ### Platform-Specific Installation
 
-=== "Windows/Linux (CUDA 11.8)"
+=== "Windows/Linux (CUDA)"
     ```bash
-    pip install sleap-nn[torch-cuda118]
+    # CUDA 12.8
+    pip install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128
+
+    # CUDA 11.8
+    pip install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu118
     ```
 
-=== "Windows/Linux (CUDA 12.8)"
+=== "Windows/Linux (CPU)"
     ```bash
-    pip install sleap-nn[torch-cuda128]
+    pip install sleap-nn[torch] --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu
     ```
 
-=== "macOS/CPU Only"
+=== "macOS"
     ```bash
-    pip install sleap-nn[torch-cpu]
+    pip install sleap-nn[torch]
     ```
 
-!!! info "macOS MPS Support"
-    Even with `torch-cpu`, macOS automatically enables MPS (Metal Performance Shaders) for Apple Silicon acceleration.
+!!! info
+    - For more information on which CUDA version to use for your system, see the [PyTorch installation guide](https://pytorch.org/get-started/locally/).  
+      The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
+    - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
+
 
 ### Verify Installation
 
@@ -88,7 +195,7 @@ python -c "import torch; print(f'PyTorch: {torch.__version__}'); print(f'CUDA av
 
 ---
 
-## Development Setup with uv
+## Installation from source
 
 For contributing to sleap-nn or development workflows.
 


### PR DESCRIPTION
Previously, `uv tool install sleap-nn[torch-cuda128]` didn't  install torch with cuda support on windows (Related issue: #307). CUDA libraries aren’t getting installed because PyPi doesn’t have access to `tool.uv.index` . When we run `uv tool install` (installing `sleap-nn` from PyPi), it defaults to pulling in the standard torch and torchvision and for windows the default wheels is CPU (linux - CUDA if cuda is available, mac - CPU). This happens because PyPi cannot see the custom indices we provide in [tool.uv.index](https://github.com/talmolab/sleap-nn/blob/99b80451f2af0758c2f944f7ebc0465b71b59c37/pyproject.toml#L108-L139) (the metadata is not published with the wheel), so it cannot resolve CUDA wheels. 

`uv tool install` works when `--extra-index-url` is provided to point to the appropriate Torch wheels. In this PR, we update the documentation to include the required index URLs for installing with CUDA support.