### PR TITLE
chore: Bump version to 0.1.1

### DIFF
--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -50,7 +50,7 @@ logger.add(
     colorize=False,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # Public API
 from sleap_nn.evaluation import load_metrics


### PR DESCRIPTION
## Summary
- Bumps version from 0.1.0 to 0.1.1 in preparation for the v0.1.1 release

## Changes
- Updated `sleap_nn/__init__.py` to set `__version__ = "0.1.1"`

## Test plan
- CI should pass (tests, linting, type checking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)