### PR TITLE
Fix wandb deprecation warning for get_url method

### DIFF
--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -610,7 +610,7 @@ class ProgressReporterZMQ(Callback):
             # Include WandB URL if available
             wandb_url = None
             if wandb.run is not None:
-                wandb_url = wandb.run.get_url()
+                wandb_url = wandb.run.url
             self.send("train_begin", wandb_url=wandb_url)
         trainer.strategy.barrier()
 


### PR DESCRIPTION
## Summary
- Replace deprecated `wandb.run.get_url()` with `wandb.run.url` property in `ZMQProgressCallback`

## Test plan
- [x] Existing tests should pass (no functional change)
- [ ] CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)