### PR TITLE
Align predict CLI defaults with track CLI for bottom-up models

### DIFF
--- a/sleap_nn/export/cli.py
+++ b/sleap_nn/export/cli.py
@@ -852,14 +852,14 @@ def export(
 @click.option(
     "--min-line-scores",
     type=float,
-    default=-0.5,
+    default=0.25,
     show_default=True,
     help="Bottom-up: minimum line score threshold.",
 )
 @click.option(
     "--peak-conf-threshold",
     type=float,
-    default=0.1,
+    default=0.2,
     show_default=True,
     help="Bottom-up: peak confidence threshold for filtering candidates.",
 )
@@ -1340,7 +1340,7 @@ def _predict_bottomup_frames(
     paf_scorer,
     candidate_template,
     input_scale,
-    peak_conf_threshold=0.1,
+    peak_conf_threshold=0.2,
     max_instances=None,
 ):
     """Convert bottom-up model outputs to LabeledFrames."""
@@ -1584,7 +1584,7 @@ def _predict_multiclass_bottomup_frames(
     skeleton,
     class_names: list,
     input_scale: float = 1.0,
-    peak_conf_threshold: float = 0.1,
+    peak_conf_threshold: float = 0.2,
     max_instances: int = None,
 ):
     """Convert bottom-up multiclass model outputs to LabeledFrames.


### PR DESCRIPTION
## Summary
- Aligns `sleap-nn predict` default thresholds with `sleap-nn track` for bottom-up models
- `peak_conf_threshold`: 0.1 → **0.2** (matches `track`)
- `min_line_scores`: -0.5 → **0.25** (matches `track`)

The previous defaults caused `predict` (ONNX/TensorRT) to output ~20% more instances than `track` (PyTorch) on the same video, due to more permissive peak acceptance and PAF matching thresholds.

**Note:** The two pipelines also differ in peak detection method (top-K NMS vs morphological local-NMS), which is left as a separate follow-up.

Fixes #459

## Test plan
- [ ] Run `sleap-nn predict` on a bottom-up model and verify instance counts are closer to `sleap-nn track`
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)