### PR TITLE
Fix ID models

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -689,9 +689,9 @@ The trainer configuration section controls the training process, including data 
 ### Data Loader Settings
 - `train_data_loader`:
     - `batch_size`: (int) Number of samples per batch or batch size for training data. **Default**: `1`
-    - `shuffle`: (bool) True to have the data reshuffled at every epoch. **Default**: `False`
+    - `shuffle`: (bool) True to have the data reshuffled at every epoch. **Default**: `True`
     - `num_workers`: (int) Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process. **Default**: `0`
-- `val_data_loader`: (Similar to `train_data_loader`)
+- `val_data_loader`: (Similar to `train_data_loader`, but `shuffle` is set to `False` by default)
 
 **Example Data Loader configurations:**
 

--- a/docs/sample_configs/config_bottomup_unet_large_rf.yaml
+++ b/docs/sample_configs/config_bottomup_unet_large_rf.yaml
@@ -48,7 +48,7 @@ data_config:
       mixup_lambda_min: 0.01
       mixup_lambda_max: 0.05
       mixup_p: 0.0
-  skeletons: []
+  skeletons:
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/docs/sample_configs/config_bottomup_unet_medium_rf.yaml
+++ b/docs/sample_configs/config_bottomup_unet_medium_rf.yaml
@@ -48,7 +48,7 @@ data_config:
       mixup_lambda_min: 0.01
       mixup_lambda_max: 0.05
       mixup_p: 0.0
-  skeletons: []
+  skeletons:
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -48,7 +48,7 @@ data_config:
       mixup_lambda_min: 0.01
       mixup_lambda_max: 0.05
       mixup_p: 0.0
-  skeletons: []
+  skeletons:
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/docs/sample_configs/config_single_instance_unet_large_rf.yaml
+++ b/docs/sample_configs/config_single_instance_unet_large_rf.yaml
@@ -48,7 +48,7 @@ data_config:
       mixup_lambda_min: 0.01
       mixup_lambda_max: 0.05
       mixup_p: 0.0
-  skeletons: []
+  skeletons:
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/docs/sample_configs/config_single_instance_unet_medium_rf.yaml
+++ b/docs/sample_configs/config_single_instance_unet_medium_rf.yaml
@@ -48,7 +48,7 @@ data_config:
       mixup_lambda_min: 0.01
       mixup_lambda_max: 0.05
       mixup_p: 0.0
-  skeletons: []
+  skeletons:
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/docs/sample_configs/config_topdown_centered_instance_unet_large_rf.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet_large_rf.yaml
@@ -48,7 +48,7 @@ data_config:
       mixup_lambda_min: 0.01
       mixup_lambda_max: 0.05
       mixup_p: 0.0
-  skeletons: []
+  skeletons:
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/docs/sample_configs/config_topdown_centered_instance_unet_medium_rf.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet_medium_rf.yaml
@@ -48,7 +48,7 @@ data_config:
       mixup_lambda_min: 0.01
       mixup_lambda_max: 0.05
       mixup_p: 0.0
-  skeletons: []
+  skeletons:
 model_config:
   init_weights: default
   pretrained_backbone_weights: null

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -59,7 +59,7 @@ model_config:
       kernel_size: 3
       filters: 16
       filters_rate: 1.5
-      max_stride: 8
+      max_stride: 16
       stem_stride: null
       middle_block: true
       up_interpolate: true

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -466,6 +466,10 @@ def data_mapper(legacy_config: dict) -> DataConfig:
     data_cfg_args["use_augmentations_train"] = (
         True if any(intensity_args.values()) or any(geometric_args.values()) else False
     )
