### PR TITLE
feat: Add anchor_part field to ExportMetadata

### DIFF
--- a/sleap_nn/export/cli.py
+++ b/sleap_nn/export/cli.py
@@ -18,6 +18,7 @@ from sleap_nn.export.metadata import (
 )
 from sleap_nn.export.utils import (
     load_training_config,
+    resolve_anchor_part,
     resolve_backbone_type,
     resolve_class_maps_output_stride,
     resolve_class_names,
@@ -328,6 +329,7 @@ def export(
             n_classes=metadata_n_classes,
             class_names=metadata_class_names,
             peak_threshold=peak_threshold,
+            anchor_part=resolve_anchor_part(cfg, model_type),
         )
 
         metadata.save(export_dir / "export_metadata.json")
@@ -401,6 +403,7 @@ def export(
                 n_classes=metadata_n_classes,
                 class_names=metadata_class_names,
                 peak_threshold=peak_threshold,
+                anchor_part=resolve_anchor_part(cfg, model_type),
             )
             trt_metadata.save(export_dir / "model.trt.metadata.json")
         return
@@ -553,6 +556,7 @@ def export(
             input_dtype="uint8",
             normalization="0_to_1",
             peak_threshold=peak_threshold,
+            anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
         )
 
         metadata.save(export_dir / "export_metadata.json")
@@ -603,6 +607,7 @@ def export(
                 input_dtype="uint8",
                 normalization="0_to_1",
                 peak_threshold=peak_threshold,
+                anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
             )
             trt_metadata.save(export_dir / "model.trt.metadata.json")
         return
@@ -761,6 +766,7 @@ def export(
             n_classes=n_classes,
             class_names=class_names,
             peak_threshold=peak_threshold,
+            anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
         )
         metadata.save(export_dir / "export_metadata.json")
         click.echo(f"ONNX model exported to: {model_out_path}")
@@ -807,6 +813,7 @@ def export(
                 n_classes=n_classes,
                 class_names=class_names,
                 peak_threshold=peak_threshold,
+                anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
             )
             trt_metadata.save(export_dir / "model.trt.metadata.json")
         return

--- a/sleap_nn/export/metadata.py
+++ b/sleap_nn/export/metadata.py
@@ -54,6 +54,9 @@ class ExportMetadata:
     n_classes: Optional[int] = None
     class_names: Optional[List[str]] = None
 
+    # Centroid/top-down anchor point
+    anchor_part: Optional[str] = None
+
     # Training config reference
     training_config_embedded: bool = False
     training_config_hash: str = ""
@@ -98,6 +101,7 @@ class ExportMetadata:
             n_classes=data.get("n_classes"),
             class_names=data.get("class_names"),
             peak_threshold=data.get("peak_threshold"),
+            anchor_part=data.get("anchor_part"),
             training_config_embedded=bool(data.get("training_config_embedded", False)),
             training_config_hash=data.get("training_config_hash", ""),
         )
