### PR TITLE
fix: Expose missing functions to window in config picker

### DIFF
--- a/docs/configuration/config-picker/app.html
+++ b/docs/configuration/config-picker/app.html
@@ -3492,6 +3492,36 @@ Input → [Encoder] → [Middle] → [Decoder] → Head → Output
         window.selectAnchor = selectAnchor;
         window.selectModelType = selectModelType;
 
+        // Expose augmentation slider functions
+        window.updateAugSliderValue = updateAugSliderValue;
+        window.updateCIAugSliderValue = updateCIAugSliderValue;
+
+        // Expose sigma visualization functions
+        window.updateSigmaVisualization = updateSigmaVisualization;
+        window.updateCISigmaVisualization = updateCISigmaVisualization;
+
+        // Expose cache memory estimate functions
+        window.updateCacheMemoryEstimate = updateCacheMemoryEstimate;
+        window.updateCICacheMemoryEstimate = updateCICacheMemoryEstimate;
+        window.toggleDiskCacheOptions = toggleDiskCacheOptions;
+        window.toggleCIDiskCacheOptions = toggleCIDiskCacheOptions;
+
+        // Expose training option toggle functions
+        window.toggleEarlyStoppingOptions = toggleEarlyStoppingOptions;
+        window.toggleCIEarlyStoppingOptions = toggleCIEarlyStoppingOptions;
+        window.updateSchedulerOptions = updateSchedulerOptions;
+        window.updateCISchedulerOptions = updateCISchedulerOptions;
+        window.toggleSaveCkptOptions = toggleSaveCkptOptions;
+        window.toggleCISaveCkptOptions = toggleCISaveCkptOptions;
+        window.toggleOhkmOptions = toggleOhkmOptions;
+        window.toggleCIOhkmOptions = toggleCIOhkmOptions;
+        window.toggleWandbOptions = toggleWandbOptions;
+        window.toggleCIWandbOptions = toggleCIWandbOptions;
+        window.toggleVizOptions = toggleVizOptions;
+        window.toggleCIVizOptions = toggleCIVizOptions;
+        window.toggleEvalOptions = toggleEvalOptions;
+        window.toggleCIEvalOptions = toggleCIEvalOptions;
+
         function initAnchorCanvas() {
             const canvas = document.getElementById('anchor-preview-canvas');
             if (canvas) {


### PR DESCRIPTION
## Summary
- Fixes broken augmentation sliders and missing CPU cache memory estimates in the config picker
- Exposes 22 missing functions to the `window` object that were inaccessible due to ES module scope

## Changes Made
- Added window exposure for augmentation slider functions (`updateAugSliderValue`, `updateCIAugSliderValue`)
- Added window exposure for sigma visualization functions (`updateSigmaVisualization`, `updateCISigmaVisualization`)
- Added window exposure for cache memory estimate functions (`updateCacheMemoryEstimate`, `updateCICacheMemoryEstimate`, `toggleDiskCacheOptions`, `toggleCIDiskCacheOptions`)
- Added window exposure for training option toggles (early stopping, scheduler, checkpoint, OHKM, W&B, visualization, evaluation options for both model types)

## Root Cause
When the config picker was ported from the vibes repo, it was changed from a standard `<script>` tag to an ES module (`<script type="module">`). This created a module scope that prevented inline HTML event handlers (`oninput`, `onchange`) from accessing the functions they needed to call.

The original port partially exposed some functions to `window` for `onclick` handlers but missed the 22 functions used by `oninput` and `onchange` handlers.

## Testing
- Verified all functions called by `oninput`/`onchange` handlers are now exposed to `window`
- Manual testing: augmentation sliders should now update values, CPU cache memory estimate should appear when changing caching method or number of workers

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)