### PR TITLE
Mask wandb API key in initial_config.yaml

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -720,7 +720,10 @@ class ModelTrainer:
             loggers.append(wandb_logger)
 
             # save the configs as yaml in the checkpoint dir
+            # Mask API key in both configs to prevent saving to disk
             self.config.trainer_config.wandb.api_key = ""
+            if self._initial_config is not None:
+                self._initial_config.trainer_config.wandb.api_key = ""
 
         # zmq callbacks
         if self.config.trainer_config.zmq.controller_port is not None:

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -381,6 +381,12 @@ def test_model_trainer_centered_instance(caplog, config, tmp_path: str):
     assert training_config.data_config.skeletons
     assert training_config.data_config.preprocessing.crop_size == 104
 
+    # Verify API key is also masked in initial_config.yaml
+    initial_config = OmegaConf.load(
+        f"{model_trainer.config.trainer_config.ckpt_dir}/{model_trainer.config.trainer_config.run_name}/initial_config.yaml"
+    )
+    assert initial_config.trainer_config.wandb.api_key == ""
+
     checkpoint = torch.load(
         (
             Path(model_trainer.config.trainer_config.ckpt_dir)


### PR DESCRIPTION
## Summary
- Fixed security issue where wandb API key was being saved to `initial_config.yaml` in plain text
- Added API key masking for `_initial_config` alongside existing masking for `training_config.yaml`
- Added test to verify API key is properly masked in both config files

## Details
Previously, only `training_config.yaml` had the wandb API key masked (set to empty string) before saving to disk. However, `initial_config.yaml` retained the actual API key because:
- `_initial_config` is created at line 141 (before API key masking)
- API key masking happens at line 723 only for `self.config`
- `_initial_config` is saved at line 985-988 without masking

## Changes
- **model_trainer.py (line 725-726)**: Added API key masking for `_initial_config` 
- **test_model_trainer.py (line 384-388)**: Added assertion to verify API key is masked in `initial_config.yaml`

## Test plan
- [x] Test passes: `test_model_trainer_centered_instance` now verifies both config files have masked API keys
- [x] Linting passes
- [ ] CI/CD pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)