### PR TITLE
Add: option to clean up wandb local logs after training

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -845,6 +845,7 @@ trainer_config:
     - `wandb_mode`: (str) "offline" if only local logging is required. **Default**: `"None"`
     - `prv_runid`: (str) Previous run ID if training should be resumed from a previous ckpt. **Default**: `None`
     - `group`: (str) Group name for the run.
+    - `delete_local_logs`: (bool, optional) If `True`, delete local wandb logs folder (`wandb/`) after training completes. If `False`, keep the folder. If `None` (default), automatically delete if logging online (`wandb_mode` != "offline") and keep if logging offline. This can save significant disk space since wandb local logs can be several GB. **Default**: `None`
 
 **Example WandB configurations:**
 
@@ -874,6 +875,18 @@ trainer_config:
     wandb_mode: "online"
     prv_runid: "abc123def456"
     group: "continued_experiments"
+```
+
+**Keep local wandb logs (override auto-delete):**
+```yaml
+trainer_config:
+  use_wandb: true
+  wandb:
+    entity: "your_username"
+    project: "sleap_nn_experiments"
+    name: "training_run"
+    wandb_mode: "online"
+    delete_local_logs: false  # Keep local logs even when syncing online
 ```
 
 **No WandB logging:**

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -677,6 +677,7 @@ def get_trainer_config(
     wandb_save_viz_imgs_wandb: bool = False,
     wandb_resume_prv_runid: Optional[str] = None,
     wandb_group_name: Optional[str] = None,
+    wandb_delete_local_logs: Optional[bool] = None,
     optimizer: str = "Adam",
     learning_rate: float = 1e-3,
     amsgrad: bool = False,
@@ -746,6 +747,9 @@ def get_trainer_config(
         wandb_resume_prv_runid: Previous run ID if training should be resumed from a previous
             ckpt. Default: None
         wandb_group_name: Group name for the wandb run. Default: None.
+        wandb_delete_local_logs: If True, delete local wandb logs folder after training.
+            If False, keep the folder. If None (default), automatically delete if logging
+            online (wandb_mode != "offline") and keep if logging offline. Default: None.
         optimizer: Optimizer to be used. One of ["Adam", "AdamW"]. Default: "Adam".
         learning_rate: Learning rate of type float. Default: 1e-3.
         amsgrad: Enable AMSGrad with the optimizer. Default: False.
@@ -846,6 +850,7 @@ def get_trainer_config(
             save_viz_imgs_wandb=wandb_save_viz_imgs_wandb,
             prv_runid=wandb_resume_prv_runid,
             group=wandb_group_name,
+            delete_local_logs=wandb_delete_local_logs,
         ),
         save_ckpt=save_ckpt,
         ckpt_dir=ckpt_dir,

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -90,6 +90,10 @@ class WandBConfig:
         viz_box_size: (float) Size of keypoint boxes in pixels (for viz_boxes). *Default*: `5.0`.
         viz_confmap_threshold: (float) Threshold for confidence map masks (for viz_masks). *Default*: `0.1`.
         log_viz_table: (bool) If True, also log images to a wandb.Table for backwards compatibility. *Default*: `False`.
+        delete_local_logs: (bool, optional) If True, delete local wandb logs folder after
+            training. If False, keep the folder. If None (default), automatically delete
+            if logging online (wandb_mode != "offline") and keep if logging offline.
+            *Default*: `None`.
     """
 
     entity: Optional[str] = None
@@ -107,6 +111,7 @@ class WandBConfig:
     viz_box_size: float = 5.0
     viz_confmap_threshold: float = 0.1
     log_viz_table: bool = False
+    delete_local_logs: Optional[bool] = None
 
 
 @define

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -175,6 +175,7 @@ def train(
     wandb_save_viz_imgs_wandb: bool = False,
     wandb_resume_prv_runid: Optional[str] = None,
     wandb_group_name: Optional[str] = None,
+    wandb_delete_local_logs: Optional[bool] = None,
     optimizer: str = "Adam",
     learning_rate: float = 1e-3,
     amsgrad: bool = False,
@@ -353,6 +354,9 @@ def train(
         wandb_resume_prv_runid: Previous run ID if training should be resumed from a previous
             ckpt. Default: None
         wandb_group_name: Group name for the wandb run. Default: None.
+        wandb_delete_local_logs: If True, delete local wandb logs folder after training.
+            If False, keep the folder. If None (default), automatically delete if logging
+            online (wandb_mode != "offline") and keep if logging offline. Default: None.
         optimizer: Optimizer to be used. One of ["Adam", "AdamW"]. Default: "Adam".
         learning_rate: Learning rate of type float. Default: 1e-3.
         amsgrad: Enable AMSGrad with the optimizer. Default: False.
@@ -456,6 +460,7 @@ def train(
         wandb_save_viz_imgs_wandb=wandb_save_viz_imgs_wandb,
         wandb_resume_prv_runid=wandb_resume_prv_runid,
         wandb_group_name=wandb_group_name,
+        wandb_delete_local_logs=wandb_delete_local_logs,
         optimizer=optimizer,
         learning_rate=learning_rate,
         amsgrad=amsgrad,

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -123,6 +123,52 @@ def test_wandb_config():
     assert custom_conf.project == "test_project"
 
 
+def test_wandb_config_delete_local_logs():
+    """Test delete_local_logs field in WandBConfig.
+
+    Verifies default value and auto-detection logic.
+    """
+    # Check default value is None
+    conf = OmegaConf.structured(WandBConfig)
+    assert conf.delete_local_logs is None
+
+    # Test explicit True
+    custom_conf = OmegaConf.structured(WandBConfig(delete_local_logs=True))
+    assert custom_conf.delete_local_logs is True
+
+    # Test explicit False
+    custom_conf = OmegaConf.structured(WandBConfig(delete_local_logs=False))
+    assert custom_conf.delete_local_logs is False
+
+    # Test auto-detection logic: online mode (wandb_mode=None) should delete
+    config = WandBConfig(wandb_mode=None)
+    should_delete = config.delete_local_logs is True or (
+        config.delete_local_logs is None and config.wandb_mode != "offline"
+    )
+    assert should_delete is True
+
+    # Test auto-detection logic: offline mode should keep
+    config = WandBConfig(wandb_mode="offline")
+    should_delete = config.delete_local_logs is True or (
+        config.delete_local_logs is None and config.wandb_mode != "offline"
+    )
+    assert should_delete is False
+
+    # Test explicit True overrides offline mode
+    config = WandBConfig(wandb_mode="offline", delete_local_logs=True)
+    should_delete = config.delete_local_logs is True or (
+        config.delete_local_logs is None and config.wandb_mode != "offline"
+    )
+    assert should_delete is True
+
+    # Test explicit False overrides online mode
+    config = WandBConfig(wandb_mode=None, delete_local_logs=False)
+    should_delete = config.delete_local_logs is True or (
+        config.delete_local_logs is None and config.wandb_mode != "offline"
+    )
+    assert should_delete is False
+
+
 def test_optimizer_config(caplog):
     """optimizer_config tests.
 


### PR DESCRIPTION
## Summary

- Add `delete_local_logs` option to `WandBConfig` that automatically deletes the local wandb logs folder after training completes
- This can save significant disk space since wandb local logs can be several GB
- Default behavior: auto-delete if logging online, keep if logging offline
- Prints informative messages during setup and cleanup with hints to disable

## Behavior

| `delete_local_logs` | `wandb_mode` | Result |
|---------------------|--------------|--------|
| `None` (default) | `None` (online) | Delete |
| `None` (default) | `"offline"` | Keep |
| `True` | any | Delete |
| `False` | any | Keep |

## Messages

**During setup:**
```
WandB local logs will be deleted after training completes. To keep logs, set trainer_config.wandb.delete_local_logs=false
```

**During cleanup:**
```
Deleting local wandb logs at {path}... (set trainer_config.wandb.delete_local_logs=false to disable)
```

## Test plan

- [x] Added `test_wandb_config_delete_local_logs()` test covering all config combinations
- [x] All existing tests pass
- [ ] Manual test with actual wandb training run

🤖 Generated with [Claude Code](https://claude.ai/code)