### PR TITLE
chore: trigger docs rebuild

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -116,3 +116,4 @@
     Questions? [Start a discussion](https://github.com/talmolab/sleap-nn/discussions)
 
 </div>
+


### PR DESCRIPTION
Race condition between PR #472 and #473 caused the docs deployment to use an older version. This empty change triggers a rebuild with the correct code.