### PR TITLE
fix(config): default memory caching + 2 workers; simplify --pipeline CLI

### DIFF
--- a/docs/configuration/config-picker/app.html
+++ b/docs/configuration/config-picker/app.html
@@ -1939,12 +1939,12 @@ Input → [Encoder] → [Middle] → [Decoder] → Head → Output
                                 <label>
                                     Num Workers
                                     <span class="tooltip">?
-                                        <span class="tooltip-text">Number of parallel processes for loading data.<br><br><b>0 (Default):</b> Required when using torch_dataset (reading directly from video). This is the recommended setting.<br><br><b>>0:</b> Only use with caching pipelines (cache_img_memory/disk). More workers can speed up training but use more RAM.<br><br><b>Note:</b> On Mac/Windows, only use >0 with caching enabled.</span>
+                                        <span class="tooltip-text">Number of parallel processes for loading data.<br><br><b>2 (Default):</b> Recommended with caching pipelines (cache_img_memory/disk). More workers can speed up training but use more RAM.<br><br><b>0:</b> Required when using torch_dataset (reading directly from video).<br><br><b>Note:</b> On Mac/Windows, only use >0 with caching enabled.</span>
                                     </span>
                                 </label>
                                 <select id="num-workers" onchange="updateCacheMemoryEstimate()">
-                                    <option value="0" selected>0 (Default)</option>
-                                    <option value="2">2</option>
+                                    <option value="0">0</option>
+                                    <option value="2" selected>2 (Default)</option>
                                     <option value="4">4</option>
                                     <option value="8">8</option>
                                 </select>
@@ -1957,8 +1957,8 @@ Input → [Encoder] → [Middle] → [Decoder] → Head → Output
                                     </span>
                                 </label>
                                 <select id="data-pipeline" onchange="updateCacheMemoryEstimate(); toggleDiskCacheOptions()">
-                                    <option value="torch_dataset" selected>torch_dataset (Default)</option>
-                                    <option value="torch_dataset_cache_img_memory">Cache to Memory</option>
+                                    <option value="torch_dataset">torch_dataset</option>
+                                    <option value="torch_dataset_cache_img_memory" selected>Cache to Memory (Default)</option>
                                     <option value="torch_dataset_cache_img_disk">Cache to Disk</option>
                                 </select>
                             </div>
@@ -2872,12 +2872,12 @@ Input → [Encoder] → [Middle] → [Decoder] → Head → Output
                                 <label>
                                     Num Workers
                                     <span class="tooltip">?
-                                        <span class="tooltip-text">Parallel processes for loading data.<br><br><b>0:</b> Required for torch_dataset (default).<br><b>>0:</b> Only with caching pipelines.</span>
+                                        <span class="tooltip-text">Parallel processes for loading data.<br><br><b>2 (Default):</b> Recommended with caching pipelines.<br><b>0:</b> Required for torch_dataset.</span>
                                     </span>
                                 </label>
                                 <select id="ci-num-workers" onchange="updateCICacheMemoryEstimate()">
-                                    <option value="0" selected>0 (Default)</option>
-                                    <option value="2">2</option>
+                                    <option value="0">0</option>
+                                    <option value="2" selected>2 (Default)</option>
                                     <option value="4">4</option>
                                     <option value="8">8</option>
                                 </select>
@@ -2890,8 +2890,8 @@ Input → [Encoder] → [Middle] → [Decoder] → Head → Output
                                     </span>
                                 </label>
                                 <select id="ci-data-pipeline" onchange="updateCICacheMemoryEstimate(); toggleCIDiskCacheOptions()">
-                                    <option value="torch_dataset" selected>torch_dataset (Default)</option>
-                                    <option value="torch_dataset_cache_img_memory">Cache to Memory</option>
+                                    <option value="torch_dataset">torch_dataset</option>
+                                    <option value="torch_dataset_cache_img_memory" selected>Cache to Memory (Default)</option>
                                     <option value="torch_dataset_cache_img_disk">Cache to Disk</option>
                                 </select>
                             </div>

