### PR TITLE
Add centroid-specific evaluation callback with distance-based metrics

### DIFF
--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -267,12 +267,15 @@ class EvalConfig:
         frequency: (int) Evaluate every N epochs. *Default*: `1`.
         oks_stddev: (float) OKS standard deviation for evaluation. *Default*: `0.025`.
         oks_scale: (float) OKS scale override. If None, uses default. *Default*: `None`.
+        match_threshold: (float) Maximum distance in pixels for centroid matching.
+            Only used for centroid model evaluation. *Default*: `50.0`.
     """
 
     enabled: bool = False
     frequency: int = field(default=1, validator=validators.ge(1))
     oks_stddev: float = field(default=0.025, validator=validators.gt(0))
     oks_scale: Optional[float] = None
+    match_threshold: float = field(default=50.0, validator=validators.gt(0))
 
 
 @define

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -1240,6 +1240,9 @@ class CentroidLightningModule(LightningModel):
 
         # Collect predictions for epoch-end evaluation if enabled
         if self._collect_val_predictions:
+            # Save GT centroids before inference (inference overwrites batch["centroids"])
+            batch["gt_centroids"] = batch["centroids"].clone()
+
             with torch.no_grad():
                 inference_output = self.centroid_inf_layer(batch)
 
@@ -1255,8 +1258,9 @@ class CentroidLightningModule(LightningModel):
                 pred_vals = inference_output["centroid_vals"][i].cpu().numpy()
 
                 # Transform GT centroids from preprocessed to original image space
+                # Use "gt_centroids" since inference overwrites "centroids" with predictions
                 gt_centroids_prep = (
-                    batch["centroids"][i].cpu().numpy()
+                    batch["gt_centroids"][i].cpu().numpy()
                 )  # (n_samples=1, max_inst, 2)
                 gt_centroids_orig = gt_centroids_prep.squeeze(0) / eff  # (max_inst, 2)
                 num_inst = batch["num_instances"][i].item()

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -56,6 +56,7 @@ from sleap_nn.training.callbacks import (
     CSVLoggerCallback,
     SleapProgressBar,
     EpochEndEvaluationCallback,
+    CentroidEvaluationCallback,
     UnifiedVizCallback,
 )
 from sleap_nn import RANK
@@ -1069,15 +1070,26 @@ class ModelTrainer:
 
         # Add epoch-end evaluation callback if enabled
         if self.config.trainer_config.eval.enabled:
-            callbacks.append(
-                EpochEndEvaluationCallback(
-                    skeleton=self.skeletons[0],
-                    videos=self.val_labels[0].videos,
-                    eval_frequency=self.config.trainer_config.eval.frequency,
-                    oks_stddev=self.config.trainer_config.eval.oks_stddev,
-                    oks_scale=self.config.trainer_config.eval.oks_scale,
+            if self.model_type == "centroid":
+                # Use centroid-specific evaluation with distance-based metrics
+                callbacks.append(
+                    CentroidEvaluationCallback(
+                        videos=self.val_labels[0].videos,
+                        eval_frequency=self.config.trainer_config.eval.frequency,
+                        match_threshold=self.config.trainer_config.eval.match_threshold,
+                    )
                 )
-            )
+            else:
+                # Use standard OKS/PCK evaluation for pose models
+                callbacks.append(
+                    EpochEndEvaluationCallback(
+                        skeleton=self.skeletons[0],
+                        videos=self.val_labels[0].videos,
+                        eval_frequency=self.config.trainer_config.eval.frequency,
+                        oks_stddev=self.config.trainer_config.eval.oks_stddev,
+                        oks_scale=self.config.trainer_config.eval.oks_scale,
+                    )
+                )
 
         return loggers, callbacks
 


### PR DESCRIPTION
## Summary

- Fixes epoch-end evaluation for centroid models which was failing with shape mismatch error (`could not broadcast input array from shape (13,) into shape (1,)`)
- Adds `CentroidEvaluationCallback` with distance-based metrics appropriate for point detection tasks
- Uses Hungarian algorithm for optimal prediction-to-GT matching

## Changes

- Add `match_centroids()` function using scipy's `linear_sum_assignment`
- Add `CentroidEvaluationCallback` class for centroid-specific evaluation
- Update `ModelTrainer` to route centroid models to new callback
- Add `match_threshold` config field to `EvalConfig` (default: 50px)
- Fix GT centroid overwrite bug in `validation_step` (clone before inference)
- Add 25 new tests for matching and callback functionality

## Metrics Logged

```python
# Distance metrics (WandB)
"eval/val/centroid_dist_avg"      # Mean Euclidean distance (pixels)
"eval/val/centroid_dist_median"   # Median distance
"eval/val/centroid_dist_p90"      # 90th percentile
"eval/val/centroid_dist_p95"      # 95th percentile
"eval/val/centroid_dist_max"      # Maximum distance

# Detection metrics
"eval/val/centroid_precision"     # TP / (TP + FP)
"eval/val/centroid_recall"        # TP / (TP + FN)
"eval/val/centroid_f1"            # F1 score
```

## Test plan

- [x] All 25 new unit tests pass
- [x] Tested locally with real centroid training (precision=0.9967, recall=1.0, dist_avg=3.32px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)