-    data_cfg_args["skeletons"] = skeletons_list
+    data_cfg_args["skeletons"] = (
+        skeletons_list
+        if skeletons_list is not None and len(skeletons_list) > 0
+        else None
+    )
 
     return DataConfig(**data_cfg_args)

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -37,7 +37,8 @@ from sleap_nn.config.model_config import (
 from sleap_nn.config.data_config import DataConfig, PreprocessingConfig
 from sleap_nn.config.model_config import ModelConfig
 from sleap_nn.config.trainer_config import (
-    DataLoaderConfig,
+    TrainDataLoaderConfig,
+    ValDataLoaderConfig,
     LRSchedulerConfig,
     StepLRConfig,
     EarlyStoppingConfig,
@@ -647,7 +648,7 @@ def get_model_config(
 
 def get_trainer_config(
     batch_size: int = 1,
-    shuffle_train: bool = False,
+    shuffle_train: bool = True,
     num_workers: int = 0,
     ckpt_save_top_k: int = 1,
     ckpt_save_last: Optional[bool] = None,
@@ -697,7 +698,7 @@ def get_trainer_config(
 
     Args:
         batch_size: Number of samples per batch or batch size for training data. Default: 4.
-        shuffle_train: True to have the train data reshuffled at every epoch. Default: False.
+        shuffle_train: True to have the train data reshuffled at every epoch. Default: True.
         num_workers: Number of subprocesses to use for data loading. 0 means that the data
             will be loaded in the main process. Default: 0.
         ckpt_save_top_k: If save_top_k == k, the best k models according to the quantity
@@ -785,10 +786,10 @@ def get_trainer_config(
             should wait to receive a response and should be set to a small value to minimize the impact on training speed.
     """
     # constrict trainer config
-    train_dataloader_cfg = DataLoaderConfig(
+    train_dataloader_cfg = TrainDataLoaderConfig(
         batch_size=batch_size, shuffle=shuffle_train, num_workers=num_workers
     )
-    val_dataloader_cfg = DataLoaderConfig(
+    val_dataloader_cfg = ValDataLoaderConfig(
         batch_size=batch_size, shuffle=False, num_workers=num_workers
     )
 

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -14,9 +14,7 @@ import re
 
 @define
 class DataLoaderConfig:
-    """Train and val DataLoaderConfig.
-
-    Any parameters from Torch's DataLoader could be used.
+    """Train DataLoaderConfig.
 
     Attributes:
         batch_size: (int) Number of samples per batch or batch size for training/validation data. *Default*: `1`.
@@ -27,6 +25,32 @@ class DataLoaderConfig:
     batch_size: int = 1
     shuffle: bool = False
     num_workers: int = 0
+
+
+@define
+class TrainDataLoaderConfig(DataLoaderConfig):
+    """Train DataLoaderConfig.
+
+    Attributes:
+        batch_size: (int) Number of samples per batch or batch size for training/validation data. *Default*: `1`.
+        shuffle: (bool) True to have the data reshuffled at every epoch. *Default*: `True`.
+        num_workers: (int) Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process. *Default*: `0`.
+    """
+
+    shuffle: bool = True
+
+
+@define
+class ValDataLoaderConfig(DataLoaderConfig):
+    """Validation DataLoaderConfig.
+
+    Attributes:
+        batch_size: (int) Number of samples per batch or batch size for training/validation data. *Default*: `1`.
+        shuffle: (bool) True to have the data reshuffled at every epoch. *Default*: `False`.
+        num_workers: (int) Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process. *Default*: `0`.
+    """
+
+    shuffle: bool = False
 
 
 @define
@@ -232,8 +256,8 @@ class TrainerConfig:
         zmq: Zmq config with publish and controller port addresses.
     """
 
-    train_data_loader: DataLoaderConfig = field(factory=DataLoaderConfig)
-    val_data_loader: DataLoaderConfig = field(factory=DataLoaderConfig)
+    train_data_loader: TrainDataLoaderConfig = field(factory=TrainDataLoaderConfig)
+    val_data_loader: ValDataLoaderConfig = field(factory=ValDataLoaderConfig)
     model_ckpt: ModelCkptConfig = field(factory=ModelCkptConfig)
     trainer_devices: Optional[Any] = field(
         default=None,
@@ -346,7 +370,7 @@ def trainer_mapper(legacy_config: dict) -> TrainerConfig:
             "num_workers"
         ]
 
-    trainer_cfg_args["train_data_loader"] = DataLoaderConfig(
+    trainer_cfg_args["train_data_loader"] = TrainDataLoaderConfig(
         **train_dataloader_cfg_args
     )
 
@@ -359,7 +383,7 @@ def trainer_mapper(legacy_config: dict) -> TrainerConfig:
             "num_workers"
         ]
 
-    trainer_cfg_args["val_data_loader"] = DataLoaderConfig(**val_dataloader_cfg_args)
+    trainer_cfg_args["val_data_loader"] = ValDataLoaderConfig(**val_dataloader_cfg_args)
 
     # model ckpt
     if (

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -93,7 +93,7 @@ def process_lf(
         "instances": instances,
         "video_idx": torch.tensor(video_idx, dtype=torch.int32),
         "frame_idx": torch.tensor(lf.frame_idx, dtype=torch.int32),
-        "orig_size": torch.Tensor([img_height, img_width]),
+        "orig_size": torch.Tensor([img_height, img_width]).unsqueeze(0),
         "num_instances": num_instances,
     }
 
@@ -187,7 +187,7 @@ class VideoReader(Thread):
                         "image": torch.from_numpy(img.copy()),
                         "frame_idx": torch.tensor(idx, dtype=torch.int32),
                         "video_idx": torch.tensor(0, dtype=torch.int32),
-                        "orig_size": torch.Tensor(img.shape[-2:]),
+                        "orig_size": torch.Tensor(img.shape[-2:]).unsqueeze(0),
                     }
                 )
 
@@ -320,7 +320,7 @@ class LabelsReader(Thread):
                     "image": torch.from_numpy(img.copy()),
                     "frame_idx": torch.tensor(lf.frame_idx, dtype=torch.int32),
                     "video_idx": torch.tensor(video_idx, dtype=torch.int32),
-                    "orig_size": torch.Tensor(img.shape[-2:]),
+                    "orig_size": torch.Tensor(img.shape[-2:]).unsqueeze(0),
                 }
 
                 if self.instances_key:

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -138,7 +138,7 @@ def train(
     backbone_config: Union[str, Dict[str, Any]] = "unet",
     head_configs: Union[str, Dict[str, Any]] = None,
     batch_size: int = 1,
-    shuffle_train: bool = False,
+    shuffle_train: bool = True,
     num_workers: int = 0,
     ckpt_save_top_k: int = 1,
     ckpt_save_last: Optional[bool] = None,
@@ -291,7 +291,7 @@ def train(
                             }
                     }
         batch_size: Number of samples per batch or batch size for training data. Default: 1.
-        shuffle_train: True to have the train data reshuffled at every epoch. Default: False.
+        shuffle_train: True to have the train data reshuffled at every epoch. Default: True.
         num_workers: Number of subprocesses to use for data loading. 0 means that the data
             will be loaded in the main process. Default: 0.
         ckpt_save_top_k: If save_top_k == k, the best k models according to the quantity

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -11,7 +11,8 @@ from loguru import logger
 from _pytest.logging import LogCaptureFixture
 
 from sleap_nn.config.trainer_config import (
-    DataLoaderConfig,
+    TrainDataLoaderConfig,
+    ValDataLoaderConfig,
     ModelCkptConfig,
     WandBConfig,
     OptimizerConfig,
@@ -63,8 +64,16 @@ def test_dataloader_config():
     Check default values and customization
     """
     # Check default values
-    conf = OmegaConf.structured(DataLoaderConfig)
-    conf_instance = OmegaConf.structured(DataLoaderConfig())
+    conf = OmegaConf.structured(TrainDataLoaderConfig)
+    conf_instance = OmegaConf.structured(TrainDataLoaderConfig())
+    assert conf == conf_instance
+    assert conf.batch_size == 1
+    assert conf.shuffle is True
+    assert conf.num_workers == 0
+
+    # Check default values
+    conf = OmegaConf.structured(ValDataLoaderConfig)
+    conf_instance = OmegaConf.structured(ValDataLoaderConfig())
     assert conf == conf_instance
     assert conf.batch_size == 1
     assert conf.shuffle is False
@@ -72,7 +81,7 @@ def test_dataloader_config():
 
     # Test customization
     custom_conf = OmegaConf.structured(
-        DataLoaderConfig(batch_size=16, shuffle=True, num_workers=4)
+        TrainDataLoaderConfig(batch_size=16, shuffle=True, num_workers=4)
     )
     assert custom_conf.batch_size == 16
     assert custom_conf.shuffle is True
@@ -215,8 +224,8 @@ def test_trainer_config(caplog):
     # Test customization
     custom_conf = TrainerConfig(
         max_epochs=20,
-        train_data_loader=DataLoaderConfig(batch_size=32),
-        val_data_loader=DataLoaderConfig(batch_size=32),
+        train_data_loader=TrainDataLoaderConfig(batch_size=32),
+        val_data_loader=ValDataLoaderConfig(batch_size=32),
         optimizer=OptimizerConfig(lr=0.01),
         use_wandb=True,
     )

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -249,7 +249,13 @@ def test_bottomup_multiclass_dataset(minimal_instance, tmp_path):
     )
 
     confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
-    class_maps_head = DictConfig({"sigma": 4, "output_stride": 4, "classes": None})
+    class_maps_head = DictConfig(
+        {
+            "sigma": 4,
+            "output_stride": 4,
+            "classes": [x.name for x in tracked_labels.tracks],
+        }
+    )
 
     dataset = BottomUpMultiClassDataset(
         max_stride=32,
@@ -270,7 +276,6 @@ def test_bottomup_multiclass_dataset(minimal_instance, tmp_path):
         "num_instances",
         "class_maps",
         "labels_idx",
-        "track_ids",
         "num_tracks",
         "eff_scale",
     ]
@@ -686,13 +691,16 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
     )
 
     confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": None})
-    class_vectors_head = DictConfig({"classes": None})
+    class_vectors_head = DictConfig(
+        {"classes": [x.name for x in tracked_labels.tracks]}
+    )
 
     ## save imgs
     dataset = TopDownCenteredInstanceMultiClassDataset(
         max_stride=16,
         scale=1.0,
         confmap_head_config=confmap_head,
+        class_vectors_head_config=class_vectors_head,
         crop_size=crop_size,
         labels=[
             tracked_labels,
@@ -716,7 +724,6 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         "orig_size",
         "num_instances",
         "labels_idx",
-        "track_id",
         "class_vectors",
         "eff_scale",
     ]
@@ -736,6 +743,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=1.0,
         confmap_head_config=confmap_head,
+        class_vectors_head_config=class_vectors_head,
         crop_size=crop_size,
         labels=[tracked_labels],
         cache_img="memory",
@@ -803,6 +811,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         ensure_rgb=True,
         ensure_grayscale=False,
         confmap_head_config=confmap_head,
+        class_vectors_head_config=class_vectors_head,
         crop_size=100,
         labels=[tracked_labels],
         apply_aug=base_topdown_data_config.use_augmentations_train,
@@ -867,6 +876,7 @@ def test_centered_multiclass_dataset(minimal_instance, tmp_path):
         max_stride=16,
         scale=2.0,
         confmap_head_config=confmap_head,
+        class_vectors_head_config=class_vectors_head,
         crop_size=100,
         labels=[tracked_labels],
         apply_aug=base_topdown_data_config.use_augmentations_train,

--- a/tests/training/test_lightning_modules.py
+++ b/tests/training/test_lightning_modules.py
@@ -78,12 +78,12 @@ def test_topdown_centered_instance_model(
     input_cm = input_["confidence_maps"]
     preds = model(input_["instance_image"])
 
-    # check the output shape
-    assert preds.shape == (1, 2, 80, 80)
-
     # check the loss value
     loss = model.training_step(input_, 0)
-    assert abs(loss - mse_loss(preds, input_cm)) < 1e-3
+    assert abs(loss - mse_loss(preds, input_cm[0])) < 1e-3
+
+    # check the output shape
+    assert preds.shape == (1, 2, 80, 80)
 
     # convnext with pretrained weights
     OmegaConf.update(config, "model_config.backbone_config.unet", None)


### PR DESCRIPTION
This PR fixes a few minor issues with TopDown and BottomUp ID models. 
- The ID models dataset classes were re-computing the tracks from the labels file. However, they should just grab it from the head config `classes` parameter.
- Fix shape mismatch issue with BottomUp ID models