### PR TITLE
Append video name to output path when video_index is specified

### DIFF
--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -510,9 +510,15 @@ def run_inference(
             if video_index is not None and len(output.videos) > video_index:
                 video = output.videos[video_index]
                 # Get video filename and sanitize it for use in path
-                video_name = Path(video.filename).stem if isinstance(video.filename, str) else f"video_{video_index}"
+                video_name = (
+                    Path(video.filename).stem
+                    if isinstance(video.filename, str)
+                    else f"video_{video_index}"
+                )
                 # Insert video name before .predictions.slp extension
-                output_path = base_path.parent / f"{base_path.stem}.{video_name}.predictions.slp"
+                output_path = (
+                    base_path.parent / f"{base_path.stem}.{video_name}.predictions.slp"
+                )
             else:
                 output_path = base_path.with_suffix(".predictions.slp")
         output.save(Path(output_path).as_posix(), restore_original_videos=False)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1454,7 +1454,9 @@ def test_video_index_output_path(
     # The output file should contain the video name
     output_file = output_files[0]
     video_name = Path(labels.videos[0].filename).stem
-    assert video_name in output_file.stem, f"Video name '{video_name}' not found in output path '{output_file}'"
+    assert (
+        video_name in output_file.stem
+    ), f"Video name '{video_name}' not found in output path '{output_file}'"
 
     # Clean up
     for f in output_files:


### PR DESCRIPTION
## Summary
Fixes an issue where running inference with `video_index` on multiple videos from the same .slp file would overwrite the output file. The output path now includes the video name to create unique filenames for each video.

## Problem
When running predictions on a multi-video .slp file using the `video_index` parameter:
- All predictions would save to the same output path (e.g., `labels.predictions.slp`)
- Running inference on different videos would overwrite previous results
- Users had to manually specify unique `output_path` for each video

## Solution
When `video_index` is provided and `output_path` is None:
- Extract the video filename from `output.videos[video_index]`
- Append the video name (stem) to the output path
- Format: `<labels_file>.<video_name>.predictions.slp`
- Falls back to `video_{index}` if filename is not a simple string

## Example
**Before:**
```python
run_inference(data_path="labels.slp", video_index=0)  # → labels.predictions.slp
run_inference(data_path="labels.slp", video_index=1)  # → labels.predictions.slp (overwrites!)
```

**After:**
```python
run_inference(data_path="labels.slp", video_index=0)  # video1.mp4 → labels.video1.predictions.slp
run_inference(data_path="labels.slp", video_index=1)  # video2.mp4 → labels.video2.predictions.slp
```

## Changes
- Modified `run_inference()` in `sleap_nn/predict.py` to append video name when `video_index` is specified
- Added `test_video_index_output_path()` test to verify the behavior

## Testing
- New test verifies video name is included in output path when using video_index
- Existing tests continue to pass (no breaking changes)
- Behavior unchanged when video_index is None or output_path is explicitly provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>