### PR TITLE
chore: Bump version to 0.1.2

### DIFF
--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -50,7 +50,7 @@ logger.add(
     colorize=False,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 # Public API
 from sleap_nn.evaluation import load_metrics


### PR DESCRIPTION
## Summary
- Bump sleap-nn version from 0.1.1 to 0.1.2 in preparation for the next release

## Changes Made
- Updated `__version__` in `sleap_nn/__init__.py` from `0.1.1` to `0.1.2`

## Notes
- `sleap-io` dependency is already at the latest version (v0.6.5), no update needed

---
🤖 Generated with [Claude Code](https://claude.ai/code)