### PR TITLE
Move dev dependencies to PEP 735 dependency-groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Install dev dependencies and torch
-        run: uv sync --extra dev --extra torch-cpu
+        run: uv sync --extra torch-cpu
 
       - name: Run Black
         run: uv run black --check sleap_nn tests
@@ -69,11 +69,11 @@ jobs:
 
       - name: Install dev dependencies and torch (self-hosted GPU)
         if: matrix.os == 'self-hosted-gpu'
-        run: uv sync --python 3.13 --extra dev --extra torch-cuda128
+        run: uv sync --python 3.13 --extra torch-cuda128
 
       - name: Install dev dependencies and torch (non-self-hosted GPU)
         if: matrix.os != 'self-hosted-gpu'
-        run: uv sync --extra dev --extra torch-cpu
+        run: uv sync --extra torch-cpu
 
       - name: Print environment info
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra dev --extra torch-cpu --extra docs
+          uv sync --extra torch-cpu --group docs
 
       - name: Print environment info
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,24 +27,24 @@ Thank you for your interest in contributing to sleap-nn! This guide will help yo
      - **Windows/Linux with NVIDIA GPU (CUDA 11.8):**
 
       ```bash
-      uv sync --extra dev --extra torch-cuda118
+      uv sync --extra torch-cuda118
       ```
 
       - **Windows/Linux with NVIDIA GPU (CUDA 12.8):**
 
       ```bash
-      uv sync --extra dev --extra torch-cuda128
+      uv sync --extra torch-cuda128
       ```
      
      - **macOS with Apple Silicon (M1, M2, M3, M4) or CPU-only (no GPU or unsupported GPU):** 
      Note: Even if torch-cpu is used on macOS, the MPS backend will be available.
      ```bash
-      uv sync --extra dev --extra torch-cpu
+      uv sync --extra torch-cpu
       ```
 > **Upgrading All Dependencies**
 > To ensure you have the latest versions of all dependencies, use the `--upgrade` flag with `uv sync`:
 > ```bash
-> uv sync --extra dev --upgrade
+> uv sync --upgrade
 > ```
 > This will upgrade all installed packages in your environment to the latest available versions compatible with your `pyproject.toml`.
 
@@ -124,7 +124,7 @@ cd sleap-nn
 
 2. Install `sleap-nn` with docs dependencies:
    ```bash
-   uv sync --extra docs --extra dev --extra torch-cpu
+   uv sync --group docs --extra torch-cpu
    ```
 
 3. Build and tag a new documentation version:

--- a/README.md
+++ b/README.md
@@ -56,19 +56,19 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
    - **Windows/Linux with NVIDIA GPU (CUDA 11.8):**
 
    ```bash
-   uv sync --extra dev --extra torch-cuda118
+   uv sync --extra torch-cuda118
    ```
 
    - **Windows/Linux with NVIDIA GPU (CUDA 12.8):**
 
    ```bash
-   uv sync --extra dev --extra torch-cuda128
+   uv sync --extra torch-cuda128
    ```
    
    - **macOS with Apple Silicon (M1, M2, M3, M4) or CPU-only (no GPU or unsupported GPU):** 
    Note: Even if torch-cpu is used on macOS, the MPS backend will be available.
    ```bash
-   uv sync --extra dev --extra torch-cpu
+   uv sync --extra torch-cpu
    ```
 
 4. **Run tests**  
@@ -85,6 +85,6 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 > **Upgrading All Dependencies**
 > To ensure you have the latest versions of all dependencies, use the `--upgrade` flag with `uv sync`:
 > ```bash
-> uv sync --extra dev --upgrade
+> uv sync --upgrade
 > ```
 > This will upgrade all installed packages in your environment to the latest available versions compatible with your `pyproject.toml`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -376,17 +376,17 @@ cd sleap-nn
 
 === "Windows/Linux (CUDA 11.8)"
     ```bash
-    uv sync --extra dev --extra torch-cuda118
+    uv sync --extra torch-cuda118
     ```
 
 === "Windows/Linux (CUDA 12.8)"
     ```bash
-    uv sync --extra dev --extra torch-cuda128
+    uv sync --extra torch-cuda128
     ```
 
 === "macOS/CPU Only"
     ```bash
-    uv sync --extra dev --extra torch-cpu
+    uv sync --extra torch-cpu
     ```
 
 #### 4. Updating Dependencies
@@ -395,17 +395,17 @@ To update sleap-nn and its dependencies to their latest versions:
 
 === "Windows/Linux (CUDA 11.8)"
     ```bash
-    uv sync --extra dev --extra torch-cuda118 --upgrade
+    uv sync --extra torch-cuda118 --upgrade
     ```
 
 === "Windows/Linux (CUDA 12.8)"
     ```bash
-    uv sync --extra dev --extra torch-cuda128 --upgrade
+    uv sync --extra torch-cuda128 --upgrade
     ```
 
 === "macOS/CPU Only"
     ```bash
-    uv sync --extra dev --extra torch-cpu --upgrade
+    uv sync --extra torch-cpu --upgrade
     ```
 
 !!! tip "How --upgrade Works"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ torch-cuda128 = [
     "torch",
     "torchvision>=0.20.0,<0.24.0",
 ]
+
+[dependency-groups]
+# PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv sync`)
 dev = [
     "pytest",
     "pytest-cov",
@@ -77,7 +80,7 @@ dev = [
     "twine",
     "build",
     "ipython",
-    "ruff"
+    "ruff",
 ]
 docs = [
     "mkdocs",
@@ -87,7 +90,7 @@ docs = [
     "mkdocstrings[python]",
     "mkdocs-gen-files",
     "mkdocs-literate-nav",
-    "mkdocs-section-index"
+    "mkdocs-section-index",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Migrate `dev` and `docs` from `[project.optional-dependencies]` to `[dependency-groups]` per PEP 735
- `uv sync` now automatically installs the `dev` group, simplifying developer setup
- Updated all docs and CI workflows to remove `--extra dev` and use `--group docs`

## Test plan
- [ ] CI passes (lint + tests)
- [ ] Verify `uv sync --extra torch-cpu` installs dev dependencies automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)