### PR TITLE
Fix double squeeze bug in SingleInstanceLightningModule.forward()

### DIFF
--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -654,7 +654,11 @@ class SingleInstanceLightningModule(LightningModel):
 
     def forward(self, img):
         """Forward pass of the model."""
-        img = torch.squeeze(img, dim=1).to(self.device)
+        # Only squeeze n_samples dim if 5D (batch, n_samples, C, H, W) -> (batch, C, H, W)
+        # Avoid double-squeezing when called from validation_step which already squeezes
+        if img.ndim == 5:
+            img = img.squeeze(1)
+        img = img.to(self.device)
         img = normalize_on_gpu(img)
         return self.model(img)["SingleInstanceConfmapsHead"]
 


### PR DESCRIPTION
## Summary

- Fixes a double squeeze bug in `SingleInstanceLightningModule.forward()` that caused channel mismatch errors during validation
- The bug was triggered when `_collect_val_predictions` was enabled (after epoch 0)
- Adds regression test to prevent future occurrences

Closes https://github.com/talmolab/sleap/issues/2615

## Root Cause

The `validation_step()` method squeezes the image from 5D to 4D before calling the inference layer:
```python
# validation_step lines 745-746
if inference_batch["image"].ndim == 5:
    inference_batch["image"] = inference_batch["image"].squeeze(1)
```

Then `forward()` was unconditionally squeezing again:
```python
# forward() line 657 (before fix)
img = torch.squeeze(img, dim=1).to(self.device)
```

This removed the channel dimension, causing PyTorch to misinterpret the batch dimension as channels:
- Input: `(4, 1, 384, 384)` (batch=4, C=1, H, W)
- After double squeeze: `(4, 384, 384)` 
- PyTorch interprets as: `(1, 4, 384, 384)` (batch=1, C=4, H, W)

## Fix

Make `forward()` only squeeze when input is 5D:
```python
if img.ndim == 5:
    img = img.squeeze(1)
```

## Test plan

- [x] New regression test `test_single_instance_forward_handles_4d_and_5d_inputs` passes
- [x] Existing `test_single_instance_model` passes
- [x] Existing `test_single_instance_inference_model` passes

🤖 Generated with [Claude Code](https://claude.ai/code)