### PR TITLE
Add egocentric rotation support to centroid cropping inference

### DIFF
--- a/sleap_nn/data/instance_cropping.py
+++ b/sleap_nn/data/instance_cropping.py
@@ -5,8 +5,117 @@ import math
 import numpy as np
 import sleap_io as sio
 import torch
-from kornia.geometry.transform import crop_and_resize
+from kornia.geometry.transform import crop_and_resize, warp_affine
 
+def apply_egocentric_rotation(
+    image: torch.Tensor,
+    instance: torch.Tensor,
+    centroid: torch.Tensor,
+    orientation_anchor_inds: Union[int, List[int]],
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Apply egocentric rotation to align centroid->orientation_anchor vector with x-axis.
+
+    Args:
+        image: Input image. Shape: (1, C, H, W) - singleton batch dimension for kornia
+        instance: Input keypoints for a single instance. Shape: (n_nodes, 2)
+        centroid: Centroid point. Shape: (2,)
+        orientation_anchor_inds: Index or list of indices (in priority order) of nodes to use
+            for orientation alignment (e.g., head/snout). The function will try nodes in order
+            and use the first one that is not NaN. The vector from centroid to this point will
+            be aligned with the positive x-axis. If a single int is provided, it's treated as
+            a single-element list.
+
+    Returns:
+        Tuple of (rotated_image, rotated_instance, rotated_centroid, rotation_angle) all rotated
+        so that the centroid->orientation_anchor vector points along positive x-axis.
+        - rotated_image: Shape (1, C, H, W)
+        - rotated_instance: Shape (n_nodes, 2)
+        - rotated_centroid: Shape (2,) - same as input (centroid doesn't move)
+        - rotation_angle: Rotation angle applied in radians (torch.Tensor scalar)
+    """
+    # Convert single int to list for uniform handling
+    if isinstance(orientation_anchor_inds, int):
+        orientation_anchor_inds = [orientation_anchor_inds]
+    
+    # Try nodes in priority order, use first one that's not NaN
+    orientation_anchor = None
+    for anchor_ind in orientation_anchor_inds:
+        candidate_anchor = instance[anchor_ind, :]  # (2,)
+        # Check if this candidate is valid (not NaN)
+        if not torch.isnan(candidate_anchor).any():
+            orientation_anchor = candidate_anchor
+            break
+    
+    # If no valid orientation anchor found, no rotation needed
+    if orientation_anchor is None:
+        return image, instance, centroid, torch.tensor(0.0, dtype=image.dtype, device=image.device)
+
+    # Compute vector from centroid to orientation anchor
+    direction_vector = orientation_anchor - centroid  # (2,)
+
+    # Check if vector has zero length (shouldn't rotate in this case)
+    vector_length = torch.sqrt(direction_vector[0]**2 + direction_vector[1]**2)
+    if vector_length < 1e-6:
+        return image, instance, centroid, torch.tensor(0.0, dtype=image.dtype, device=image.device)
+    
+    # Compute angle to align with x-axis (positive x-axis = 0 degrees)
+    # atan2(y, x) gives angle from x-axis in radians
+    # In image coordinates: +x is right, +y is down
+    # We want to rotate so that direction_vector points along +x axis (to the right)
+    current_angle = torch.atan2(direction_vector[1], direction_vector[0])  # Current angle from +x axis
+    target_angle = torch.tensor(0.0, dtype=image.dtype, device=image.device)  # We want it to point along +x axis (to the right)
+    rotation_angle_rad = target_angle - current_angle  # Angle to rotate (counter-clockwise is positive)
+    rotation_angle_deg = torch.rad2deg(rotation_angle_rad)
+    
+    # Get image dimensions for rotation center
+    _, C, H, W = image.shape
+
+    # Rotate image around centroid using affine transformation
+    # To rotate around point (cx, cy), we need: translate -> rotate -> translate_back
+    # The affine matrix is: M = T_back @ R @ T_to_origin
+
+    cx, cy = centroid[0].item(), centroid[1].item()
+    cos_a = torch.cos(rotation_angle_rad).item()
+    sin_a = torch.sin(rotation_angle_rad).item()
+
+    # Create 2x3 affine transformation matrix
+    # For rotation around (cx, cy), the matrix is:
+    # [cos(θ)  -sin(θ)  -cx*cos(θ) + cy*sin(θ) + cx]
+    # [sin(θ)   cos(θ)  -cx*sin(θ) - cy*cos(θ) + cy]
+    affine_matrix = torch.tensor([
+        [cos_a, -sin_a, -cx * cos_a + cy * sin_a + cx],
+        [sin_a, cos_a, -cx * sin_a - cy * cos_a + cy]
+    ], dtype=image.dtype, device=image.device).unsqueeze(0)  # (1, 2, 3)
+
+    # Apply affine transformation
+    rotated_image = warp_affine(
+        image,
+        affine_matrix,
+        dsize=(H, W),
+        mode='bilinear',
+        padding_mode='zeros',
+        align_corners=False,
+    )
+    
+    # Create rotation matrix for keypoints: [cos(θ) -sin(θ); sin(θ) cos(θ)]
+    # This rotates counter-clockwise by rotation_angle_rad
+    # Reuse cos_a and sin_a computed above for consistency
+    rotation_matrix = torch.tensor(
+        [[cos_a, -sin_a],
+         [sin_a, cos_a]],
+        dtype=image.dtype,
+        device=image.device,
+    )
+    
+    # Rotate keypoints around centroid (centroid stays fixed)
+    instance_relative = instance - centroid  # (n_nodes, 2) - relative to centroid
+    rotated_instance_relative = torch.matmul(instance_relative, rotation_matrix.T)  # (n_nodes, 2)
+    rotated_instance = rotated_instance_relative + centroid  # (n_nodes, 2) - back to absolute coords
+    
+    # Centroid doesn't move (we rotated around it)
+    rotated_centroid = centroid
+
+    return rotated_image, rotated_instance, rotated_centroid, rotation_angle_rad
 
 def find_instance_crop_size(
     labels: sio.Labels,

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -130,6 +130,7 @@ class Predictor(ABC):
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
         anchor_part: Optional[str] = None,
+        orientation_anchor_parts: Optional[Union[str, List[str]]] = None,
     ) -> "Predictor":
         """Create the appropriate `Predictor` subclass from from the ckpt path.
 
@@ -162,6 +163,11 @@ class Predictor(ABC):
                 in the `data_config.preprocessing` section.
             anchor_part: (str) The name of the node to use as the anchor for the centroid. If not
                 provided, the anchor part in the `training_config.yaml` is used instead. Default: None.
+            orientation_anchor_parts: (str or List[str]) Node name(s) to use for egocentric alignment.
+                Can be a single node name or a list of node names in priority order. The function will
+                try nodes in order and use the first valid (non-NaN) node. If provided, images and
+                keypoints will be rotated so the vector from centroid to this node aligns with the
+                positive x-axis. If `None`, no egocentric rotation is applied. Default: None.
 
         Returns:
             A subclass of `Predictor`.
@@ -230,6 +236,7 @@ class Predictor(ABC):
                     device=device,
                     preprocess_config=preprocess_config,
                     anchor_part=anchor_part,
+                    orientation_anchor_parts=orientation_anchor_parts,
                 )
             if "centered_instance" in model_names:
                 confmap_ckpt_path = model_paths[model_names.index("centered_instance")]
@@ -248,6 +255,7 @@ class Predictor(ABC):
                     device=device,
                     preprocess_config=preprocess_config,
                     anchor_part=anchor_part,
+                    orientation_anchor_parts=orientation_anchor_parts,
                 )
             elif "multi_class_topdown" in model_names:
                 confmap_ckpt_path = model_paths[
@@ -268,6 +276,7 @@ class Predictor(ABC):
                     device=device,
                     preprocess_config=preprocess_config,
                     anchor_part=anchor_part,
+                    orientation_anchor_parts=orientation_anchor_parts,
                 )
 
         elif "bottomup" in model_names:
