### PR TITLE
Fix multi-GPU DDP duplicate GPU detection error

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -1159,6 +1159,11 @@ class ModelTrainer:
                     : self.config.trainer_config.trainer_devices
                 ]
             ]
+            # Sort device indices in ascending order for NCCL compatibility.
+            # NCCL expects devices in consistent ascending order across ranks
+            # to properly set up communication rings. Without sorting, DDP may
+            # assign multiple ranks to the same GPU, causing "Duplicate GPU detected" errors.
+            devices.sort()
             logger.info(f"Using GPUs with most available memory: {devices}")
 
         # create lightning.Trainer instance.


### PR DESCRIPTION
## Summary

- Sort GPU device indices in ascending order after memory-based selection to ensure NCCL compatibility
- Fixes "Duplicate GPU detected" NCCL error when using multi-GPU DDP training with automatic GPU selection

## Problem

When `trainer_devices` is set to less than the available GPUs, the code selects GPUs with the most available memory using `np.argsort(get_gpu_memory())[::-1]`. This returns device indices in arbitrary order based on memory ranking (e.g., `[2, 1]` instead of `[1, 2]`).

NCCL expects device indices in consistent ascending order across all ranks to properly set up communication rings. When devices are in non-ascending order, NCCL's internal topology mapping gets confused and multiple ranks can end up on the same GPU, causing:

```
torch.distributed.DistBackendError: NCCL error in: /pytorch/torch/csrc/distributed/c10d/NCCLUtils.cpp:94, invalid usage
ncclInvalidUsage: This usually reflects invalid usage of NCCL library.
Last error:
Duplicate GPU detected : rank 0 and rank 1 both on CUDA device ca000
```

## Solution

Add `devices.sort()` after the memory-based GPU selection to ensure device indices are always in ascending order before passing to PyTorch Lightning's Trainer.

## Related Issues

This is a known issue pattern documented in:
- [PyTorch Lightning #8139](https://github.com/Lightning-AI/pytorch-lightning/issues/8139) - DDP with non-contiguous GPU indices
- [NVIDIA NCCL #1241](https://github.com/NVIDIA/nccl/issues/1241) - Duplicate GPU detected error

## Test plan

- [ ] Manually tested on 4x NVIDIA A40 system with `trainer_devices=2`
- [ ] No automated multi-GPU test (CI lacks multi-GPU environment)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)