### PR TITLE
Fix running inference on frames with empty instances

### DIFF
--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -71,6 +71,8 @@ def process_lf(
     for inst in instances_list:
         if not inst.is_empty:
             instances.append(inst.numpy())
+    if len(instances) == 0:
+        return None
     instances = np.stack(instances, axis=0)
 
     # Add singleton time dimension for single frames.
@@ -333,6 +335,8 @@ class LabelsReader(Thread):
                     for inst in lf:
                         if not inst.is_empty:
                             instances.append(inst.numpy())
+                    if len(instances) == 0:
+                        continue
                     instances = np.stack(instances, axis=0)
 
                     # Add singleton time dimension for single frames.


### PR DESCRIPTION
## Summary
- Skip frames with empty instances in `LabelsReader` to prevent `np.stack` error
- Return `None` from `process_lf` when all instances are empty

## Context
When running inference on labeled frames that contain only empty instances (no valid keypoints), `np.stack([])` raises an error. This fix gracefully handles these edge cases by skipping such frames in the prediction pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)