@@ -562,6 +571,11 @@ class TopDownPredictor(Predictor):
             if this is `None`.
         anchor_part: (str) The name of the node to use as the anchor for the centroid. If not
             provided, the anchor part in the `training_config.yaml` is used instead. Default: None.
+        orientation_anchor_parts: (str or List[str]) Node name(s) to use for egocentric alignment.
+            Can be a single node name or a list of node names in priority order. The function will
+            try nodes in order and use the first valid (non-NaN) node. If provided, images and
+            keypoints will be rotated so the vector from centroid to this node aligns with the
+            positive x-axis. If `None`, no egocentric rotation is applied. Default: None.
         max_stride: The maximum stride of the backbone network, as specified in the model's
             `backbone_config`. This determines the downsampling factor applied by the backbone,
             and is used to ensure that input images are padded or resized to be compatible
@@ -587,6 +601,7 @@ class TopDownPredictor(Predictor):
     preprocess_config: Optional[OmegaConf] = None
     tracker: Optional[Tracker] = None
     anchor_part: Optional[str] = None
+    orientation_anchor_parts: Optional[Union[str, List[str]]] = None
     max_stride: int = 16
 
     def _initialize_inference_model(self):
@@ -621,6 +636,19 @@ class TopDownPredictor(Predictor):
                 else None
             )
 
