### PR TITLE
Enable default augmentations with rotation and scale

### DIFF
--- a/docs/configuration/data.md
+++ b/docs/configuration/data.md
@@ -138,13 +138,13 @@ augmentation_config:
     translate_width: 0.0
     translate_height: 0.0
 
-    # Combined probability
-    affine_p: 1.0
+    # Combined probability (used when individual *_p values are null)
+    affine_p: 0.0
 
-    # Or independent probabilities
-    rotation_p: null  # Overrides affine_p for rotation
-    scale_p: null     # Overrides affine_p for scale
-    translate_p: null # Overrides affine_p for translation
+    # Independent probabilities (override affine_p when set)
+    rotation_p: 1.0   # Always apply rotation by default
+    scale_p: 1.0      # Always apply scaling by default
+    translate_p: null # Uses affine_p if null
 
     # Random erase
     erase_p: 0.0
@@ -168,7 +168,15 @@ data_config:
   use_augmentations_train: false
 ```
 
-### Geometric Only
+### Geometric Only (using defaults)
+
+```yaml
+data_config:
+  use_augmentations_train: true
+  # Default augmentation_config applies rotation ±15° and scale 0.9-1.1 with p=1.0
+```
+
+### Geometric Only (explicit)
 
 ```yaml
 data_config:
@@ -176,11 +184,12 @@ data_config:
   augmentation_config:
     intensity: null
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
-      scale_min: 0.9
-      scale_max: 1.1
-      affine_p: 0.5
+      rotation_min: -30.0
+      rotation_max: 30.0
+      rotation_p: 0.5        # 50% chance of rotation
+      scale_min: 0.8
+      scale_max: 1.2
+      scale_p: 0.5           # 50% chance of scaling
 ```
 
 ### Full Augmentation
@@ -261,10 +270,10 @@ data_config:
 |--------|------|---------|-------------|
 | `rotation_min` | float | `-15.0` | Minimum rotation angle in degrees |
 | `rotation_max` | float | `15.0` | Maximum rotation angle in degrees |
-| `rotation_p` | float | `null` | Probability of rotation (independent). If `null`, uses `affine_p` |
+| `rotation_p` | float | `1.0` | Probability of rotation (independent). If `null`, uses `affine_p` |
 | `scale_min` | float | `0.9` | Minimum scale factor |
 | `scale_max` | float | `1.1` | Maximum scale factor |
-| `scale_p` | float | `null` | Probability of scaling (independent). If `null`, uses `affine_p` |
+| `scale_p` | float | `1.0` | Probability of scaling (independent). If `null`, uses `affine_p` |
 | `translate_width` | float | `0.0` | Maximum horizontal translation as fraction of width |
 | `translate_height` | float | `0.0` | Maximum vertical translation as fraction of height |
 | `translate_p` | float | `null` | Probability of translation (independent). If `null`, uses `affine_p` |

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -109,10 +109,10 @@ class GeometricConfig:
     Attributes:
         rotation_min: (float) Minimum rotation angle in degrees. A random angle in (rotation_min, rotation_max) will be sampled and applied to both images and keypoints. Set to 0 to disable rotation augmentation. *Default*: `-15.0`.
         rotation_max: (float) Maximum rotation angle in degrees. A random angle in (rotation_min, rotation_max) will be sampled and applied to both images and keypoints. Set to 0 to disable rotation augmentation. *Default*: `15.0`.
-        rotation_p: (float, optional) Probability of applying random rotation independently. If set, rotation is applied separately from scale/translate. If `None`, falls back to `affine_p` for bundled behavior. *Default*: `None`.
+        rotation_p: (float, optional) Probability of applying random rotation independently. If set, rotation is applied separately from scale/translate. If `None`, falls back to `affine_p` for bundled behavior. *Default*: `1.0`.
         scale_min: (float) Minimum scaling factor. If scale_min and scale_max are provided, the scale is randomly sampled from the range scale_min <= scale <= scale_max for isotropic scaling. *Default*: `0.9`.
         scale_max: (float) Maximum scaling factor. If scale_min and scale_max are provided, the scale is randomly sampled from the range scale_min <= scale <= scale_max for isotropic scaling. *Default*: `1.1`.
-        scale_p: (float, optional) Probability of applying random scaling independently. If set, scaling is applied separately from rotation/translate. If `None`, falls back to `affine_p` for bundled behavior. *Default*: `None`.
+        scale_p: (float, optional) Probability of applying random scaling independently. If set, scaling is applied separately from rotation/translate. If `None`, falls back to `affine_p` for bundled behavior. *Default*: `1.0`.
         translate_width: (float) Maximum absolute fraction for horizontal translation. For example, if translate_width=a, then horizontal shift is randomly sampled in the range -img_width * a < dx < img_width * a. Will not translate by default. *Default*: `0.0`.
         translate_height: (float) Maximum absolute fraction for vertical translation. For example, if translate_height=a, then vertical shift is randomly sampled in the range -img_height * a < dy < img_height * a. Will not translate by default. *Default*: `0.0`.
         translate_p: (float, optional) Probability of applying random translation independently. If set, translation is applied separately from rotation/scale. If `None`, falls back to `affine_p` for bundled behavior. *Default*: `None`.
@@ -129,10 +129,10 @@ class GeometricConfig:
 
     rotation_min: float = field(default=-15.0, validator=validators.ge(-180))
     rotation_max: float = field(default=15.0, validator=validators.le(180))
-    rotation_p: Optional[float] = field(default=None)
+    rotation_p: Optional[float] = field(default=1.0)
     scale_min: float = field(default=0.9, validator=validators.ge(0))
     scale_max: float = field(default=1.1, validator=validators.ge(0))
-    scale_p: Optional[float] = field(default=None)
+    scale_p: Optional[float] = field(default=1.0)
     translate_width: float = 0.0
     translate_height: float = 0.0
     translate_p: Optional[float] = field(default=None)
@@ -223,7 +223,9 @@ class DataConfig:
     cache_workers: int = 0
     preprocessing: PreprocessingConfig = field(factory=PreprocessingConfig)
     use_augmentations_train: bool = True
-    augmentation_config: Optional[AugmentationConfig] = None
+    augmentation_config: Optional[AugmentationConfig] = field(
+        factory=lambda: AugmentationConfig(geometric=GeometricConfig())
+    )
     skeletons: Optional[list] = None
 
 


### PR DESCRIPTION
## Summary
- Set `rotation_p` and `scale_p` defaults to `1.0` in `GeometricConfig` (previously `None`)
- Set `augmentation_config` default to include `GeometricConfig` in `DataConfig` (previously `None`)
- By default, training now applies rotation (±15°) and scale (0.9-1.1) augmentations with probability 1.0

## Test plan
- [x] Run `pytest tests/config/test_data_config.py` - all 15 tests pass
- [ ] Verify existing training workflows still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)