### PR TITLE
Standardize model run folder file naming conventions

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -682,7 +682,11 @@ def load_metrics(model_path: str, split="val"):
     if Path(model_path).suffix == ".npz":
         metrics_path = Path(model_path)
     else:
-        metrics_path = Path(model_path) / f"{split}_0_pred_metrics.npz"
+        # Try new naming format first: metrics.{split}.0.npz
+        metrics_path = Path(model_path) / f"metrics.{split}.0.npz"
+        if not metrics_path.exists():
+            # Fall back to old naming format: {split}_0_pred_metrics.npz
+            metrics_path = Path(model_path) / f"{split}_0_pred_metrics.npz"
     if not metrics_path.exists():
         raise FileNotFoundError(f"Metrics file not found at {metrics_path}")
     with np.load(metrics_path, allow_pickle=True) as data:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -172,8 +172,12 @@ def test_train_method(minimal_instance, tmp_path: str):
         (Path(tmp_path) / "test_train_method").joinpath("training_config.yaml").exists()
     )
     assert (Path(tmp_path) / "test_train_method").joinpath("best.ckpt").exists()
-    assert (Path(tmp_path) / "test_train_method").joinpath("pred_val_0.slp").exists()
-    assert (Path(tmp_path) / "test_train_method").joinpath("pred_test.slp").exists()
+    assert (
+        (Path(tmp_path) / "test_train_method").joinpath("labels_pr.val.0.slp").exists()
+    )
+    assert (
+        (Path(tmp_path) / "test_train_method").joinpath("labels_pr.test.0.slp").exists()
+    )
 
     # with no val labels path
     train(
@@ -199,9 +203,15 @@ def test_train_method(minimal_instance, tmp_path: str):
     )
     assert (Path(tmp_path) / "test_train_method-1").joinpath("best.ckpt").exists()
     assert (
-        (Path(tmp_path) / "test_train_method-1").joinpath("pred_train_0.slp").exists()
+        (Path(tmp_path) / "test_train_method-1")
+        .joinpath("labels_pr.train.0.slp")
+        .exists()
     )
