### PR TITLE
Fix skip connection channel mismatch in ConvNext/SwinT decoders

### DIFF
--- a/sleap_nn/architectures/convnext.py
+++ b/sleap_nn/architectures/convnext.py
@@ -281,6 +281,10 @@ class ConvNextWrapper(nn.Module):
             # Keep the block output filters the same
             x_in_shape = int(self.arch["channels"][-1] * filters_rate)
 
+        # Encoder channels for skip connections (reversed to match decoder order)
+        # The forward pass uses enc_output[::2][::-1] for skip features
+        encoder_channels = self.arch["channels"][::-1]
+
         self.dec = Decoder(
             x_in_shape=x_in_shape,
             current_stride=self.current_stride,
@@ -293,6 +297,7 @@ class ConvNextWrapper(nn.Module):
             block_contraction=self.block_contraction,
             output_stride=self.output_stride,
             up_interpolate=up_interpolate,
+            encoder_channels=encoder_channels,
         )
 
         if len(self.dec.decoder_stack):

--- a/sleap_nn/architectures/swint.py
+++ b/sleap_nn/architectures/swint.py
@@ -309,6 +309,13 @@ class SwinTWrapper(nn.Module):
             self.stem_patch_stride * (2**3) * 2
         )  # stem_stride * down_blocks_stride * final_max_pool_stride
 
+        # Encoder channels for skip connections (reversed to match decoder order)
+        # SwinT channels: embed * 2^i for each stage i, then reversed
+        num_stages = len(self.arch["depths"])
+        encoder_channels = [
+            self.arch["embed"] * (2 ** (num_stages - 1 - i)) for i in range(num_stages)
+        ]
+
         self.dec = Decoder(
             x_in_shape=block_filters,
             current_stride=self.current_stride,
@@ -321,6 +328,7 @@ class SwinTWrapper(nn.Module):
             block_contraction=self.block_contraction,
             output_stride=output_stride,
             up_interpolate=up_interpolate,
+            encoder_channels=encoder_channels,
         )
 
         if len(self.dec.decoder_stack):


### PR DESCRIPTION
## Summary

- Fixes skip connection channel mismatch that caused RuntimeError when training with ConvNext/SwinT backbones
- Adds `skip_channels` parameter to `SimpleUpsamplingBlock` for explicit skip channel specification
- Adds `encoder_channels` parameter to `Decoder` to pass actual encoder channel sizes
- Updates `ConvNextWrapper` and `SwinTWrapper` to provide encoder channels to decoder

## Problem

Training with ConvNext/SwinT failed during validation:

```
RuntimeError: Given groups=1, weight of size [324, 1476, 3, 3], expected input[4, 1920, 12, 12] to have 1476 channels, but got 1920 channels instead
```

The decoder incorrectly assumed skip connection channels match computed decoder filters (`refine_convs_filters`). For ConvNext tiny with `filters_rate=1.5`:
- Expected skip: 324 channels (96 × 1.5³)
- Actual encoder skip: 768 channels

## Test plan

- [x] ConvNextWrapper forward pass works with `output_stride=4`
- [x] SwinTWrapper forward pass works with `output_stride=4`
- [x] All 24 architecture tests pass
- [x] Code formatted with black and passes ruff

🤖 Generated with [Claude Code](https://claude.ai/code)