### PR TITLE
Add prerelease alias to docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            uv run mike deploy --allow-empty --push "${{ github.event.release.tag_name }}"
+            uv run mike deploy --update-aliases --allow-empty --push "${{ github.event.release.tag_name }}" prerelease
 
       - name: Build and upload docs (dev)
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary

- Pre-release docs are now aliased to `prerelease` in addition to their versioned path
- Example: `v0.1.0a3` docs will be accessible at both `/v0.1.0a3/` and `/prerelease/`

## Changes

- `.github/workflows/docs.yml`: Add `--update-aliases` and `prerelease` alias to mike deploy command for pre-releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)