@@ -156,6 +160,7 @@ def build_base_metadata(
     n_classes: Optional[int] = None,
     class_names: Optional[List[str]] = None,
     peak_threshold: Optional[float] = None,
+    anchor_part: Optional[str] = None,
 ) -> ExportMetadata:
     """Create an ExportMetadata instance with standard defaults."""
     return ExportMetadata(
@@ -183,6 +188,7 @@ def build_base_metadata(
         n_classes=n_classes,
         class_names=class_names,
         peak_threshold=peak_threshold,
+        anchor_part=anchor_part,
         training_config_embedded=training_config_embedded,
         training_config_hash=training_config_hash,
     )

--- a/sleap_nn/export/utils.py
+++ b/sleap_nn/export/utils.py
@@ -168,6 +168,31 @@ def resolve_backbone_type(cfg: DictConfig) -> str:
     return get_backbone_type_from_cfg(cfg)
 
 
+def resolve_anchor_part(cfg: DictConfig, model_type: str) -> Optional[str]:
+    """Resolve anchor_part from config for centroid and centered_instance models.
+
+    Args:
+        cfg: The training job configuration.
+        model_type: The model type (e.g., "centroid", "centered_instance").
+
+    Returns:
+        The anchor part name if configured, None otherwise.
+        Only returns a value for "centroid" and "centered_instance" model types.
+    """
+    head_configs = cfg.model_config.head_configs
+
+    if model_type == "centroid":
+        head = getattr(head_configs, "centroid", None)
+    elif model_type == "centered_instance":
+        head = getattr(head_configs, "centered_instance", None)
+    else:
+        return None
+
+    if head and hasattr(head, "confmaps"):
+        return getattr(head.confmaps, "anchor_part", None)
+    return None
+
+
 def resolve_input_shape(
     cfg: DictConfig,
     input_height: Optional[int] = None,

--- a/tests/export/test_metadata.py
+++ b/tests/export/test_metadata.py
@@ -50,6 +50,7 @@ class TestExportMetadata:
         assert metadata.class_names is None
         assert metadata.training_config_embedded is False
         assert metadata.training_config_hash == ""
+        assert metadata.anchor_part is None
 
     def test_export_metadata_to_dict(self):
         """Test that to_dict() produces a serializable dict with all keys."""
@@ -101,6 +102,7 @@ class TestExportMetadata:
             "n_classes",
             "class_names",
             "peak_threshold",
+            "anchor_part",
             "training_config_embedded",
             "training_config_hash",
         }
@@ -140,6 +142,7 @@ class TestExportMetadata:
             "normalization": "0_to_1",
             "n_classes": 2,
             "class_names": ["female", "male"],
+            "anchor_part": "thorax",
             "training_config_embedded": True,
             "training_config_hash": "abc123",
         }
@@ -154,6 +157,7 @@ class TestExportMetadata:
         assert metadata.precision == "fp16"
         assert metadata.n_classes == 2
         assert metadata.class_names == ["female", "male"]
+        assert metadata.anchor_part == "thorax"
         assert metadata.training_config_embedded is True
 
     def test_export_metadata_from_dict_minimal(self):
@@ -175,6 +179,7 @@ class TestExportMetadata:
         assert metadata.normalization == "0_to_1"
         assert metadata.edge_inds == []
         assert metadata.crop_size is None
+        assert metadata.anchor_part is None
 
     def test_export_metadata_from_dict_unknown_keys(self):
         """Test that unknown keys in dict are ignored gracefully."""
@@ -292,6 +297,53 @@ class TestExportMetadata:
         assert loaded.n_classes == 2
         assert loaded.class_names == ["female", "male"]
 
+    def test_anchor_part_field(self):
+        """Test that anchor_part field works correctly for centroid/top-down models."""
+        # With anchor_part set
+        metadata_with_anchor = ExportMetadata(
+            sleap_nn_version=__version__,
+            export_timestamp="2026-01-18",
+            export_format="onnx",
+            model_type="centroid",
+            model_name="test",
+            checkpoint_path="/path",
+            backbone="unet",
+            n_nodes=13,
+            n_edges=12,
+            node_names=["head", "thorax", "abdomen"] + [f"n{i}" for i in range(10)],
+            edge_inds=[(i, i + 1) for i in range(12)],
+            input_scale=1.0,
+            input_channels=1,
+            output_stride=2,
+            anchor_part="thorax",
+        )
+        assert metadata_with_anchor.anchor_part == "thorax"
+
+        # Without anchor_part (default None)
+        metadata_no_anchor = ExportMetadata(
+            sleap_nn_version=__version__,
+            export_timestamp="2026-01-18",
+            export_format="onnx",
+            model_type="bottomup",
+            model_name="test",
+            checkpoint_path="/path",
+            backbone="unet",
+            n_nodes=5,
+            n_edges=4,
+            node_names=["n0", "n1", "n2", "n3", "n4"],
+            edge_inds=[(0, 1), (1, 2), (2, 3), (3, 4)],
+            input_scale=1.0,
+            input_channels=1,
+            output_stride=4,
+        )
+        assert metadata_no_anchor.anchor_part is None
+
+        # Check roundtrip preserves anchor_part
+        d = metadata_with_anchor.to_dict()
+        assert d["anchor_part"] == "thorax"
+        loaded = ExportMetadata.from_dict(d)
+        assert loaded.anchor_part == "thorax"
+
     def test_default_timestamp(self):
         """Test that default_timestamp() returns a valid ISO format string."""
         ts = ExportMetadata.default_timestamp()
