### PR TITLE
Bump version to 0.1.0a1

### DIFF
--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -50,7 +50,7 @@ logger.add(
     colorize=False,
 )
 
-__version__ = "0.1.0a0"
+__version__ = "0.1.0a1"
 
 # Public API
 from sleap_nn.evaluation import load_metrics


### PR DESCRIPTION
## Summary
- Bump version to 0.1.0a1 for next pre-release

## Test plan
- [ ] Verify version number in `sleap_nn/__init__.py`
- [ ] CI passes

---

Generated with [Claude Code](https://claude.com/claude-code)