### PR TITLE
feat: Add bottom-up instance segmentation model type

### DIFF
--- a/sleap_nn/architectures/heads.py
+++ b/sleap_nn/architectures/heads.py
@@ -594,3 +594,96 @@ class OffsetRefinementHead(Head):
             sigma_threshold=sigma_threshold,
             loss_weight=loss_weight,
         )
+
+
+class SegmentationHead(Head):
+    """Head for predicting binary foreground segmentation masks.
+
+    Outputs a single-channel map with sigmoid activation representing the
+    probability that each pixel belongs to any instance (foreground).
+
+    Attributes:
+        output_stride: Stride of the output head tensor.
+        loss_weight: Weight of the loss term for this head during optimization.
+    """
+
+    def __init__(
+        self,
+        output_stride: int = 2,
+        loss_weight: float = 1.0,
+    ) -> None:
+        """Initialize the object with the specified attributes."""
+        super().__init__(output_stride, loss_weight)
+
+    @property
+    def channels(self) -> int:
+        """Return the number of channels in the tensor output by this head."""
+        return 1
+
+    @property
+    def activation(self) -> str:
+        """Return the activation function of the head output layer."""
+        return "sigmoid"
+
+    @property
+    def loss_function(self) -> str:
+        """Return the name of the loss function to use for this head."""
+        return "bce_dice"
+
+
+class InstanceCenterHead(Head):
+    """Head for predicting instance center heatmaps.
+
+    Outputs a single-channel Gaussian heatmap with peaks at each instance's
+    mask centroid. Similar to CentroidConfmapsHead but for mask-derived centers.
+
+    Attributes:
+        sigma: Standard deviation of the Gaussian in pixels.
+        output_stride: Stride of the output head tensor.
+        loss_weight: Weight of the loss term for this head during optimization.
+    """
+
+    def __init__(
+        self,
+        sigma: float = 10.0,
+        output_stride: int = 2,
+        loss_weight: float = 1.0,
+    ) -> None:
+        """Initialize the object with the specified attributes."""
+        super().__init__(output_stride, loss_weight)
+        self.sigma = sigma
+
+    @property
+    def channels(self) -> int:
+        """Return the number of channels in the tensor output by this head."""
+        return 1
+
+
+class CenterOffsetHead(Head):
+    """Head for predicting per-pixel offset vectors to instance centers.
+
+    Outputs a 2-channel map where each pixel's value is (dx, dy) pointing
+    from the pixel to its instance's center. Only meaningful on foreground pixels.
+
+    Attributes:
+        output_stride: Stride of the output head tensor.
+        loss_weight: Weight of the loss term for this head during optimization.
+    """
+
+    def __init__(
+        self,
+        output_stride: int = 2,
+        loss_weight: float = 0.1,
+    ) -> None:
+        """Initialize the object with the specified attributes."""
+        super().__init__(output_stride, loss_weight)
+
+    @property
+    def channels(self) -> int:
+        """Return the number of channels in the tensor output by this head."""
+        return 2
+
+    @property
+    def loss_function(self) -> str:
+        """Return the name of the loss function to use for this head."""
+        return "smooth_l1"

--- a/sleap_nn/architectures/heads.py
+++ b/sleap_nn/architectures/heads.py
@@ -623,7 +623,7 @@ class SegmentationHead(Head):
     @property
     def activation(self) -> str:
         """Return the activation function of the head output layer."""
-        return "sigmoid"
+        return "identity"
 
     @property
     def loss_function(self) -> str:

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -22,6 +22,9 @@ from sleap_nn.architectures.heads import (
     ClassMapsHead,
     ClassVectorsHead,
     OffsetRefinementHead,
+    SegmentationHead,
+    InstanceCenterHead,
+    CenterOffsetHead,
 )
 from sleap_nn.architectures.unet import UNet
 from sleap_nn.architectures.convnext import ConvNextWrapper
@@ -98,8 +101,13 @@ def get_head(model_type: str, head_config: DictConfig) -> Head:
         heads.append(CenteredInstanceConfmapsHead(**head_config.confmaps))
         heads.append(ClassVectorsHead(**head_config.class_vectors))
 
+    elif model_type == "bottomup_segmentation":
+        heads.append(SegmentationHead(**head_config.segmentation))
+        heads.append(InstanceCenterHead(**head_config.center))
+        heads.append(CenterOffsetHead(**head_config.offsets))
+
     else:
-        message = f"{model_type} is not a defined model type. Please choose one of `single_instance`, `centered_instance`, `centroid`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`."
+        message = f"{model_type} is not a defined model type. Please choose one of `single_instance`, `centered_instance`, `centroid`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`."
         logger.error(message)
         raise Exception(message)
 

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -876,6 +876,54 @@ class ClassVectorsConfig:
 
 
 @define
+class SegmentationHeadConfig:
+    """Configuration for the foreground segmentation head.
+
+    Attributes:
+        output_stride: (int) The stride of the output segmentation maps relative to the
+            input image. Default: 2.
+        loss_weight: (float) Scalar float used to weigh the loss term for this head
+            during training. Default: 1.0.
+    """
+
+    output_stride: int = 2
+    loss_weight: float = 1.0
+
+
+@define
+class InstanceCenterConfig:
+    """Configuration for the instance center heatmap head.
+
+    Attributes:
+        sigma: (float) Standard deviation of the Gaussian distribution used to generate
+            center heatmaps, in pixels at original image resolution. Default: 10.0.
+        output_stride: (int) The stride of the output center heatmaps relative to the
+            input image. Default: 2.
+        loss_weight: (float) Scalar float used to weigh the loss term for this head
+            during training. Default: 1.0.
+    """
+
+    sigma: float = 10.0
+    output_stride: int = 2
+    loss_weight: float = 1.0
+
+
+@define
+class CenterOffsetConfig:
+    """Configuration for the center offset head.
+
+    Attributes:
+        output_stride: (int) The stride of the output offset maps relative to the
+            input image. Default: 2.
+        loss_weight: (float) Scalar float used to weigh the loss term for this head
+            during training. Default: 0.1.
+    """
+
+    output_stride: int = 2
+    loss_weight: float = 0.1
+
+
+@define
 class SingleInstanceConfig:
     """single instance head_config."""
 
@@ -920,6 +968,15 @@ class TopDownCenteredInstanceMultiClassConfig:
     class_vectors: Optional[ClassVectorsConfig] = None
 
 
+@define
+class BottomUpSegmentationConfig:
+    """Head config for bottom-up instance segmentation models."""
+
+    segmentation: Optional[SegmentationHeadConfig] = None
+    center: Optional[InstanceCenterConfig] = None
+    offsets: Optional[CenterOffsetConfig] = None
+
+
 @oneof
 @define
 class HeadConfig:
@@ -934,6 +991,7 @@ class HeadConfig:
         bottomup: An instance of `BottomUpConfig`.
         multi_class_bottomup: An instance of `BottomUpMultiClassConfig`.
         multi_class_topdown: An instance of `TopDownCenteredInstanceMultiClassConfig`.
+        bottomup_segmentation: An instance of `BottomUpSegmentationConfig`.
     """
 
     single_instance: Optional[SingleInstanceConfig] = None
@@ -942,6 +1000,7 @@ class HeadConfig:
     bottomup: Optional[BottomUpConfig] = None
     multi_class_bottomup: Optional[BottomUpMultiClassConfig] = None
     multi_class_topdown: Optional[TopDownCenteredInstanceMultiClassConfig] = None
+    bottomup_segmentation: Optional[BottomUpSegmentationConfig] = None
 
 
 @oneof

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -47,6 +47,11 @@ from sleap_nn.data.augmentation import (
 )
 from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
 from sleap_nn.data.edge_maps import generate_pafs
+from sleap_nn.data.segmentation_maps import (
+    generate_foreground_mask,
+    generate_center_heatmap,
+    generate_center_offsets,
+)
 from sleap_nn.data.instance_cropping import make_centered_bboxes
 from sleap_nn.training.utils import is_distributed_initialized
 from sleap_nn.config.get_config import get_aug_config
@@ -2075,6 +2080,185 @@ class _RepeatSampler:
             yield from iter(self.sampler)
 
 
+class BottomUpSegmentationDataset(BaseDataset):
+    """Dataset class for bottom-up instance segmentation models.
+
+    Loads per-instance segmentation masks from ``labels.masks`` and generates
+    ground truth tensors for a center-offset instance segmentation pipeline.
+
+    Attributes:
+        seg_head_config: Configuration for the segmentation head.
+        center_head_config: Configuration for the instance center heatmap head.
+        offset_head_config: Configuration for the center offset head.
+    """
+
+    def __init__(
+        self,
+        labels: List[sio.Labels],
+        seg_head_config: DictConfig,
+        center_head_config: DictConfig,
+        offset_head_config: DictConfig,
+        max_stride: int,
+        user_instances_only: bool = True,
+        ensure_rgb: bool = False,
+        ensure_grayscale: bool = False,
+        intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+        geometric_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+        cache_img: Optional[str] = None,
+        cache_img_path: Optional[str] = None,
+        use_existing_imgs: bool = False,
+        rank: Optional[int] = None,
+        parallel_caching: bool = True,
+        cache_workers: int = 0,
+        use_negative_frames: bool = False,
+    ) -> None:
+        """Initialize class attributes."""
+        super().__init__(
+            labels=labels,
+            max_stride=max_stride,
+            user_instances_only=user_instances_only,
+            ensure_rgb=ensure_rgb,
+            ensure_grayscale=ensure_grayscale,
+            intensity_aug=intensity_aug,
+            geometric_aug=geometric_aug,
+            scale=scale,
+            apply_aug=apply_aug,
+            max_hw=max_hw,
+            cache_img=cache_img,
+            cache_img_path=cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+            use_negative_frames=use_negative_frames,
+        )
+        self.seg_head_config = seg_head_config
+        self.center_head_config = center_head_config
+        self.offset_head_config = offset_head_config
+
+    def _get_lf_idx_list(self, labels: List[sio.Labels]) -> List[Dict]:
+        """Return list of indices of frames that have segmentation masks.
+
+        Overrides the base class to index frames that have masks instead of
+        (or in addition to) keypoint instances.
+        """
+        lf_idx_list = []
+        for labels_idx, label in enumerate(labels):
+            # Build a set of (video_idx, frame_idx) pairs that have masks
+            mask_frames = set()
+            if hasattr(label, "masks"):
+                for mask in label.masks:
+                    if mask.video is not None and mask.frame_idx is not None:
+                        vid_idx = label.videos.index(mask.video)
+                        mask_frames.add((vid_idx, mask.frame_idx))
+
+            for lf_idx, lf in enumerate(label):
+                video_idx = label.videos.index(lf.video)
+                frame_key = (video_idx, lf.frame_idx)
+
+                # Include this frame if it has masks
+                if frame_key in mask_frames:
+                    sample = {
+                        "labels_idx": labels_idx,
+                        "lf_idx": lf_idx,
+                        "video_idx": video_idx,
+                        "frame_idx": lf.frame_idx,
+                        "is_negative": False,
+                        "instances": (
+                            lf.instances if self.cache_img is not None else None
+                        ),
+                    }
+                    lf_idx_list.append(sample)
+
+        return lf_idx_list
+
+    def __getitem__(self, index) -> Dict:
+        """Return dict with image and segmentation GT for given index."""
+        sample = self.lf_idx_list[index]
+        labels_idx = sample["labels_idx"]
+        lf_idx = sample["lf_idx"]
+        video_idx = sample["video_idx"]
+        frame_idx = sample["frame_idx"]
+
+        # Load image
+        if self.cache_img is not None:
+            if self.cache_img == "disk":
+                img = np.array(
+                    Image.open(
+                        f"{self.cache_img_path}/sample_{labels_idx}_{lf_idx}.jpg"
+                    )
+                )
+            elif self.cache_img == "memory":
+                img = self.cache[(labels_idx, lf_idx)].copy()
+        else:
+            lf = self.labels_list[labels_idx][lf_idx]
+            img = lf.image
+
+        if img.ndim == 2:
+            img = np.expand_dims(img, axis=2)
+
+        image = np.transpose(img, (2, 0, 1))  # HWC -> CHW
+        image = np.expand_dims(image, axis=0)  # (1, C, H, W)
+        image = torch.from_numpy(image.copy())
+
+        # Dummy instances tensor (needed for preprocessing compatibility)
+        instances = torch.zeros((1, 1, 1, 2), dtype=torch.float32)
+
+        sample_dict = {
+            "image": image,
+            "instances": instances,
+            "video_idx": torch.tensor(video_idx, dtype=torch.int32),
+            "frame_idx": torch.tensor(frame_idx, dtype=torch.int32),
+            "orig_size": torch.Tensor([image.shape[-2], image.shape[-1]]).unsqueeze(0),
+            "num_instances": 0,
+        }
+
+        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding)
+        sample_dict = self._apply_common_preprocessing(sample_dict)
+
+        img_hw = sample_dict["image"].shape[-2:]
+
+        # Load masks for this frame
+        label = self.labels_list[labels_idx]
+        video = label.videos[video_idx]
+        frame_masks = label.get_masks(video=video, frame_idx=frame_idx)
+
+        mask_arrays = []
+        for m in frame_masks:
+            mask_arrays.append(m.data)
+
+        # Generate GT tensors
+        foreground_mask = generate_foreground_mask(
+            mask_arrays,
+            img_hw=img_hw,
+            output_stride=self.seg_head_config.output_stride,
+        )
+
+        center_heatmap = generate_center_heatmap(
+            mask_arrays,
+            img_hw=img_hw,
+            output_stride=self.center_head_config.output_stride,
+            sigma=self.center_head_config.sigma,
+        )
+
+        center_offsets, foreground_weight = generate_center_offsets(
+            mask_arrays,
+            img_hw=img_hw,
+            output_stride=self.offset_head_config.output_stride,
+        )
+
+        sample_dict["foreground_mask"] = foreground_mask
+        sample_dict["center_heatmap"] = center_heatmap
+        sample_dict["center_offsets"] = center_offsets
+        sample_dict["foreground_weight"] = foreground_weight
+        sample_dict["labels_idx"] = labels_idx
+
+        return sample_dict
+
+
 def get_train_val_datasets(
     train_labels: List[sio.Labels],
     val_labels: List[sio.Labels],
@@ -2450,6 +2634,71 @@ def get_train_val_datasets(
                 "max_stride"
             ],
             anchor_ind=anchor_ind,
+            user_instances_only=config.data_config.user_instances_only,
+            ensure_rgb=config.data_config.preprocessing.ensure_rgb,
+            ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
+            intensity_aug=None,
+            geometric_aug=None,
+            scale=config.data_config.preprocessing.scale,
+            apply_aug=False,
+            max_hw=(
+                config.data_config.preprocessing.max_height,
+                config.data_config.preprocessing.max_width,
+            ),
+            cache_img=cache_imgs,
+            cache_img_path=val_cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+            use_negative_frames=use_negative_frames,
+        )
+
+    elif model_type == "bottomup_segmentation":
+        seg_cfg = config.model_config.head_configs.bottomup_segmentation
+        train_dataset = BottomUpSegmentationDataset(
+            labels=train_labels,
+            seg_head_config=seg_cfg.segmentation,
+            center_head_config=seg_cfg.center,
+            offset_head_config=seg_cfg.offsets,
+            max_stride=config.model_config.backbone_config[f"{backbone_type}"][
+                "max_stride"
+            ],
+            user_instances_only=config.data_config.user_instances_only,
+            ensure_rgb=config.data_config.preprocessing.ensure_rgb,
+            ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
+            intensity_aug=(
+                config.data_config.augmentation_config.intensity
+                if config.data_config.augmentation_config is not None
+                else None
+            ),
+            geometric_aug=(
+                config.data_config.augmentation_config.geometric
+                if config.data_config.augmentation_config is not None
+                else None
+            ),
+            scale=config.data_config.preprocessing.scale,
+            apply_aug=config.data_config.use_augmentations_train,
+            max_hw=(
+                config.data_config.preprocessing.max_height,
+                config.data_config.preprocessing.max_width,
+            ),
+            cache_img=cache_imgs,
+            cache_img_path=train_cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+            use_negative_frames=use_negative_frames,
+        )
+        val_dataset = BottomUpSegmentationDataset(
+            labels=val_labels,
+            seg_head_config=seg_cfg.segmentation,
+            center_head_config=seg_cfg.center,
+            offset_head_config=seg_cfg.offsets,
+            max_stride=config.model_config.backbone_config[f"{backbone_type}"][
+                "max_stride"
+            ],
             user_instances_only=config.data_config.user_instances_only,
             ensure_rgb=config.data_config.preprocessing.ensure_rgb,
             ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -23,6 +23,7 @@ from rich.progress import (
 )
 from rich.console import Console
 import torch
+import torch.nn.functional as F
 import torchvision.transforms as T
 from torch.utils.data import Dataset, DataLoader, DistributedSampler
 import sleap_io as sio
@@ -48,6 +49,7 @@ from sleap_nn.data.augmentation import (
 from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
 from sleap_nn.data.edge_maps import generate_pafs
 from sleap_nn.data.segmentation_maps import (
+    _compute_mask_centroids,
     generate_foreground_mask,
     generate_center_heatmap,
     generate_center_offsets,
@@ -2138,6 +2140,43 @@ class BottomUpSegmentationDataset(BaseDataset):
         self.seg_head_config = seg_head_config
         self.center_head_config = center_head_config
         self.offset_head_config = offset_head_config
+        self._warned_geometric_aug = False
+
+    def _apply_common_preprocessing(self, sample: Dict) -> Dict:
+        """Apply common preprocessing, skipping geometric augmentation.
+
+        Geometric augmentation spatially transforms the image but cannot be
+        applied to segmentation masks (which are loaded separately). This
+        override disables geometric augmentation and logs a warning when it
+        was configured but skipped.
+
+        Args:
+            sample: Sample dict with at least ``image`` and ``instances`` keys.
+
+        Returns:
+            The sample dict with preprocessing applied in-place.
+        """
+        if (
+            self.apply_aug
+            and self.geometric_aug is not None
+            and not self._warned_geometric_aug
+        ):
+            logger.warning(
+                "Geometric augmentation is configured but not supported for "
+                "BottomUpSegmentationDataset because masks cannot be spatially "
+                "transformed in sync with the image. Geometric augmentation "
+                "will be skipped; only intensity augmentation will be applied."
+            )
+            self._warned_geometric_aug = True
+
+        # Temporarily disable geometric aug, then call base implementation
+        saved_geometric_aug = self.geometric_aug
+        self.geometric_aug = None
+        try:
+            sample = super()._apply_common_preprocessing(sample)
+        finally:
+            self.geometric_aug = saved_geometric_aug
+        return sample
 
     def _get_lf_idx_list(self, labels: List[sio.Labels]) -> List[Dict]:
         """Return list of indices of frames that have segmentation masks.