@@ -348,6 +400,46 @@ class TestBuildBaseMetadata:
 
         assert metadata.n_classes == 3
         assert metadata.class_names == ["class_a", "class_b", "class_c"]
+
+    def test_build_base_metadata_with_anchor_part(self):
+        """Test build_base_metadata with anchor_part for centroid models."""
+        metadata = build_base_metadata(
+            export_format="onnx",
+            model_type="centroid",
+            model_name="centroid_test",
+            checkpoint_path="/path/to/ckpt",
+            backbone="unet",
+            n_nodes=13,
+            n_edges=12,
+            node_names=["head", "thorax", "abdomen"] + [f"n{i}" for i in range(10)],
+            edge_inds=[(i, i + 1) for i in range(12)],
+            input_scale=0.5,
+            input_channels=1,
+            output_stride=2,
+            anchor_part="thorax",
+        )
+
+        assert metadata.anchor_part == "thorax"
+        assert metadata.model_type == "centroid"
+
+    def test_build_base_metadata_without_anchor_part(self):
+        """Test build_base_metadata defaults anchor_part to None."""
+        metadata = build_base_metadata(
+            export_format="onnx",
+            model_type="bottomup",
+            model_name="bottomup_test",
+            checkpoint_path="/path/to/ckpt",
+            backbone="unet",
+            n_nodes=5,
+            n_edges=4,
+            node_names=["n0", "n1", "n2", "n3", "n4"],
+            edge_inds=[(0, 1), (1, 2), (2, 3), (3, 4)],
+            input_scale=1.0,
+            input_channels=1,
+            output_stride=4,
+        )
+
+        assert metadata.anchor_part is None
 
 
 class TestHashFile:

--- a/tests/export/test_utils.py
+++ b/tests/export/test_utils.py
@@ -735,6 +735,127 @@ class TestResolveCropSizeEdgeCases:
         assert result is None
 
 
