### PR TITLE
Fix self.log warnings when no logger is configured

### DIFF
--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -336,7 +336,6 @@ class LightningModel(L.LightningModule):
             prog_bar=False,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         # Log epoch explicitly for custom x-axis support in wandb
@@ -345,7 +344,6 @@ class LightningModel(L.LightningModule):
             float(self.current_epoch),
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         # Log epoch-averaged training loss
@@ -357,7 +355,6 @@ class LightningModel(L.LightningModule):
                 prog_bar=False,
                 on_step=False,
                 on_epoch=True,
-                logger=True,
                 sync_dist=True,
             )
         # Log current learning rate (useful for monitoring LR schedulers)
@@ -369,7 +366,6 @@ class LightningModel(L.LightningModule):
                 prog_bar=False,
                 on_step=False,
                 on_epoch=True,
-                logger=True,
                 sync_dist=True,
             )
 
@@ -389,7 +385,6 @@ class LightningModel(L.LightningModule):
             prog_bar=False,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         # Log epoch explicitly so val/* metrics can use it as x-axis in wandb
@@ -399,7 +394,6 @@ class LightningModel(L.LightningModule):
             float(self.current_epoch),
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -655,7 +649,6 @@ class SingleInstanceLightningModule(LightningModel):
                     prog_bar=False,
                     on_step=False,
                     on_epoch=True,
-                    logger=True,
                     sync_dist=True,
                 )
         # Log step-level loss (every batch, uses global_step x-axis)
@@ -665,7 +658,6 @@ class SingleInstanceLightningModule(LightningModel):
             prog_bar=True,
             on_step=True,
             on_epoch=False,
-            logger=True,
             sync_dist=True,
         )
         # Accumulate for epoch-averaged loss (logged in on_train_epoch_end)
@@ -698,7 +690,6 @@ class SingleInstanceLightningModule(LightningModel):
             prog_bar=True,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -921,7 +912,6 @@ class TopDownCenteredInstanceLightningModule(LightningModel):
                     prog_bar=False,
                     on_step=False,
                     on_epoch=True,
-                    logger=True,
                     sync_dist=True,
                 )
 
@@ -932,7 +922,6 @@ class TopDownCenteredInstanceLightningModule(LightningModel):
             prog_bar=True,
             on_step=True,
             on_epoch=False,
-            logger=True,
             sync_dist=True,
         )
         # Accumulate for epoch-averaged loss (logged in on_train_epoch_end)
@@ -965,7 +954,6 @@ class TopDownCenteredInstanceLightningModule(LightningModel):
             prog_bar=True,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -1181,7 +1169,6 @@ class CentroidLightningModule(LightningModel):
             prog_bar=True,
             on_step=True,
             on_epoch=False,
-            logger=True,
             sync_dist=True,
         )
         # Accumulate for epoch-averaged loss (logged in on_train_epoch_end)
@@ -1204,7 +1191,6 @@ class CentroidLightningModule(LightningModel):
             prog_bar=True,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -1482,7 +1468,6 @@ class BottomUpLightningModule(LightningModel):
             prog_bar=True,
             on_step=True,
             on_epoch=False,
-            logger=True,
             sync_dist=True,
         )
         # Accumulate for epoch-averaged loss (logged in on_train_epoch_end)
@@ -1492,7 +1477,6 @@ class BottomUpLightningModule(LightningModel):
             confmap_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -1500,7 +1484,6 @@ class BottomUpLightningModule(LightningModel):
             pafs_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         return loss
@@ -1551,7 +1534,6 @@ class BottomUpLightningModule(LightningModel):
             prog_bar=True,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -1559,7 +1541,6 @@ class BottomUpLightningModule(LightningModel):
             confmap_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -1567,7 +1548,6 @@ class BottomUpLightningModule(LightningModel):
             pafs_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -1827,7 +1807,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
             prog_bar=True,
             on_step=True,
             on_epoch=False,
-            logger=True,
             sync_dist=True,
         )
         # Accumulate for epoch-averaged loss (logged in on_train_epoch_end)
@@ -1837,7 +1816,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
             confmap_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -1845,7 +1823,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
             classmaps_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -1898,7 +1875,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
                     class_accuracy,
                     on_step=False,
                     on_epoch=True,
-                    logger=True,
                     sync_dist=True,
                 )
 
@@ -1941,7 +1917,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
             prog_bar=True,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -1949,7 +1924,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
             confmap_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -1957,7 +1931,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
             classmaps_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -2010,7 +1983,6 @@ class BottomUpMultiClassLightningModule(LightningModel):
                     class_accuracy,
                     on_step=False,
                     on_epoch=True,
-                    logger=True,
                     sync_dist=True,
                 )
 
@@ -2246,7 +2218,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
                     prog_bar=False,
                     on_step=False,
                     on_epoch=True,
-                    logger=True,
                     sync_dist=True,
                 )
 
@@ -2257,7 +2228,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             prog_bar=True,
             on_step=True,
             on_epoch=False,
-            logger=True,
             sync_dist=True,
         )
         # Accumulate for epoch-averaged loss (logged in on_train_epoch_end)
@@ -2267,7 +2237,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             confmap_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -2275,7 +2244,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             classvector_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -2289,7 +2257,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             class_accuracy,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         return loss
@@ -2329,7 +2296,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             prog_bar=True,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -2337,7 +2303,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             confmap_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
         self.log(
@@ -2345,7 +2310,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             classvector_loss,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 
@@ -2359,7 +2323,6 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
             class_accuracy,
             on_step=False,
             on_epoch=True,
-            logger=True,
             sync_dist=True,
         )
 


### PR DESCRIPTION
## Summary
- Remove explicit `logger=True` parameter from all `self.log()` calls in `lightning_modules.py`
- Fixes warnings that appear when training without wandb enabled:
  ```
  You called `self.log('train/loss', ..., logger=True)` but have no logger configured.
  ```

## Changes
The `logger` parameter in `self.log()` defaults to `None`, which auto-detects whether a logger is configured. By removing the explicit `logger=True`, metrics are still logged when a logger exists, but no warning is shown when one doesn't.

37 occurrences updated across all Lightning module classes.

## Test plan
- [x] Run training with `use_wandb=False` and verify no logger warnings appear
- [x] Run training with `use_wandb=True` and verify metrics still log to wandb

🤖 Generated with [Claude Code](https://claude.ai/code)