--- a/docs/guides/config-generator.md
+++ b/docs/guides/config-generator.md
@@ -58,7 +58,7 @@ For top-down pipelines, this creates two config files:
 |--------|-------|-------------|---------|
 | `--output` | `-o` | Output path for config file(s) | `<slp_name>_config.yaml` |
 | `--auto` | | Auto-generate without interactive TUI | `false` |
-| `--pipeline` | | Pipeline: `single_instance`, `bottomup`, or `topdown` | Auto-detected |
+| `--pipeline` | | Pipeline: `single_instance`, `bottomup`, `topdown`, `multi_class_bottomup`, or `multi_class_topdown` | Auto-detected |
 | `--show-yaml` | | Print YAML to stdout instead of saving | `false` |
 
 ---

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,6 +5,7 @@ Task-oriented guides for common workflows.
 | Guide | Description |
 |-------|-------------|
 | [Training](training.md) | Configure training, fine-tune models |
+| &nbsp;&nbsp;&nbsp;&nbsp;[Config Generator](config-generator.md) | Generate training configs via TUI or auto mode |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Negative Frames](negative-frames.md) | Reduce false positives with background frames |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Monitoring](monitoring.md) | WandB, visualizations, epoch-end evaluation |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Multi-GPU](multi-gpu.md) | Scale training across multiple GPUs |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -253,7 +253,7 @@ sleap-nn config SLP_PATH [OPTIONS]
 |--------|-------|-------------|--------|---------|
 | `--output` | `-o` | Output path for config file(s) | `PATH` | `<slp_name>_config.yaml` |
 | `--auto` | | Auto-generate without interactive TUI | Flag | `false` |
-| `--pipeline` | | Model pipeline type | `single_instance`, `bottomup`, `topdown` | Auto-detected |
+| `--pipeline` | | Model pipeline type | `single_instance`, `bottomup`, `topdown`, `multi_class_bottomup`, `multi_class_topdown` | Auto-detected |
 | `--show-yaml` | | Print YAML to stdout instead of saving | Flag | `false` |
 
 ### Modes

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1060,15 +1060,14 @@ def _register_export_commands():
     type=click.Choice(
         [
             "single_instance",
-            "centroid",
-            "centered_instance",
             "bottomup",
+            "topdown",
             "multi_class_bottomup",
             "multi_class_topdown",
         ]
     ),
     default=None,
