### PR TITLE
Bump version to 0.1.0a3

### DIFF
--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -50,7 +50,7 @@ logger.add(
     colorize=False,
 )
 
-__version__ = "0.1.0a2"
+__version__ = "0.1.0a3"
 
 # Public API
 from sleap_nn.evaluation import load_metrics


### PR DESCRIPTION
## Summary
- Bump version from `0.1.0a2` to `0.1.0a3`

This prepares for the v0.1.0a3 pre-release.