### PR TITLE
Fix DDP synchronization in training callbacks

### DIFF
--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -1044,9 +1044,8 @@ class EpochEndEvaluationCallback(Callback):
 
         # Determine if we should run evaluation this epoch (only on rank 0)
         should_evaluate = (
-            (trainer.current_epoch + 1) % self.eval_frequency == 0
-            and trainer.is_global_zero
-        )
+            trainer.current_epoch + 1
+        ) % self.eval_frequency == 0 and trainer.is_global_zero
 
         if should_evaluate:
             # Check if we have predictions


### PR DESCRIPTION
## Summary

- Fix multiple callbacks that caused training to freeze/deadlock after each epoch when using multi-GPU DDP training (`trainer_devices > 1`)
- The issue was that some processes reached `trainer.strategy.barrier()` while others returned early, causing infinite waits

## Problem

When running multi-GPU DDP training, training would appear to freeze after each epoch. This was caused by DDP synchronization bugs in several callbacks where:

1. **Non-rank-0 processes** returned early without reaching the barrier
2. **Rank-0** returned early (e.g., when wandb logger was None) without reaching the barrier
3. **Missing barriers** in some callbacks entirely

This caused deadlocks because `trainer.strategy.barrier()` requires ALL ranks to reach the same point.

## Callbacks Fixed

| Callback | Issue | Fix |
|----------|-------|-----|
| `UnifiedVizCallback` | Early return for non-rank-0 skipped barrier | Changed to `if trainer.is_global_zero:` block pattern |
| `EpochEndEvaluationCallback` | No barrier at all, multiple early returns | Added barrier, restructured to avoid early returns |
| `WandBVizCallback` | Early return inside rank-0 check skipped barrier | Replaced early return with conditional block |
| `WandBVizCallbackWithPAFs` | Same as above | Same fix |

## Correct Pattern

The correct pattern (used by working callbacks like `CSVLoggerCallback`, `MatplotlibSaver`, `TrainingControllerZMQ`):

```python
def on_train_epoch_end(self, trainer, pl_module):
    if trainer.is_global_zero:
        # rank-0 only work (no early returns!)
        ...
    # ALL ranks ALWAYS reach this barrier
    trainer.strategy.barrier()
```

## Test plan

- [ ] Manually tested on 4x NVIDIA A40 system with `trainer_devices=2` and `log_viz=true`
- [ ] Verified epochs complete without freezing
- [ ] No automated multi-GPU test (CI lacks multi-GPU environment)

## Related

- Follows up on #436 which fixed the duplicate GPU detection error
- Investigation documented in `scratch/2026-01-23-multi-gpu-ddp-investigation/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)