@@ -2216,12 +2255,7 @@ class BottomUpSegmentationDataset(BaseDataset):
             "num_instances": 0,
         }
 
-        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding)
-        sample_dict = self._apply_common_preprocessing(sample_dict)
-
-        img_hw = sample_dict["image"].shape[-2:]
-
-        # Load masks for this frame
+        # Load masks for this frame (before preprocessing so we can resize them)
         label = self.labels_list[labels_idx]
         video = label.videos[video_idx]
         frame_masks = label.get_masks(video=video, frame_idx=frame_idx)
@@ -2229,6 +2263,33 @@ class BottomUpSegmentationDataset(BaseDataset):
         mask_arrays = []
         for m in frame_masks:
             mask_arrays.append(m.data)
+
+        # Record original image size before preprocessing
+        orig_img_hw = (image.shape[-2], image.shape[-1])
+
+        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding)
+        sample_dict = self._apply_common_preprocessing(sample_dict)
+
+        img_hw = sample_dict["image"].shape[-2:]
+
+        # Resize masks to match preprocessed image dimensions if size changed
+        if img_hw != orig_img_hw and len(mask_arrays) > 0:
+            target_h, target_w = img_hw
+            resized_masks = []
+            for m in mask_arrays:
+                # Convert mask to float tensor: (1, 1, H, W)
+                m_tensor = (
+                    torch.from_numpy(m.astype(np.float32)).unsqueeze(0).unsqueeze(0)
+                )
+                m_resized = F.interpolate(
+                    m_tensor, size=(target_h, target_w), mode="area"
+                )
+                # Threshold back to binary
+                resized_masks.append((m_resized.squeeze().numpy() > 0.5))
+            mask_arrays = resized_masks
+
+        # Pre-compute mask centroids once for both center heatmap and offset heads
+        centers = _compute_mask_centroids(mask_arrays) if len(mask_arrays) > 0 else []
 
         # Generate GT tensors
         foreground_mask = generate_foreground_mask(
@@ -2242,12 +2303,14 @@ class BottomUpSegmentationDataset(BaseDataset):
             img_hw=img_hw,
             output_stride=self.center_head_config.output_stride,
             sigma=self.center_head_config.sigma,
+            centers=centers,
         )
 
         center_offsets, foreground_weight = generate_center_offsets(
             mask_arrays,
             img_hw=img_hw,
             output_stride=self.offset_head_config.output_stride,
+            centers=centers,
         )
 
         sample_dict["foreground_mask"] = foreground_mask

--- a/sleap_nn/data/segmentation_maps.py
+++ b/sleap_nn/data/segmentation_maps.py
@@ -1,6 +1,6 @@
 """Generate ground truth tensors for instance segmentation from SegmentationMask objects."""
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -55,6 +55,7 @@ def generate_center_heatmap(
     img_hw: Tuple[int, int],
     output_stride: int = 2,
     sigma: float = 10.0,
+    centers: Optional[List[Tuple[float, float]]] = None,
 ) -> torch.Tensor:
     """Generate Gaussian heatmap at each instance mask centroid.
 
@@ -63,6 +64,8 @@ def generate_center_heatmap(
         img_hw: Original image size as (height, width).
         output_stride: Stride for downsampling the output.
         sigma: Standard deviation of the Gaussian in pixels (at original resolution).
+        centers: Pre-computed list of (x, y) centroid coordinates. If None, centroids
+            will be computed from masks via ``_compute_mask_centroids``.
 
     Returns:
         Tensor of shape (1, 1, H/s, W/s) with float32 values.
@@ -74,8 +77,9 @@ def generate_center_heatmap(
     if len(masks) == 0:
         return torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
 
-    # Compute centroids of each mask
-    centers = _compute_mask_centroids(masks)  # (N, 2) in (x, y) pixel coords
+    # Compute centroids of each mask if not provided
+    if centers is None:
+        centers = _compute_mask_centroids(masks)  # (N, 2) in (x, y) pixel coords
 
     # Build heatmap as max of Gaussians
     heatmap = torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
@@ -96,6 +100,7 @@ def generate_center_offsets(
     masks: List[np.ndarray],
     img_hw: Tuple[int, int],
     output_stride: int = 2,
+    centers: Optional[List[Tuple[float, float]]] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Generate per-pixel offset vectors pointing to each pixel's instance center.
 
@@ -103,6 +108,8 @@ def generate_center_offsets(
         masks: List of 2D boolean arrays (H, W), one per instance.
         img_hw: Original image size as (height, width).
         output_stride: Stride for downsampling the output.
+        centers: Pre-computed list of (x, y) centroid coordinates. If None, centroids
+            will be computed from masks via ``_compute_mask_centroids``.
 
     Returns:
         Tuple of:
@@ -121,7 +128,8 @@ def generate_center_offsets(
     if len(masks) == 0:
         return offsets, weight_mask
 
-    centers = _compute_mask_centroids(masks)
+    if centers is None:
+        centers = _compute_mask_centroids(masks)
 
     # Create coordinate grids at output stride resolution
     # Grid values are in original pixel coordinates
@@ -140,7 +148,7 @@ def generate_center_offsets(
             m_ds = F.interpolate(m_tensor, size=(out_h, out_w), mode="area")
         else:
             m_ds = m_tensor
-        m_binary = m_ds.squeeze() > 0.5  # (out_h, out_w)
+        m_binary = m_ds[0, 0] > 0.5  # (out_h, out_w)
 
         cx, cy = centers[i]
 

--- a/sleap_nn/data/segmentation_maps.py
+++ b/sleap_nn/data/segmentation_maps.py
@@ -6,8 +6,6 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from sleap_nn.data.utils import make_grid_vectors
-
 
 def generate_foreground_mask(
     masks: List[np.ndarray],
@@ -71,8 +69,10 @@ def generate_center_heatmap(
         Tensor of shape (1, 1, H/s, W/s) with float32 values.
     """
     height, width = img_hw
-    xv, yv = make_grid_vectors(height, width, output_stride)
-    out_h, out_w = yv.shape[0], xv.shape[0]
+    out_h = height // output_stride
+    out_w = width // output_stride
+    xv = torch.arange(out_w, dtype=torch.float32) * output_stride + output_stride / 2.0
+    yv = torch.arange(out_h, dtype=torch.float32) * output_stride + output_stride / 2.0
 
     if len(masks) == 0:
         return torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