-    help="Override model pipeline type.",
+    help="Override model pipeline type. 'topdown' generates paired centroid + centered_instance configs.",
 )
 @click.option(
     "--show-yaml",
@@ -1113,7 +1112,9 @@ def config(
 
         # Apply overrides
         if pipeline:
-            gen.pipeline(pipeline)
+            # 'topdown' is a CLI alias for the centroid stage, which triggers
+            # paired centroid + centered_instance config generation.
+            gen.pipeline("centroid" if pipeline == "topdown" else pipeline)
 
         if show_yaml:
             click.echo(gen.to_yaml())

--- a/sleap_nn/config_generator/tui/screens/configure_screen.py
+++ b/sleap_nn/config_generator/tui/screens/configure_screen.py
@@ -1452,25 +1452,25 @@ class ConfigureScreen(Widget):
             yield Label("Num Workers:", classes="param-label")
             yield Select(
                 [
-                    ("0 (Default)", "0"),
-                    ("2", "2"),
+                    ("0", "0"),
+                    ("2 (Default)", "2"),
                     ("4", "4"),
                     ("8", "8"),
                 ],
-                value=str(self._state._num_workers if self._state else 0),
+                value=str(self._state._num_workers if self._state else 2),
                 id="num-workers-select",
                 classes="param-input",
             )
 
         current_pipeline = (
-            self._state._data_pipeline.value if self._state else "torch_dataset"
+            self._state._data_pipeline.value if self._state else "litdata"
         )
         with Horizontal(classes="param-row"):
             yield Label("Data Pipeline:", classes="param-label")
             yield Select(
                 [
-                    ("Video (default)", "torch_dataset"),
-                    ("Cache to Memory", "litdata"),
+                    ("Video", "torch_dataset"),
+                    ("Cache to Memory (default)", "litdata"),
                     ("Cache to Disk", "litdata_disk"),
                 ],
                 value=current_pipeline,
@@ -2640,12 +2640,12 @@ class ConfigureScreen(Widget):
                 yield Label("Num Workers:", classes="param-label")
                 yield Select(
                     [
-                        ("0 (Default)", "0"),
-                        ("2", "2"),
+                        ("0", "0"),
+                        ("2 (Default)", "2"),
                         ("4", "4"),
                         ("8", "8"),
                     ],
-                    value=str(self._state._num_workers if self._state else 0),
+                    value=str(self._state._num_workers if self._state else 2),
                     id="centroid-num-workers-select",
                     classes="param-input",
                 )
@@ -2653,14 +2653,14 @@ class ConfigureScreen(Widget):
 
             # Data Pipeline
             current_pipeline = (
-                self._state._data_pipeline.value if self._state else "torch_dataset"
+                self._state._data_pipeline.value if self._state else "litdata"
             )
             with Horizontal(classes="param-row"):
                 yield Label("Data Pipeline:", classes="param-label")
                 yield Select(
                     [
-                        ("Video (default)", "torch_dataset"),
-                        ("Cache to Memory", "litdata"),
+                        ("Video", "torch_dataset"),
+                        ("Cache to Memory (default)", "litdata"),
                         ("Cache to Disk", "litdata_disk"),
                     ],
                     value=current_pipeline,
@@ -3451,12 +3451,12 @@ class ConfigureScreen(Widget):
                 yield Label("Num Workers:", classes="param-label")
                 yield Select(
                     [
-                        ("0 (Default)", "0"),
-                        ("2", "2"),
+                        ("0", "0"),
+                        ("2 (Default)", "2"),
                         ("4", "4"),
                         ("8", "8"),
                     ],
-                    value=str(self._state._num_workers if self._state else 0),
+                    value=str(self._state._num_workers if self._state else 2),
                     id="instance-num-workers-select",
                     classes="param-input",
                 )
@@ -3464,14 +3464,14 @@ class ConfigureScreen(Widget):
 
             # Data Pipeline
             current_pipeline = (
-                self._state._data_pipeline.value if self._state else "torch_dataset"
+                self._state._data_pipeline.value if self._state else "litdata"
             )
             with Horizontal(classes="param-row"):
                 yield Label("Data Pipeline:", classes="param-label")
                 yield Select(
                     [
-                        ("Video (default)", "torch_dataset"),
-                        ("Cache to Memory", "litdata"),
+                        ("Video", "torch_dataset"),
+                        ("Cache to Memory (default)", "litdata"),
                         ("Cache to Disk", "litdata_disk"),
                     ],
                     value=current_pipeline,

--- a/sleap_nn/config_generator/tui/state.py
+++ b/sleap_nn/config_generator/tui/state.py
@@ -205,8 +205,8 @@ class ConfigState:
         self._max_width: Optional[int] = None
         self._ensure_rgb: bool = False
         self._ensure_grayscale: bool = False
-        self._data_pipeline: DataPipelineType = DataPipelineType.TORCH_DATASET
-        self._num_workers: int = 0
+        self._data_pipeline: DataPipelineType = DataPipelineType.MEMORY_CACHE
+        self._num_workers: int = 2
         self._validation_fraction: float = 0.1
         self._user_instances_only: bool = True  # Web app default
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -272,6 +272,118 @@ class TestInfoCommand:
         assert result.exit_code != 0
 
 
+class TestConfigCommand:
+    """Tests for `sleap-nn config` CLI surface (pipeline choices, output files)."""
+
+    def test_pipeline_topdown_writes_paired_configs(self, minimal_instance, tmp_path):
+        """`--pipeline topdown` produces both centroid and centered_instance configs."""
+        out = tmp_path / "cfg.yaml"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                str(minimal_instance),
+                "--auto",
+                "--pipeline",
+                "topdown",
+                "-o",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "cfg_centroid.yaml").exists()
+        assert (tmp_path / "cfg_centered_instance.yaml").exists()
+
+    def test_pipeline_multi_class_topdown_writes_paired_configs(
+        self, minimal_instance, tmp_path
+    ):
+        """`--pipeline multi_class_topdown` also produces both configs."""
+        out = tmp_path / "cfg.yaml"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                str(minimal_instance),
+                "--auto",
+                "--pipeline",
+                "multi_class_topdown",
+                "-o",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "cfg_centroid.yaml").exists()
+        assert (tmp_path / "cfg_centered_instance.yaml").exists()
+
+    @pytest.mark.parametrize(
+        "pipeline", ["single_instance", "bottomup", "multi_class_bottomup"]
+    )
+    def test_pipeline_single_stage_writes_one_config(
+        self, minimal_instance, tmp_path, pipeline
+    ):
+        """Non-topdown pipelines write a single config file."""
+        out = tmp_path / "cfg.yaml"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                str(minimal_instance),
+                "--auto",
+                "--pipeline",
+                pipeline,
+                "-o",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        # Should not have produced split top-down files
+        assert not (tmp_path / "cfg_centroid.yaml").exists()
+        assert not (tmp_path / "cfg_centered_instance.yaml").exists()
+
+    @pytest.mark.parametrize("removed", ["centroid", "centered_instance"])
+    def test_internal_pipeline_names_not_exposed(
+        self, minimal_instance, tmp_path, removed
+    ):
+        """Internal stage names (centroid, centered_instance) are not valid CLI choices."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                str(minimal_instance),
+                "--auto",
+                "--pipeline",
+                removed,
+                "-o",
+                str(tmp_path / "cfg.yaml"),
+            ],
+        )
+        assert result.exit_code != 0
+        # Click rejects invalid choices with "Invalid value"
+        assert (
+            "Invalid value" in result.output
+            or "invalid choice" in result.output.lower()
+        )
+
+    def test_config_help_lists_pipeline_choices(self):
+        """`--help` lists the user-facing pipeline choices."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "--help"], terminal_width=200)
+        assert result.exit_code == 0
+        for choice in [
+            "single_instance",
+            "bottomup",
+            "topdown",
+            "multi_class_bottomup",
+            "multi_class_topdown",
+        ]:
+            assert choice in result.output
+
+
 # =============================================================================
 # Subprocess-based tests (integration tests, run external process)
 # =============================================================================


### PR DESCRIPTION
## Summary

- **Defaults**: TUI (`sleap-nn config`) and web-app config picker now default to **Cache to Memory** with **2 workers** (previously: no caching, 0 workers). Underlying Python schema defaults are unchanged so programmatic `TrainingJobConfig()` users are unaffected.
- **CLI surface**: `sleap-nn config --pipeline` now accepts `topdown` as a single user-facing value (instead of exposing the internal `centroid` / `centered_instance` stages). `topdown` and `multi_class_topdown` both produce the paired centroid + centered_instance configs.
- **Docs**: Config Generator now linked from `guides/index.md`; `--pipeline` choice lists synced in `guides/config-generator.md` and `reference/cli.md`.

## Pipeline CLI mapping

Before → After:

| Old `--pipeline` value | New |
|---|---|
| `single_instance` | `single_instance` |
| `bottomup` | `bottomup` |
| `centroid` | _(removed — use `topdown`)_ |
| `centered_instance` | _(removed — use `topdown`)_ |
| `multi_class_bottomup` | `multi_class_bottomup` |
| `multi_class_topdown` | `multi_class_topdown` |
| _(new)_ | `topdown` → produces both centroid & centered_instance configs |

The internal `PipelineType` Literal and `gen.pipeline()` Python method still accept all 6 canonical types, so existing tests and power-user code paths are unchanged.

## Test plan

- [x] `pytest tests/test_cli.py::TestConfigCommand` (8 new tests) — pass locally
- [x] Manual: `uv run sleap-nn config tests/assets/datasets/minimal_instance.pkg.slp --auto --pipeline topdown -o /tmp/x.yaml` writes both `_centroid.yaml` and `_centered_instance.yaml`
- [x] Manual: `--pipeline centroid` is rejected with helpful error listing new choices
- [x] `black` + `ruff` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)