### PR TITLE
Fix docs issues and add installation instructions

### DIFF
--- a/docs/getting-started/first-model.md
+++ b/docs/getting-started/first-model.md
@@ -171,7 +171,7 @@ Once training completes, run on `val.pkg.slp` (or a video):
 ```bash
 sleap-nn track \
     --data_path val.pkg.slp \
-    --model_paths models/fly_single_instance/
+    --model_paths models/fly_single_instance/ \
     -o predictions.slp
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,9 +4,18 @@ Train a model and run inference in under 5 minutes.
 
 ---
 
+## Installation
+
+```bash
+uv tool install sleap-nn[torch] --torch-backend auto
+```
+
+See [full installation guide](../installation.md) for other methods and troubleshooting.
+
+---
+
 ## Prerequisites
 
-- [SLEAP-NN installed](../installation.md)
 - A training dataset (`.slp` or `.pkg.slp` file)
 
 !!! tip "Sample Data"

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -20,7 +20,7 @@ sleap-nn eval \
 | `-g` / `--ground_truth_path` | Ground truth labels file | Required |
 | `-p` / `--predicted_path` | Predicted labels file | Required |
 | `-s` / `--save_metrics` | Save metrics to .npz file | None |
-| `--oks_stddev` | OKS standard deviation | `0.025` |
+| `--oks_stddev` | OKS standard deviation | `0.05` |
 | `--user_labels_only` | Only evaluate user-labeled frames | `False` |
 
 ---

--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -18,13 +18,33 @@ Export models for high-performance production inference.
 
 ## Installation
 
-```bash
-# ONNX export
-pip install sleap-nn[export]
+Export requires additional dependencies. Install them with your preferred method:
 
-# TensorRT export (NVIDIA GPUs)
-pip install sleap-nn[export-gpu,tensorrt]
-```
+=== "uv (recommended)"
+
+    ```bash
+    # ONNX export (CPU)
+    uv tool install "sleap-nn[torch,export]" --torch-backend auto
+
+    # ONNX export (GPU runtime)
+    uv tool install "sleap-nn[torch,export-gpu]" --torch-backend auto
+
+    # TensorRT export (Linux/Windows with NVIDIA GPU)
+    uv tool install "sleap-nn[torch,export-gpu,tensorrt]" --torch-backend auto
+    ```
+
+=== "pip"
+
+    ```bash
+    # ONNX export (CPU)
+    pip install sleap-nn[torch,export]
+
+    # TensorRT export (NVIDIA GPUs)
+    pip install sleap-nn[torch,export-gpu,tensorrt]
+    ```
+
+!!! note "TensorRT availability"
+    TensorRT is only available on Linux and Windows with NVIDIA GPUs.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -114,9 +114,6 @@ SLEAP-NN uses [**uv**](https://docs.astral.sh/uv/) for installation and environm
     sleap-nn system
     ```
 
-!!! success "Done!"
-    Run `sleap-nn system` to see your GPU status and library versions.
-
 ---
 
 ## Updating


### PR DESCRIPTION
## Summary

- Add quick installation step to quickstart guide
- Remove redundant "SLEAP-NN installed" prerequisite (now inline)
- Fix missing backslash in first-model.md track command
- Fix incorrect `--oks_stddev` default in evaluation.md (0.025 → 0.05)
- Add uv installation instructions for export extras
- Fix pip export extras to include `[torch]`
- Remove redundant "Done!" admonition from installation.md

## Test plan

- [ ] Preview docs locally with `uv run --frozen --group docs mkdocs serve`
- [ ] Verify quickstart has installation section
- [ ] Verify export guide shows uv and pip tabs with correct extras

🤖 Generated with [Claude Code](https://claude.ai/code)