+class TestResolveAnchorPart:
+    """Tests for resolve_anchor_part function."""
+
+    def test_resolve_anchor_part_centroid(self):
+        """Test extracting anchor_part for centroid models."""
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "centroid": {"confmaps": {"anchor_part": "thorax"}}
+                    }
+                }
+            }
+        )
+        anchor = resolve_anchor_part(cfg, "centroid")
+        assert anchor == "thorax"
+
+    def test_resolve_anchor_part_centered_instance(self):
+        """Test extracting anchor_part for centered_instance models."""
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "centered_instance": {"confmaps": {"anchor_part": "head"}}
+                    }
+                }
+            }
+        )
+        anchor = resolve_anchor_part(cfg, "centered_instance")
+        assert anchor == "head"
+
+    def test_resolve_anchor_part_none_when_not_set(self):
+        """Test that anchor_part returns None when not configured."""
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "centroid": {"confmaps": {"output_stride": 2, "sigma": 5.0}}
+                    }
+                }
+            }
+        )
+        anchor = resolve_anchor_part(cfg, "centroid")
+        assert anchor is None
+
+    def test_resolve_anchor_part_none_for_bottomup(self):
+        """Test that anchor_part returns None for bottomup models."""
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "bottomup": {
+                            "confmaps": {"output_stride": 2},
+                            "pafs": {"output_stride": 4},
+                        }
+                    }
+                }
+            }
+        )
+        anchor = resolve_anchor_part(cfg, "bottomup")
+        assert anchor is None
+
+    def test_resolve_anchor_part_none_for_single_instance(self):
+        """Test that anchor_part returns None for single_instance models."""
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "single_instance": {"confmaps": {"output_stride": 2}}
+                    }
+                }
+            }
+        )
+        anchor = resolve_anchor_part(cfg, "single_instance")
+        assert anchor is None
+
+    def test_resolve_anchor_part_none_for_unsupported_model(self):
+        """Test that anchor_part returns None for unsupported model types."""
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create({"model_config": {"head_configs": {}}})
+        anchor = resolve_anchor_part(cfg, "nonexistent_model")
+        assert anchor is None
+
+    def test_resolve_anchor_part_with_real_config(self, minimal_instance_centroid_ckpt):
+        """Test resolve_anchor_part with real centroid config."""
+        from sleap_nn.export.utils import load_training_config, resolve_anchor_part
+
+        cfg = load_training_config(minimal_instance_centroid_ckpt)
+        anchor = resolve_anchor_part(cfg, "centroid")
+        # anchor_part may be None or a string depending on config
+        assert anchor is None or isinstance(anchor, str)
+
+    def test_resolve_anchor_part_with_centered_instance_config(
+        self, minimal_instance_centered_instance_ckpt
+    ):
+        """Test resolve_anchor_part with real centered_instance config."""
+        from sleap_nn.export.utils import load_training_config, resolve_anchor_part
+
+        cfg = load_training_config(minimal_instance_centered_instance_ckpt)
+        anchor = resolve_anchor_part(cfg, "centered_instance")
+        # anchor_part may be None or a string depending on config
+        assert anchor is None or isinstance(anchor, str)
+
+
 class TestResolveNodeNamesEdgeCases:
     """Edge case tests for resolve_node_names."""
 


### PR DESCRIPTION
## Summary
- Add `anchor_part` field to `ExportMetadata` for centroid and centered_instance models
- Enables downstream tools to determine which skeleton node is used as the centroid anchor without parsing the training config

## Changes Made
- **`sleap_nn/export/metadata.py`**: Added `anchor_part: Optional[str] = None` field to `ExportMetadata` dataclass and updated `from_dict()` and `build_base_metadata()` functions
- **`sleap_nn/export/utils.py`**: Added `resolve_anchor_part()` helper function that extracts anchor_part from config for centroid and centered_instance model types only (returns None for all other model types)
- **`sleap_nn/export/cli.py`**: Updated all `build_base_metadata()` calls to include anchor_part

## Example Usage
After export, the `export_metadata.json` will include the anchor_part field:

```json
{
  "model_type": "centroid",
  "node_names": ["head", "thorax", "abdomen", ...],
  "anchor_part": "thorax",
  ...
}
```

For downstream consumers:
```python
from sleap_nn.export.metadata import ExportMetadata

metadata = ExportMetadata.load("export_metadata.json")
if metadata.anchor_part:
    anchor_idx = metadata.node_names.index(metadata.anchor_part)
```

## API Changes
- `ExportMetadata` dataclass: New optional field `anchor_part: Optional[str] = None`
- `build_base_metadata()`: New optional parameter `anchor_part: Optional[str] = None`
- New function `resolve_anchor_part(cfg, model_type) -> Optional[str]`

## Testing
- Added `TestResolveAnchorPart` class with 8 test cases covering:
  - Centroid model with anchor_part set
  - Centered_instance model with anchor_part set
  - Models without anchor_part configured
  - Bottomup, single_instance, and unsupported model types (return None)
  - Integration tests with real config files
- Added tests for `ExportMetadata.anchor_part` field
- Added tests for `build_base_metadata()` with anchor_part
- All 80 tests pass (3 skipped due to optional ONNX dependency)

## Design Decisions
- Only returns anchor_part for `centroid` and `centered_instance` model types as per user clarification - other models return `None`
- Used string name rather than index since the index can be computed from `node_names.index(anchor_part)`
- Defaults to `None` for backwards compatibility with existing exports

Closes #493

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)