### PR TITLE
Improve load_metrics with format compatibility and flexible paths

### DIFF
--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -49,3 +49,8 @@ logger.add(
 )
 
 __version__ = "0.1.0"
+
+# Public API
+from sleap_nn.evaluation import load_metrics
+
+__all__ = ["load_metrics", "__version__"]


### PR DESCRIPTION
## Summary

- Support both old format (individual keys at top level) and new format (single `metrics` key) for metrics NPZ files
- Add `dataset_idx` parameter for multi-dataset training scenarios
- Add automatic `test` → `val` fallback when test metrics not found
- Support both old (`{split}_{idx}_pred_metrics.npz`) and new (`metrics.{split}.{idx}.npz`) file naming conventions
- Expose `load_metrics` at top level via `sleap_nn.load_metrics`
- Expand test coverage for all new functionality

## Test plan

- [x] Existing tests pass
- [x] New tests cover old/new formats, dataset_idx, and fallback behavior
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)