### PR TITLE
Add warmup learning rate schedulers

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -785,6 +785,24 @@ trainer_config:
     - `factor`: (float) Factor by which the learning rate will be reduced. new_lr = lr * factor. **Default**: `0.5`
     - `min_lr`: (float or List[float]) A scalar or a list of scalars. A lower bound on the learning rate of all param groups or each group respectively. **Default**: `1e-8`
 
+#### Cosine Annealing with Linear Warmup
+The learning rate increases linearly during warmup, then decreases following a cosine curve to the minimum value. This schedule is widely used in vision transformers and modern CNN architectures.
+
+- `lr_scheduler.cosine_annealing_warmup`:
+    - `warmup_epochs`: (int) Number of epochs for linear warmup phase. **Default**: `5`
+    - `max_epochs`: (int) Total number of training epochs. If `None`, uses `trainer_config.max_epochs`. **Default**: `None`
+    - `warmup_start_lr`: (float) Learning rate at start of warmup. **Default**: `0.0`
+    - `eta_min`: (float) Minimum learning rate at end of cosine decay. **Default**: `0.0`
+
+#### Linear Warmup + Linear Decay
+The learning rate increases linearly during warmup, then decreases linearly to the end learning rate. This schedule provides a simple, interpretable learning rate trajectory.
+
+- `lr_scheduler.linear_warmup_linear_decay`:
+    - `warmup_epochs`: (int) Number of epochs for linear warmup phase. **Default**: `5`
+    - `max_epochs`: (int) Total number of training epochs. If `None`, uses `trainer_config.max_epochs`. **Default**: `None`
+    - `warmup_start_lr`: (float) Learning rate at start of warmup. **Default**: `0.0`
+    - `end_lr`: (float) Learning rate at end of training. **Default**: `0.0`
+
 **Example Learning Rate Scheduler configurations:**
 
 **No scheduler (constant learning rate):**
@@ -793,6 +811,8 @@ trainer_config:
   lr_scheduler:
     step_lr: null
     reduce_lr_on_plateau: null
+    cosine_annealing_warmup: null
+    linear_warmup_linear_decay: null
 ```
 
 **Step LR Scheduler:**
@@ -803,6 +823,8 @@ trainer_config:
       step_size: 20
       gamma: 0.5
     reduce_lr_on_plateau: null
+    cosine_annealing_warmup: null
+    linear_warmup_linear_decay: null
 ```
 
 **Reduce LR on Plateau:**
@@ -817,6 +839,34 @@ trainer_config:
       patience: 5
       factor: 0.5
       min_lr: 1e-8