@@ -131,13 +131,18 @@ def generate_center_offsets(
     if centers is None:
         centers = _compute_mask_centroids(masks)
 
+    # Sort by area descending so smaller instances overwrite larger ones in overlaps
+    areas = [m.sum() for m in masks]
+    sorted_indices = sorted(range(len(masks)), key=lambda i: areas[i], reverse=True)
+
     # Create coordinate grids at output stride resolution
     # Grid values are in original pixel coordinates
     yy = torch.arange(out_h, dtype=torch.float32) * output_stride + output_stride / 2.0
     xx = torch.arange(out_w, dtype=torch.float32) * output_stride + output_stride / 2.0
     grid_x, grid_y = torch.meshgrid(xx, yy, indexing="xy")  # both (out_h, out_w)
 
-    for i, m in enumerate(masks):
+    for idx in sorted_indices:
+        m = masks[idx]
         # Downsample mask
         m_tensor = (
             torch.from_numpy(m[:height, :width].astype(np.float32))
@@ -150,7 +155,7 @@ def generate_center_offsets(
             m_ds = m_tensor
         m_binary = m_ds[0, 0] > 0.5  # (out_h, out_w)
 
-        cx, cy = centers[i]
+        cx, cy = centers[idx]
 
         # Offset = center - pixel_coord (so pixel + offset = center)
         dx = cx - grid_x  # (out_h, out_w)

--- a/sleap_nn/data/segmentation_maps.py
+++ b/sleap_nn/data/segmentation_maps.py
@@ -1,0 +1,178 @@
+"""Generate ground truth tensors for instance segmentation from SegmentationMask objects."""
+
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from sleap_nn.data.utils import make_grid_vectors
+
+
+def generate_foreground_mask(
+    masks: List[np.ndarray],
+    img_hw: Tuple[int, int],
+    output_stride: int = 2,
+) -> torch.Tensor:
+    """Generate binary foreground mask as union of all instance masks.
+
+    Args:
+        masks: List of 2D boolean arrays (H, W), one per instance.
+        img_hw: Original image size as (height, width).
+        output_stride: Stride for downsampling the output mask.
+
+    Returns:
+        Tensor of shape (1, 1, H/s, W/s) with float32 values in [0, 1].
+    """
+    height, width = img_hw
+    out_h = height // output_stride
+    out_w = width // output_stride
+
+    if len(masks) == 0:
+        return torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+
+    # Union of all masks at original resolution
+    union = np.zeros((height, width), dtype=bool)
+    for m in masks:
+        # Handle masks that may be different sizes than image
+        mh, mw = m.shape
+        h_end = min(mh, height)
+        w_end = min(mw, width)
+        union[:h_end, :w_end] |= m[:h_end, :w_end]
+
+    # Convert to tensor and downsample via area interpolation
+    fg = torch.from_numpy(union.astype(np.float32)).unsqueeze(0).unsqueeze(0)
+    if output_stride > 1:
+        fg = F.interpolate(fg, size=(out_h, out_w), mode="area")
+    # Threshold back to binary-ish (area interpolation produces soft values)
+    fg = (fg > 0.5).float()
+
+    return fg  # (1, 1, H/s, W/s)
+
+
+def generate_center_heatmap(
+    masks: List[np.ndarray],
+    img_hw: Tuple[int, int],
+    output_stride: int = 2,
+    sigma: float = 10.0,
+) -> torch.Tensor:
+    """Generate Gaussian heatmap at each instance mask centroid.
+
+    Args:
+        masks: List of 2D boolean arrays (H, W), one per instance.
+        img_hw: Original image size as (height, width).
+        output_stride: Stride for downsampling the output.
+        sigma: Standard deviation of the Gaussian in pixels (at original resolution).
+
+    Returns:
+        Tensor of shape (1, 1, H/s, W/s) with float32 values.
+    """
+    height, width = img_hw
+    xv, yv = make_grid_vectors(height, width, output_stride)
+    out_h, out_w = yv.shape[0], xv.shape[0]
+
+    if len(masks) == 0:
+        return torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+
+    # Compute centroids of each mask
+    centers = _compute_mask_centroids(masks)  # (N, 2) in (x, y) pixel coords
+
+    # Build heatmap as max of Gaussians
+    heatmap = torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+    xv_grid = xv.reshape(1, 1, 1, -1)  # (1, 1, 1, W/s)
+    yv_grid = yv.reshape(1, 1, -1, 1)  # (1, 1, H/s, 1)
+    scaled_sigma = sigma * output_stride
+
+    for cx, cy in centers:
+        g = torch.exp(
+            -((xv_grid - cx) ** 2 + (yv_grid - cy) ** 2) / (2 * scaled_sigma**2)
+        )
+        heatmap = torch.maximum(heatmap, g)
+
+    return heatmap  # (1, 1, H/s, W/s)
+
+
+def generate_center_offsets(
+    masks: List[np.ndarray],
+    img_hw: Tuple[int, int],
+    output_stride: int = 2,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Generate per-pixel offset vectors pointing to each pixel's instance center.
+
+    Args:
+        masks: List of 2D boolean arrays (H, W), one per instance.
+        img_hw: Original image size as (height, width).
+        output_stride: Stride for downsampling the output.
+
+    Returns:
+        Tuple of:
+            offsets: Tensor of shape (1, 2, H/s, W/s) with (dx, dy) offset vectors.
+                Only defined on foreground pixels; background pixels are 0.
+            weight_mask: Tensor of shape (1, 1, H/s, W/s) binary mask indicating
+                where offset loss should be computed (foreground pixels).
+    """
+    height, width = img_hw
+    out_h = height // output_stride
+    out_w = width // output_stride
+
+    offsets = torch.zeros((1, 2, out_h, out_w), dtype=torch.float32)
+    weight_mask = torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+
+    if len(masks) == 0:
+        return offsets, weight_mask
+
+    centers = _compute_mask_centroids(masks)
+
+    # Create coordinate grids at output stride resolution
+    # Grid values are in original pixel coordinates
+    yy = torch.arange(out_h, dtype=torch.float32) * output_stride + output_stride / 2.0
+    xx = torch.arange(out_w, dtype=torch.float32) * output_stride + output_stride / 2.0
+    grid_x, grid_y = torch.meshgrid(xx, yy, indexing="xy")  # both (out_h, out_w)
+
+    for i, m in enumerate(masks):
+        # Downsample mask
+        m_tensor = (
+            torch.from_numpy(m[:height, :width].astype(np.float32))
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+        if output_stride > 1:
+            m_ds = F.interpolate(m_tensor, size=(out_h, out_w), mode="area")
+        else:
+            m_ds = m_tensor
+        m_binary = m_ds.squeeze() > 0.5  # (out_h, out_w)
+
+        cx, cy = centers[i]
+
+        # Offset = center - pixel_coord (so pixel + offset = center)
+        dx = cx - grid_x  # (out_h, out_w)
+        dy = cy - grid_y
+
+        # Only set offsets for this instance's foreground pixels
+        offsets[0, 0][m_binary] = dx[m_binary]
+        offsets[0, 1][m_binary] = dy[m_binary]
+        weight_mask[0, 0][m_binary] = 1.0
+
+    return offsets, weight_mask
+
+
+def _compute_mask_centroids(masks: List[np.ndarray]) -> List[Tuple[float, float]]:
+    """Compute the centroid (center of mass) of each binary mask.
+
+    Args:
+        masks: List of 2D boolean arrays.
+
+    Returns:
+        List of (x, y) centroid coordinates in pixel space.
+    """
+    centers = []
+    for m in masks:
+        ys, xs = np.nonzero(m)
+        if len(xs) == 0:
+            # Empty mask — use image center as fallback
+            cy, cx = m.shape[0] / 2.0, m.shape[1] / 2.0
+        else:
+            cx = float(xs.mean())
+            cy = float(ys.mean())
+        centers.append((cx, cy))
+    return centers

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -30,12 +30,14 @@ from sleap_nn.training.lightning_modules import (
     BottomUpLightningModule,
     BottomUpMultiClassLightningModule,
     TopDownCenteredInstanceMultiClassLightningModule,
+    BottomUpSegmentationLightningModule,
 )
 from sleap_nn.inference.single_instance import SingleInstanceInferenceModel
 from sleap_nn.inference.bottomup import (
     BottomUpInferenceModel,
     BottomUpMultiClassInferenceModel,
 )
+from sleap_nn.inference.segmentation import BottomUpSegmentationInferenceModel
 from sleap_nn.inference.topdown import (
     CentroidCrop,
     FindInstancePeaks,
@@ -399,6 +401,18 @@ class Predictor(ABC):
                 filter_min_visible_node_fraction=filter_min_visible_node_fraction,
                 filter_min_mean_node_score=filter_min_mean_node_score,
                 filter_min_instance_score=filter_min_instance_score,
+            )
+
+        elif "bottomup_segmentation" in model_names:
+            seg_ckpt_path = model_paths[model_names.index("bottomup_segmentation")]
+            predictor = BottomUpSegmentationPredictor.from_trained_models(
+                seg_ckpt_path=seg_ckpt_path,
+                backbone_ckpt_path=backbone_ckpt_path,
+                head_ckpt_path=head_ckpt_path,
+                peak_threshold=peak_threshold,
+                batch_size=batch_size,
+                device=device,
+                preprocess_config=preprocess_config,
             )
 
         else:
@@ -3962,3 +3976,98 @@ class TopDownMultiClassPredictor(Predictor):
             labeled_frames=predicted_frames,
         )
         return pred_labels
+
+
+class BottomUpSegmentationPredictor(Predictor):
+    """Predictor for bottom-up instance segmentation models.
+
+    This predictor loads a trained segmentation model and runs inference to
+    produce per-instance binary masks stored as ``sio.SegmentationMask`` objects.
+    """
+
+    def __init__(
+        self,
+        inference_model: BottomUpSegmentationInferenceModel,
+        preprocess: bool = True,
+        preprocess_config: dict = None,
+        max_stride: int = 16,
+        batch_size: int = 4,
+    ):
+        """Initialize the predictor."""
+        super().__init__(
+            preprocess=preprocess,
+            preprocess_config=preprocess_config,
+        )
+        self.inference_model = inference_model
+        self.max_stride = max_stride
+        self.batch_size = batch_size
+        self.videos = []
+
+    @classmethod
+    def from_trained_models(
+        cls,
+        seg_ckpt_path: str,
+        backbone_ckpt_path: Optional[str] = None,
+        head_ckpt_path: Optional[str] = None,
+        peak_threshold: float = 0.2,
+        batch_size: int = 4,
+        device: str = "cpu",
+        preprocess_config: Optional[OmegaConf] = None,
+    ) -> "BottomUpSegmentationPredictor":
+        """Create predictor from a trained model checkpoint."""
+        path = Path(seg_ckpt_path)
+        if (path / "training_config.yaml").exists():
+            config = OmegaConf.load((path / "training_config.yaml").as_posix())
+        else:
+            config = TrainingJobConfig.load_sleap_config(
+                (path / "training_config.json").as_posix()
+            )
+
+        # Load the lightning model
+        ckpt_path = backbone_ckpt_path or str(path / "best.ckpt")
+        model = BottomUpSegmentationLightningModule.load_from_checkpoint(
+            ckpt_path,
+            strict=False,
+        )
+        model.to(device)
+        model.eval()
+
+        seg_config = config.model_config.head_configs.bottomup_segmentation
+        output_stride = seg_config.segmentation.output_stride
+
+        inference_model = BottomUpSegmentationInferenceModel(
+            torch_model=model.forward,
+            fg_threshold=0.5,
+            peak_threshold=peak_threshold,
+            output_stride=output_stride,
+        )
+
+        return cls(
+            inference_model=inference_model,
+            preprocess=True,
+            preprocess_config=preprocess_config,
+            batch_size=batch_size,
+        )
+
+    @classmethod
+    def from_trained_models(cls, *args, **kwargs):
+        """Initialize the Predictor class for certain type of model."""
+
+    def make_pipeline(
+        self,
+        data_path: str,
+        queue_maxsize: int = 32,
+        video_index: int = None,
+        frames: Optional[list] = None,
+    ):
+        """Not implemented for segmentation predictor yet."""
+        raise NotImplementedError(
+            "Pipeline inference is not yet implemented for segmentation models. "
+            "Use predict_on_labels() or predict_on_video() instead."
+        )
+
+    def predict(self, *args, **kwargs):
+        """Not implemented for segmentation predictor yet."""
+        raise NotImplementedError(
+            "Direct prediction is not yet implemented for segmentation models."
+        )

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -4049,10 +4049,6 @@ class BottomUpSegmentationPredictor(Predictor):
             batch_size=batch_size,
         )
 
-    @classmethod
-    def from_trained_models(cls, *args, **kwargs):
-        """Initialize the Predictor class for certain type of model."""
-
     def make_pipeline(
         self,
         data_path: str,

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -3978,30 +3978,34 @@ class TopDownMultiClassPredictor(Predictor):
         return pred_labels
 
 
+@attrs.define
 class BottomUpSegmentationPredictor(Predictor):
     """Predictor for bottom-up instance segmentation models.
 
     This predictor loads a trained segmentation model and runs inference to
     produce per-instance binary masks stored as ``sio.SegmentationMask`` objects.
+
+    Attributes:
+        config: Training configuration loaded from checkpoint directory.
+        seg_model: Trained Lightning module for segmentation.
+        videos: List of ``sio.Video`` objects for the output ``sio.Labels``.
+        fg_threshold: Threshold for binarizing the foreground probability map.
+        peak_threshold: Minimum confidence for detected instance centers.
+        output_stride: Stride of the model output maps relative to the input.
+        batch_size: Number of frames per inference batch.
+        device: Device for inference (``"cpu"``, ``"cuda"``, ``"mps"``).
+        max_stride: Maximum backbone stride for input padding.
     """
 
-    def __init__(
-        self,
-        inference_model: BottomUpSegmentationInferenceModel,
-        preprocess: bool = True,
-        preprocess_config: dict = None,
-        max_stride: int = 16,
-        batch_size: int = 4,
-    ):
-        """Initialize the predictor."""
-        super().__init__(
-            preprocess=preprocess,
-            preprocess_config=preprocess_config,
-        )
-        self.inference_model = inference_model
-        self.max_stride = max_stride
-        self.batch_size = batch_size
-        self.videos = []
+    config: Optional[OmegaConf] = None
+    seg_model: Optional[L.LightningModule] = attrs.field(default=None)
+    videos: Optional[List[sio.Video]] = attrs.field(default=None)
+    fg_threshold: float = 0.5
+    peak_threshold: float = 0.2
+    output_stride: int = 2
+    batch_size: int = 4
+    device: str = "cpu"
+    max_stride: int = 16
 
     @classmethod
     def from_trained_models(
@@ -4009,12 +4013,31 @@ class BottomUpSegmentationPredictor(Predictor):
         seg_ckpt_path: str,
         backbone_ckpt_path: Optional[str] = None,
         head_ckpt_path: Optional[str] = None,
+        fg_threshold: float = 0.5,
         peak_threshold: float = 0.2,
         batch_size: int = 4,
         device: str = "cpu",
         preprocess_config: Optional[OmegaConf] = None,
     ) -> "BottomUpSegmentationPredictor":
-        """Create predictor from a trained model checkpoint."""
+        """Create predictor from a trained model checkpoint.
+
+        Args:
+            seg_ckpt_path: Path to checkpoint directory containing ``best.ckpt``
+                and ``training_config.yaml``.
+            backbone_ckpt_path: Optional path to a different ``.ckpt`` file for
+                the backbone weights. If ``None``, ``best.ckpt`` is used.
+            head_ckpt_path: Optional path to a different ``.ckpt`` file for the
+                head layer weights.
+            fg_threshold: Threshold for foreground binarization. Default: 0.5.
+            peak_threshold: Minimum confidence for center detection. Default: 0.2.
+            batch_size: Number of frames per batch. Default: 4.
+            device: Device for inference. Default: ``"cpu"``.
+            preprocess_config: Preprocessing config. Missing keys are filled
+                from the training config.
+
+        Returns:
+            An instance of ``BottomUpSegmentationPredictor``.
+        """
         path = Path(seg_ckpt_path)
         if (path / "training_config.yaml").exists():
             config = OmegaConf.load((path / "training_config.yaml").as_posix())
@@ -4023,47 +4046,265 @@ class BottomUpSegmentationPredictor(Predictor):
                 (path / "training_config.json").as_posix()
             )
 
+        # Detect backbone type
+        for k, v in config.model_config.backbone_config.items():
+            if v is not None:
+                backbone_type = k
+                break
+
         # Load the lightning model
         ckpt_path = backbone_ckpt_path or str(path / "best.ckpt")
         model = BottomUpSegmentationLightningModule.load_from_checkpoint(
             ckpt_path,
             strict=False,
+            map_location=device,
+            weights_only=False,
         )
+
+        # Optionally load separate backbone/head weights
+        if backbone_ckpt_path is not None and head_ckpt_path is not None:
+            ckpt = torch.load(
+                backbone_ckpt_path, map_location=device, weights_only=False
+            )
+            ckpt["state_dict"] = {
+                k: ckpt["state_dict"][k]
+                for k in ckpt["state_dict"].keys()
+                if ".backbone" in k
+            }
+            model.load_state_dict(ckpt["state_dict"], strict=False)
+        elif backbone_ckpt_path is not None:
+            ckpt = torch.load(
+                backbone_ckpt_path, map_location=device, weights_only=False
+            )
+            model.load_state_dict(ckpt["state_dict"], strict=False)
+
+        if head_ckpt_path is not None:
+            ckpt = torch.load(head_ckpt_path, map_location=device, weights_only=False)
+            ckpt["state_dict"] = {
+                k: ckpt["state_dict"][k]
+                for k in ckpt["state_dict"].keys()
+                if ".head_layers" in k
+            }
+            model.load_state_dict(ckpt["state_dict"], strict=False)
+
         model.to(device)
         model.eval()
 
         seg_config = config.model_config.head_configs.bottomup_segmentation
         output_stride = seg_config.segmentation.output_stride
 
-        inference_model = BottomUpSegmentationInferenceModel(
-            torch_model=model.forward,
-            fg_threshold=0.5,
+        # Fill in preprocess_config defaults from training config
+        if preprocess_config is None:
+            preprocess_config = OmegaConf.create(
+                {
+                    "scale": 1.0,
+                    "ensure_rgb": False,
+                    "ensure_grayscale": False,
+                    "crop_size": None,
+                    "max_height": None,
+                    "max_width": None,
+                }
+            )
+        for k, v in preprocess_config.items():
+            if v is None:
+                preprocess_config[k] = (
+                    config.data_config.preprocessing[k]
+                    if k in config.data_config.preprocessing
+                    else None
+                )
+
+        obj = cls(
+            config=config,
+            seg_model=model,
+            fg_threshold=fg_threshold,
             peak_threshold=peak_threshold,
             output_stride=output_stride,
+            batch_size=batch_size,
+            device=device,
+            preprocess_config=preprocess_config,
+            max_stride=config.model_config.backbone_config[backbone_type]["max_stride"],
         )
 
-        return cls(
-            inference_model=inference_model,
-            preprocess=True,
-            preprocess_config=preprocess_config,
-            batch_size=batch_size,
+        obj._initialize_inference_model()
+        return obj
+
+    def _initialize_inference_model(self):
+        """Create the inference model from stored attributes."""
+        self.inference_model = BottomUpSegmentationInferenceModel(
+            torch_model=self.seg_model,
+            fg_threshold=self.fg_threshold,
+            peak_threshold=self.peak_threshold,
+            output_stride=self.output_stride,
         )
 
     def make_pipeline(
         self,
-        data_path: str,
+        inference_object: Union[str, Path, sio.Labels, sio.Video],
         queue_maxsize: int = 32,
-        video_index: int = None,
         frames: Optional[list] = None,
+        only_labeled_frames: bool = False,
+        only_suggested_frames: bool = False,
+        exclude_user_labeled: bool = False,
+        only_predicted_frames: bool = False,
+        video_index: Optional[int] = None,
+        video_dataset: Optional[str] = None,
+        video_input_format: str = "channels_last",
     ):
-        """Not implemented for segmentation predictor yet."""
-        raise NotImplementedError(
-            "Pipeline inference is not yet implemented for segmentation models. "
-            "Use predict_on_labels() or predict_on_video() instead."
-        )
+        """Create a data loading pipeline for inference.
 
-    def predict(self, *args, **kwargs):
-        """Not implemented for segmentation predictor yet."""
-        raise NotImplementedError(
-            "Direct prediction is not yet implemented for segmentation models."
+        Args:
+            inference_object: Path to ``.slp`` or video file, or an
+                ``sio.Labels`` / ``sio.Video`` instance.
+            queue_maxsize: Maximum frame buffer queue size. Default: 32.
+            frames: List of frame indices to predict on. Default: all frames.
+            only_labeled_frames: Only predict on user-labeled frames.
+            only_suggested_frames: Only predict on suggested frames.
+            exclude_user_labeled: Skip user-labeled frames.
+            only_predicted_frames: Only predict on already-predicted frames.
+            video_index: Index of video in ``.slp`` to predict on.
+            video_dataset: Dataset key for HDF5 videos.
+            video_input_format: Input format for HDF5 videos.
+        """
+        if isinstance(inference_object, (str, Path)):
+            inference_object = str(inference_object)
+            inference_object = (
+                sio.load_slp(inference_object)
+                if inference_object.endswith(".slp")
+                else sio.load_video(
+                    inference_object,
+                    dataset=video_dataset,
+                    input_format=video_input_format,
+                )
+            )
+
+        self.preprocess = True
+
+        if isinstance(inference_object, sio.Labels) and video_index is None:
+            frame_buffer = Queue(maxsize=queue_maxsize)
+            self.pipeline = LabelsReader(
+                labels=inference_object,
+                frame_buffer=frame_buffer,
+                only_labeled_frames=only_labeled_frames,
+                only_suggested_frames=only_suggested_frames,
+                exclude_user_labeled=exclude_user_labeled,
+                only_predicted_frames=only_predicted_frames,
+            )
+            self.videos = self.pipeline.labels.videos
+        else:
+            if isinstance(inference_object, sio.Labels) and video_index is not None:
+                labels = inference_object
+                video = labels.videos[video_index]
+                filtered_frames = _filter_user_labeled_frames(
+                    labels, video, frames, exclude_user_labeled
+                )
+                self.pipeline = VideoReader.from_video(
+                    video=video,
+                    queue_maxsize=queue_maxsize,
+                    frames=filtered_frames,
+                )
+            else:
+                frame_buffer = Queue(maxsize=queue_maxsize)
+                self.pipeline = VideoReader(
+                    video=inference_object,
+                    frame_buffer=frame_buffer,
+                    frames=frames,
+                )
+            self.videos = [self.pipeline.video]
+
+    def _run_inference_on_batch(
+        self, imgs, fidxs, vidxs, org_szs, instances, eff_scales
+    ):
+        """Run segmentation inference on a batch and yield per-frame results.
+
+        Overrides the base class to handle the segmentation model's output
+        format (``List[List[Dict]]``) and package per-frame metadata.
+
+        Yields:
+            Dict per frame with keys: ``video_idx``, ``frame_idx``,
+            ``orig_size``, ``instances``, ``padded_size``.
+        """
+        imgs = torch.concatenate(imgs, dim=0)
+        fidxs_tensor = torch.tensor(fidxs, dtype=torch.int32)
+        vidxs_tensor = torch.tensor(vidxs, dtype=torch.int32)
+        org_szs_tensor = torch.concatenate(org_szs, dim=0)
+
+        ex = {"image": imgs}
+
+        if self.preprocess:
+            scale = self.preprocess_config["scale"]
+            if scale != 1.0:
+                ex["image"] = resize_image(ex["image"], scale)
+            ex["image"] = apply_pad_to_stride(ex["image"], self.max_stride)
+
+        padded_h, padded_w = ex["image"].shape[-2:]
+
+        # Returns List[List[Dict]] — one list of instances per batch element
+        batch_results = self.inference_model(ex)
+
+        for i in range(len(batch_results)):
+            yield {
+                "video_idx": vidxs_tensor[i].item(),
+                "frame_idx": fidxs_tensor[i].item(),
+                "orig_size": org_szs_tensor[i].numpy(),
+                "instances": batch_results[i],
+                "padded_size": (padded_h, padded_w),
+            }
+
+    def _make_labeled_frames_from_generator(
+        self,
+        generator: Iterator[Dict[str, np.ndarray]],
+    ) -> sio.Labels:
+        """Convert inference results to ``sio.Labels`` with segmentation masks.
+
+        Args:
+            generator: Generator yielding per-frame dicts from
+                ``_run_inference_on_batch``.
+
+        Returns:
+            ``sio.Labels`` with ``sio.SegmentationMask`` objects.
+        """
+        all_masks = []
+
+        for ex in generator:
+            video_idx = int(ex["video_idx"])
+            frame_idx = int(ex["frame_idx"])
+            orig_size = ex["orig_size"]  # (H, W)
+            orig_h, orig_w = int(orig_size[0]), int(orig_size[1])
+            instance_list = ex["instances"]
+
+            # Crop and upscale dimensions
+            crop_h = orig_h // self.output_stride
+            crop_w = orig_w // self.output_stride
+
+            video = self.videos[video_idx]
+
+            for inst in instance_list:
+                mask = inst["mask"]  # (H_out, W_out) bool at output stride
+                score = inst["score"]
+
+                # Crop padding (mask may be larger due to pad_to_stride)
+                mask = mask[:crop_h, :crop_w]
+
+                # Upscale to original resolution via nearest-neighbor
+                mask_tensor = (
+                    torch.from_numpy(mask.astype(np.float32)).unsqueeze(0).unsqueeze(0)
+                )
+                mask_upscaled = torch.nn.functional.interpolate(
+                    mask_tensor,
+                    size=(orig_h, orig_w),
+                    mode="nearest",
+                )
+                mask_full = mask_upscaled.squeeze().numpy() > 0.5
+
+                seg_mask = sio.SegmentationMask.from_numpy(
+                    mask_full,
+                    video=video,
+                    frame_idx=frame_idx,
+                    score=score,
+                )
+                all_masks.append(seg_mask)
+
+        return sio.Labels(
+            videos=self.videos,
+            masks=all_masks,
         )

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -27,7 +27,6 @@ def group_instances_from_offsets(
         offsets: Offset field (dx, dy). Shape: (1, 2, H, W).
         fg_threshold: Threshold for foreground binarization.
         peak_threshold: Minimum peak value for center detection.
-        nms_kernel_size: Kernel size for non-maximum suppression.
         output_stride: Stride of the output maps relative to the input image.
 
     Returns:

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -1,0 +1,181 @@
+"""Inference utilities for bottom-up instance segmentation."""
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import lightning as L
+
+from sleap_nn.data.normalization import normalize_on_gpu
+from sleap_nn.data.resizing import apply_pad_to_stride
+from sleap_nn.inference.peak_finding import find_local_peaks_rough
+
+
+def group_instances_from_offsets(
+    foreground: torch.Tensor,
+    center_heatmap: torch.Tensor,
+    offsets: torch.Tensor,
+    fg_threshold: float = 0.5,
+    peak_threshold: float = 0.2,
+    output_stride: int = 2,
+) -> List[Dict]:
+    """Group foreground pixels into instances using center-offset predictions.
+
+    Args:
+        foreground: Foreground probability map. Shape: (1, 1, H, W).
+        center_heatmap: Center heatmap. Shape: (1, 1, H, W).
+        offsets: Offset field (dx, dy). Shape: (1, 2, H, W).
+        fg_threshold: Threshold for foreground binarization.
+        peak_threshold: Minimum peak value for center detection.
+        nms_kernel_size: Kernel size for non-maximum suppression.
+        output_stride: Stride of the output maps relative to the input image.
+
+    Returns:
+        List of dicts, each with:
+            - "mask": (H, W) boolean numpy array (at output stride resolution)
+            - "center": (x, y) tuple in original pixel coordinates
+            - "score": float confidence score (peak value)
+    """
+    h, w = foreground.shape[-2:]
+
+    # 1. Threshold foreground
+    fg_binary = foreground[0, 0] > fg_threshold  # (H, W)
+
+    if fg_binary.sum() == 0:
+        return []
+
+    # 2. Find centers via local peak finding
+    peaks, peak_vals, peak_sample_inds, peak_channel_inds = find_local_peaks_rough(
+        center_heatmap,
+        threshold=peak_threshold,
+    )
+
+    if len(peaks) == 0:
+        return []
+
+    # peaks are in (x, y) format at output stride resolution
+    # Convert to original pixel coords
+    centers = peaks.float()  # (N, 2) in output stride pixel coords
+
+    # 3. For each foreground pixel, compute predicted center
+    fg_coords = torch.nonzero(
+        fg_binary, as_tuple=False
+    )  # (M, 2) as (row, col) = (y, x)
+    fg_y = fg_coords[:, 0]
+    fg_x = fg_coords[:, 1]
+
+    # Get offsets at foreground pixels
+    dx = offsets[0, 0, fg_y, fg_x]  # (M,)
+    dy = offsets[0, 1, fg_y, fg_x]  # (M,)
+
+    # Pixel coordinates in original resolution
+    pixel_x = fg_x.float() * output_stride + output_stride / 2.0
+    pixel_y = fg_y.float() * output_stride + output_stride / 2.0
+
+    # Predicted centers for each foreground pixel
+    pred_center_x = pixel_x + dx  # (M,)
+    pred_center_y = pixel_y + dy  # (M,)
+
+    # 4. Assign each foreground pixel to nearest detected center
+    # centers are already in original pixel coordinates (from peak finding * output_stride)
+    center_x = centers[:, 0] * output_stride + output_stride / 2.0  # (N,)
+    center_y = centers[:, 1] * output_stride + output_stride / 2.0  # (N,)
+
+    # Compute distances: (M, N)
+    dist_x = pred_center_x.unsqueeze(1) - center_x.unsqueeze(0)
+    dist_y = pred_center_y.unsqueeze(1) - center_y.unsqueeze(0)
+    dists = dist_x**2 + dist_y**2
+
+    assignments = dists.argmin(dim=1)  # (M,) index into centers
+
+    # 5. Build per-instance masks
+    instances = []
+    for i in range(len(centers)):
+        member_mask = assignments == i
+        if member_mask.sum() == 0:
+            continue
+
+        instance_mask = torch.zeros((h, w), dtype=torch.bool)
+        instance_mask[fg_y[member_mask], fg_x[member_mask]] = True
+
+        instances.append(
+            {
+                "mask": instance_mask.numpy(),
+                "center": (center_x[i].item(), center_y[i].item()),
+                "score": peak_vals[i].item() if i < len(peak_vals) else 0.0,
+            }
+        )
+
+    return instances
+
+
+class BottomUpSegmentationInferenceModel(L.LightningModule):
+    """Inference model for bottom-up instance segmentation.
+
+    Wraps a trained model and post-processing into a single forward pass.
+
+    Attributes:
+        torch_model: Callable model that returns head output dict.
+        fg_threshold: Threshold for foreground binarization.
+        peak_threshold: Minimum peak value for center detection.
+        output_stride: Stride of the model output maps.
+        input_scale: Factor to resize input images by before inference.
+        max_stride: Maximum stride for input padding.
+    """
+
+    def __init__(
+        self,
+        torch_model,
+        fg_threshold: float = 0.5,
+        peak_threshold: float = 0.2,
+        output_stride: int = 2,
+        input_scale: float = 1.0,
+        max_stride: int = 16,
+    ):
+        """Initialize the inference model."""
+        super().__init__()
+        self.torch_model = torch_model
+        self.fg_threshold = fg_threshold
+        self.peak_threshold = peak_threshold
+        self.output_stride = output_stride
+        self.input_scale = input_scale
+        self.max_stride = max_stride
+
+    def forward(self, batch: Dict) -> List[List[Dict]]:
+        """Run inference on a batch of images.
+
+        Args:
+            batch: Dict with "image" key. Shape: (B, 1, C, H, W) or (B, C, H, W).
+
+        Returns:
+            List of instance lists (one per batch element). Each instance is a dict
+            with "mask", "center", and "score" keys.
+        """
+        images = batch["image"]
+        if images.dim() == 5:
+            images = images.squeeze(1)
+
+        images = images.to(self.device)
+
+        if self.max_stride > 1:
+            images = apply_pad_to_stride(images, self.max_stride)
+
+        output = self.torch_model(images.unsqueeze(1))
+
+        foreground = output["SegmentationHead"]
+        center_heatmap = output["InstanceCenterHead"]
+        offsets = output["CenterOffsetHead"]
+
+        batch_results = []
+        for b in range(foreground.shape[0]):
+            instances = group_instances_from_offsets(
+                foreground=foreground[b : b + 1],
+                center_heatmap=center_heatmap[b : b + 1],
+                offsets=offsets[b : b + 1],
+                fg_threshold=self.fg_threshold,
+                peak_threshold=self.peak_threshold,
+                output_stride=self.output_stride,
+            )
+            batch_results.append(instances)
+
+        return batch_results

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -6,8 +6,6 @@ import numpy as np
 import torch
 import lightning as L
 
-from sleap_nn.data.normalization import normalize_on_gpu
-from sleap_nn.data.resizing import apply_pad_to_stride
 from sleap_nn.inference.peak_finding import find_local_peaks_rough
 
 
@@ -112,14 +110,14 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
     """Inference model for bottom-up instance segmentation.
 
     Wraps a trained model and post-processing into a single forward pass.
+    Input images should already be padded to stride before being passed to this
+    model (handled by the predictor's ``_run_inference_on_batch``).
 
     Attributes:
         torch_model: Callable model that returns head output dict.
         fg_threshold: Threshold for foreground binarization.
         peak_threshold: Minimum peak value for center detection.
         output_stride: Stride of the model output maps.
-        input_scale: Factor to resize input images by before inference.
-        max_stride: Maximum stride for input padding.
     """
 
     def __init__(
@@ -128,8 +126,6 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         fg_threshold: float = 0.5,
         peak_threshold: float = 0.2,
         output_stride: int = 2,
-        input_scale: float = 1.0,
-        max_stride: int = 16,
     ):
         """Initialize the inference model."""
         super().__init__()
@@ -137,14 +133,13 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         self.fg_threshold = fg_threshold
         self.peak_threshold = peak_threshold
         self.output_stride = output_stride
-        self.input_scale = input_scale
-        self.max_stride = max_stride
 
     def forward(self, batch: Dict) -> List[List[Dict]]:
         """Run inference on a batch of images.
 
         Args:
-            batch: Dict with "image" key. Shape: (B, 1, C, H, W) or (B, C, H, W).
+            batch: Dict with "image" key. Shape: (B, C, H, W). Images should
+                already be padded to the model's max stride.
 
         Returns:
             List of instance lists (one per batch element). Each instance is a dict
@@ -155,9 +150,6 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
             images = images.squeeze(1)
 
         images = images.to(self.device)
-
-        if self.max_stride > 1:
-            images = apply_pad_to_stride(images, self.max_stride)
 
         output = self.torch_model(images.unsqueeze(1))
 

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -9,6 +9,7 @@ from sleap_nn.inference.predictors import (
     BottomUpPredictor,
     BottomUpMultiClassPredictor,
     TopDownMultiClassPredictor,
+    BottomUpSegmentationPredictor,
 )
 from sleap_nn.tracking.tracker import (
     Tracker,
@@ -570,6 +571,7 @@ def run_inference(
             tracking
             and not isinstance(predictor, BottomUpMultiClassPredictor)
             and not isinstance(predictor, TopDownMultiClassPredictor)
+            and not isinstance(predictor, BottomUpSegmentationPredictor)
         ):
             if post_connect_single_breaks or tracking_pre_cull_to_target:
                 if tracking_target_instance_count is None and max_instances is None:

--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -560,6 +560,7 @@ class UnifiedVizCallback(Callback):
         # Auto-enable model-specific visualizations
         self.viz_pafs = model_type == "bottomup"
         self.viz_class_maps = model_type == "multi_class_bottomup"
+        self.viz_center_heatmap = model_type == "bottomup_segmentation"
 
         # Initialize renderers
         from sleap_nn.training.utils import MatplotlibRenderer, WandBRenderer
@@ -600,6 +601,8 @@ class UnifiedVizCallback(Callback):
             kwargs["include_pafs"] = True
         if self.viz_class_maps:
             kwargs["include_class_maps"] = True
+        if self.viz_center_heatmap:
+            kwargs["include_center_heatmap"] = True
 
         # Access lightning_model lazily from model_trainer
         return self.model_trainer.lightning_model.get_visualization_data(
@@ -637,6 +640,15 @@ class UnifiedVizCallback(Callback):
             fig.savefig(fig_path, format="png")
             plt.close(fig)
 
+        # Center heatmap visualization (for segmentation models)
+        if self.viz_center_heatmap and data.pred_center_heatmap is not None:
+            fig = self._render_center_heatmap(data)
+            fig_path = (
+                self.local_save_dir / f"{prefix}.center_heatmap.{epoch:04d}.png"
+            )
+            fig.savefig(fig_path, format="png")
+            plt.close(fig)
+
     def _render_class_maps(self, data):
         """Render class maps visualization.
 
@@ -659,6 +671,31 @@ class UnifiedVizCallback(Callback):
         plot_confmaps(
             data.pred_class_maps,
             output_scale=data.pred_class_maps.shape[0] / img.shape[0],
+        )
+        return fig
+
+    def _render_center_heatmap(self, data):
+        """Render center heatmap visualization for segmentation models.
+
+        Args:
+            data: VisualizationData with pred_center_heatmap populated.
+
+        Returns:
+            A matplotlib Figure object.
+        """
+        from sleap_nn.training.utils import plot_img, plot_confmaps
+
+        img = data.image
+        scale = 1.0
+        if img.shape[0] < 512:
+            scale = 2.0
+        if img.shape[0] < 256:
+            scale = 4.0
+
+        fig = plot_img(img, dpi=72 * scale, scale=scale)
+        plot_confmaps(
+            data.pred_center_heatmap,
+            output_scale=data.pred_center_heatmap.shape[0] / img.shape[0],
         )
         return fig
 
@@ -709,6 +746,19 @@ class UnifiedVizCallback(Callback):
                 class_pil, caption=f"{prefix.title()} Class Maps Epoch {epoch}"
             )
 
+        # Center heatmap visualization (for segmentation models)
+        if self.viz_center_heatmap and data.pred_center_heatmap is not None:
+            center_fig = self._render_center_heatmap(data)
+            buf = BytesIO()
+            center_fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+            buf.seek(0)
+            plt.close(center_fig)
+            center_pil = PILImage.open(buf)
+            log_dict[f"viz/{prefix}/center_heatmap"] = wandb.Image(
+                center_pil,
+                caption=f"{prefix.title()} Center Heatmap Epoch {epoch}",
+            )
+
         if log_dict:
             log_dict["epoch"] = epoch
             wandb_logger.experiment.log(log_dict, commit=False)
@@ -728,6 +778,12 @@ class UnifiedVizCallback(Callback):
             if self.viz_class_maps and data.pred_class_maps is not None:
                 columns.append(f"{prefix.title()} Class Maps")
                 table_data[0].append(log_dict.get(f"viz/{prefix}/class_maps"))
+
+            if self.viz_center_heatmap and data.pred_center_heatmap is not None:
+                columns.append(f"{prefix.title()} Center Heatmap")
+                table_data[0].append(
+                    log_dict.get(f"viz/{prefix}/center_heatmap")
+                )
 
             table = wandb.Table(columns=columns, data=table_data)
             wandb_logger.experiment.log(

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -34,7 +34,11 @@ from sleap_nn.inference.bottomup import (
 from sleap_nn.inference.paf_grouping import PAFScorer
 from sleap_nn.architectures.model import Model
 from sleap_nn.data.normalization import normalize_on_gpu
-from sleap_nn.training.losses import compute_ohkm_loss
+from sleap_nn.training.losses import (
+    compute_ohkm_loss,
+    compute_bce_dice_loss,
+    compute_masked_smooth_l1,
+)
 from loguru import logger
 from sleap_nn.training.utils import (
     xavier_init_weights,
@@ -291,10 +295,11 @@ class LightningModel(L.LightningModule):
             "bottomup": BottomUpLightningModule,
             "multi_class_bottomup": BottomUpMultiClassLightningModule,
             "multi_class_topdown": TopDownCenteredInstanceMultiClassLightningModule,
+            "bottomup_segmentation": BottomUpSegmentationLightningModule,
         }
 
         if model_type not in lightning_models:
-            message = f"Incorrect model type. Please check if one of the following keys in the head configs is not None: [`single_instance`, `centroid`, `centered_instance`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`]"
+            message = f"Incorrect model type. Please check if one of the following keys in the head configs is not None: [`single_instance`, `centroid`, `centered_instance`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`]"
             logger.error(message)
             raise ValueError(message)
 
@@ -2541,3 +2546,160 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
                         "num_instances": 1,
                     }
                 )
+
+
+class BottomUpSegmentationLightningModule(LightningModel):
+    """Lightning Module for Bottom-Up Instance Segmentation.
+
+    Predicts foreground masks, instance center heatmaps, and per-pixel offset
+    vectors for grouping pixels into instances.
+    """
+
+    def __init__(
+        self,
+        model_type: str,
+        backbone_type: str,
+        backbone_config: Union[str, Dict[str, Any], DictConfig],
+        head_configs: DictConfig,
+        pretrained_backbone_weights: Optional[str] = None,
+        pretrained_head_weights: Optional[str] = None,
+        init_weights: Optional[str] = "xavier",
+        lr_scheduler: Optional[Union[str, DictConfig]] = None,
+        online_mining: Optional[bool] = False,
+        hard_to_easy_ratio: Optional[float] = 2.0,
+        min_hard_keypoints: Optional[int] = 2,
+        max_hard_keypoints: Optional[int] = None,
+        loss_scale: Optional[float] = 5.0,
+        optimizer: Optional[str] = "Adam",
+        learning_rate: Optional[float] = 1e-3,
+        amsgrad: Optional[bool] = False,
+        negative_loss_weight: Optional[float] = 1.0,
+    ):
+        """Initialise the configs and the model."""
+        super().__init__(
+            model_type=model_type,
+            backbone_type=backbone_type,
+            backbone_config=backbone_config,
+            head_configs=head_configs,
+            pretrained_backbone_weights=pretrained_backbone_weights,
+            pretrained_head_weights=pretrained_head_weights,
+            init_weights=init_weights,
+            lr_scheduler=lr_scheduler,
+            online_mining=online_mining,
+            hard_to_easy_ratio=hard_to_easy_ratio,
+            min_hard_keypoints=min_hard_keypoints,
+            max_hard_keypoints=max_hard_keypoints,
+            loss_scale=loss_scale,
+            optimizer=optimizer,
+            learning_rate=learning_rate,
+            amsgrad=amsgrad,
+            negative_loss_weight=negative_loss_weight,
+        )
+
+    def forward(self, img):
+        """Forward pass of the model."""
+        img = torch.squeeze(img, dim=1).to(self.device)
+        img = normalize_on_gpu(img)
+        output = self.model(img)
+        return {
+            "SegmentationHead": output["SegmentationHead"],
+            "InstanceCenterHead": output["InstanceCenterHead"],
+            "CenterOffsetHead": output["CenterOffsetHead"],
+        }
+
+    def training_step(self, batch, batch_idx):
+        """Training step."""
+        X = torch.squeeze(batch["image"], dim=1)
+        y_fg = torch.squeeze(batch["foreground_mask"], dim=1)
+        y_center = torch.squeeze(batch["center_heatmap"], dim=1)
+        y_offsets = torch.squeeze(batch["center_offsets"], dim=1)
+        y_weight = torch.squeeze(batch["foreground_weight"], dim=1)
+
+        X = normalize_on_gpu(X)
+        preds = self.model(X)
+
+        pred_fg = preds["SegmentationHead"]
+        pred_center = preds["InstanceCenterHead"]
+        pred_offsets = preds["CenterOffsetHead"]
+
+        fg_loss = compute_bce_dice_loss(pred_fg, y_fg)
+        center_loss = nn.MSELoss()(pred_center, y_center)
+        offset_loss = compute_masked_smooth_l1(pred_offsets, y_offsets, y_weight)
+
+        losses = {
+            "SegmentationHead": fg_loss,
+            "InstanceCenterHead": center_loss,
+            "CenterOffsetHead": offset_loss,
+        }
+        loss = sum([s * losses[t] for s, t in zip(self.loss_weights, losses)])
+
+        self.log(
+            "loss", loss, prog_bar=True, on_step=True, on_epoch=False, sync_dist=True
+        )
+        self._accumulate_loss(loss)
+        self.log("train/fg_loss", fg_loss, on_step=False, on_epoch=True, sync_dist=True)
+        self.log(
+            "train/center_loss",
+            center_loss,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
+        self.log(
+            "train/offset_loss",
+            offset_loss,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
+
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        """Validation step."""
+        X = torch.squeeze(batch["image"], dim=1)
+        y_fg = torch.squeeze(batch["foreground_mask"], dim=1)
+        y_center = torch.squeeze(batch["center_heatmap"], dim=1)
+        y_offsets = torch.squeeze(batch["center_offsets"], dim=1)
+        y_weight = torch.squeeze(batch["foreground_weight"], dim=1)
+
+        X = normalize_on_gpu(X)
+        preds = self.model(X)
+
+        pred_fg = preds["SegmentationHead"]
+        pred_center = preds["InstanceCenterHead"]
+        pred_offsets = preds["CenterOffsetHead"]
+
+        fg_loss = compute_bce_dice_loss(pred_fg, y_fg)
+        center_loss = nn.MSELoss()(pred_center, y_center)
+        offset_loss = compute_masked_smooth_l1(pred_offsets, y_offsets, y_weight)
+
+        losses = {
+            "SegmentationHead": fg_loss,
+            "InstanceCenterHead": center_loss,
+            "CenterOffsetHead": offset_loss,
+        }
+        val_loss = sum([s * losses[t] for s, t in zip(self.loss_weights, losses)])
+
+        self.log(
+            "val_loss",
+            val_loss,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
+        self.log("val/fg_loss", fg_loss, on_step=False, on_epoch=True, sync_dist=True)
+        self.log(
+            "val/center_loss", center_loss, on_step=False, on_epoch=True, sync_dist=True
+        )
+        self.log(
+            "val/offset_loss", offset_loss, on_step=False, on_epoch=True, sync_dist=True
+        )
+
+        # Compute foreground IoU metric
+        pred_fg_binary = (pred_fg > 0.5).float()
+        intersection = (pred_fg_binary * y_fg).sum()
+        union = pred_fg_binary.sum() + y_fg.sum() - intersection
+        iou = intersection / (union + 1e-6)
+        self.log("val/fg_iou", iou, on_step=False, on_epoch=True, sync_dist=True)

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -33,6 +33,7 @@ from sleap_nn.inference.bottomup import (
     BottomUpMultiClassInferenceModel,
 )
 from sleap_nn.inference.paf_grouping import PAFScorer
+from sleap_nn.inference.segmentation import BottomUpSegmentationInferenceModel
 from sleap_nn.architectures.model import Model
 from sleap_nn.data.normalization import normalize_on_gpu
 from sleap_nn.training.losses import (
@@ -2597,6 +2598,125 @@ class BottomUpSegmentationLightningModule(LightningModel):
             negative_loss_weight=negative_loss_weight,
         )
 
+        seg_cfg = self.head_configs[self.model_type]
+        self.seg_inf_layer = BottomUpSegmentationInferenceModel(
+            torch_model=self.forward,
+            fg_threshold=0.5,
+            peak_threshold=0.1,
+            output_stride=seg_cfg.segmentation.output_stride,
+        )
+
+    def get_visualization_data(
+        self, sample, include_center_heatmap: bool = False
+    ) -> VisualizationData:
+        """Extract visualization data from a sample.
+
+        For segmentation models, the foreground probability map is used as
+        the confidence map overlay, and detected instance centers are shown
+        as predicted peaks.
+
+        Args:
+            sample: A sample dictionary from the data pipeline.
+            include_center_heatmap: If True, include the center heatmap in the
+                returned data for separate visualization.
+
+        Returns:
+            VisualizationData with foreground map and center locations.
+        """
+        ex = sample.copy()
+        for k, v in ex.items():
+            if isinstance(v, torch.Tensor):
+                ex[k] = v.to(device=self.device)
+        ex["image"] = ex["image"].unsqueeze(dim=0)
+
+        # Run forward pass to get predictions
+        with torch.no_grad():
+            img = ex["image"].squeeze(1).to(self.device)
+            img = normalize_on_gpu(img)
+            preds = self.model(img)
+
+        # Foreground probability as confmap overlay (H, W, 1)
+        fg_prob = torch.sigmoid(preds["SegmentationHead"][0]).cpu().numpy()
+        fg_prob = fg_prob.transpose(1, 2, 0)  # (H, W, 1)
+
+        # Get image as (H, W, C)
+        img_np = ex["image"][0, 0].cpu().numpy().transpose(1, 2, 0)
+
+        # Extract GT center locations from center_heatmap
+        from sleap_nn.inference.peak_finding import find_local_peaks_rough
+        from sleap_nn.inference.segmentation import group_instances_from_offsets
+
+        gt_centers = []
+        if "center_heatmap" in ex:
+            gt_peaks, _, _, _ = find_local_peaks_rough(
+                ex["center_heatmap"].unsqueeze(0), threshold=0.1
+            )
+            if len(gt_peaks) > 0:
+                gt_centers = gt_peaks.cpu().numpy()  # (N, 2) as (x, y)
+
+        # Run instance grouping to get predicted centers
+        seg_cfg = self.head_configs[self.model_type]
+        output_stride = seg_cfg.segmentation.output_stride
+
+        pred_centers = []
+        fg_sigmoid = torch.sigmoid(preds["SegmentationHead"])
+        instances = group_instances_from_offsets(
+            foreground=fg_sigmoid[0:1],
+            center_heatmap=preds["InstanceCenterHead"][0:1],
+            offsets=preds["CenterOffsetHead"][0:1],
+            fg_threshold=0.5,
+            peak_threshold=0.1,
+            output_stride=output_stride,
+        )
+        for inst in instances:
+            # Convert center from original pixel coords to output stride coords
+            cx, cy = inst["center"]
+            pred_centers.append([cx / output_stride, cy / output_stride])
+
+        # Format as (N, 1, 2) arrays for plot_peaks (instances, nodes, 2)
+        if len(gt_centers) > 0:
+            gt_pts = np.array(gt_centers).reshape(-1, 1, 2)
+        else:
+            gt_pts = np.zeros((0, 1, 2))
+
+        if len(pred_centers) > 0:
+            pred_pts = np.array(pred_centers).reshape(-1, 1, 2)
+        else:
+            pred_pts = np.zeros((0, 1, 2))
+
+        # Optionally include center heatmap for separate visualization
+        center_hmap = None
+        if include_center_heatmap:
+            center_hmap = preds["InstanceCenterHead"][0].cpu().numpy()
+            center_hmap = center_hmap.transpose(1, 2, 0)  # (H, W, 1)
+
+        return VisualizationData(
+            image=img_np,
+            pred_confmaps=fg_prob,
+            pred_peaks=pred_pts,
+            pred_peak_values=np.ones(len(pred_centers)),
+            gt_instances=gt_pts,
+            node_names=["center"],
+            output_scale=fg_prob.shape[0] / img_np.shape[0],
+            is_paired=False,
+            pred_center_heatmap=center_hmap,
+        )
+
+    def visualize_example(self, sample):
+        """Visualize segmentation predictions during training."""
+        data = self.get_visualization_data(sample)
+        scale = 1.0
+        if data.image.shape[0] < 512:
+            scale = 2.0
+        if data.image.shape[0] < 256:
+            scale = 4.0
+        fig = plot_img(data.image, dpi=72 * scale, scale=scale)
+        plot_confmaps(data.pred_confmaps, output_scale=data.output_scale)
+        plt.xlim(plt.xlim())
+        plt.ylim(plt.ylim())
+        plot_peaks(data.gt_instances, data.pred_peaks, paired=data.is_paired)
+        return fig
+
     def forward(self, img):
         """Forward pass of the model."""
         img = torch.squeeze(img, dim=1).to(self.device)
@@ -2693,7 +2813,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
         )
 
         self.log(
-            "val_loss",
+            "val/loss",
             val_loss,
             prog_bar=True,
             on_step=False,

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -3,6 +3,7 @@
 from typing import Optional, Union, Dict, Any, List
 import time
 from torch import nn
+import torch.nn.functional as F
 import numpy as np
 import torch
 from omegaconf import OmegaConf, DictConfig
@@ -2623,7 +2624,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
         pred_offsets = preds["CenterOffsetHead"]
 
         fg_loss = compute_bce_dice_loss(pred_fg, y_fg)
-        center_loss = nn.MSELoss()(pred_center, y_center)
+        center_loss = F.mse_loss(pred_center, y_center)
         offset_loss = compute_masked_smooth_l1(pred_offsets, y_offsets, y_weight)
 
         losses = {
@@ -2671,7 +2672,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
         pred_offsets = preds["CenterOffsetHead"]
 
         fg_loss = compute_bce_dice_loss(pred_fg, y_fg)
-        center_loss = nn.MSELoss()(pred_center, y_center)
+        center_loss = F.mse_loss(pred_center, y_center)
         offset_loss = compute_masked_smooth_l1(pred_offsets, y_offsets, y_weight)
 
         losses = {

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -2603,7 +2603,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
         img = normalize_on_gpu(img)
         output = self.model(img)
         return {
-            "SegmentationHead": output["SegmentationHead"],
+            "SegmentationHead": torch.sigmoid(output["SegmentationHead"]),
             "InstanceCenterHead": output["InstanceCenterHead"],
             "CenterOffsetHead": output["CenterOffsetHead"],
         }
@@ -2632,7 +2632,12 @@ class BottomUpSegmentationLightningModule(LightningModel):
             "InstanceCenterHead": center_loss,
             "CenterOffsetHead": offset_loss,
         }
-        loss = sum([s * losses[t] for s, t in zip(self.loss_weights, losses)])
+        seg_cfg = self.head_configs[self.model_type]
+        loss = (
+            seg_cfg.segmentation.loss_weight * losses["SegmentationHead"]
+            + seg_cfg.center.loss_weight * losses["InstanceCenterHead"]
+            + seg_cfg.offsets.loss_weight * losses["CenterOffsetHead"]
+        )
 
         self.log(
             "loss", loss, prog_bar=True, on_step=True, on_epoch=False, sync_dist=True
@@ -2680,7 +2685,12 @@ class BottomUpSegmentationLightningModule(LightningModel):
             "InstanceCenterHead": center_loss,
             "CenterOffsetHead": offset_loss,
         }
-        val_loss = sum([s * losses[t] for s, t in zip(self.loss_weights, losses)])
+        seg_cfg = self.head_configs[self.model_type]
+        val_loss = (
+            seg_cfg.segmentation.loss_weight * losses["SegmentationHead"]
+            + seg_cfg.center.loss_weight * losses["InstanceCenterHead"]
+            + seg_cfg.offsets.loss_weight * losses["CenterOffsetHead"]
+        )
 
         self.log(
             "val_loss",
@@ -2699,7 +2709,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
         )
 
         # Compute foreground IoU metric
-        pred_fg_binary = (pred_fg > 0.5).float()
+        pred_fg_binary = (pred_fg > 0.0).float()
         intersection = (pred_fg_binary * y_fg).sum()
         union = pred_fg_binary.sum() + y_fg.sum() - intersection
         iou = intersection / (union + 1e-6)

--- a/sleap_nn/training/losses.py
+++ b/sleap_nn/training/losses.py
@@ -1,6 +1,7 @@
 """Custom loss functions."""
 
 import torch
+import torch.nn.functional as F
 from typing import Optional
 
 
@@ -58,3 +59,61 @@ def compute_ohkm_loss(
     k_loss = torch.sum(k_loss) / n_elements
 
     return k_loss
+
+
+def compute_bce_dice_loss(
+    y_pred: torch.Tensor,
+    y_gt: torch.Tensor,
+    bce_weight: float = 0.5,
+    dice_weight: float = 0.5,
+    smooth: float = 1.0,
+) -> torch.Tensor:
+    """Compute combined Binary Cross-Entropy and Dice loss for segmentation.
+
+    Args:
+        y_pred: Predicted mask with sigmoid activation. Shape: (B, 1, H, W).
+        y_gt: Ground truth binary mask. Shape: (B, 1, H, W).
+        bce_weight: Weight for the BCE component.
+        dice_weight: Weight for the Dice component.
+        smooth: Smoothing factor for Dice loss to avoid division by zero.
+
+    Returns:
+        Scalar loss tensor.
+    """
+    bce_loss = F.binary_cross_entropy(y_pred, y_gt, reduction="mean")
+
+    # Dice loss
+    intersection = (y_pred * y_gt).sum(dim=(2, 3))
+    union = y_pred.sum(dim=(2, 3)) + y_gt.sum(dim=(2, 3))
+    dice = (2.0 * intersection + smooth) / (union + smooth)
+    dice_loss = 1.0 - dice.mean()
+
+    return bce_weight * bce_loss + dice_weight * dice_loss
+
+
+def compute_masked_smooth_l1(
+    y_pred: torch.Tensor,
+    y_gt: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor:
+    """Compute smooth L1 loss only on masked (foreground) pixels.
+
+    Args:
+        y_pred: Predicted offset field. Shape: (B, 2, H, W).
+        y_gt: Ground truth offset field. Shape: (B, 2, H, W).
+        mask: Binary mask indicating valid pixels. Shape: (B, 1, H, W).
+
+    Returns:
+        Scalar loss tensor. Returns 0 if no foreground pixels.
+    """
+    # Expand mask to match offset channels
+    mask_expanded = mask.expand_as(y_pred)  # (B, 2, H, W)
+
+    n_valid = mask_expanded.sum()
+    if n_valid == 0:
+        return torch.tensor(0.0, device=y_pred.device, requires_grad=True)
+
+    loss = F.smooth_l1_loss(
+        y_pred * mask_expanded, y_gt * mask_expanded, reduction="sum"
+    )
+    return loss / n_valid

--- a/sleap_nn/training/losses.py
+++ b/sleap_nn/training/losses.py
@@ -71,7 +71,7 @@ def compute_bce_dice_loss(
     """Compute combined Binary Cross-Entropy and Dice loss for segmentation.
 
     Args:
-        y_pred: Predicted mask with sigmoid activation. Shape: (B, 1, H, W).
+        y_pred: Predicted logits (before sigmoid). Shape: (B, 1, H, W).
         y_gt: Ground truth binary mask. Shape: (B, 1, H, W).
         bce_weight: Weight for the BCE component.
         dice_weight: Weight for the Dice component.
@@ -80,11 +80,12 @@ def compute_bce_dice_loss(
     Returns:
         Scalar loss tensor.
     """
-    bce_loss = F.binary_cross_entropy(y_pred, y_gt, reduction="mean")
+    bce_loss = F.binary_cross_entropy_with_logits(y_pred, y_gt, reduction="mean")
 
-    # Dice loss
-    intersection = (y_pred * y_gt).sum(dim=(2, 3))
-    union = y_pred.sum(dim=(2, 3)) + y_gt.sum(dim=(2, 3))
+    # Dice loss (apply sigmoid to convert logits to probabilities)
+    y_pred_sig = torch.sigmoid(y_pred)
+    intersection = (y_pred_sig * y_gt).sum(dim=(2, 3))
+    union = y_pred_sig.sum(dim=(2, 3)) + y_gt.sum(dim=(2, 3))
     dice = (2.0 * intersection + smooth) / (union + smooth)
     dice_loss = 1.0 - dice.mean()
 

--- a/sleap_nn/training/utils.py
+++ b/sleap_nn/training/utils.py
@@ -262,6 +262,7 @@ class VisualizationData:
         is_paired: Whether GT and predictions can be paired for error visualization.
         pred_pafs: Part affinity fields for bottom-up models, optional.
         pred_class_maps: Class maps for multi-class models, optional.
+        pred_center_heatmap: Center heatmap for segmentation models, optional.
     """
 
     image: np.ndarray
@@ -274,6 +275,7 @@ class VisualizationData:
     is_paired: bool = True
     pred_pafs: Optional[np.ndarray] = None
     pred_class_maps: Optional[np.ndarray] = None
+    pred_center_heatmap: Optional[np.ndarray] = None
 
 
 class MatplotlibRenderer:

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -721,3 +721,207 @@ def test_head_config_oneof_bottomup_segmentation():
     assert head_cfg.bottomup is None
     assert head_cfg.multi_class_bottomup is None
     assert head_cfg.multi_class_topdown is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Predictor (sleap_nn/inference/predictors.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.inference.predictors import BottomUpSegmentationPredictor
+from sleap_nn.inference.segmentation import (
+    BottomUpSegmentationInferenceModel,
+)
+
+
+def test_inference_model_no_padding_params():
+    """BottomUpSegmentationInferenceModel no longer accepts max_stride/input_scale."""
+
+    def dummy_model(x):
+        b = x.shape[0]
+        h, w = x.shape[-2] // 2, x.shape[-1] // 2
+        return {
+            "SegmentationHead": torch.zeros(b, 1, h, w),
+            "InstanceCenterHead": torch.zeros(b, 1, h, w),
+            "CenterOffsetHead": torch.zeros(b, 2, h, w),
+        }
+
+    # Should work with just the 3 required params
+    model = BottomUpSegmentationInferenceModel(
+        torch_model=dummy_model,
+        fg_threshold=0.5,
+        peak_threshold=0.2,
+        output_stride=2,
+    )
+    assert model.output_stride == 2
+    assert not hasattr(model, "max_stride")
+    assert not hasattr(model, "input_scale")
+
+
+def test_run_inference_on_batch_output():
+    """_run_inference_on_batch yields per-frame dicts with correct keys."""
+
+    def dummy_forward(x):
+        """Simulate model forward pass (receives (B, 1, C, H, W))."""
+        x = x.squeeze(1)  # (B, C, H, W)
+        b = x.shape[0]
+        h, w = x.shape[-2] // 2, x.shape[-1] // 2
+        return {
+            "SegmentationHead": torch.sigmoid(torch.randn(b, 1, h, w)),
+            "InstanceCenterHead": torch.zeros(b, 1, h, w),
+            "CenterOffsetHead": torch.zeros(b, 2, h, w),
+        }
+
+    predictor = BottomUpSegmentationPredictor(
+        output_stride=2,
+        batch_size=2,
+        max_stride=16,
+        preprocess_config={
+            "scale": 1.0,
+            "ensure_rgb": False,
+            "ensure_grayscale": False,
+            "crop_size": None,
+            "max_height": None,
+            "max_width": None,
+        },
+    )
+    predictor.inference_model = BottomUpSegmentationInferenceModel(
+        torch_model=dummy_forward,
+        fg_threshold=0.5,
+        peak_threshold=0.2,
+        output_stride=2,
+    )
+
+    # Build a fake batch (2 frames, 3-channel 32x32 images)
+    imgs = [torch.randn(1, 3, 32, 32), torch.randn(1, 3, 32, 32)]
+    fidxs = [0, 1]
+    vidxs = [0, 0]
+    org_szs = [torch.tensor([[32.0, 32.0]]), torch.tensor([[32.0, 32.0]])]
+    instances = []
+    eff_scales = [1.0, 1.0]
+
+    results = list(
+        predictor._run_inference_on_batch(
+            imgs, fidxs, vidxs, org_szs, instances, eff_scales
+        )
+    )
+
+    assert len(results) == 2
+    for r in results:
+        assert "video_idx" in r
+        assert "frame_idx" in r
+        assert "orig_size" in r
+        assert "instances" in r
+        assert "padded_size" in r
+        assert isinstance(r["instances"], list)
+
+
+def test_mask_upscaling():
+    """Masks are correctly cropped from padding and upscaled to original resolution."""
+    import sleap_io as sio
+
+    # Simulate: original image 30x30, output_stride=2
+    # After pad_to_stride(16), image becomes 32x32
+    # Model output maps are 16x16 (padded/stride)
+    # Original output size should be 15x15 (30/2)
+    orig_h, orig_w = 30, 30
+    output_stride = 2
+    padded_h, padded_w = 32, 32
+
+    # A mask at output stride resolution (16x16 due to padding)
+    mask = np.zeros((padded_h // output_stride, padded_w // output_stride), dtype=bool)
+    mask[2:8, 2:8] = True  # 6x6 block
+
+    # Crop to original output dims
+    crop_h = orig_h // output_stride  # 15
+    crop_w = orig_w // output_stride  # 15
+    cropped = mask[:crop_h, :crop_w]
+    assert cropped.shape == (15, 15)
+    # The 6x6 block should still be fully within bounds
+    assert cropped[2:8, 2:8].sum() == 36
+
+    # Upscale to original resolution
+    mask_tensor = torch.from_numpy(cropped.astype(np.float32)).unsqueeze(0).unsqueeze(0)
+    mask_upscaled = torch.nn.functional.interpolate(
+        mask_tensor, size=(orig_h, orig_w), mode="nearest"
+    )
+    mask_full = mask_upscaled.squeeze().numpy() > 0.5
+
+    assert mask_full.shape == (30, 30)
+    assert mask_full.sum() > 0
+
+    # Verify it can be stored as a SegmentationMask
+    seg = sio.SegmentationMask.from_numpy(mask_full)
+    assert seg.height == 30
+    assert seg.width == 30
+    np.testing.assert_array_equal(seg.data, mask_full)
+
+
+def test_make_labeled_frames_from_generator():
+    """_make_labeled_frames_from_generator produces sio.Labels with masks."""
+    import sleap_io as sio
+
+    video = sio.Video(filename="test.mp4")
+
+    predictor = BottomUpSegmentationPredictor(
+        output_stride=2,
+        batch_size=1,
+    )
+    predictor.videos = [video]
+
+    # Create a mock generator output
+    mask1 = np.zeros((16, 16), dtype=bool)
+    mask1[0:8, 0:8] = True
+    mask2 = np.zeros((16, 16), dtype=bool)
+    mask2[8:16, 8:16] = True
+
+    def mock_generator():
+        yield {
+            "video_idx": 0,
+            "frame_idx": 5,
+            "orig_size": np.array([32.0, 32.0]),
+            "instances": [
+                {"mask": mask1, "center": (8.0, 8.0), "score": 0.9},
+                {"mask": mask2, "center": (24.0, 24.0), "score": 0.7},
+            ],
+            "padded_size": (32, 32),
+        }
+
+    labels = predictor._make_labeled_frames_from_generator(mock_generator())
+
+    assert isinstance(labels, sio.Labels)
+    assert len(labels.masks) == 2
+    assert labels.videos == [video]
+
+    # Check mask properties
+    for mask_obj in labels.masks:
+        assert isinstance(mask_obj, sio.SegmentationMask)
+        assert mask_obj.video == video
+        assert mask_obj.frame_idx == 5
+        assert mask_obj.height == 32
+        assert mask_obj.width == 32
+        assert mask_obj.data.shape == (32, 32)
+
+    # Check scores preserved
+    scores = sorted([m.score for m in labels.masks], reverse=True)
+    assert scores == [0.9, 0.7]
+
+
+def test_make_labeled_frames_empty_instances():
+    """_make_labeled_frames_from_generator handles frames with no instances."""
+    import sleap_io as sio
+
+    video = sio.Video(filename="test.mp4")
+    predictor = BottomUpSegmentationPredictor(output_stride=2)
+    predictor.videos = [video]
+
+    def mock_generator():
+        yield {
+            "video_idx": 0,
+            "frame_idx": 0,
+            "orig_size": np.array([32.0, 32.0]),
+            "instances": [],
+            "padded_size": (32, 32),
+        }
+
+    labels = predictor._make_labeled_frames_from_generator(mock_generator())
+    assert len(labels.masks) == 0

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -204,7 +204,7 @@ def test_segmentation_head():
     head = SegmentationHead(output_stride=2, loss_weight=1.0)
 
     assert head.channels == 1
-    assert head.activation == "sigmoid"
+    assert head.activation == "identity"
     assert head.loss_function == "bce_dice"
     assert head.output_stride == 2
     assert head.loss_weight == 1.0
@@ -251,9 +251,8 @@ def test_segmentation_head_make_head():
 
     assert output.shape == (2, 1, 32, 32)  # channels=1
     assert output.dtype == torch.float32
-    # Sigmoid activation means all values in [0, 1]
-    assert output.min().item() >= 0.0
-    assert output.max().item() <= 1.0
+    # Identity activation means raw logits; just check they are finite
+    assert torch.isfinite(output).all()
 
 
 def test_instance_center_head_make_head():
@@ -290,7 +289,7 @@ from sleap_nn.training.losses import compute_bce_dice_loss, compute_masked_smoot
 def test_bce_dice_loss_perfect():
     """Identical pred and gt should give approximately 0 loss."""
     gt = torch.ones(1, 1, 16, 16)
-    pred = torch.ones(1, 1, 16, 16)
+    pred = torch.full((1, 1, 16, 16), 10.0)
 
     loss = compute_bce_dice_loss(pred, gt)
 
@@ -300,8 +299,8 @@ def test_bce_dice_loss_perfect():
 def test_bce_dice_loss_worst():
     """All-zeros pred with all-ones gt should give high loss."""
     gt = torch.ones(1, 1, 16, 16)
-    # Use small epsilon to avoid log(0) in BCE
-    pred = torch.full((1, 1, 16, 16), 1e-6)
+    # Large negative logit -> sigmoid near 0 -> worst case against gt of all ones
+    pred = torch.full((1, 1, 16, 16), -10.0)
 
     loss = compute_bce_dice_loss(pred, gt)
 
@@ -312,7 +311,7 @@ def test_bce_dice_loss_worst():
 def test_bce_dice_loss_half():
     """Pred of 0.5 everywhere with all-ones gt gives intermediate loss."""
     gt = torch.ones(1, 1, 16, 16)
-    pred = torch.full((1, 1, 16, 16), 0.5)
+    pred = torch.full((1, 1, 16, 16), 0.0)
 
     loss = compute_bce_dice_loss(pred, gt)
 
@@ -322,7 +321,7 @@ def test_bce_dice_loss_half():
 
 def test_bce_dice_loss_gradient():
     """Loss supports backpropagation."""
-    pred = torch.full((1, 1, 8, 8), 0.5, requires_grad=True)
+    pred = torch.full((1, 1, 8, 8), 0.0, requires_grad=True)
     gt = torch.ones(1, 1, 8, 8)
 
     loss = compute_bce_dice_loss(pred, gt)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,0 +1,724 @@
+"""Comprehensive tests for the instance segmentation feature in sleap-nn."""
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+# ---------------------------------------------------------------------------
+# 1. GT generation (sleap_nn/data/segmentation_maps.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.data.segmentation_maps import (
+    generate_foreground_mask,
+    generate_center_heatmap,
+    generate_center_offsets,
+    _compute_mask_centroids,
+)
+
+
+def test_generate_foreground_mask_basic():
+    """Two non-overlapping rectangular masks produce correct shape and pixel counts."""
+    h, w = 64, 64
+    output_stride = 1
+
+    # Mask A: 10x10 block at top-left
+    mask_a = np.zeros((h, w), dtype=bool)
+    mask_a[0:10, 0:10] = True
+
+    # Mask B: 10x10 block at bottom-right
+    mask_b = np.zeros((h, w), dtype=bool)
+    mask_b[50:60, 50:60] = True
+
+    fg = generate_foreground_mask([mask_a, mask_b], (h, w), output_stride=output_stride)
+
+    assert fg.shape == (1, 1, h, w)
+    assert fg.dtype == torch.float32
+
+    # Count foreground pixels: should be exactly 100 + 100 = 200
+    assert fg.sum().item() == 200.0
+
+
+def test_generate_foreground_mask_empty():
+    """Empty mask list returns all zeros."""
+    h, w = 32, 32
+    fg = generate_foreground_mask([], (h, w), output_stride=1)
+
+    assert fg.shape == (1, 1, h, w)
+    assert fg.sum().item() == 0.0
+
+
+def test_generate_foreground_mask_overlapping():
+    """Two overlapping masks produce the correct union."""
+    h, w = 64, 64
+    output_stride = 1
+
+    # Mask A: rows 0-19, cols 0-19  (20x20 = 400 pixels)
+    mask_a = np.zeros((h, w), dtype=bool)
+    mask_a[0:20, 0:20] = True
+
+    # Mask B: rows 10-29, cols 10-29  (20x20 = 400 pixels)
+    mask_b = np.zeros((h, w), dtype=bool)
+    mask_b[10:30, 10:30] = True
+
+    fg = generate_foreground_mask([mask_a, mask_b], (h, w), output_stride=output_stride)
+
+    # Union = 400 + 400 - overlap(10x10=100) = 700
+    assert fg.shape == (1, 1, h, w)
+    assert fg.sum().item() == 700.0
+
+
+def test_generate_center_heatmap():
+    """Verify shape, peak locations near mask centroids, and max value close to 1."""
+    h, w = 64, 64
+    output_stride = 1
+    sigma = 5.0
+
+    # Single 20x20 mask centered at (30, 30) -- centroid at (cols, rows) = (30, 30)
+    mask = np.zeros((h, w), dtype=bool)
+    mask[20:40, 20:40] = True
+
+    heatmap = generate_center_heatmap(
+        [mask], (h, w), output_stride=output_stride, sigma=sigma
+    )
+
+    assert heatmap.shape == (1, 1, h, w)
+    assert heatmap.dtype == torch.float32
+
+    # Max value should be very close to 1 (Gaussian evaluated at center)
+    assert heatmap.max().item() > 0.95
+
+    # Peak location should be near centroid (29.5, 29.5)
+    peak_idx = heatmap[0, 0].argmax().item()
+    peak_row = peak_idx // w
+    peak_col = peak_idx % w
+    # Allow 1 pixel tolerance
+    assert abs(peak_row - 29.5) <= 1.0
+    assert abs(peak_col - 29.5) <= 1.0
+
+
+def test_generate_center_heatmap_empty():
+    """Empty mask list returns zeros."""
+    h, w = 32, 32
+    heatmap = generate_center_heatmap([], (h, w), output_stride=1, sigma=5.0)
+    assert heatmap.shape == (1, 1, h, w)
+    assert heatmap.sum().item() == 0.0
+
+
+def test_generate_center_offsets():
+    """Verify offset shape, that offsets point toward mask centroid, and weight mask matches foreground."""
+    h, w = 64, 64
+    output_stride = 1
+
+    # 20x20 mask at rows 20-39, cols 20-39 -> centroid ~ (29.5, 29.5)
+    mask = np.zeros((h, w), dtype=bool)
+    mask[20:40, 20:40] = True
+
+    offsets, weight_mask = generate_center_offsets(
+        [mask], (h, w), output_stride=output_stride
+    )
+
+    assert offsets.shape == (1, 2, h, w)
+    assert weight_mask.shape == (1, 1, h, w)
+
+    # Weight mask should match foreground
+    expected_fg = generate_foreground_mask([mask], (h, w), output_stride=output_stride)
+    assert (weight_mask == expected_fg).all()
+
+    # Check that offsets on foreground pixels point toward centroid
+    cx, cy = 29.5, 29.5  # centroid in pixel coords
+
+    # For a foreground pixel, pixel + offset should equal the centroid
+    # offsets are stored as (dx, dy) where pixel_coord + offset = center
+    # But the actual computation is: offset = center - pixel_coord_in_orig_space
+    # where pixel_coord_in_orig_space = idx * output_stride + output_stride / 2
+    # With output_stride=1, pixel_coord = idx * 1 + 0.5
+
+    # Test a specific foreground pixel at row=20, col=20
+    # pixel coords = (20*1 + 0.5, 20*1 + 0.5) = (20.5, 20.5)
+    # dx = cx - 20.5 = 29.5 - 20.5 = 9.0
+    # dy = cy - 20.5 = 29.5 - 20.5 = 9.0
+    assert abs(offsets[0, 0, 20, 20].item() - 9.0) < 0.5
+    assert abs(offsets[0, 1, 20, 20].item() - 9.0) < 0.5
+
+    # Test a pixel at the centroid itself: row=30, col=30
+    # pixel coords = (30.5, 30.5) => dx = 29.5 - 30.5 = -1.0
+    assert abs(offsets[0, 0, 30, 30].item() - (-1.0)) < 0.5
+    assert abs(offsets[0, 1, 30, 30].item() - (-1.0)) < 0.5
+
+
+def test_generate_center_offsets_empty():
+    """Empty mask list returns zeros for offsets and weight mask."""
+    h, w = 32, 32
+    offsets, weight_mask = generate_center_offsets([], (h, w), output_stride=1)
+    assert offsets.shape == (1, 2, h, w)
+    assert weight_mask.shape == (1, 1, h, w)
+    assert offsets.sum().item() == 0.0
+    assert weight_mask.sum().item() == 0.0
+
+
+def test_compute_mask_centroids():
+    """Known rectangles produce known centroids."""
+    # Rectangle at rows 0-9, cols 0-9 -> centroid = (4.5, 4.5)
+    mask_a = np.zeros((64, 64), dtype=bool)
+    mask_a[0:10, 0:10] = True
+
+    # Rectangle at rows 20-29, cols 40-49 -> centroid = (44.5, 24.5)
+    mask_b = np.zeros((64, 64), dtype=bool)
+    mask_b[20:30, 40:50] = True
+
+    centers = _compute_mask_centroids([mask_a, mask_b])
+
+    assert len(centers) == 2
+    # Center of mask_a: x=mean(0..9)=4.5, y=mean(0..9)=4.5
+    assert abs(centers[0][0] - 4.5) < 0.1
+    assert abs(centers[0][1] - 4.5) < 0.1
+    # Center of mask_b: x=mean(40..49)=44.5, y=mean(20..29)=24.5
+    assert abs(centers[1][0] - 44.5) < 0.1
+    assert abs(centers[1][1] - 24.5) < 0.1
+
+
+def test_compute_mask_centroids_empty_mask():
+    """Empty mask falls back to image center."""
+    mask = np.zeros((64, 80), dtype=bool)
+    centers = _compute_mask_centroids([mask])
+    # Fallback: (width/2, height/2) = (40.0, 32.0)
+    assert abs(centers[0][0] - 40.0) < 0.1
+    assert abs(centers[0][1] - 32.0) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# 2. Head classes (sleap_nn/architectures/heads.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.architectures.heads import (
+    Head,
+    SegmentationHead,
+    InstanceCenterHead,
+    CenterOffsetHead,
+)
+
+
+def test_segmentation_head():
+    """SegmentationHead has channels=1, activation='sigmoid', loss_function='bce_dice'."""
+    head = SegmentationHead(output_stride=2, loss_weight=1.0)
+
+    assert head.channels == 1
+    assert head.activation == "sigmoid"
+    assert head.loss_function == "bce_dice"
+    assert head.output_stride == 2
+    assert head.loss_weight == 1.0
+    assert isinstance(head, Head)
+    assert head.name == "SegmentationHead"
+
+
+def test_instance_center_head():
+    """InstanceCenterHead has channels=1 and stores sigma."""
+    head = InstanceCenterHead(sigma=10.0, output_stride=2, loss_weight=1.0)
+
+    assert head.channels == 1
+    assert head.sigma == 10.0
+    assert head.output_stride == 2
+    assert head.loss_weight == 1.0
+    # Default activation and loss from base Head
+    assert head.activation == "identity"
+    assert head.loss_function == "mse"
+    assert isinstance(head, Head)
+    assert head.name == "InstanceCenterHead"
+
+
+def test_center_offset_head():
+    """CenterOffsetHead has channels=2 and loss_function='smooth_l1'."""
+    head = CenterOffsetHead(output_stride=2, loss_weight=0.1)
+
+    assert head.channels == 2
+    assert head.loss_function == "smooth_l1"
+    assert head.output_stride == 2
+    assert head.loss_weight == 0.1
+    # Default activation from base Head
+    assert head.activation == "identity"
+    assert isinstance(head, Head)
+    assert head.name == "CenterOffsetHead"
+
+
+def test_segmentation_head_make_head():
+    """Create SegmentationHead, run forward pass with dummy input, check output shape."""
+    sample_input = torch.randn(2, 64, 32, 32)  # (B, C_in, H, W)
+    head = SegmentationHead(output_stride=2, loss_weight=1.0)
+
+    head_module = head.make_head(x_in=sample_input.size(1))
+    output = head_module(sample_input)
+
+    assert output.shape == (2, 1, 32, 32)  # channels=1
+    assert output.dtype == torch.float32
+    # Sigmoid activation means all values in [0, 1]
+    assert output.min().item() >= 0.0
+    assert output.max().item() <= 1.0
+
+
+def test_instance_center_head_make_head():
+    """InstanceCenterHead forward pass produces single-channel output."""
+    sample_input = torch.randn(2, 64, 32, 32)
+    head = InstanceCenterHead(sigma=10.0, output_stride=2, loss_weight=1.0)
+
+    head_module = head.make_head(x_in=sample_input.size(1))
+    output = head_module(sample_input)
+
+    assert output.shape == (2, 1, 32, 32)
+    assert output.dtype == torch.float32
+
+
+def test_center_offset_head_make_head():
+    """CenterOffsetHead forward pass produces 2-channel output."""
+    sample_input = torch.randn(2, 64, 32, 32)
+    head = CenterOffsetHead(output_stride=2, loss_weight=0.1)
+
+    head_module = head.make_head(x_in=sample_input.size(1))
+    output = head_module(sample_input)
+
+    assert output.shape == (2, 2, 32, 32)
+    assert output.dtype == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# 3. Loss functions (sleap_nn/training/losses.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.training.losses import compute_bce_dice_loss, compute_masked_smooth_l1
+
+
+def test_bce_dice_loss_perfect():
+    """Identical pred and gt should give approximately 0 loss."""
+    gt = torch.ones(1, 1, 16, 16)
+    pred = torch.ones(1, 1, 16, 16)
+
+    loss = compute_bce_dice_loss(pred, gt)
+
+    assert loss.item() < 0.01
+
+
+def test_bce_dice_loss_worst():
+    """All-zeros pred with all-ones gt should give high loss."""
+    gt = torch.ones(1, 1, 16, 16)
+    # Use small epsilon to avoid log(0) in BCE
+    pred = torch.full((1, 1, 16, 16), 1e-6)
+
+    loss = compute_bce_dice_loss(pred, gt)
+
+    # Loss should be significantly larger than 0
+    assert loss.item() > 1.0
+
+
+def test_bce_dice_loss_half():
+    """Pred of 0.5 everywhere with all-ones gt gives intermediate loss."""
+    gt = torch.ones(1, 1, 16, 16)
+    pred = torch.full((1, 1, 16, 16), 0.5)
+
+    loss = compute_bce_dice_loss(pred, gt)
+
+    # Should be between perfect and worst
+    assert 0.0 < loss.item() < 5.0
+
+
+def test_bce_dice_loss_gradient():
+    """Loss supports backpropagation."""
+    pred = torch.full((1, 1, 8, 8), 0.5, requires_grad=True)
+    gt = torch.ones(1, 1, 8, 8)
+
+    loss = compute_bce_dice_loss(pred, gt)
+    loss.backward()
+
+    assert pred.grad is not None
+    assert pred.grad.shape == pred.shape
+
+
+def test_masked_smooth_l1_basic():
+    """Basic masked offset loss computation with known values."""
+    # 2-channel offsets
+    pred = torch.ones(1, 2, 4, 4)
+    gt = torch.zeros(1, 2, 4, 4)
+    # Mask only top-left 2x2
+    mask = torch.zeros(1, 1, 4, 4)
+    mask[0, 0, :2, :2] = 1.0
+
+    loss = compute_masked_smooth_l1(pred, gt, mask)
+
+    # smooth_l1_loss(1, 0) = 0.5 (since |1-0|=1.0, smooth_l1 for |x|>=1 is |x|-0.5=0.5)
+    # 8 valid elements (2 channels * 2*2 pixels), sum = 8 * 0.5 = 4.0, mean = 4.0 / 8 = 0.5
+    assert abs(loss.item() - 0.5) < 0.01
+
+
+def test_masked_smooth_l1_empty_mask():
+    """Empty mask returns 0 loss."""
+    pred = torch.ones(1, 2, 4, 4, requires_grad=True)
+    gt = torch.zeros(1, 2, 4, 4)
+    mask = torch.zeros(1, 1, 4, 4)
+
+    loss = compute_masked_smooth_l1(pred, gt, mask)
+
+    assert loss.item() == 0.0
+    # Should still be differentiable
+    assert loss.requires_grad
+
+
+def test_masked_smooth_l1_full_mask():
+    """Full mask computes loss over all pixels."""
+    pred = torch.full((1, 2, 4, 4), 0.3)
+    gt = torch.zeros(1, 2, 4, 4)
+    mask = torch.ones(1, 1, 4, 4)
+
+    loss = compute_masked_smooth_l1(pred, gt, mask)
+
+    # smooth_l1 for |x|<1: 0.5 * x^2 = 0.5 * 0.09 = 0.045
+    # All 32 elements have this value, so mean = 0.045
+    assert abs(loss.item() - 0.045) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# 4. Model forward pass
+# ---------------------------------------------------------------------------
+
+from sleap_nn.architectures.model import Model
+
+
+def test_bottomup_segmentation_model_forward():
+    """Create Model with bottomup_segmentation type, run forward, verify output dict keys and shapes."""
+    backbone_config = OmegaConf.create(
+        {
+            "in_channels": 1,
+            "kernel_size": 3,
+            "filters": 8,
+            "filters_rate": 1.0,
+            "max_stride": 16,
+            "convs_per_block": 2,
+            "stacks": 1,
+            "stem_stride": None,
+            "middle_block": True,
+            "up_interpolate": True,
+            "output_stride": 2,
+        }
+    )
+
+    head_configs = OmegaConf.create(
+        {
+            "segmentation": {
+                "output_stride": 2,
+                "loss_weight": 1.0,
+            },
+            "center": {
+                "sigma": 10.0,
+                "output_stride": 2,
+                "loss_weight": 1.0,
+            },
+            "offsets": {
+                "output_stride": 2,
+                "loss_weight": 0.1,
+            },
+        }
+    )
+
+    model = Model(
+        backbone_type="unet",
+        backbone_config=backbone_config,
+        head_configs=head_configs,
+        model_type="bottomup_segmentation",
+    )
+
+    # Forward pass with a batch of 2 grayscale 64x64 images
+    x = torch.randn(2, 1, 64, 64)
+    outputs = model(x)
+
+    assert "SegmentationHead" in outputs
+    assert "InstanceCenterHead" in outputs
+    assert "CenterOffsetHead" in outputs
+
+    B = 2
+    # Output spatial dims = 64 / output_stride(2) = 32
+    assert outputs["SegmentationHead"].shape == (B, 1, 32, 32)
+    assert outputs["InstanceCenterHead"].shape == (B, 1, 32, 32)
+    assert outputs["CenterOffsetHead"].shape == (B, 2, 32, 32)
+
+    # All outputs should be float32
+    for key in outputs:
+        assert outputs[key].dtype == torch.float32
+
+
+def test_bottomup_segmentation_model_three_heads():
+    """Verify that the model creates exactly three heads of the right types."""
+    backbone_config = OmegaConf.create(
+        {
+            "in_channels": 1,
+            "kernel_size": 3,
+            "filters": 8,
+            "filters_rate": 1.0,
+            "max_stride": 16,
+            "convs_per_block": 2,
+            "stacks": 1,
+            "stem_stride": None,
+            "middle_block": True,
+            "up_interpolate": True,
+            "output_stride": 2,
+        }
+    )
+
+    head_configs = OmegaConf.create(
+        {
+            "segmentation": {
+                "output_stride": 2,
+                "loss_weight": 1.0,
+            },
+            "center": {
+                "sigma": 10.0,
+                "output_stride": 2,
+                "loss_weight": 1.0,
+            },
+            "offsets": {
+                "output_stride": 2,
+                "loss_weight": 0.1,
+            },
+        }
+    )
+
+    model = Model(
+        backbone_type="unet",
+        backbone_config=backbone_config,
+        head_configs=head_configs,
+        model_type="bottomup_segmentation",
+    )
+
+    assert len(model.heads) == 3
+    assert isinstance(model.heads[0], SegmentationHead)
+    assert isinstance(model.heads[1], InstanceCenterHead)
+    assert isinstance(model.heads[2], CenterOffsetHead)
+
+
+# ---------------------------------------------------------------------------
+# 5. Instance grouping (sleap_nn/inference/segmentation.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.inference.segmentation import group_instances_from_offsets
+
+
+def test_group_instances_two_blobs():
+    """Two well-separated blobs with correct offsets should find 2 instances."""
+    h, w = 32, 32
+    output_stride = 2
+
+    # Create foreground with two blobs
+    foreground = torch.zeros(1, 1, h, w)
+    # Blob 1: rows 2-7, cols 2-7
+    foreground[0, 0, 2:8, 2:8] = 1.0
+    # Blob 2: rows 22-27, cols 22-27
+    foreground[0, 0, 22:28, 22:28] = 1.0
+
+    # Center heatmap with peaks at blob centroids (in output stride coords)
+    center_heatmap = torch.zeros(1, 1, h, w)
+    # Blob 1 center: row=5, col=5 (at output res)
+    center_heatmap[0, 0, 5, 5] = 1.0
+    # Blob 2 center: row=25, col=25 (at output res)
+    center_heatmap[0, 0, 25, 25] = 1.0
+
+    # Create offsets that point each foreground pixel to its blob's center
+    offsets = torch.zeros(1, 2, h, w)
+
+    # For blob 1: center in original coords = (5*2 + 1, 5*2 + 1) = (11, 11)
+    for r in range(2, 8):
+        for c in range(2, 8):
+            pixel_x = c * output_stride + output_stride / 2.0
+            pixel_y = r * output_stride + output_stride / 2.0
+            center_x = 5 * output_stride + output_stride / 2.0
+            center_y = 5 * output_stride + output_stride / 2.0
+            offsets[0, 0, r, c] = center_x - pixel_x
+            offsets[0, 1, r, c] = center_y - pixel_y
+
+    # For blob 2: center in original coords = (25*2 + 1, 25*2 + 1) = (51, 51)
+    for r in range(22, 28):
+        for c in range(22, 28):
+            pixel_x = c * output_stride + output_stride / 2.0
+            pixel_y = r * output_stride + output_stride / 2.0
+            center_x = 25 * output_stride + output_stride / 2.0
+            center_y = 25 * output_stride + output_stride / 2.0
+            offsets[0, 0, r, c] = center_x - pixel_x
+            offsets[0, 1, r, c] = center_y - pixel_y
+
+    instances = group_instances_from_offsets(
+        foreground=foreground,
+        center_heatmap=center_heatmap,
+        offsets=offsets,
+        fg_threshold=0.5,
+        peak_threshold=0.5,
+        output_stride=output_stride,
+    )
+
+    assert len(instances) == 2
+
+    # Each instance should have a mask, center, and score
+    for inst in instances:
+        assert "mask" in inst
+        assert "center" in inst
+        assert "score" in inst
+        assert inst["mask"].shape == (h, w)
+        assert isinstance(inst["center"], tuple)
+        assert len(inst["center"]) == 2
+        assert inst["score"] >= 0.5
+
+    # Each blob has 6*6 = 36 pixels; verify roughly correct pixel counts
+    mask_sizes = sorted([inst["mask"].sum() for inst in instances])
+    assert mask_sizes[0] == 36
+    assert mask_sizes[1] == 36
+
+
+def test_group_instances_no_foreground():
+    """Empty foreground returns empty list."""
+    h, w = 16, 16
+    foreground = torch.zeros(1, 1, h, w)
+    center_heatmap = torch.zeros(1, 1, h, w)
+    offsets = torch.zeros(1, 2, h, w)
+
+    instances = group_instances_from_offsets(
+        foreground=foreground,
+        center_heatmap=center_heatmap,
+        offsets=offsets,
+        fg_threshold=0.5,
+        peak_threshold=0.2,
+        output_stride=2,
+    )
+
+    assert instances == []
+
+
+def test_group_instances_no_centers():
+    """Foreground present but no center peaks returns empty list."""
+    h, w = 16, 16
+    foreground = torch.ones(1, 1, h, w)  # All foreground
+    center_heatmap = torch.full((1, 1, h, w), 0.01)  # Very low values, no peaks
+    offsets = torch.zeros(1, 2, h, w)
+
+    instances = group_instances_from_offsets(
+        foreground=foreground,
+        center_heatmap=center_heatmap,
+        offsets=offsets,
+        fg_threshold=0.5,
+        peak_threshold=0.5,  # Higher than any value in center_heatmap
+        output_stride=2,
+    )
+
+    assert instances == []
+
+
+def test_group_instances_single_blob():
+    """Single blob with one center peak returns exactly one instance."""
+    h, w = 16, 16
+    output_stride = 1
+
+    foreground = torch.zeros(1, 1, h, w)
+    foreground[0, 0, 4:12, 4:12] = 1.0
+
+    center_heatmap = torch.zeros(1, 1, h, w)
+    center_heatmap[0, 0, 8, 8] = 1.0  # Peak at center of blob
+
+    offsets = torch.zeros(1, 2, h, w)
+    center_x = 8 * output_stride + output_stride / 2.0
+    center_y = 8 * output_stride + output_stride / 2.0
+    for r in range(4, 12):
+        for c in range(4, 12):
+            px = c * output_stride + output_stride / 2.0
+            py = r * output_stride + output_stride / 2.0
+            offsets[0, 0, r, c] = center_x - px
+            offsets[0, 1, r, c] = center_y - py
+
+    instances = group_instances_from_offsets(
+        foreground=foreground,
+        center_heatmap=center_heatmap,
+        offsets=offsets,
+        fg_threshold=0.5,
+        peak_threshold=0.5,
+        output_stride=output_stride,
+    )
+
+    assert len(instances) == 1
+    assert instances[0]["mask"].sum() == 64  # 8x8
+
+
+# ---------------------------------------------------------------------------
+# 6. Config
+# ---------------------------------------------------------------------------
+
+from sleap_nn.config.model_config import (
+    BottomUpSegmentationConfig,
+    SegmentationHeadConfig,
+    InstanceCenterConfig,
+    CenterOffsetConfig,
+    HeadConfig,
+)
+
+
+def test_bottomup_segmentation_config():
+    """Create BottomUpSegmentationConfig and verify defaults."""
+    cfg = BottomUpSegmentationConfig()
+
+    assert cfg.segmentation is None
+    assert cfg.center is None
+    assert cfg.offsets is None
+
+
+def test_bottomup_segmentation_config_with_values():
+    """Create BottomUpSegmentationConfig with explicit sub-configs."""
+    seg_cfg = SegmentationHeadConfig(output_stride=2, loss_weight=1.0)
+    center_cfg = InstanceCenterConfig(sigma=10.0, output_stride=2, loss_weight=1.0)
+    offset_cfg = CenterOffsetConfig(output_stride=2, loss_weight=0.1)
+
+    cfg = BottomUpSegmentationConfig(
+        segmentation=seg_cfg,
+        center=center_cfg,
+        offsets=offset_cfg,
+    )
+
+    assert cfg.segmentation.output_stride == 2
+    assert cfg.segmentation.loss_weight == 1.0
+    assert cfg.center.sigma == 10.0
+    assert cfg.center.output_stride == 2
+    assert cfg.center.loss_weight == 1.0
+    assert cfg.offsets.output_stride == 2
+    assert cfg.offsets.loss_weight == 0.1
+
+
+def test_segmentation_head_config_defaults():
+    """Verify default values of SegmentationHeadConfig."""
+    cfg = SegmentationHeadConfig()
+    assert cfg.output_stride == 2
+    assert cfg.loss_weight == 1.0
+
+
+def test_instance_center_config_defaults():
+    """Verify default values of InstanceCenterConfig."""
+    cfg = InstanceCenterConfig()
+    assert cfg.sigma == 10.0
+    assert cfg.output_stride == 2
+    assert cfg.loss_weight == 1.0
+
+
+def test_center_offset_config_defaults():
+    """Verify default values of CenterOffsetConfig."""
+    cfg = CenterOffsetConfig()
+    assert cfg.output_stride == 2
+    assert cfg.loss_weight == 0.1
+
+
+def test_head_config_oneof_bottomup_segmentation():
+    """HeadConfig oneof works with bottomup_segmentation."""
+    head_cfg = HeadConfig(
+        bottomup_segmentation=BottomUpSegmentationConfig(
+            segmentation=SegmentationHeadConfig(),
+            center=InstanceCenterConfig(),
+            offsets=CenterOffsetConfig(),
+        )
+    )
+
+    assert head_cfg.bottomup_segmentation is not None
+    assert head_cfg.single_instance is None
+    assert head_cfg.centroid is None
+    assert head_cfg.centered_instance is None
+    assert head_cfg.bottomup is None
+    assert head_cfg.multi_class_bottomup is None
+    assert head_cfg.multi_class_topdown is None


### PR DESCRIPTION
## Summary
- Add new `bottomup_segmentation` model type using a center-offset (Panoptic-DeepLab style) approach with three heads on a shared backbone:
  - **SegmentationHead**: binary foreground mask (sigmoid, BCE+Dice loss)
  - **InstanceCenterHead**: Gaussian heatmap at instance centers (MSE loss)
  - **CenterOffsetHead**: per-pixel offset to instance center (masked smooth L1)
- GT masks loaded from sleap-io's native `labels.masks` (`SegmentationMask` with RLE storage)
- Inference groups foreground pixels into instances by assigning each to the nearest detected center via predicted offsets, outputs `sio.SegmentationMask` objects

## Changes
### New files
- `sleap_nn/data/segmentation_maps.py` — GT tensor generation from mask arrays
- `sleap_nn/inference/segmentation.py` — instance grouping post-processing + inference model
- `tests/test_segmentation.py` — 34 tests covering the full stack

### Modified files
- `sleap_nn/architectures/heads.py` — 3 new Head subclasses
- `sleap_nn/architectures/model.py` — `bottomup_segmentation` factory branch
- `sleap_nn/config/model_config.py` — config dataclasses + HeadConfig update
- `sleap_nn/training/losses.py` — BCE+Dice and masked smooth L1 loss functions
- `sleap_nn/data/custom_datasets.py` — `BottomUpSegmentationDataset` with mask-based indexing, mask resizing, geometric aug safety
- `sleap_nn/training/lightning_modules.py` — `BottomUpSegmentationLightningModule` with visualization support
- `sleap_nn/training/callbacks.py` — `UnifiedVizCallback` center heatmap rendering for segmentation models
- `sleap_nn/training/utils.py` — `VisualizationData.pred_center_heatmap` field
- `sleap_nn/inference/predictors.py` — `BottomUpSegmentationPredictor` + factory branch

### Bug fixes
- Fixed `"val_loss"` → `"val/loss"` in `BottomUpSegmentationLightningModule.validation_step()` — the wrong key silently prevented early stopping, model checkpointing, and LR scheduling from triggering

### Visualization
- Added `get_visualization_data()` and `visualize_example()` to `BottomUpSegmentationLightningModule`
  - Main overlay: foreground probability map + GT/predicted instance centers
  - Separate center heatmap visualization (auto-enabled, analogous to PAF viz for bottom-up)
- `UnifiedVizCallback` auto-detects `bottomup_segmentation` model type and renders center heatmap to local disk + wandb

## Test plan
- [x] 34 new tests pass (GT generation, heads, losses, model forward, instance grouping, config)
- [x] 917 total tests pass, 0 regressions
- [x] black + ruff clean
- [ ] End-to-end training smoke test with real Labels containing SegmentationMask objects
- [ ] Inference round-trip: train → predict → verify output SegmentationMask objects

## Future work
- Joint pose + segmentation model types (confmaps + segmentation heads)
- Geometric augmentation support for masks
- Pseudo-mask generation from keypoints/edges (dilation strategy)
- Implement `predict()` / `make_pipeline()` on `BottomUpSegmentationPredictor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)