### PR TITLE
Update default augmentation settings in train API

### DIFF
--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -463,9 +463,9 @@ def get_data_config(
     crop_size: Optional[int] = None,
     min_crop_size: Optional[int] = 100,
     crop_padding: Optional[int] = None,
-    use_augmentations_train: bool = False,
+    use_augmentations_train: bool = True,
     intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
-    geometry_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+    geometry_aug: Optional[Union[str, List[str], Dict[str, Any]]] = "rotation",
 ):
     """Train a pose-estimation model with SLEAP-NN framework.
 
@@ -517,7 +517,7 @@ def get_data_config(
             crop size. If `None`, padding is auto-computed based on augmentation settings.
             Only used when `crop_size` is `None`. Default: None.
         use_augmentations_train: True if the data augmentation should be applied to the
-            training data, else False. Default: False.
+            training data, else False. Default: True.
         intensity_aug: One of ["uniform_noise", "gaussian_noise", "contrast", "brightness"]
             or list of strings from the above allowed values. To have custom values, pass
             a dict with the structure in `sleap_nn.config.data_config.IntensityConfig`.
@@ -529,7 +529,8 @@ def get_data_config(
             or list of strings from the above allowed values. To have custom values, pass
             a dict with the structure in `sleap_nn.config.data_config.GeometryConfig`.
             For eg: {
-                        "rotation": 45,
+                        "rotation_min": -45,
+                        "rotation_max": 45,
                         "affine_p": 1.0
                     }
     """

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -203,9 +203,9 @@ def train(
     crop_size: Optional[int] = None,
     min_crop_size: Optional[int] = 100,
     crop_padding: Optional[int] = None,
-    use_augmentations_train: bool = False,
+    use_augmentations_train: bool = True,
     intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
-    geometry_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+    geometry_aug: Optional[Union[str, List[str], Dict[str, Any]]] = "rotation",
     init_weight: str = "default",
     pretrained_backbone_weights: Optional[str] = None,
     pretrained_head_weights: Optional[str] = None,
@@ -306,7 +306,7 @@ def train(
             crop size. If `None`, padding is auto-computed based on augmentation settings.
             Only used when `crop_size` is `None`. Default: None.
         use_augmentations_train: True if the data augmentation should be applied to the
-            training data, else False. Default: False.
+            training data, else False. Default: True.
         intensity_aug: One of ["uniform_noise", "gaussian_noise", "contrast", "brightness"]
             or list of strings from the above allowed values. To have custom values, pass
             a dict with the structure in `sleap_nn.config.data_config.IntensityConfig`.
@@ -318,7 +318,8 @@ def train(
             or list of strings from the above allowed values. To have custom values, pass
             a dict with the structure in `sleap_nn.config.data_config.GeometryConfig`.
             For eg: {
-                        "rotation": 45,
+                        "rotation_min": -45,
+                        "rotation_max": 45,
                         "affine_p": 1.0
                     }
         init_weight: model weights initialization method. "default" uses kaiming uniform


### PR DESCRIPTION
## Summary
- Set `use_augmentations_train` default to `True` (was `False`)
- Set `geometry_aug` default to `"rotation"` (was `None`)
- Update docstrings to reflect new defaults
- Fix `geometry_aug` docstring example to use `rotation_min`/`rotation_max`

This aligns the `train()` and `get_data_config()` function defaults with the updated `DataConfig` defaults from #445.

## Test plan
- [ ] Verify training works with new defaults
- [ ] Verify augmentation is applied by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)