-    assert (Path(tmp_path) / "test_train_method-1").joinpath("pred_test.slp").exists()
+    assert (
+        (Path(tmp_path) / "test_train_method-1")
+        .joinpath("labels_pr.test.0.slp")
+        .exists()
+    )
 
     # convnext
     train(
@@ -222,8 +232,8 @@ def test_train_method(minimal_instance, tmp_path: str):
     assert folder_created
     assert (Path(tmp_path) / "test_convnext").joinpath("training_config.yaml").exists()
     assert (Path(tmp_path) / "test_convnext").joinpath("best.ckpt").exists()
-    assert (Path(tmp_path) / "test_convnext").joinpath("pred_val_0.slp").exists()
-    assert (Path(tmp_path) / "test_convnext").joinpath("pred_test.slp").exists()
+    assert (Path(tmp_path) / "test_convnext").joinpath("labels_pr.val.0.slp").exists()
+    assert (Path(tmp_path) / "test_convnext").joinpath("labels_pr.test.0.slp").exists()
 
     # swint
     train(
@@ -244,8 +254,8 @@ def test_train_method(minimal_instance, tmp_path: str):
     assert folder_created
     assert (Path(tmp_path) / "test_swint").joinpath("training_config.yaml").exists()
     assert (Path(tmp_path) / "test_swint").joinpath("best.ckpt").exists()
-    assert (Path(tmp_path) / "test_swint").joinpath("pred_val_0.slp").exists()
-    assert (Path(tmp_path) / "test_swint").joinpath("pred_test.slp").exists()
+    assert (Path(tmp_path) / "test_swint").joinpath("labels_pr.val.0.slp").exists()
+    assert (Path(tmp_path) / "test_swint").joinpath("labels_pr.test.0.slp").exists()
 
     # test for multiple slp files
     train(
@@ -266,13 +276,13 @@ def test_train_method(minimal_instance, tmp_path: str):
     assert folder_created
     assert (Path(tmp_path) / "test_swint-1").joinpath("training_config.yaml").exists()
     assert (Path(tmp_path) / "test_swint-1").joinpath("best.ckpt").exists()
-    assert (Path(tmp_path) / "test_swint-1").joinpath("pred_val_0.slp").exists()
-    assert (Path(tmp_path) / "test_swint-1").joinpath("pred_val_1.slp").exists()
-    assert (Path(tmp_path) / "test_swint-1").joinpath("pred_val_2.slp").exists()
-    assert (Path(tmp_path) / "test_swint-1").joinpath("pred_train_0.slp").exists()
-    assert (Path(tmp_path) / "test_swint-1").joinpath("pred_train_1.slp").exists()
-    assert (Path(tmp_path) / "test_swint-1").joinpath("pred_train_2.slp").exists()
-    assert (Path(tmp_path) / "test_swint-1").joinpath("pred_test.slp").exists()
+    assert (Path(tmp_path) / "test_swint-1").joinpath("labels_pr.val.0.slp").exists()
+    assert (Path(tmp_path) / "test_swint-1").joinpath("labels_pr.val.1.slp").exists()
+    assert (Path(tmp_path) / "test_swint-1").joinpath("labels_pr.val.2.slp").exists()
+    assert (Path(tmp_path) / "test_swint-1").joinpath("labels_pr.train.0.slp").exists()
+    assert (Path(tmp_path) / "test_swint-1").joinpath("labels_pr.train.1.slp").exists()
+    assert (Path(tmp_path) / "test_swint-1").joinpath("labels_pr.train.2.slp").exists()
+    assert (Path(tmp_path) / "test_swint-1").joinpath("labels_pr.test.0.slp").exists()
 
     # with augmentations
     with pytest.raises(ValueError):
@@ -649,12 +659,12 @@ def test_main(sample_cfg, minimal_instance):
     )
     assert (
         (Path(sample_cfg.trainer_config.ckpt_dir) / sample_cfg.trainer_config.run_name)
-        .joinpath("pred_train_0.slp")
+        .joinpath("labels_pr.train.0.slp")
         .exists()
     )
     assert (
         (Path(sample_cfg.trainer_config.ckpt_dir) / sample_cfg.trainer_config.run_name)
-        .joinpath("pred_val_0.slp")
+        .joinpath("labels_pr.val.0.slp")
         .exists()
     )
     assert (
@@ -662,7 +672,7 @@ def test_main(sample_cfg, minimal_instance):
             Path(sample_cfg.trainer_config.ckpt_dir)
             / sample_cfg.trainer_config.run_name
         )
-        .joinpath("pred_test.slp")
+        .joinpath("labels_pr.test.0.slp")
         .exists()
     )
 
@@ -680,6 +690,6 @@ def test_main(sample_cfg, minimal_instance):
         Path(
             f"{sample_cfg.trainer_config.ckpt_dir}/{sample_cfg.trainer_config.run_name}-1"
         )
-        .joinpath("pred_test.slp")
+        .joinpath("labels_pr.test.0.slp")
         .exists()
     )


### PR DESCRIPTION
## Summary

- Standardizes file naming in model run folders to use consistent `{type}.{split}.{idx}.{ext}` pattern
- Adds missing test ground truth saving (`labels_gt.test.{idx}.slp`)
- Fixes test metrics indexing bug (was `test_pred_metrics.npz`, now `metrics.test.0.npz`)
- Adds backwards compatibility to `load_metrics()` for loading old format metrics

## Changes

| Old Pattern | New Pattern |
|-------------|-------------|
| `labels_train_gt_0.slp` | `labels_gt.train.0.slp` |
| `labels_val_gt_0.slp` | `labels_gt.val.0.slp` |
| (missing) | `labels_gt.test.0.slp` |
| `pred_train_0.slp` | `labels_pr.train.0.slp` |
| `pred_val_0.slp` | `labels_pr.val.0.slp` |
| `pred_test.slp` | `labels_pr.test.0.slp` |
| `train_0_pred_metrics.npz` | `metrics.train.0.npz` |
| `val_0_pred_metrics.npz` | `metrics.val.0.npz` |
| `test_pred_metrics.npz` | `metrics.test.0.npz` |

## Test plan

- [ ] Run existing tests to verify new naming works
- [ ] Verify `load_metrics()` backwards compat with old model folders
- [ ] Test with multi-dataset training

🤖 Generated with [Claude Code](https://claude.com/claude-code)