+        # Process orientation_anchor_parts to indices
+        orientation_anchor_inds = None
+        if self.orientation_anchor_parts is not None:
+            if isinstance(self.orientation_anchor_parts, str):
+                # Single node name
+                orientation_anchor_inds = [self.skeletons[0].node_names.index(self.orientation_anchor_parts)]
+            elif isinstance(self.orientation_anchor_parts, list):
+                # List of node names
+                orientation_anchor_inds = [
+                    self.skeletons[0].node_names.index(part)
+                    for part in self.orientation_anchor_parts
+                ]
+
         if self.centroid_config is None:
             centroid_crop_layer = CentroidCrop(
                 use_gt_centroids=True,
@@ -629,6 +657,7 @@ class TopDownPredictor(Predictor):
                     self.preprocess_config.crop_size,
                 ),
                 anchor_ind=anchor_ind,
+                orientation_anchor_inds=orientation_anchor_inds,
                 return_crops=return_crops,
             )
 
@@ -653,6 +682,8 @@ class TopDownPredictor(Predictor):
                     self.preprocess_config.crop_size,
                 ),
                 use_gt_centroids=False,
+                anchor_ind=anchor_ind,
+                orientation_anchor_inds=orientation_anchor_inds,
             )
 
         # Create an instance of FindInstancePeaks layer if confmap_config is not None
@@ -704,6 +735,7 @@ class TopDownPredictor(Predictor):
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
         anchor_part: Optional[str] = None,
+        orientation_anchor_parts: Optional[Union[str, List[str]]] = None,
     ) -> "TopDownPredictor":
         """Create predictor from saved models.
 
@@ -733,6 +765,11 @@ class TopDownPredictor(Predictor):
                 in the `data_config.preprocessing` section.
             anchor_part: (str) The name of the node to use as the anchor for the centroid. If not
                 provided, the anchor part in the `training_config.yaml` is used instead. Default: None.
+            orientation_anchor_parts: (str or List[str]) Node name(s) to use for egocentric alignment.
+                Can be a single node name or a list of node names in priority order. The function will
+                try nodes in order and use the first valid (non-NaN) node. If provided, images and
+                keypoints will be rotated so the vector from centroid to this node aligns with the
+                positive x-axis. If `None`, no egocentric rotation is applied. Default: None.
 
         Returns:
             An instance of `TopDownPredictor` with the loaded models.
@@ -1055,6 +1092,7 @@ class TopDownPredictor(Predictor):
             device=device,
             preprocess_config=preprocess_config,
             anchor_part=anchor_part,
+            orientation_anchor_parts=orientation_anchor_parts,
             max_stride=(
                 centroid_config.model_config.backbone_config[
                     f"{centroid_backbone_type}"
@@ -2607,6 +2645,7 @@ class TopDownMultiClassPredictor(Predictor):
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
     anchor_part: Optional[str] = None
+    orientation_anchor_parts: Optional[Union[str, List[str]]] = None
     max_stride: int = 16
 
     def _initialize_inference_model(self):
@@ -2641,6 +2680,19 @@ class TopDownMultiClassPredictor(Predictor):
                 else None
             )
 
+        # Process orientation_anchor_parts to indices
+        orientation_anchor_inds = None
+        if self.orientation_anchor_parts is not None:
+            if isinstance(self.orientation_anchor_parts, str):
+                # Single node name
+                orientation_anchor_inds = [self.skeletons[0].node_names.index(self.orientation_anchor_parts)]
+            elif isinstance(self.orientation_anchor_parts, list):
+                # List of node names
+                orientation_anchor_inds = [
+                    self.skeletons[0].node_names.index(part)
+                    for part in self.orientation_anchor_parts
+                ]
+
         if self.centroid_config is None:
             centroid_crop_layer = CentroidCrop(
                 use_gt_centroids=True,
@@ -2649,6 +2701,7 @@ class TopDownMultiClassPredictor(Predictor):
                     self.preprocess_config.crop_size,
                 ),
                 anchor_ind=anchor_ind,
+                orientation_anchor_inds=orientation_anchor_inds,
                 return_crops=return_crops,
             )
 
@@ -2673,6 +2726,8 @@ class TopDownMultiClassPredictor(Predictor):
                     self.preprocess_config.crop_size,
                 ),
                 use_gt_centroids=False,
+                anchor_ind=anchor_ind,
+                orientation_anchor_inds=orientation_anchor_inds,
             )
 
         max_stride = self.confmap_config.model_config.backbone_config[
@@ -2718,6 +2773,7 @@ class TopDownMultiClassPredictor(Predictor):
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
         anchor_part: Optional[str] = None,
+        orientation_anchor_parts: Optional[Union[str, List[str]]] = None,
         max_stride: int = 16,
     ) -> "TopDownPredictor":
         """Create predictor from saved models.
