### PR TITLE
Move callback_metrics access before is_global_zero to fix DDP collective mismatch

### DIFF
--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -75,11 +75,13 @@ class CSVLoggerCallback(Callback):
 
     def on_validation_epoch_end(self, trainer, pl_module):
         """Log metrics to csv at the end of validation epoch."""
+        # Access callback_metrics BEFORE the is_global_zero guard so all
+        # ranks participate in the implicit all_reduce that fires when
+        # sync_dist=True metrics are first read.  Only rank 0 does I/O.
+        metrics = trainer.callback_metrics
         if trainer.is_global_zero:
             if not self.initialized:
                 self._init_file()
-
-            metrics = trainer.callback_metrics
             log_data = {}
             for key in self.keys:
                 if key == "epoch":
@@ -945,8 +947,11 @@ class ProgressReporterZMQ(Callback):
 
     def on_train_epoch_end(self, trainer, pl_module):
         """Called at the end of each epoch."""
+        # Access callback_metrics BEFORE the is_global_zero guard so all
+        # ranks participate in the implicit all_reduce that fires when
+        # sync_dist=True metrics are first read.  Only rank 0 sends ZMQ.
+        logs = trainer.callback_metrics
         if trainer.is_global_zero:
-            logs = trainer.callback_metrics
             self.send(
                 "epoch_end", epoch=trainer.current_epoch, logs=self._sanitize_logs(logs)
             )
@@ -960,8 +965,11 @@ class ProgressReporterZMQ(Callback):
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         """Called at the end of each training batch."""
+        # Access callback_metrics BEFORE the is_global_zero guard so all
+        # ranks participate in the implicit all_reduce that fires when
+        # sync_dist=True metrics are first read.  Only rank 0 sends ZMQ.
+        logs = trainer.callback_metrics
         if trainer.is_global_zero:
-            logs = trainer.callback_metrics
             self.send(
                 "batch_end",
                 epoch=trainer.current_epoch,


### PR DESCRIPTION
## Summary
- Fix DDP collective mismatch that crashes multi-GPU training at the sanity check
- Move `trainer.callback_metrics` access outside `if trainer.is_global_zero:` so all ranks participate in the implicit `all_reduce`

## Changes Made
- `CSVLoggerCallback.on_validation_epoch_end`: moved `metrics = trainer.callback_metrics` before the `is_global_zero` guard
- `ProgressReporterZMQ.on_train_epoch_end`: moved `logs = trainer.callback_metrics` before the `is_global_zero` guard
- `ProgressReporterZMQ.on_train_batch_end`: moved `logs = trainer.callback_metrics` before the `is_global_zero` guard

## Problem
When training with 2+ GPUs (DDP), accessing `trainer.callback_metrics` inside `if trainer.is_global_zero:` causes a collective mismatch. The property triggers an implicit `all_reduce` (via `compute()` → `strategy.reduce()`) when metrics are logged with `sync_dist=True`. Since only rank 0 enters the guard, rank 1 hits a `barrier` instead — ALLREDUCE on rank 0 vs BARRIER on rank 1.

This is invisible without `TORCH_DISTRIBUTED_DEBUG=DETAIL` because NCCL silently handles mismatched operations (undefined behavior). With DETAIL enabled, PyTorch validates collective symmetry and raises a RuntimeError at the sanity check before epoch 0.

**Why sleap-nn is specifically affected:** `sync_dist=False` is Lightning's default for `self.log()`. In sleap-nn, every one of the 37 `self.log()` calls in `lightning_modules.py` explicitly sets `sync_dist=True` — the correct choice for DDP so all ranks agree on metric values, but it means every `callback_metrics` access triggers a collective. This is a sleap-nn-specific issue, not a general Lightning gotcha.

## Reproduction
```bash
TORCH_DISTRIBUTED_DEBUG=DETAIL sleap-nn train --config <config_with_trainer_devices_2>.yaml
```
Crashes immediately at sanity check with:
```
RuntimeError: Detected mismatch between collectives on ranks. Rank 0 is running collective:
CollectiveFingerPrint(SequenceNumber=15, OpType=ALLREDUCE, ...), but Rank 1 is running collective:
CollectiveFingerPrint(SequenceNumber=0, OpType=REDUCE)
```

## Testing
- All 104 existing callback tests pass
- Manually verified: without fix + `TORCH_DISTRIBUTED_DEBUG=DETAIL` → immediate crash at sanity check
- Manually verified: with fix + `TORCH_DISTRIBUTED_DEBUG=DETAIL` → passes sanity check, training proceeds normally
- Tested on both large-memory and 16 GB containers with 2 GPUs

## Design Decisions
- The original `is_global_zero` guard was reasonable from an I/O perspective (only rank 0 should write CSV / send ZMQ), but `trainer.callback_metrics` is not a simple property read — it lazily triggers `compute()` which calls `all_reduce` for every metric logged with `sync_dist=True`
- The fix keeps all I/O rank-0-only while ensuring the collective operation runs symmetrically on all ranks
- All other `is_global_zero` guards in the file were audited — none access `callback_metrics` or other collective-triggering properties, so no further changes are needed

## ⚠️ Test Coverage Warning
The existing test suite **cannot detect regressions in this fix**. All 104 callback tests use `MagicMock()` for the trainer, where `mock_trainer.callback_metrics = {...}` is a plain dict assignment. Accessing a mock dict does not trigger `compute()`, `strategy.reduce()`, or any NCCL collective — the entire distributed machinery is bypassed.

This class of bug (collective ordering mismatch) is only reproducible when:
1. A real distributed process group is initialized (`torchrun --nproc_per_node=2`)
2. Real Lightning metric tracking is running (not mocked)
3. Metrics are logged with `sync_dist=True` (all 37 `self.log()` calls in `lightning_modules.py`)

A proper regression test would require a multi-GPU integration test that spins up real DDP workers and asserts no crash with `TORCH_DISTRIBUTED_DEBUG=DETAIL` — which is outside the scope of the current unit test suite and requires 2 GPUs in CI.

**Safety for non-DDP setups:** Moving `callback_metrics` access before the `is_global_zero` guard is safe for single-GPU and CPU training. Without a distributed process group, `meta.sync()` inside `compute()` is a no-op — the all_reduce becomes a local operation and the property read behaves identically to before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)