+    cosine_annealing_warmup: null
+    linear_warmup_linear_decay: null
+```
+
+**Cosine Annealing with Linear Warmup:**
+```yaml
+trainer_config:
+  lr_scheduler:
+    step_lr: null
+    reduce_lr_on_plateau: null
+    cosine_annealing_warmup:
+      warmup_epochs: 5
+      warmup_start_lr: 0.0
+      eta_min: 1e-6
+    linear_warmup_linear_decay: null
+```
+
+**Linear Warmup + Linear Decay:**
+```yaml
+trainer_config:
+  lr_scheduler:
+    step_lr: null
+    reduce_lr_on_plateau: null
+    cosine_annealing_warmup: null
+    linear_warmup_linear_decay:
+      warmup_epochs: 5
+      warmup_start_lr: 0.0
+      end_lr: 1e-6
 ```
 
 ### Early Stopping

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -179,18 +179,68 @@ class ReduceLROnPlateauConfig:
 
 
 @define
+class CosineAnnealingWarmupConfig:
+    """Configuration for Cosine Annealing with Linear Warmup scheduler.
+
+    The learning rate increases linearly during warmup, then decreases following
+    a cosine curve to the minimum value.
+
+    Attributes:
+        warmup_epochs: (int) Number of epochs for linear warmup phase. *Default*: `5`.
+        max_epochs: (int) Total number of training epochs. Will be overridden by
+            trainer's max_epochs if not specified. *Default*: `None`.
+        warmup_start_lr: (float) Learning rate at start of warmup. *Default*: `0.0`.
+        eta_min: (float) Minimum learning rate at end of cosine decay. *Default*: `0.0`.
+    """
+
+    warmup_epochs: int = field(default=5, validator=validators.ge(0))
+    max_epochs: Optional[int] = None
+    warmup_start_lr: float = field(default=0.0, validator=validators.ge(0))
+    eta_min: float = field(default=0.0, validator=validators.ge(0))
+
+
+@define
+class LinearWarmupLinearDecayConfig:
+    """Configuration for Linear Warmup + Linear Decay scheduler.
+
+    The learning rate increases linearly during warmup, then decreases linearly
+    to the end learning rate.
+
+    Attributes:
+        warmup_epochs: (int) Number of epochs for linear warmup phase. *Default*: `5`.
+        max_epochs: (int) Total number of training epochs. Will be overridden by
+            trainer's max_epochs if not specified. *Default*: `None`.
+        warmup_start_lr: (float) Learning rate at start of warmup. *Default*: `0.0`.
+        end_lr: (float) Learning rate at end of training. *Default*: `0.0`.
+    """
+
+    warmup_epochs: int = field(default=5, validator=validators.ge(0))
+    max_epochs: Optional[int] = None
+    warmup_start_lr: float = field(default=0.0, validator=validators.ge(0))
+    end_lr: float = field(default=0.0, validator=validators.ge(0))
+
+
+@define
 class LRSchedulerConfig:
     """Configuration for lr_scheduler.
+
+    Only one scheduler should be configured at a time. If multiple are set,
+    priority order is: cosine_annealing_warmup > linear_warmup_linear_decay >
+    step_lr > reduce_lr_on_plateau.
 
     Attributes:
         step_lr: Configuration for StepLR scheduler.
         reduce_lr_on_plateau: Configuration for ReduceLROnPlateau scheduler.
+        cosine_annealing_warmup: Configuration for Cosine Annealing with Linear Warmup scheduler.
+        linear_warmup_linear_decay: Configuration for Linear Warmup + Linear Decay scheduler.
     """
 
     step_lr: Optional[StepLRConfig] = None
     reduce_lr_on_plateau: Optional[ReduceLROnPlateauConfig] = field(
         factory=ReduceLROnPlateauConfig
     )
+    cosine_annealing_warmup: Optional[CosineAnnealingWarmupConfig] = None
+    linear_warmup_linear_decay: Optional[LinearWarmupLinearDecayConfig] = None
 
 
 @define

--- a/sleap_nn/training/schedulers.py
+++ b/sleap_nn/training/schedulers.py
@@ -1,0 +1,191 @@
+"""Custom learning rate schedulers for sleap-nn training.
+
+This module provides learning rate schedulers with warmup phases that are commonly
+used in deep learning for pose estimation and computer vision tasks.
+"""
+
+import math
+from torch.optim.lr_scheduler import LRScheduler
+
+
+class LinearWarmupCosineAnnealingLR(LRScheduler):
+    """Cosine annealing learning rate scheduler with linear warmup.
+
+    The learning rate increases linearly from `warmup_start_lr` to the optimizer's
+    base learning rate over `warmup_epochs`, then decreases following a cosine
+    curve to `eta_min` over the remaining epochs.
+
+    This schedule is widely used in vision transformers and modern CNN architectures
+    as it provides stable early training (warmup) and smooth convergence (cosine decay).
+
+    Args:
+        optimizer: Wrapped optimizer.
+        warmup_epochs: Number of epochs for the linear warmup phase.
+        max_epochs: Total number of training epochs.
+        warmup_start_lr: Learning rate at the start of warmup. Default: 0.0.
+        eta_min: Minimum learning rate at the end of the schedule. Default: 0.0.
+        last_epoch: The index of the last epoch. Default: -1.
+
+    Example:
+        >>> optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        >>> scheduler = LinearWarmupCosineAnnealingLR(
+        ...     optimizer, warmup_epochs=5, max_epochs=100, eta_min=1e-6
+        ... )
+        >>> for epoch in range(100):
+        ...     train(...)
+        ...     scheduler.step()
+    """
+
+    def __init__(
+        self,
+        optimizer,
+        warmup_epochs: int,
+        max_epochs: int,
+        warmup_start_lr: float = 0.0,
+        eta_min: float = 0.0,
+        last_epoch: int = -1,
+    ):
+        """Initialize the scheduler.
+
+        Args:
+            optimizer: Wrapped optimizer.
+            warmup_epochs: Number of epochs for the linear warmup phase.
+            max_epochs: Total number of training epochs.
+            warmup_start_lr: Learning rate at the start of warmup. Default: 0.0.
+            eta_min: Minimum learning rate at the end of the schedule. Default: 0.0.
+            last_epoch: The index of the last epoch. Default: -1.
+        """
+        if warmup_epochs < 0:
+            raise ValueError(f"warmup_epochs must be >= 0, got {warmup_epochs}")
+        if max_epochs <= 0:
+            raise ValueError(f"max_epochs must be > 0, got {max_epochs}")
+        if warmup_epochs >= max_epochs:
+            raise ValueError(
+                f"warmup_epochs ({warmup_epochs}) must be < max_epochs ({max_epochs})"
+            )
+        if warmup_start_lr < 0:
+            raise ValueError(f"warmup_start_lr must be >= 0, got {warmup_start_lr}")
+        if eta_min < 0:
+            raise ValueError(f"eta_min must be >= 0, got {eta_min}")
+
+        self.warmup_epochs = warmup_epochs
+        self.max_epochs = max_epochs
+        self.warmup_start_lr = warmup_start_lr
+        self.eta_min = eta_min
+        super().__init__(optimizer, last_epoch)
+
+    def get_lr(self):
+        """Compute the learning rate at the current epoch."""
+        if self.last_epoch < self.warmup_epochs:
+            # Linear warmup phase
+            if self.warmup_epochs == 0:
+                return list(self.base_lrs)
+            alpha = self.last_epoch / self.warmup_epochs
+            return [
+                self.warmup_start_lr + alpha * (base_lr - self.warmup_start_lr)
+                for base_lr in self.base_lrs
+            ]
+        else:
+            # Cosine annealing phase
+            decay_epochs = self.max_epochs - self.warmup_epochs
+            if decay_epochs == 0:
+                return [self.eta_min for _ in self.base_lrs]
+            progress = (self.last_epoch - self.warmup_epochs) / decay_epochs
+            # Clamp progress to [0, 1] to handle epochs beyond max_epochs
+            progress = min(1.0, progress)
+            return [
+                self.eta_min
+                + (base_lr - self.eta_min) * (1 + math.cos(math.pi * progress)) / 2
+                for base_lr in self.base_lrs
+            ]
+
+
+class LinearWarmupLinearDecayLR(LRScheduler):
+    """Linear warmup followed by linear decay learning rate scheduler.
+
+    The learning rate increases linearly from `warmup_start_lr` to the optimizer's
+    base learning rate over `warmup_epochs`, then decreases linearly to `end_lr`
+    over the remaining epochs.
+
+    This schedule provides a simple, interpretable learning rate trajectory and is
+    commonly used in transformer-based models and NLP tasks.
+
+    Args:
+        optimizer: Wrapped optimizer.
+        warmup_epochs: Number of epochs for the linear warmup phase.
+        max_epochs: Total number of training epochs.
+        warmup_start_lr: Learning rate at the start of warmup. Default: 0.0.
+        end_lr: Learning rate at the end of training. Default: 0.0.
+        last_epoch: The index of the last epoch. Default: -1.
+
+    Example:
+        >>> optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        >>> scheduler = LinearWarmupLinearDecayLR(
+        ...     optimizer, warmup_epochs=5, max_epochs=100, end_lr=1e-6
+        ... )
+        >>> for epoch in range(100):
+        ...     train(...)
+        ...     scheduler.step()
+    """
+
+    def __init__(
+        self,
+        optimizer,
+        warmup_epochs: int,
+        max_epochs: int,
+        warmup_start_lr: float = 0.0,
+        end_lr: float = 0.0,
+        last_epoch: int = -1,
+    ):
+        """Initialize the scheduler.
+
+        Args:
+            optimizer: Wrapped optimizer.
+            warmup_epochs: Number of epochs for the linear warmup phase.
+            max_epochs: Total number of training epochs.
+            warmup_start_lr: Learning rate at the start of warmup. Default: 0.0.
+            end_lr: Learning rate at the end of training. Default: 0.0.
+            last_epoch: The index of the last epoch. Default: -1.
+        """
+        if warmup_epochs < 0:
+            raise ValueError(f"warmup_epochs must be >= 0, got {warmup_epochs}")
+        if max_epochs <= 0:
+            raise ValueError(f"max_epochs must be > 0, got {max_epochs}")
+        if warmup_epochs >= max_epochs:
+            raise ValueError(
+                f"warmup_epochs ({warmup_epochs}) must be < max_epochs ({max_epochs})"
+            )
+        if warmup_start_lr < 0:
+            raise ValueError(f"warmup_start_lr must be >= 0, got {warmup_start_lr}")
+        if end_lr < 0:
+            raise ValueError(f"end_lr must be >= 0, got {end_lr}")
+
+        self.warmup_epochs = warmup_epochs
+        self.max_epochs = max_epochs
+        self.warmup_start_lr = warmup_start_lr
+        self.end_lr = end_lr
+        super().__init__(optimizer, last_epoch)
+
+    def get_lr(self):
+        """Compute the learning rate at the current epoch."""
+        if self.last_epoch < self.warmup_epochs:
+            # Linear warmup phase
+            if self.warmup_epochs == 0:
+                return list(self.base_lrs)
+            alpha = self.last_epoch / self.warmup_epochs
+            return [
+                self.warmup_start_lr + alpha * (base_lr - self.warmup_start_lr)
+                for base_lr in self.base_lrs
+            ]
+        else:
+            # Linear decay phase
+            decay_epochs = self.max_epochs - self.warmup_epochs
+            if decay_epochs == 0:
+                return [self.end_lr for _ in self.base_lrs]
+            progress = (self.last_epoch - self.warmup_epochs) / decay_epochs
+            # Clamp progress to [0, 1] to handle epochs beyond max_epochs
+            progress = min(1.0, progress)
+            return [
+                base_lr + progress * (self.end_lr - base_lr)
+                for base_lr in self.base_lrs
+            ]

--- a/tests/training/test_schedulers.py
+++ b/tests/training/test_schedulers.py
@@ -1,0 +1,353 @@
+"""Tests for custom learning rate schedulers."""
+
+import math
+
+import pytest
+import torch
+from torch import nn
+
+from sleap_nn.training.schedulers import (
+    LinearWarmupCosineAnnealingLR,
+    LinearWarmupLinearDecayLR,
+)
+
+
+@pytest.fixture
+def simple_model():
+    """Create a simple model for testing."""
+    return nn.Linear(10, 1)
+
+
+@pytest.fixture
+def optimizer(simple_model):
+    """Create an optimizer for testing."""
+    return torch.optim.Adam(simple_model.parameters(), lr=1e-3)
+
+
+class TestLinearWarmupCosineAnnealingLR:
+    """Tests for LinearWarmupCosineAnnealingLR scheduler."""
+
+    def test_warmup_phase(self, optimizer):
+        """Test that learning rate increases linearly during warmup."""
+        scheduler = LinearWarmupCosineAnnealingLR(
+            optimizer,
+            warmup_epochs=5,
+            max_epochs=100,
+            warmup_start_lr=0.0,
+            eta_min=1e-6,
+        )
+
+        lrs = []
+        for epoch in range(5):
+            lrs.append(scheduler.get_last_lr()[0])
+            scheduler.step()
+
+        # LR should increase linearly from 0 to 1e-3 over 5 epochs
+        expected_lrs = [0.0, 0.2e-3, 0.4e-3, 0.6e-3, 0.8e-3]
+        for actual, expected in zip(lrs, expected_lrs):
+            assert abs(actual - expected) < 1e-9
+
+    def test_cosine_phase(self, optimizer):
+        """Test that learning rate follows cosine curve after warmup."""
+        scheduler = LinearWarmupCosineAnnealingLR(
+            optimizer,
+            warmup_epochs=5,
+            max_epochs=15,
+            warmup_start_lr=0.0,
+            eta_min=0.0,
+        )
+
+        # Skip warmup phase
+        for _ in range(5):
+            scheduler.step()
+
+        # Get LR at start of cosine phase (should be base_lr)
+        lr_at_warmup_end = scheduler.get_last_lr()[0]
+        assert abs(lr_at_warmup_end - 1e-3) < 1e-9
+
+        # Step through cosine phase
+        for _ in range(10):
+            scheduler.step()
+
+        # At end, LR should be eta_min (0.0)
+        lr_at_end = scheduler.get_last_lr()[0]
+        assert abs(lr_at_end - 0.0) < 1e-9
+
+    def test_cosine_midpoint(self, optimizer):
+        """Test LR at midpoint of cosine phase is half of base_lr."""
+        scheduler = LinearWarmupCosineAnnealingLR(
+            optimizer,
+            warmup_epochs=0,
+            max_epochs=100,
+            warmup_start_lr=0.0,
+            eta_min=0.0,
+        )
+
+        # Step to midpoint
+        for _ in range(50):
+            scheduler.step()
+
+        # At midpoint of cosine, LR should be base_lr / 2
+        lr_at_midpoint = scheduler.get_last_lr()[0]
+        assert abs(lr_at_midpoint - 0.5e-3) < 1e-9
+
+    def test_eta_min(self, optimizer):
+        """Test that LR doesn't go below eta_min."""
+        eta_min = 1e-5
+        scheduler = LinearWarmupCosineAnnealingLR(
+            optimizer,
+            warmup_epochs=5,
+            max_epochs=20,
+            warmup_start_lr=0.0,
+            eta_min=eta_min,
+        )
+
+        # Step through all epochs
+        for _ in range(25):  # Go past max_epochs
+            scheduler.step()
+
+        lr = scheduler.get_last_lr()[0]
+        assert lr >= eta_min - 1e-10
+
+    def test_validation_errors(self, optimizer):
+        """Test that invalid parameters raise errors."""
+        with pytest.raises(ValueError, match="warmup_epochs must be >= 0"):
+            LinearWarmupCosineAnnealingLR(optimizer, warmup_epochs=-1, max_epochs=100)
+
+        with pytest.raises(ValueError, match="max_epochs must be > 0"):
+            LinearWarmupCosineAnnealingLR(optimizer, warmup_epochs=5, max_epochs=0)
+
+        with pytest.raises(ValueError, match="warmup_epochs.*must be < max_epochs"):
+            LinearWarmupCosineAnnealingLR(optimizer, warmup_epochs=100, max_epochs=50)
+
+        with pytest.raises(ValueError, match="warmup_start_lr must be >= 0"):
+            LinearWarmupCosineAnnealingLR(
+                optimizer, warmup_epochs=5, max_epochs=100, warmup_start_lr=-0.1
+            )
+
+        with pytest.raises(ValueError, match="eta_min must be >= 0"):
+            LinearWarmupCosineAnnealingLR(
+                optimizer, warmup_epochs=5, max_epochs=100, eta_min=-0.1
+            )
+
+    def test_no_warmup(self, optimizer):
+        """Test scheduler with zero warmup epochs."""
+        scheduler = LinearWarmupCosineAnnealingLR(
+            optimizer,
+            warmup_epochs=0,
+            max_epochs=10,
+            warmup_start_lr=0.0,
+            eta_min=0.0,
+        )
+
+        # First LR should be base_lr (no warmup)
+        lr = scheduler.get_last_lr()[0]
+        assert abs(lr - 1e-3) < 1e-9
+
+
+class TestLinearWarmupLinearDecayLR:
+    """Tests for LinearWarmupLinearDecayLR scheduler."""
+
+    def test_warmup_phase(self, optimizer):
+        """Test that learning rate increases linearly during warmup."""
+        scheduler = LinearWarmupLinearDecayLR(
+            optimizer,
+            warmup_epochs=5,
+            max_epochs=100,
+            warmup_start_lr=0.0,
+            end_lr=1e-6,
+        )
+
+        lrs = []
+        for epoch in range(5):
+            lrs.append(scheduler.get_last_lr()[0])
+            scheduler.step()
+
+        # LR should increase linearly from 0 to 1e-3 over 5 epochs
+        expected_lrs = [0.0, 0.2e-3, 0.4e-3, 0.6e-3, 0.8e-3]
+        for actual, expected in zip(lrs, expected_lrs):
+            assert abs(actual - expected) < 1e-9
+
+    def test_decay_phase(self, optimizer):
+        """Test that learning rate decreases linearly after warmup."""
+        scheduler = LinearWarmupLinearDecayLR(
+            optimizer,
+            warmup_epochs=0,
+            max_epochs=10,
+            warmup_start_lr=0.0,
+            end_lr=0.0,
+        )
+
+        lrs = []
+        for _ in range(11):
+            lrs.append(scheduler.get_last_lr()[0])
+            scheduler.step()
+
+        # LR should decrease linearly from 1e-3 to 0 over 10 epochs
+        for i, lr in enumerate(lrs[:11]):
+            expected = 1e-3 * (1 - i / 10)
+            assert abs(lr - expected) < 1e-9
+
+    def test_end_lr(self, optimizer):
+        """Test that LR reaches end_lr at max_epochs."""
+        end_lr = 1e-5
+        scheduler = LinearWarmupLinearDecayLR(
+            optimizer,
+            warmup_epochs=5,
+            max_epochs=20,
+            warmup_start_lr=0.0,
+            end_lr=end_lr,
+        )
+
+        # Step to max_epochs
+        for _ in range(20):
+            scheduler.step()
+
+        lr = scheduler.get_last_lr()[0]
+        assert abs(lr - end_lr) < 1e-9
+
+    def test_midpoint_decay(self, optimizer):
+        """Test LR at midpoint of decay phase."""
+        scheduler = LinearWarmupLinearDecayLR(
+            optimizer,
+            warmup_epochs=0,
+            max_epochs=100,
+            warmup_start_lr=0.0,
+            end_lr=0.0,
+        )
+
+        # Step to midpoint
+        for _ in range(50):
+            scheduler.step()
+
+        # At midpoint of linear decay, LR should be base_lr / 2
+        lr = scheduler.get_last_lr()[0]
+        assert abs(lr - 0.5e-3) < 1e-9
+
+    def test_validation_errors(self, optimizer):
+        """Test that invalid parameters raise errors."""
+        with pytest.raises(ValueError, match="warmup_epochs must be >= 0"):
+            LinearWarmupLinearDecayLR(optimizer, warmup_epochs=-1, max_epochs=100)
+
+        with pytest.raises(ValueError, match="max_epochs must be > 0"):
+            LinearWarmupLinearDecayLR(optimizer, warmup_epochs=5, max_epochs=0)
+
+        with pytest.raises(ValueError, match="warmup_epochs.*must be < max_epochs"):
+            LinearWarmupLinearDecayLR(optimizer, warmup_epochs=100, max_epochs=50)
+
+        with pytest.raises(ValueError, match="warmup_start_lr must be >= 0"):
+            LinearWarmupLinearDecayLR(
+                optimizer, warmup_epochs=5, max_epochs=100, warmup_start_lr=-0.1
+            )
+
+        with pytest.raises(ValueError, match="end_lr must be >= 0"):
+            LinearWarmupLinearDecayLR(
+                optimizer, warmup_epochs=5, max_epochs=100, end_lr=-0.1
+            )
+
+    def test_no_warmup(self, optimizer):
+        """Test scheduler with zero warmup epochs."""
+        scheduler = LinearWarmupLinearDecayLR(
+            optimizer,
+            warmup_epochs=0,
+            max_epochs=10,
+            warmup_start_lr=0.0,
+            end_lr=0.0,
+        )
+
+        # First LR should be base_lr (no warmup)
+        lr = scheduler.get_last_lr()[0]
+        assert abs(lr - 1e-3) < 1e-9
+
+    def test_multiple_param_groups(self):
+        """Test scheduler works with multiple parameter groups."""
+        model = nn.Sequential(nn.Linear(10, 5), nn.Linear(5, 1))
+        optimizer = torch.optim.Adam(
+            [
+                {"params": model[0].parameters(), "lr": 1e-3},
+                {"params": model[1].parameters(), "lr": 1e-4},
+            ]
+        )
+
+        scheduler = LinearWarmupLinearDecayLR(
+            optimizer,
+            warmup_epochs=5,
+            max_epochs=100,
+            warmup_start_lr=0.0,
+            end_lr=0.0,
+        )
+
+        lrs = scheduler.get_last_lr()
+        assert len(lrs) == 2
+        assert abs(lrs[0] - 0.0) < 1e-9  # warmup_start_lr for group 1
+        assert abs(lrs[1] - 0.0) < 1e-9  # warmup_start_lr for group 2
+
+        # After warmup
+        for _ in range(5):
+            scheduler.step()
+
+        lrs = scheduler.get_last_lr()
+        assert abs(lrs[0] - 1e-3) < 1e-9  # base_lr for group 1
+        assert abs(lrs[1] - 1e-4) < 1e-9  # base_lr for group 2
+
+
+class TestSchedulerIntegration:
+    """Integration tests for schedulers with training loop."""
+
+    def test_cosine_full_training_loop(self, simple_model, optimizer):
+        """Test cosine scheduler through a full training loop."""
+        scheduler = LinearWarmupCosineAnnealingLR(
+            optimizer,
+            warmup_epochs=2,
+            max_epochs=10,
+            warmup_start_lr=0.0,
+            eta_min=1e-6,
+        )
+
+        lrs = []
+        for epoch in range(10):
+            # Simulate training step
+            x = torch.randn(4, 10)
+            y = simple_model(x)
+            loss = y.sum()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+            lrs.append(optimizer.param_groups[0]["lr"])
+            scheduler.step()
+
+        # Verify LR trajectory
+        assert lrs[0] < lrs[1]  # Warmup: increasing
+        assert lrs[1] < lrs[2]  # Warmup: increasing
+        assert lrs[2] > lrs[5]  # Cosine: decreasing
+        assert lrs[5] > lrs[9]  # Cosine: decreasing
+
+    def test_linear_full_training_loop(self, simple_model, optimizer):
+        """Test linear scheduler through a full training loop."""
+        scheduler = LinearWarmupLinearDecayLR(
+            optimizer,
+            warmup_epochs=2,
+            max_epochs=10,
+            warmup_start_lr=0.0,
+            end_lr=1e-6,
+        )
+
+        lrs = []
+        for epoch in range(10):
+            # Simulate training step
+            x = torch.randn(4, 10)
+            y = simple_model(x)
+            loss = y.sum()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+            lrs.append(optimizer.param_groups[0]["lr"])
+            scheduler.step()
+
+        # Verify LR trajectory
+        assert lrs[0] < lrs[1]  # Warmup: increasing
+        assert lrs[1] < lrs[2]  # Warmup: increasing
+        assert lrs[2] > lrs[5]  # Decay: decreasing
+        assert lrs[5] > lrs[9]  # Decay: decreasing


### PR DESCRIPTION
## Summary

- Add two new learning rate schedulers with warmup phases for more stable training
- **LinearWarmupCosineAnnealingLR**: Linear warmup followed by cosine annealing decay
- **LinearWarmupLinearDecayLR**: Linear warmup followed by linear decay
- Add configuration classes and update `configure_optimizers()` in Lightning modules
- Update documentation with new scheduler options and examples

## New Schedulers

### Cosine Annealing with Linear Warmup
The learning rate increases linearly during warmup, then decreases following a cosine curve. Widely used in vision transformers and modern CNN architectures.

```yaml
lr_scheduler:
  cosine_annealing_warmup:
    warmup_epochs: 5
    warmup_start_lr: 0.0
    eta_min: 1e-6
```

### Linear Warmup + Linear Decay
The learning rate increases linearly during warmup, then decreases linearly to the end learning rate. Simple and interpretable schedule.

```yaml
lr_scheduler:
  linear_warmup_linear_decay:
    warmup_epochs: 5
    warmup_start_lr: 0.0
    end_lr: 1e-6
```

## Test plan
- [x] Unit tests for both scheduler classes (warmup phase, decay phase, edge cases)
- [x] Validation error tests for invalid parameters
- [x] Integration tests with training loop simulation
- [x] Multiple parameter group support tested
- [x] All 15 new tests passing
- [ ] Manual testing with actual training run

🤖 Generated with [Claude Code](https://claude.com/claude-code)