@@ -3094,6 +3150,7 @@ class TopDownMultiClassPredictor(Predictor):
             device=device,
             preprocess_config=preprocess_config,
             anchor_part=anchor_part,
+            orientation_anchor_parts=orientation_anchor_parts,
             max_stride=(
                 centroid_config.model_config.backbone_config[
                     f"{centroid_backbone_type}"

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -56,6 +56,7 @@ def run_inference(
     input_scale: Optional[float] = None,
     ensure_grayscale: Optional[bool] = None,
     anchor_part: Optional[str] = None,
+    orientation_anchor_parts: Optional[Union[str, List[str]]] = None,
     only_labeled_frames: bool = False,
     only_suggested_frames: bool = False,
     no_empty_frames: bool = False,
@@ -134,6 +135,11 @@ def run_inference(
                 values from the training config are used. Default: `None`.
         anchor_part: (str) The node name to use as the anchor for the centroid. If not
                 provided, the anchor part in the `training_config.yaml` is used. Default: `None`.
+        orientation_anchor_parts: (str or List[str]) Node name(s) to use for egocentric alignment.
+                Can be a single node name or a list of node names in priority order. The function will
+                try nodes in order and use the first valid (non-NaN) node. If provided, images and
+                keypoints will be rotated so the vector from centroid to this node aligns with the
+                positive x-axis. If `None`, no egocentric rotation is applied. Default: `None`.
         only_labeled_frames: (bool) `True` if inference should be run only on user-labeled frames. Default: `False`.
         only_suggested_frames: (bool) `True` if inference should be run only on unlabeled suggested frames. Default: `False`.
         no_empty_frames: (bool) `True` if empty frames that did not have predictions should be cleared before saving to output. Default: `False`.
@@ -378,6 +384,7 @@ def run_inference(
             device=device,
             preprocess_config=OmegaConf.create(preprocess_config),
             anchor_part=anchor_part,
+            orientation_anchor_parts=orientation_anchor_parts,
         )
 
         if (

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -96,6 +96,7 @@ class ModelTrainer:
     }
 
     trainer: Optional[L.Trainer] = None
+    orientation_anchor_parts: Optional[List[str]] = None
 
     @classmethod
     def get_model_trainer_from_config(
@@ -103,12 +104,14 @@ class ModelTrainer:
         config: DictConfig,
         train_labels: Optional[List[sio.Labels]] = None,
         val_labels: Optional[List[sio.Labels]] = None,
+        orientation_anchor_parts: Optional[List[str]] = None,
     ):
         """Create a model trainer instance from config."""
         # Verify config structure.
         config = verify_training_cfg(config)
 
         model_trainer = cls(config=config)
+        model_trainer.orientation_anchor_parts = orientation_anchor_parts
 
         model_trainer.model_type = get_model_type_from_cfg(model_trainer.config)
         model_trainer.backbone_type = get_backbone_type_from_cfg(model_trainer.config)
@@ -603,6 +606,7 @@ class ModelTrainer:
             val_labels=self.val_labels,
             config=data_viz_config,
             rank=-1,
+            orientation_anchor_inds=self.orientation_anchor_parts,
         )
 
     def _setup_datasets(self):
@@ -640,6 +644,7 @@ class ModelTrainer:
             val_labels=self.val_labels,
             config=self.config,
             rank=self.trainer.global_rank,
+            orientation_anchor_inds=self.orientation_anchor_parts,
         )
 
     def _setup_loggers_callbacks(self, viz_train_dataset, viz_val_dataset):


### PR DESCRIPTION
## Summary
Extends centroid cropping with optional orientation-based rotation during inference, similar to the egocentric rotation already available in the training pipeline.

## What's Different from Standard Centroid Cropping?
Standard centroid cropping extracts fixed-size crops around detected centroids without rotation. This branch adds **optional egocentric rotation** that aligns instances to a canonical orientation before cropping:

- Images and keypoints are rotated to align orientation anchor points along the positive x-axis
- Crops are extracted from the rotated images
- Predictions are inverse-rotated back to the original orientation
- Coordinates are correctly transformed from crop space to full image space

## Usage Example
```python
from omegaconf import OmegaConf
from sleap_nn.training.model_trainer import ModelTrainer

if __name__ == "__main__":

    config = OmegaConf.load("config.yaml")
    trainer = ModelTrainer.get_model_trainer_from_config(config, orientation_anchor_parts=["nose", "top of neck", "left ear", "right ear"])
    trainer.train()
```

## Key Changes
- Add `orientation_anchor_parts` parameter throughout inference pipeline
- Apply per-instance egocentric rotation in `CentroidCrop._generate_crops()`
- Store rotation angles and apply inverse rotation in `FindInstancePeaks.forward()`
- Fix coordinate transformation from crop to full image space

🤖 Generated with [Claude Code](https://claude.com/claude-code)