### PR TITLE
Fix confusing weight loading logging for legacy models

### DIFF
--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -229,7 +229,9 @@ class LightningModel(L.LightningModule):
             elif self.pretrained_backbone_weights.endswith(".h5"):
                 # load from sleap model weights
                 load_legacy_model_weights(
-                    self.model.backbone, self.pretrained_backbone_weights
+                    self.model.backbone,
+                    self.pretrained_backbone_weights,
+                    component="backbone",
                 )
 
             else:
@@ -258,7 +260,9 @@ class LightningModel(L.LightningModule):
             elif self.pretrained_head_weights.endswith(".h5"):
                 # load from sleap model weights
                 load_legacy_model_weights(
-                    self.model.head_layers, self.pretrained_head_weights
+                    self.model.head_layers,
+                    self.pretrained_head_weights,
+                    component="head",
                 )
 
             else:


### PR DESCRIPTION
## Summary
- Fixes confusing logging when loading backbone/head weights separately from legacy `.h5` files
- Adds component-based filtering to only process relevant weights
- Warnings now only show for truly unexpected mismatches

## Problem
When loading legacy TensorFlow/Keras weights into separate PyTorch components (backbone vs head), users saw:
1. Confusing counts like "22/26 loaded" instead of "22/22"
2. Many warnings about "No matching PyTorch parameter" for weights that belong to the other component (expected behavior, not an error)

## Solution
Added a `component` parameter to filter legacy weights before mapping:
- `component="backbone"`: Only processes encoder/decoder weights (excludes "Head" layers)
- `component="head"`: Only processes head layer weights
- `component=None`: No filtering (default, for full model loading in inference)

## Changes

### `sleap_nn/legacy_models.py`
- Added `filter_legacy_weights_by_component()` helper function
- Added `component` parameter to `map_legacy_to_pytorch_layers()` and `load_legacy_model_weights()`
- Cleaned up unused imports

### `sleap_nn/training/lightning_modules.py`
- Updated backbone loading to pass `component="backbone"`
- Updated head loading to pass `component="head"`

## Result

**Before:**
```
Loading backbone weights from `model.h5` ...
No matching PyTorch parameter found for model_weights/CentroidConfmapsHead_0/...
No matching PyTorch parameter found for model_weights/OffsetRefinementHead_0/...
Successfully mapped 22/26 legacy weights to PyTorch parameters
```

**After:**
```
Loading backbone weights from `model.h5` ...
Filtered legacy weights for backbone: 22/26 weights
Successfully mapped 22/22 PyTorch parameters from legacy weights
```

## Test plan
- [x] Verified fix with test script showing correct logging output
- [x] All existing `test_legacy_models.py` tests pass (35 passed, 4 skipped, 3 xfailed)
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)