### PR TITLE
fix: Overwrite sleap_nn_version in saved checkpoint configs

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -7,6 +7,7 @@ import torch
 import random
 import numpy as np
 import sleap_io as sio
+import sleap_nn
 import time
 import lightning as L
 import wandb
@@ -1260,6 +1261,11 @@ class ModelTrainer:
                 Path(self.config.trainer_config.ckpt_dir)
                 / self.config.trainer_config.run_name
             ).as_posix()
+
+            # Overwrite version with current sleap-nn version
+            self._initial_config.sleap_nn_version = sleap_nn.__version__
+            self.config.sleap_nn_version = sleap_nn.__version__
+
             OmegaConf.save(
                 self._initial_config,
                 (Path(ckpt_path) / "initial_config.yaml").as_posix(),


### PR DESCRIPTION
## Summary
- When saving `initial_config.yaml` and `training_config.yaml` during checkpointing, the `sleap_nn_version` field is now overwritten with the current `sleap_nn.__version__` before saving.
- This ensures checkpoint configs always reflect the version of sleap-nn that produced them, regardless of what version was in the original/loaded config.

## Changes Made
- `sleap_nn/training/model_trainer.py`: Added `import sleap_nn` and two lines to overwrite `sleap_nn_version` on both `self._initial_config` and `self.config` before `OmegaConf.save()` calls.

## Testing
- Existing model trainer tests cover the checkpoint saving path.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)