### PR TITLE
PR 10 of #508 — CLI unification: `sleap-nn infer` (#518)

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -985,12 +985,16 @@ def _run_inference_impl(**kwargs):
 
     Coerces tuple-shaped multi-options into lists, parses the
     ``--frames`` string into a list of int frame indices, validates the
-    new PR 10 flags, and delegates to the legacy ``run_inference``.
+    new PR 10 flags, and routes to the right backend:
+
+    * ``--stream-to-file`` set → builds a new :class:`Predictor` via
+      :func:`sleap_nn.inference.factory.from_model_paths` and writes
+      incrementally with :meth:`Predictor.predict_to_file` (PR 12).
+    * Otherwise → delegates to the legacy ``run_inference`` flow
+      (which still owns tracking, frame filtering, GUI progress, etc.).
     """
     from sleap_nn.predict import frame_list, run_inference
 
-    # Strip new-flow flags before delegating to legacy run_inference;
-    # they don't have a legacy hook to land on yet.
     paf_workers = kwargs.pop("paf_workers", 0) or 0
     cpu_workers = kwargs.pop("cpu_workers", None)
     stream_to_file = kwargs.pop("stream_to_file", None)
@@ -1005,20 +1009,9 @@ def _run_inference_impl(**kwargs):
         )
         if paf_workers == 0:
             paf_workers = cpu_workers
-    if stream_to_file is not None:
-        raise click.UsageError(
-            "--stream-to-file requires the new Predictor.predict_to_file flow; "
-            "this lands in a follow-up PR (#519). Until then, omit this flag and "
-            "use the default in-memory output."
-        )
     if write_interval is not None and stream_to_file is None:
         raise click.UsageError(
             "--write-interval is only meaningful together with --stream-to-file."
-        )
-    if paf_workers > 0:
-        logger.warning(
-            "--paf-workers > 0 has no effect in the current CLI release; "
-            "the worker pool ships with the new Predictor flow (#519)."
         )
 
     if "model_paths" in kwargs and kwargs["model_paths"]:
@@ -1031,7 +1024,408 @@ def _run_inference_impl(**kwargs):
     else:
         kwargs["frames"] = None
 
+    # ── Stream-to-file path: new Predictor + IncrementalLabelsWriter ───
+    if stream_to_file is not None:
+        return _run_stream_to_file(
+            kwargs,
+            stream_to_file=stream_to_file,
+            write_interval=write_interval or 500,
+            paf_workers=paf_workers,
+        )
+
+    # ── In-memory new-flow path (PR 13–16) ─────────────────────────────
+    # As of PR 16 the new flow handles every documented flag, so this
+    # always routes here. The legacy ``run_inference`` body is kept for
+    # backward-compat external callers and is removed in PR 17.
+    if _can_use_new_in_memory_flow(kwargs):
+        return _run_in_memory_new_flow(kwargs, paf_workers=paf_workers)
+
     return run_inference(**kwargs)
+
+
+def _can_use_new_in_memory_flow(kwargs: dict) -> bool:
+    """Return True iff the new factory + Predictor.predict can serve this call.
+
+    As of PR 16 the new flow handles every documented flag combination
+    that ``run_inference`` ever supported:
+
+    * Video or ``.slp`` source · one or more ``.ckpt`` model dirs
+    * ``--backbone_ckpt_path`` / ``--head_ckpt_path`` (threaded through
+      the factory's existing kwargs).
+    * ``--tracking`` + every tracking knob (via :class:`TrackerConfig`).
+    * Every ``--filter_*`` knob (via :class:`FilterConfig`).
+    * The four frame-selection flags (``only_suggested_frames`` /
+      ``exclude_user_labeled`` / ``only_predicted_frames`` /
+      ``no_empty_frames``).
+    * ``--gui`` (JSON progress emission via ``progress_callback``).
+    * Tracking-only retrack (no ``model_paths``, ``--tracking`` set,
+      ``.slp`` data path) — handled by :meth:`Predictor.retrack`.
+
+    The function returns ``True`` whenever any of these combinations is
+    requested. The legacy ``run_inference`` is no longer reached during
+    normal CLI use; the body is kept for one release as a deprecation
+    target and removed in PR 17.
+    """
+    return True
+
+
+def _resolve_device(value: object) -> str:
+    """Resolve a CLI ``--device`` value to a concrete torch device string.
+
+    The legacy :func:`sleap_nn.predict.run_inference` resolves ``"auto"``
+    before any checkpoint loading; the new flow needs the same so
+    ``torch.load(map_location="auto")`` doesn't blow up on the legacy
+    factory loader.
+    """
+    if hasattr(value, "type"):
+        value = str(value)
+    if value in (None, "", "auto"):
+        import torch
+
+        if torch.cuda.is_available():
+            return "cuda"
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return "mps"
+        return "cpu"
+    return str(value)
+
+
+def _build_filter_config(kwargs: dict) -> "object":
+    """Build a :class:`FilterConfig` from the CLI ``--filter_*`` flags.
+
+    Returns ``None`` when every knob is at its default — the
+    :class:`Predictor`'s default ``FilterConfig()`` is the no-op
+    identity, so we save a few attrs constructions in the common case.
+    """
+    from sleap_nn.inference.filters import FilterConfig
+
+    overlapping = bool(kwargs.get("filter_overlapping"))
+    min_visible_nodes = int(kwargs.get("filter_min_visible_nodes") or 0)
+    min_visible_node_fraction = float(
+        kwargs.get("filter_min_visible_node_fraction") or 0.0
+    )
+    min_mean_node_score = float(kwargs.get("filter_min_mean_node_score") or 0.0)
+    min_instance_score = float(kwargs.get("filter_min_instance_score") or 0.0)
+    if not (
+        overlapping
+        or min_visible_nodes
+        or min_visible_node_fraction
+        or min_mean_node_score
+        or min_instance_score
+    ):
+        return None
+    return FilterConfig(
+        overlapping=overlapping,
+        overlapping_method=kwargs.get("filter_overlapping_method", "iou"),
+        overlapping_threshold=float(
+            kwargs.get("filter_overlapping_threshold", 0.8) or 0.8
+        ),
+        min_visible_nodes=min_visible_nodes,
+        min_visible_node_fraction=min_visible_node_fraction,
+        min_mean_node_score=min_mean_node_score,
+        min_instance_score=min_instance_score,
+    )
+
+
+def _build_tracker_config(kwargs: dict) -> "object":
+    """Build a :class:`TrackerConfig` from the CLI ``--tracking_*`` flags."""
+    from sleap_nn.inference.tracking import TrackerConfig
+
+    return TrackerConfig(
+        window_size=kwargs.get("tracking_window_size", 5),
+        min_new_track_points=kwargs.get("min_new_track_points", 0),
+        candidates_method=kwargs.get("candidates_method", "fixed_window"),
+        min_match_points=kwargs.get("min_match_points", 0),
+        features=kwargs.get("features", "keypoints"),
+        scoring_method=kwargs.get("scoring_method", "oks"),
+        scoring_reduction=kwargs.get("scoring_reduction", "mean"),
+        robust_best_instance=kwargs.get("robust_best_instance", 1.0),
+        track_matching_method=kwargs.get("track_matching_method", "hungarian"),
+        max_tracks=kwargs.get("max_tracks"),
+        use_flow=kwargs.get("use_flow", False),
+        of_img_scale=kwargs.get("of_img_scale", 1.0),
+        of_window_size=kwargs.get("of_window_size", 21),
+        of_max_levels=kwargs.get("of_max_levels", 3),
+        tracking_target_instance_count=kwargs.get("tracking_target_instance_count"),
+        tracking_pre_cull_to_target=kwargs.get("tracking_pre_cull_to_target", 0),
+        tracking_pre_cull_iou_threshold=kwargs.get(
+            "tracking_pre_cull_iou_threshold", 0.0
+        ),
+        tracking_clean_instance_count=kwargs.get("tracking_clean_instance_count", 0),
+        tracking_clean_iou_threshold=kwargs.get("tracking_clean_iou_threshold", 0.0),
+        post_connect_single_breaks=kwargs.get("post_connect_single_breaks", False),
+    )
+
+
+def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
+    """Run the new ``Predictor`` flow synchronously and save the resulting Labels.
+
+    Routes to :meth:`Predictor.retrack` for the tracking-only retrack
+    case (no ``model_paths``, ``--tracking`` set, ``.slp`` data path);
+    otherwise builds a ``Predictor`` via the factory and calls
+    :meth:`Predictor.predict`.
+    """
+    from pathlib import Path
+
+    import sleap_io as sio
+
+    from sleap_nn.inference.factory import from_model_paths
+    from sleap_nn.inference.predictor import Predictor as NewPredictor
+    from sleap_nn.inference.providers import LabelsProvider, VideoProvider
+
+    # ── Tracking-only retrack: no model_paths, --tracking on a .slp ────
+    if not kwargs.get("model_paths") and kwargs.get("tracking"):
+        return _run_retrack_only(kwargs, NewPredictor)
+
+    factory_kwargs = {
+        "device": _resolve_device(kwargs.get("device")),
+        "peak_threshold": kwargs.get("peak_threshold", 0.2),
+        "integral_refinement": kwargs.get("integral_refinement", "integral"),
+        "integral_patch_size": kwargs.get("integral_patch_size", 5),
+        "batch_size": kwargs.get("batch_size", 4),
+        "max_instances": kwargs.get("max_instances"),
+        "anchor_part": kwargs.get("anchor_part"),
+        "paf_workers": paf_workers,
+    }
+    if kwargs.get("backbone_ckpt_path"):
+        factory_kwargs["backbone_ckpt_path"] = kwargs["backbone_ckpt_path"]
+    if kwargs.get("head_ckpt_path"):
+        factory_kwargs["head_ckpt_path"] = kwargs["head_ckpt_path"]
+    if kwargs.get("tracking"):
+        factory_kwargs["tracker_config"] = _build_tracker_config(kwargs)
+    filter_config = _build_filter_config(kwargs)
+    if filter_config is not None:
+        factory_kwargs["filter_config"] = filter_config
+    predictor = from_model_paths(kwargs["model_paths"], **factory_kwargs)
+
+    src = Path(kwargs["data_path"])
+    if src.suffix == ".slp":
+        provider = LabelsProvider(
+            labels=str(src),
+            batch_size=kwargs.get("batch_size", 4),
+            only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
+            only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
+            exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
+            only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
+        )
+        loaded = sio.load_slp(str(src))
+        skeleton = loaded.skeletons[0]
+        videos = list(loaded.videos)
+    else:
+        provider = VideoProvider(
+            video=str(src),
+            batch_size=kwargs.get("batch_size", 4),
+            frames=kwargs.get("frames"),
+            dataset=kwargs.get("video_dataset"),
+            input_format=kwargs.get("video_input_format"),
+        )
+        skeleton = _skeleton_from_predictor(predictor, kwargs["model_paths"][0])
+        # ``Labels.save()`` traverses ``video.backend``; pass the loaded
+        # ``sio.Video`` so the saved .slp has a real backend reference.
+        videos = [sio.load_video(str(src))]
+
+    labels = predictor.predict(
+        provider,
+        make_labels=True,
+        skeleton=skeleton,
+        videos=videos,
+        clean_empty_frames=bool(kwargs.get("no_empty_frames")),
+        progress_callback=_gui_progress_callback() if kwargs.get("gui") else None,
+    )
+
+    output_path = kwargs.get("output_path") or f"{src}.slp"
+    labels.save(output_path)
+    return labels
+
+
+def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
+    """Pure-tracking retrack of an existing ``.slp`` (no inference)."""
+    from pathlib import Path
+
+    import sleap_io as sio
+
+    src = Path(kwargs["data_path"])
+    if src.suffix != ".slp":
+        raise click.UsageError(
+            "Tracking-only mode requires --data_path to be a .slp file. "
+            "Pass --model_paths to run inference + tracking."
+        )
+
+    labels = sio.load_slp(str(src))
+
+    # video_index filter (optional)
+    video_index = kwargs.get("video_index")
+    if video_index is not None and video_index < len(labels.videos):
+        target_video = labels.videos[video_index]
+        labels = sio.Labels(
+            videos=labels.videos,
+            skeletons=labels.skeletons,
+            labeled_frames=labels.find(video=target_video),
+        )
+
+    # frames filter (optional)
+    frames = kwargs.get("frames")
+    if frames:
+        wanted = set(frames)
+        labels = sio.Labels(
+            videos=labels.videos,
+            skeletons=labels.skeletons,
+            labeled_frames=[
+                lf for lf in labels.labeled_frames if lf.frame_idx in wanted
+            ],
+        )
+
+    tracker_config = _build_tracker_config(kwargs)
+    out = predictor_cls.retrack(
+        labels,
+        tracker_config,
+        clean_empty_frames=bool(kwargs.get("no_empty_frames")),
+    )
+    output_path = kwargs.get("output_path") or f"{src}.slp"
+    out.save(output_path)
+    return out
+
+
+def _gui_progress_callback():
+    """Build a JSON-progress emitter compatible with the legacy ``--gui`` mode.
+
+    Emits one JSON line per batch with ``n_processed`` / ``n_total`` /
+    ``rate`` / ``eta``, throttled to ~4Hz so a downstream GUI process
+    can read progress via stdout. Matches the format used by the legacy
+    ``Predictor._predict_generator_gui`` exactly.
+    """
+    import json
+    from time import time as _now
+
+    state = {"start": _now(), "last": 0.0, "processed_at_last": 0}
+
+    def cb(processed: int, total: int) -> None:
+        now = _now()
+        is_last = total > 0 and processed >= total
+        if not is_last and (now - state["last"]) < 0.25:
+            return
+        elapsed = now - state["start"]
+        rate = processed / elapsed if elapsed > 0 else 0.0
+        remaining = max(total - processed, 0) if total > 0 else 0
+        eta = remaining / rate if rate > 0 else 0.0
+        print(
+            json.dumps(
+                {
+                    "n_processed": processed,
+                    "n_total": total if total > 0 else None,
+                    "rate": round(rate, 1),
+                    "eta": round(eta, 1),
+                }
+            ),
+            flush=True,
+        )
+        state["last"] = now
+
+    return cb
+
+
+def _run_stream_to_file(
+    kwargs: dict,
+    stream_to_file: str,
+    write_interval: int,
+    paf_workers: int,
+) -> str:
+    """Build a new ``Predictor`` and stream predictions to ``stream_to_file``.
+
+    Handles the ``--stream-to-file`` CLI path (PR 12). Restricted to the
+    cases the new factory + ``Predictor.predict_to_file`` support today:
+    inference on a video / labels file, no tracking, default frame
+    selection. Anything richer raises ``UsageError`` and points at the
+    legacy ``--no-stream-to-file`` path.
+    """
+    if kwargs.get("tracking"):
+        raise click.UsageError(
+            "--stream-to-file does not yet support --tracking; tracking "
+            "lands in a follow-up PR. Drop --stream-to-file to use the "
+            "legacy in-memory path with tracking."
+        )
+    if kwargs.get("no_empty_frames"):
+        raise click.UsageError(
+            "--no_empty_frames is incompatible with --stream-to-file: "
+            "streaming writes each batch to disk and cannot drop empty "
+            "frames after the fact. Drop --stream-to-file to use it."
+        )
+    if not kwargs.get("model_paths"):
+        raise click.UsageError("--model_paths is required for --stream-to-file.")
+    data_path = kwargs.get("data_path")
+    if not data_path:
+        raise click.UsageError("--data_path is required for --stream-to-file.")
+
+    from pathlib import Path
+
+    import sleap_io as sio
+
+    from sleap_nn.inference.factory import from_model_paths
+    from sleap_nn.inference.providers import LabelsProvider, VideoProvider
+
+    factory_kwargs = {
+        "device": _resolve_device(kwargs.get("device")),
+        "peak_threshold": kwargs.get("peak_threshold", 0.2),
+        "integral_refinement": kwargs.get("integral_refinement", "integral"),
+        "integral_patch_size": kwargs.get("integral_patch_size", 5),
+        "batch_size": kwargs.get("batch_size", 4),
+        "max_instances": kwargs.get("max_instances"),
+        "return_confmaps": False,
+        "anchor_part": kwargs.get("anchor_part"),
+        "paf_workers": paf_workers,
+    }
+    if kwargs.get("backbone_ckpt_path"):
+        factory_kwargs["backbone_ckpt_path"] = kwargs["backbone_ckpt_path"]
+    if kwargs.get("head_ckpt_path"):
+        factory_kwargs["head_ckpt_path"] = kwargs["head_ckpt_path"]
+    filter_config = _build_filter_config(kwargs)
+    if filter_config is not None:
+        factory_kwargs["filter_config"] = filter_config
+
+    predictor = from_model_paths(kwargs["model_paths"], **factory_kwargs)
+
+    src = Path(data_path)
+    if src.suffix == ".slp":
+        provider = LabelsProvider(
+            labels=str(src),
+            batch_size=kwargs.get("batch_size", 4),
+            only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
+            only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
+            exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
+            only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
+        )
+        labels = sio.load_slp(str(src))
+        skeleton = labels.skeletons[0]
+    else:
+        provider = VideoProvider(
+            video=str(src),
+            batch_size=kwargs.get("batch_size", 4),
+            frames=kwargs.get("frames"),
+            dataset=kwargs.get("video_dataset"),
+            input_format=kwargs.get("video_input_format"),
+        )
+        # Skeleton comes from the model's training_config — pull via the layer.
+        skeleton = _skeleton_from_predictor(predictor, kwargs["model_paths"][0])
+
+    return predictor.predict_to_file(
+        provider,
+        path=str(stream_to_file),
+        skeleton=skeleton,
+        write_interval=write_interval,
+        progress_callback=_gui_progress_callback() if kwargs.get("gui") else None,
+    )
+
+
+def _skeleton_from_predictor(predictor, model_path: str):
+    """Extract a ``sleap_io.Skeleton`` from the model's ``training_config``."""
+    from omegaconf import OmegaConf
+
+    from sleap_nn.inference.utils import get_skeleton_from_config
+
+    cfg_path = Path(model_path) / "training_config.yaml"
+    cfg = OmegaConf.load(cfg_path.as_posix())
+    skeletons = get_skeleton_from_config(cfg.data_config.skeletons)
+    return skeletons[0]
 
 
 def _common_inference_options(f):

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -940,23 +940,314 @@ def train(
     help="Output JSON progress for GUI integration instead of Rich progress bar.",
 )
 def track(**kwargs):
-    """Run Inference and Tracking workflow."""
-    from sleap_nn.predict import run_inference, frame_list
+    """Run Inference and Tracking workflow.
 
-    # Convert model_paths from tuple to list
+    .. deprecated::
+       Use ``sleap-nn infer`` instead. The ``track`` alias will be
+       removed in a future release. This is currently equivalent to
+       ``sleap-nn infer`` (PR 10 of #508 / #518).
+    """
+    import warnings
+
+    warnings.warn(
+        "`sleap-nn track` is deprecated; use `sleap-nn infer` instead. "
+        "Aliases will be removed in v0.3.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _run_inference_impl(**kwargs)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PR 10 of #508 — `sleap-nn infer` unified inference command (#518)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# `infer`, `predict`, and `track` share an option list and dispatch to one
+# implementation. The option list is built programmatically below
+# (``_INFERENCE_OPTIONS``) so the three commands stay in lockstep — adding
+# a flag in one place updates all three.
+#
+# The new flags introduced by PR 10:
+#   --paf-workers / --cpu-workers (alias)  → wires to Predictor(paf_workers=)
+#   --stream-to-file                        → triggers Predictor.predict_to_file
+#   --write-interval                        → flush cadence for stream-to-file
+#   --peak-conf-threshold (alias)           → alternate name for --peak_threshold
+#
+# The first two are accepted but warn / error today: the underlying new
+# Predictor wiring lands in PR 14 (#519, blocked-by this PR). When that
+# PR lands, this implementation flips to call
+# ``sleap_nn.inference.predictor.Predictor`` directly without changing
+# the user-facing CLI surface.
+
+
+def _run_inference_impl(**kwargs):
+    """Shared implementation for ``infer`` / ``predict`` / ``track``.
+
+    Coerces tuple-shaped multi-options into lists, parses the
+    ``--frames`` string into a list of int frame indices, validates the
+    new PR 10 flags, and delegates to the legacy ``run_inference``.
+    """
+    from sleap_nn.predict import frame_list, run_inference
+
+    # Strip new-flow flags before delegating to legacy run_inference;
+    # they don't have a legacy hook to land on yet.
+    paf_workers = kwargs.pop("paf_workers", 0) or 0
+    cpu_workers = kwargs.pop("cpu_workers", None)
+    stream_to_file = kwargs.pop("stream_to_file", None)
+    write_interval = kwargs.pop("write_interval", None)
+    if cpu_workers is not None:
+        import warnings
+
+        warnings.warn(
+            "--cpu-workers is deprecated; use --paf-workers.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if paf_workers == 0:
+            paf_workers = cpu_workers
+    if stream_to_file is not None:
+        raise click.UsageError(
+            "--stream-to-file requires the new Predictor.predict_to_file flow; "
+            "this lands in a follow-up PR (#519). Until then, omit this flag and "
+            "use the default in-memory output."
+        )
+    if write_interval is not None and stream_to_file is None:
+        raise click.UsageError(
+            "--write-interval is only meaningful together with --stream-to-file."
+        )
+    if paf_workers > 0:
+        logger.warning(
+            "--paf-workers > 0 has no effect in the current CLI release; "
+            "the worker pool ships with the new Predictor flow (#519)."
+        )
+
     if "model_paths" in kwargs and kwargs["model_paths"]:
         kwargs["model_paths"] = list(kwargs["model_paths"])
     else:
         kwargs["model_paths"] = None
 
-    # Convert frames string to list
     if "frames" in kwargs and kwargs["frames"]:
         kwargs["frames"] = frame_list(kwargs["frames"])
     else:
         kwargs["frames"] = None
 
-    # Call the original function
     return run_inference(**kwargs)
+
+
+def _common_inference_options(f):
+    """Apply the shared inference flag list to a click command function.
+
+    Defined as a function-level decorator (not a ``@click.option`` chain)
+    so the same option set can be reused across ``infer`` / ``predict``
+    / ``track`` without copy-pasting ~70 decorator lines per command.
+    """
+    decorators = [
+        click.option(
+            "--data_path",
+            "-i",
+            type=str,
+            required=True,
+            help="Path to data to predict on. Labels (.slp) file or any supported video format.",
+        ),
+        click.option(
+            "--model_paths",
+            "-m",
+            multiple=True,
+            help="Path to trained model directory. Multiple models may be passed (each preceded by --model_paths).",
+        ),
+        click.option(
+            "--output_path",
+            "-o",
+            type=str,
+            default=None,
+            help="Output filename. Defaults to '[data_path].slp'.",
+        ),
+        click.option(
+            "--device",
+            "-d",
+            type=str,
+            default="auto",
+            help="Device on which to allocate tensors. One of (cpu, cuda, mps, auto).",
+        ),
+        click.option(
+            "--batch_size",
+            "-b",
+            type=int,
+            default=4,
+            help="Number of frames to predict at a time.",
+        ),
+        click.option(
+            "--tracking",
+            "-t",
+            is_flag=True,
+            default=False,
+            help="Run tracking on predicted instances.",
+        ),
+        click.option(
+            "-n",
+            "--max_instances",
+            type=int,
+            default=None,
+            help="Cap on instances per frame for multi-instance models.",
+        ),
+        click.option(
+            "--backbone_ckpt_path",
+            type=str,
+            default=None,
+            help="Override path to the backbone .ckpt.",
+        ),
+        click.option(
+            "--head_ckpt_path",
+            type=str,
+            default=None,
+            help="Override path to the head .ckpt.",
+        ),
+        click.option("--max_height", type=int, default=None),
+        click.option("--max_width", type=int, default=None),
+        click.option("--input_scale", type=float, default=None),
+        click.option(
+            "--ensure_rgb/--no-ensure_rgb",
+            default=None,
+            help="Force RGB conversion of input frames.",
+        ),
+        click.option(
+            "--ensure_grayscale/--no-ensure_grayscale",
+            default=None,
+            help="Force grayscale conversion of input frames.",
+        ),
+        click.option("--anchor_part", type=str, default=None),
+        click.option("--only_labeled_frames", is_flag=True, default=False),
+        click.option("--only_suggested_frames", is_flag=True, default=False),
+        click.option("--exclude_user_labeled", is_flag=True, default=False),
+        click.option("--only_predicted_frames", is_flag=True, default=False),
+        click.option("--no_empty_frames", is_flag=True, default=False),
+        click.option("--video_index", type=int, default=None),
+        click.option("--video_dataset", type=str, default=None),
+        click.option(
+            "--video_input_format",
+            type=str,
+            default="channels_last",
+        ),
+        click.option(
+            "--frames",
+            type=str,
+            default="",
+            help="Frame list as comma-separated or hyphen range (e.g., 1,2,3 or 1-3).",
+        ),
+        click.option("--integral_patch_size", type=int, default=5),
+        click.option("--max_edge_length_ratio", type=float, default=0.25),
+        click.option("--dist_penalty_weight", type=float, default=1.0),
+        click.option("--n_points", type=int, default=10),
+        click.option("--min_instance_peaks", type=float, default=0),
+        click.option("--min_line_scores", type=float, default=0.25),
+        click.option("--queue_maxsize", type=int, default=32),
+        click.option("--crop_size", type=int, default=None),
+        click.option(
+            "--peak_threshold",
+            "--peak-conf-threshold",
+            "peak_threshold",
+            type=float,
+            default=0.2,
+            help="Min confmap value for a valid peak. --peak-conf-threshold is an alias.",
+        ),
+        click.option("--filter_overlapping", is_flag=True, default=False),
+        click.option(
+            "--filter_overlapping_method",
+            type=click.Choice(["iou", "oks"]),
+            default="iou",
+        ),
+        click.option("--filter_overlapping_threshold", type=float, default=0.8),
+        click.option("--filter_min_visible_nodes", type=int, default=0),
+        click.option("--filter_min_visible_node_fraction", type=float, default=0.0),
+        click.option("--filter_min_mean_node_score", type=float, default=0.0),
+        click.option("--filter_min_instance_score", type=float, default=0.0),
+        click.option("--integral_refinement", type=str, default="integral"),
+        click.option("--tracking_window_size", type=int, default=5),
+        click.option("--min_new_track_points", type=int, default=0),
+        click.option("--candidates_method", type=str, default="fixed_window"),
+        click.option("--min_match_points", type=int, default=0),
+        click.option("--features", type=str, default="keypoints"),
+        click.option("--scoring_method", type=str, default="oks"),
+        click.option("--scoring_reduction", type=str, default="mean"),
+        click.option("--robust_best_instance", type=float, default=1.0),
+        click.option("--track_matching_method", type=str, default="hungarian"),
+        click.option("--max_tracks", type=int, default=None),
+        click.option("--use_flow", is_flag=True, default=False),
+        click.option("--of_img_scale", type=float, default=1.0),
+        click.option("--of_window_size", type=int, default=21),
+        click.option("--of_max_levels", type=int, default=3),
+        click.option("--post_connect_single_breaks", is_flag=True, default=False),
+        click.option("--tracking_target_instance_count", type=int, default=None),
+        click.option("--tracking_pre_cull_to_target", type=int, default=0),
+        click.option("--tracking_pre_cull_iou_threshold", type=float, default=0),
+        click.option("--tracking_clean_instance_count", type=int, default=0),
+        click.option("--tracking_clean_iou_threshold", type=float, default=0),
+        click.option("--gui", is_flag=True, default=False),
+        # New PR 10 flags ─────────────────────────────────────────────
+        click.option(
+            "--paf-workers",
+            "paf_workers",
+            type=int,
+            default=0,
+            help=(
+                "Number of CPU worker processes for the bottom-up PAF "
+                "grouping stage. 0 (default) keeps grouping in-process. "
+                "Replaces --cpu-workers (kept as an alias for one cycle)."
+            ),
+        ),
+        click.option(
+            "--cpu-workers",
+            "cpu_workers",
+            type=int,
+            default=None,
+            help="[DEPRECATED] Use --paf-workers.",
+        ),
+        click.option(
+            "--stream-to-file",
+            "stream_to_file",
+            type=str,
+            default=None,
+            help=(
+                "Stream predictions incrementally to this .slp path "
+                "(memory stays O(write-interval)). Triggers the new "
+                "Predictor.predict_to_file flow."
+            ),
+        ),
+        click.option(
+            "--write-interval",
+            "write_interval",
+            type=int,
+            default=None,
+            help=(
+                "Number of LabeledFrames to buffer before flushing to "
+                "disk when --stream-to-file is set. Default: 500."
+            ),
+        ),
+    ]
+    for d in reversed(decorators):
+        f = d(f)
+    return f
+
+
+@cli.command(context_settings=CONTEXT_SETTINGS)
+@_common_inference_options
+def infer(**kwargs):
+    """Run inference on videos or labels files.
+
+    Single unified inference entry point. Replaces ``track``, ``predict``,
+    and ``export predict`` (which remain as aliases with deprecation
+    warnings until v0.3).
+    """
+    return _run_inference_impl(**kwargs)
+
+
+# NOTE: The `sleap-nn predict` deprecation alias is deferred — a follow-up
+# PR will (a) convert `export` from a single command to a click group,
+# (b) re-home the existing top-level `predict` (which today runs inference
+# on an exported ONNX/TRT model) under `sleap-nn export predict`, and
+# (c) reclaim the top-level `predict` name as an alias for `infer`. PR 10
+# ships `track` deprecation and the canonical `infer` only, so users can
+# migrate via either of those paths first.
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)

--- a/sleap_nn/inference/factory.py
+++ b/sleap_nn/inference/factory.py
@@ -1,0 +1,533 @@
+"""Build a new :class:`Predictor` directly from model checkpoint paths.
+
+PR 11 of #508 (#519). The legacy ``sleap_nn.inference.predictors.Predictor``
+already knows how to:
+
+* Resolve ``training_config.{yaml,json}`` (incl. SLEAP <=1.4 legacy)
+* Reconstruct the right Lightning module per model type with all its
+  optimizer / scheduler / hard-mining hyperparams (Lightning's
+  ``load_from_checkpoint`` requires those even when only weights matter)
+* Apply ``backbone_ckpt_path`` / ``head_ckpt_path`` overrides
+* Hydrate the skeleton + place the model on the requested device
+
+That work is non-trivial and a perfect candidate for *reuse*. This
+factory delegates it to the legacy predictor, then re-wraps the loaded
+torch module(s) and PAF scorer with the new ``InferenceLayer``
+subclasses. The result is a brand-new :class:`Predictor` that accepts
+the existing ``run_inference`` kwargs without forking the model-loader
+logic.
+
+Why not delete the legacy loader entirely? It's tightly coupled to
+``LightningModule.load_from_checkpoint`` and a SLEAP <=1.4 legacy
+converter — both stable code paths. Eventually (post-#519) the legacy
+``inference_model`` and ``make_pipeline`` go away, and the factory
+keeps the loader. Until then this stays a thin adapter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+from omegaconf import OmegaConf
+
+from sleap_nn.inference.filters import FilterConfig
+from sleap_nn.inference.layers.backends import TorchBackend
+from sleap_nn.inference.tracking import TrackerConfig
+from sleap_nn.inference.layers.bottomup import BottomUpLayer
+from sleap_nn.inference.layers.bottomup_multiclass import BottomUpMultiClassLayer
+from sleap_nn.inference.layers.centered_instance import CenteredInstanceLayer
+from sleap_nn.inference.layers.centroid import CentroidLayer
+from sleap_nn.inference.layers.configs import PostprocessConfig, PreprocessConfig
+from sleap_nn.inference.layers.single_instance import SingleInstanceLayer
+from sleap_nn.inference.layers.topdown import TopDownLayer
+from sleap_nn.inference.layers.topdown_multiclass import (
+    CenteredInstanceMultiClassLayer,
+    TopDownMultiClassLayer,
+)
+
+# ─────────────────────────────────────────────────────────────────────────
+# Layer builders — one per model type, given a loaded legacy inference_model
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _neutral_preprocess() -> Any:
+    """OmegaConf preprocess overrides that mean 'use the training config'."""
+    return OmegaConf.create(
+        {
+            "ensure_rgb": None,
+            "ensure_grayscale": None,
+            "crop_size": None,
+            "max_width": None,
+            "max_height": None,
+            "scale": None,
+        }
+    )
+
+
+def _build_single_instance_layer(predictor: Any, device: str) -> SingleInstanceLayer:
+    """Wrap legacy ``SingleInstanceInferenceModel`` with the new layer."""
+    inf = predictor.inference_model
+    return SingleInstanceLayer(
+        backend=TorchBackend(model=inf.torch_model, device=device),
+        output_stride=inf.output_stride,
+        preprocess_config=PreprocessConfig(scale=inf.input_scale),
+        postprocess_config=PostprocessConfig(
+            peak_threshold=inf.peak_threshold,
+            refinement=inf.refinement or "none",
+            integral_patch_size=inf.integral_patch_size,
+            return_confmaps=getattr(inf, "return_confmaps", False),
+        ),
+    )
+
+
+def _build_bottomup_layer(predictor: Any, device: str) -> BottomUpLayer:
+    """Wrap legacy ``BottomUpInferenceModel`` with the new layer."""
+    inf = predictor.inference_model
+    max_stride = predictor.bottomup_config.model_config.backbone_config[
+        predictor.backbone_type
+    ]["max_stride"]
+    return BottomUpLayer(
+        backend=TorchBackend(model=inf.torch_model, device=device),
+        paf_scorer=inf.paf_scorer,
+        cms_output_stride=inf.cms_output_stride,
+        pafs_output_stride=inf.pafs_output_stride,
+        max_instances=getattr(inf, "max_instances", None),
+        max_stride=max_stride,
+        max_peaks_per_node=inf.max_peaks_per_node,
+        preprocess_config=PreprocessConfig(scale=inf.input_scale),
+        postprocess_config=PostprocessConfig(
+            peak_threshold=inf.peak_threshold,
+            refinement=inf.refinement or "none",
+            integral_patch_size=inf.integral_patch_size,
+            return_confmaps=getattr(inf, "return_confmaps", False),
+            return_pafs=getattr(inf, "return_pafs", False),
+            return_paf_graph=getattr(inf, "return_paf_graph", False),
+        ),
+    )
+
+
+def _build_bottomup_multiclass_layer(
+    predictor: Any, device: str
+) -> BottomUpMultiClassLayer:
+    """Wrap legacy ``BottomUpMultiClassInferenceModel`` with the new layer."""
+    inf = predictor.inference_model
+    max_stride = predictor.bottomup_config.model_config.backbone_config[
+        predictor.backbone_type
+    ]["max_stride"]
+    return BottomUpMultiClassLayer(
+        backend=TorchBackend(model=inf.torch_model, device=device),
+        cms_output_stride=inf.cms_output_stride,
+        class_maps_output_stride=inf.class_maps_output_stride,
+        max_stride=max_stride,
+        preprocess_config=PreprocessConfig(scale=inf.input_scale),
+        postprocess_config=PostprocessConfig(
+            peak_threshold=inf.peak_threshold,
+            refinement=inf.refinement or "none",
+            integral_patch_size=inf.integral_patch_size,
+            return_confmaps=getattr(inf, "return_confmaps", False),
+        ),
+    )
+
+
+def _build_centroid_layer(legacy_centroid: Any, device: str) -> CentroidLayer:
+    """Wrap legacy ``CentroidCrop`` with the new ``CentroidLayer``."""
+    return CentroidLayer(
+        backend=TorchBackend(model=legacy_centroid.torch_model, device=device),
+        output_stride=legacy_centroid.output_stride,
+        max_instances=legacy_centroid.max_instances,
+        max_stride=legacy_centroid.max_stride,
+        anchor_ind=legacy_centroid.anchor_ind,
+        use_gt_centroids=False,
+        preprocess_config=PreprocessConfig(scale=legacy_centroid.input_scale),
+        postprocess_config=PostprocessConfig(
+            peak_threshold=legacy_centroid.peak_threshold,
+            refinement=legacy_centroid.refinement or "none",
+            integral_patch_size=legacy_centroid.integral_patch_size,
+            max_instances=legacy_centroid.max_instances,
+        ),
+    )
+
+
+def _build_centered_instance_layer(
+    legacy_inst: Any, device: str
+) -> CenteredInstanceLayer:
+    """Wrap legacy ``FindInstancePeaks`` with the new layer."""
+    return CenteredInstanceLayer(
+        backend=TorchBackend(model=legacy_inst.torch_model, device=device),
+        output_stride=legacy_inst.output_stride,
+        max_stride=legacy_inst.max_stride,
+        preprocess_config=PreprocessConfig(scale=legacy_inst.input_scale),
+        postprocess_config=PostprocessConfig(
+            peak_threshold=legacy_inst.peak_threshold,
+            refinement=legacy_inst.refinement or "none",
+            integral_patch_size=legacy_inst.integral_patch_size,
+            return_confmaps=getattr(legacy_inst, "return_confmaps", False),
+        ),
+    )
+
+
+def _build_centered_instance_multiclass_layer(
+    legacy_inst: Any, device: str
+) -> CenteredInstanceMultiClassLayer:
+    """Wrap legacy ``TopDownMultiClassFindInstancePeaks`` with the new layer."""
+    return CenteredInstanceMultiClassLayer(
+        backend=TorchBackend(model=legacy_inst.torch_model, device=device),
+        output_stride=legacy_inst.output_stride,
+        max_stride=legacy_inst.max_stride,
+        preprocess_config=PreprocessConfig(scale=legacy_inst.input_scale),
+        postprocess_config=PostprocessConfig(
+            peak_threshold=legacy_inst.peak_threshold,
+            refinement=legacy_inst.refinement or "none",
+            integral_patch_size=legacy_inst.integral_patch_size,
+            return_confmaps=getattr(legacy_inst, "return_confmaps", False),
+        ),
+    )
+
+
+def _build_topdown_layer(predictor: Any, device: str) -> TopDownLayer:
+    """Compose ``CentroidLayer`` + ``CenteredInstanceLayer`` into a ``TopDownLayer``."""
+    inf = predictor.inference_model
+    centroid_layer = _build_centroid_layer(inf.centroid_crop, device)
+    inst_layer = _build_centered_instance_layer(inf.instance_peaks, device)
+    crop_h, crop_w = inf.centroid_crop.crop_hw
+    return TopDownLayer(
+        centroid_layer=centroid_layer,
+        centered_instance_layer=inst_layer,
+        crop_size=(crop_h, crop_w),
+    )
+
+
+def _build_topdown_multiclass_layer(
+    predictor: Any, device: str
+) -> TopDownMultiClassLayer:
+    """Compose centroid + multi-class centered-instance into a multiclass topdown."""
+    inf = predictor.inference_model
+    centroid_layer = _build_centroid_layer(inf.centroid_crop, device)
+    inst_layer = _build_centered_instance_multiclass_layer(inf.instance_peaks, device)
+    crop_h, crop_w = inf.centroid_crop.crop_hw
+    return TopDownMultiClassLayer(
+        centroid_layer=centroid_layer,
+        centered_instance_layer=inst_layer,
+        crop_size=(crop_h, crop_w),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Public entry point
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def from_model_paths(
+    model_paths: List[str],
+    *,
+    backbone_ckpt_path: Optional[str] = None,
+    head_ckpt_path: Optional[str] = None,
+    peak_threshold: Union[float, List[float]] = 0.2,
+    integral_refinement: str = "integral",
+    integral_patch_size: int = 5,
+    batch_size: int = 4,
+    max_instances: Optional[int] = None,
+    return_confmaps: bool = False,
+    device: str = "cpu",
+    preprocess_config: Optional[Any] = None,
+    anchor_part: Optional[str] = None,
+    filter_config: Optional[FilterConfig] = None,
+    paf_workers: int = 0,
+    tracker_config: Optional[TrackerConfig] = None,
+):
+    """Build a new :class:`Predictor` (PR 8) from one or more checkpoint paths.
+
+    Args:
+        model_paths: Directories with ``training_config.{yaml,json}`` +
+            ``best.ckpt``. For top-down inference, pass two paths
+            (centroid + centered-instance) in either order; the factory
+            detects each via its ``training_config``.
+        backbone_ckpt_path: Override the backbone weights with this
+            ``.ckpt`` (legacy ``run_inference`` knob).
+        head_ckpt_path: Override the head weights.
+        peak_threshold: Min confmap value for valid peaks. ``List[float]``
+            for top-down (centroid threshold + centered-instance threshold).
+        integral_refinement: ``"integral"`` for sub-pixel refinement,
+            ``"none"`` (or ``None``) for grid-aligned peaks.
+        integral_patch_size: Refinement patch size.
+        batch_size: Currently unused — :class:`Provider` controls batch
+            size. Kept in the signature for ``run_inference`` compatibility.
+        max_instances: Cap on instances per frame.
+        return_confmaps: Echo confmaps into ``Outputs.pred_confmaps``.
+        device: ``"cpu"``, ``"cuda"``, ``"mps"``, or ``"cuda:N"``.
+        preprocess_config: ``OmegaConf`` overrides for the data-config
+            ``preprocessing`` block. ``None`` means "use the training
+            config as-is".
+        anchor_part: Override the centroid anchor part name (top-down
+            only).
+        filter_config: Optional post-inference :class:`FilterConfig`.
+            ``None`` builds one from the legacy ``filter_*`` kwargs of
+            ``run_inference`` if any are non-default.
+        paf_workers: Number of CPU worker processes for the bottom-up
+            PAF grouping stage. Forwarded to :class:`Predictor`.
+        tracker_config: Optional :class:`TrackerConfig`. Forwarded to
+            :class:`Predictor`; when set, ``predict()`` will track
+            instances post-inference.
+
+    Returns:
+        A :class:`sleap_nn.inference.predictor.Predictor` wrapping the
+        appropriate layer composition for the given model types.
+
+    Raises:
+        ValueError: If ``model_paths`` doesn't contain a recognized
+            combination of model types (e.g., two centroid models).
+    """
+    # Local imports avoid circulars (predictor → factory → predictor).
+    from sleap_nn.config.utils import get_model_type_from_cfg
+    from sleap_nn.inference.predictor import Predictor as NewPredictor
+    from sleap_nn.inference.predictors import Predictor as LegacyPredictor
+
+    if preprocess_config is None:
+        preprocess_config = _neutral_preprocess()
+
+    legacy_predictor = LegacyPredictor.from_model_paths(
+        model_paths=model_paths,
+        backbone_ckpt_path=backbone_ckpt_path,
+        head_ckpt_path=head_ckpt_path,
+        peak_threshold=peak_threshold,
+        integral_refinement=integral_refinement,
+        integral_patch_size=integral_patch_size,
+        batch_size=batch_size,
+        max_instances=max_instances,
+        return_confmaps=return_confmaps,
+        device=device,
+        preprocess_config=preprocess_config,
+        anchor_part=anchor_part,
+    )
+    legacy_predictor._initialize_inference_model()
+
+    # Detect model types across the supplied paths.
+    model_types: list[str] = []
+    for model_path in model_paths:
+        path = Path(model_path)
+        if (path / "training_config.yaml").exists():
+            cfg = OmegaConf.load((path / "training_config.yaml").as_posix())
+        elif (path / "training_config.json").exists():
+            from sleap_nn.config.training_job_config import TrainingJobConfig
+
+            cfg = TrainingJobConfig.load_sleap_config(
+                (path / "training_config.json").as_posix()
+            )
+        else:  # pragma: no cover — guarded by legacy loader above
+            raise ValueError(f"no training_config in {model_path}")
+        model_types.append(get_model_type_from_cfg(config=cfg))
+
+    layer = _select_layer(legacy_predictor, model_types, device)
+    kwargs: dict = {"layer": layer, "paf_workers": paf_workers}
+    if filter_config is not None:
+        kwargs["filter_config"] = filter_config
+    if tracker_config is not None:
+        kwargs["tracker_config"] = tracker_config
+    return NewPredictor(**kwargs)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# from_export_dir — build a Predictor from an exported ONNX/TRT directory
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def from_export_dir(
+    export_dir: Union[str, Path],
+    *,
+    runtime: str = "auto",
+    device: str = "auto",
+    return_confmaps: bool = False,
+    filter_config: Optional[FilterConfig] = None,
+    paf_workers: int = 0,
+    tracker_config: Optional[TrackerConfig] = None,
+):
+    """Build a new :class:`Predictor` from an exported model directory.
+
+    The directory is expected to contain ``export_metadata.json`` plus
+    one of ``model.onnx`` / ``model.trt``. Pulls model-type, output stride,
+    input scale, and peak-threshold from the metadata; constructs the
+    appropriate :class:`InferenceLayer` subclass on the
+    ``does_baked_postproc=True`` path so peak finding stays inside the
+    exported graph.
+
+    Args:
+        export_dir: Directory written by ``sleap_nn export`` (or any
+            equivalent exporter that emits the same metadata schema).
+        runtime: ``"auto"`` (prefer TRT when present, else ONNX),
+            ``"onnx"``, or ``"tensorrt"``.
+        device: Device string forwarded to the backend.
+        return_confmaps: Echo confmaps onto the resulting ``Outputs``
+            when the wrapper exports a ``confmaps`` output. Layers gate
+            on this flag.
+        filter_config: Optional :class:`FilterConfig` (post-inference).
+        paf_workers: Forwarded to :class:`Predictor`. Only meaningful
+            for bottom-up exports — irrelevant for single-instance.
+        tracker_config: Optional :class:`TrackerConfig` (post-inference
+            tracker).
+
+    Returns:
+        A configured :class:`sleap_nn.inference.predictor.Predictor`.
+
+    Raises:
+        FileNotFoundError: ``export_metadata.json`` or the model file
+            isn't present at the expected path.
+        NotImplementedError: ``model_type`` is recognized but its export
+            adapter hasn't landed yet. As of PR 18 only
+            ``"single_instance"`` is supported; ``centroid`` /
+            ``centered_instance`` / top-down combined / bottom-up /
+            multiclass land in follow-up PRs.
+        ValueError: ``runtime`` isn't recognized.
+
+    Notes:
+        Skeleton hydration is *not* done here — call
+        :func:`sleap_nn.inference.utils.get_skeleton_from_config` on the
+        export's ``training_config.yaml`` separately if you need a
+        skeleton for ``Predictor.predict(make_labels=True, ...)``.
+    """
+    from sleap_nn.export.metadata import ExportMetadata
+    from sleap_nn.inference.predictor import Predictor as NewPredictor
+
+    export_dir = Path(export_dir)
+
+    metadata_path = export_dir / "export_metadata.json"
+    if not metadata_path.exists():
+        raise FileNotFoundError(
+            f"export_metadata.json not found at {metadata_path}. "
+            f"Pass a directory written by `sleap_nn export`."
+        )
+    metadata = ExportMetadata.load(metadata_path)
+
+    runtime, model_path = _resolve_export_runtime(export_dir, runtime)
+    backend = _build_export_backend(runtime, model_path, device)
+
+    layer = _select_export_layer(
+        metadata=metadata,
+        backend=backend,
+        return_confmaps=return_confmaps,
+    )
+
+    kwargs: dict = {"layer": layer, "paf_workers": paf_workers}
+    if filter_config is not None:
+        kwargs["filter_config"] = filter_config
+    if tracker_config is not None:
+        kwargs["tracker_config"] = tracker_config
+    return NewPredictor(**kwargs)
+
+
+def _resolve_export_runtime(export_dir: Path, runtime: str) -> tuple[str, Path]:
+    """Pick the runtime + model file for an export directory.
+
+    Returns ``(runtime, model_path)`` where ``runtime`` is one of
+    ``"onnx"`` or ``"tensorrt"``.
+    """
+    onnx_path = export_dir / "model.onnx"
+    trt_path = export_dir / "model.trt"
+
+    if runtime == "auto":
+        if trt_path.exists():
+            return "tensorrt", trt_path
+        if onnx_path.exists():
+            return "onnx", onnx_path
+        raise FileNotFoundError(
+            f"No model file found in {export_dir}. "
+            f"Expected model.onnx or model.trt."
+        )
+    if runtime == "onnx":
+        if not onnx_path.exists():
+            raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
+        return "onnx", onnx_path
+    if runtime == "tensorrt":
+        if not trt_path.exists():
+            raise FileNotFoundError(f"TensorRT model not found: {trt_path}")
+        return "tensorrt", trt_path
+    raise ValueError(
+        f"Unknown runtime: {runtime!r}. Expected 'auto', 'onnx', or 'tensorrt'."
+    )
+
+
+def _build_export_backend(runtime: str, model_path: Path, device: str):
+    """Construct the right ``ModelBackend`` for an exported model file."""
+    if runtime == "onnx":
+        from sleap_nn.inference.layers.backends import ONNXBackend
+
+        return ONNXBackend(model_path=str(model_path), device=device)
+    if runtime == "tensorrt":
+        from sleap_nn.inference.layers.backends import TensorRTBackend
+
+        return TensorRTBackend(engine_path=str(model_path), device=device)
+    raise ValueError(f"Unknown runtime: {runtime!r}")
+
+
+def _select_export_layer(
+    metadata: Any,
+    backend: Any,
+    return_confmaps: bool,
+):
+    """Dispatch on ``metadata.model_type`` → build the right export adapter.
+
+    Export adapters live in :mod:`sleap_nn.inference.layers.exported` —
+    thin translators that consume the wrapper's already-postprocessed
+    output (peaks already in original-image space) and produce a
+    structured :class:`Outputs`. They intentionally bypass the standard
+    layer's coord ladder so transforms aren't double-applied.
+
+    Supported as of PR 19: ``single_instance``, ``centroid``,
+    ``centered_instance``, ``topdown``. Bottom-up + multiclass land in
+    follow-up PRs.
+    """
+    from sleap_nn.inference.layers.exported import (
+        ExportedCenteredInstanceLayer,
+        ExportedCentroidLayer,
+        ExportedSingleInstanceLayer,
+        ExportedTopDownLayer,
+    )
+
+    model_type = metadata.model_type
+
+    if model_type == "single_instance":
+        return ExportedSingleInstanceLayer(
+            backend=backend, return_confmaps=return_confmaps
+        )
+    if model_type == "centered_instance":
+        return ExportedCenteredInstanceLayer(
+            backend=backend, return_confmaps=return_confmaps
+        )
+    if model_type == "centroid":
+        return ExportedCentroidLayer(backend=backend)
+    if model_type == "topdown":
+        return ExportedTopDownLayer(backend=backend)
+
+    if model_type in {"bottomup", "multi_class_bottomup", "multi_class_topdown"}:
+        raise NotImplementedError(
+            f"from_export_dir: model_type={model_type!r} adapter not yet "
+            f"implemented. Currently supported: 'single_instance', "
+            f"'centroid', 'centered_instance', 'topdown'. Use the "
+            f"legacy `sleap_nn.export.inference.predict(...)` for other "
+            f"model types until follow-up PRs land."
+        )
+
+    raise ValueError(f"Unrecognized model_type {model_type!r} in export_metadata.json.")
+
+
+def _select_layer(legacy_predictor: Any, model_types: List[str], device: str):
+    """Dispatch on detected model types → build the new layer composition."""
+    if "single_instance" in model_types:
+        return _build_single_instance_layer(legacy_predictor, device)
+    if "bottomup" in model_types:
+        return _build_bottomup_layer(legacy_predictor, device)
+    if "multi_class_bottomup" in model_types:
+        return _build_bottomup_multiclass_layer(legacy_predictor, device)
+    has_centroid = "centroid" in model_types
+    has_centered = "centered_instance" in model_types
+    has_multi_centered = "multi_class_topdown" in model_types
+    if has_centroid and has_centered:
+        return _build_topdown_layer(legacy_predictor, device)
+    if has_centroid and has_multi_centered:
+        return _build_topdown_multiclass_layer(legacy_predictor, device)
+    raise ValueError(
+        f"Unsupported model_paths combination: detected types {model_types}. "
+        f"The new Predictor.from_model_paths supports: single_instance, "
+        f"bottomup, multi_class_bottomup, top-down (centroid + centered_instance), "
+        f"or top-down multiclass (centroid + multi_class_topdown)."
+    )

--- a/sleap_nn/inference/layers/exported.py
+++ b/sleap_nn/inference/layers/exported.py
@@ -1,0 +1,217 @@
+"""Export-adapter layers — thin translators around exported ONNX/TRT models.
+
+The exported wrappers in :mod:`sleap_nn.export.wrappers` bake every
+preprocessing + postprocessing step into the ONNX graph, including
+``input_scale`` resize, ``output_stride`` rescaling, peak finding,
+and (top-down) crop extraction. By the time output keys arrive, peaks
+are already in **original-image pixel space** with the right shapes.
+
+The standard :class:`InferenceLayer` subclasses in
+``sleap_nn/inference/layers/`` were designed for ``.ckpt`` checkpoints,
+where the layer's own ``preprocess`` does the input-scale resize and
+``postprocess`` runs the coord ladder (``undo_stride`` /
+``undo_input_scale``). Reusing them for export-loaded backends would
+double-apply both transforms.
+
+This module ships dedicated adapter layers for the export path, one
+per exported model type. Each one:
+
+* skips ``input_scale`` resize (the wrapper did it)
+* feeds raw uint8 ``(B, C, H, W)`` tensors to the backend
+* skips peak finding (already baked)
+* skips the coord ladder (already in original-image space)
+* translates the wrapper's output dict into a structured :class:`Outputs`
+
+The classes intentionally don't inherit from :class:`InferenceLayer`
+— they're shaped like layers (``predict(image, **kwargs) -> Outputs``)
+but the layered preprocess/forward/postprocess pipeline doesn't apply.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import attrs
+import numpy as np
+import torch
+
+from sleap_nn.inference.layers.base import InferenceLayer
+from sleap_nn.inference.outputs import Outputs
+
+
+def _to_4d_uint8_tensor(image: Any) -> torch.Tensor:
+    """Coerce an image input to ``(B, C, H, W)`` uint8 (channel-first).
+
+    Mirrors :meth:`InferenceLayer._to_4d_float_tensor` shape-wise, but
+    keeps the dtype as the runtime expects (``ONNXBackend`` casts to
+    its declared input dtype, typically ``uint8``, before invoking the
+    session).
+    """
+    return InferenceLayer._to_4d_float_tensor(image)
+
+
+@attrs.define
+class ExportedSingleInstanceLayer:
+    """Adapter for an ONNX/TRT-exported single-instance model.
+
+    The wrapper output schema is:
+
+    * ``peaks``: ``(B, N, 2)`` in original-image (x, y) space
+    * ``peak_vals``: ``(B, N)``
+    * ``confmaps`` (optional): ``(B, N, H, W)``
+
+    ``Outputs.pred_keypoints`` uses ``(B, I, N, 2)`` so the adapter
+    inserts a singleton instance dim.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+        return_confmaps: When ``True`` and the wrapper exports a
+            ``confmaps`` output, echo it onto :attr:`Outputs.pred_confmaps`.
+    """
+
+    backend: Any
+    return_confmaps: bool = False
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        peaks = raw["peaks"]  # (B, N, 2)
+        vals = raw["peak_vals"]  # (B, N)
+        # Add singleton instance dim per the Outputs convention.
+        out = Outputs(
+            pred_keypoints=peaks.unsqueeze(1),  # (B, 1, N, 2)
+            pred_peak_values=vals.unsqueeze(1),  # (B, 1, N)
+        )
+        if self.return_confmaps and "confmaps" in raw:
+            out = attrs.evolve(out, pred_confmaps=raw["confmaps"])
+        return out
+
+
+@attrs.define
+class ExportedCenteredInstanceLayer:
+    """Adapter for an ONNX/TRT-exported centered-instance model.
+
+    Standalone centered-instance is invoked on pre-cropped images. The
+    wrapper outputs the same shape as single-instance:
+
+    * ``peaks``: ``(B_crops, N, 2)`` in crop (x, y) space
+    * ``peak_vals``: ``(B_crops, N)``
+
+    ``Outputs.pred_keypoints`` of shape ``(B_crops, 1, N, 2)``.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+        return_confmaps: Echo ``confmaps`` onto
+            :attr:`Outputs.pred_confmaps` when present.
+    """
+
+    backend: Any
+    return_confmaps: bool = False
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        peaks = raw["peaks"]  # (B_crops, N, 2)
+        vals = raw["peak_vals"]
+        out = Outputs(
+            pred_keypoints=peaks.unsqueeze(1),  # (B_crops, 1, N, 2)
+            pred_peak_values=vals.unsqueeze(1),  # (B_crops, 1, N)
+        )
+        if self.return_confmaps and "confmaps" in raw:
+            out = attrs.evolve(out, pred_confmaps=raw["confmaps"])
+        return out
+
+
+@attrs.define
+class ExportedCentroidLayer:
+    """Adapter for an ONNX/TRT-exported centroid model.
+
+    The wrapper output schema:
+
+    * ``centroids``: ``(B, I, 2)`` in original-image (x, y) space.
+      Invalid slots are zero-filled and flagged in ``instance_valid``.
+    * ``centroid_vals``: ``(B, I)``
+    * ``instance_valid``: ``(B, I)`` bool
+
+    Translates to ``Outputs.pred_centroids`` / ``pred_centroid_values``.
+    Invalid slots are turned into ``NaN`` per the ``Outputs`` convention.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+    """
+
+    backend: Any
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        centroids = raw["centroids"].clone()  # (B, I, 2)
+        centroid_vals = raw["centroid_vals"].clone()  # (B, I)
+        valid = raw["instance_valid"].bool()  # (B, I)
+
+        # Replace invalid zero-padded slots with NaN per Outputs convention.
+        invalid = ~valid
+        centroids[invalid] = float("nan")
+        centroid_vals[invalid] = float("nan")
+
+        return Outputs(
+            pred_centroids=centroids,
+            pred_centroid_values=centroid_vals,
+            instance_valid=valid,
+        )
+
+
+@attrs.define
+class ExportedTopDownLayer:
+    """Adapter for an ONNX/TRT-exported combined top-down model.
+
+    The export bakes both centroid + centered-instance stages plus the
+    crop extraction step into a single ONNX graph. Wrapper output:
+
+    * ``centroids``: ``(B, I, 2)`` in original-image (x, y) space
+    * ``centroid_vals``: ``(B, I)``
+    * ``peaks``: ``(B, I, N, 2)`` in original-image (x, y) space
+      (crop offset already added back inside the graph)
+    * ``peak_vals``: ``(B, I, N)``
+    * ``instance_valid``: ``(B, I)`` bool
+
+    Invalid slots are zero-filled by the wrapper and flagged in
+    ``instance_valid``. The adapter NaN-pads invalid slots per the
+    ``Outputs`` convention.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+    """
+
+    backend: Any
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        centroids = raw["centroids"].clone()
+        centroid_vals = raw["centroid_vals"].clone()
+        peaks = raw["peaks"].clone()
+        peak_vals = raw["peak_vals"].clone()
+        valid = raw["instance_valid"].bool()
+
+        invalid = ~valid
+        centroids[invalid] = float("nan")
+        centroid_vals[invalid] = float("nan")
+        peaks[invalid] = float("nan")
+        peak_vals[invalid] = float("nan")
+
+        return Outputs(
+            pred_keypoints=peaks,
+            pred_peak_values=peak_vals,
+            pred_centroids=centroids,
+            pred_centroid_values=centroid_vals,
+            instance_valid=valid,
+        )

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -22,7 +22,7 @@ This commit ships the synchronous :meth:`predict`. Streaming +
 
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Callable, Iterator, List, Optional, Union
 
 import attrs
 import numpy as np
@@ -31,6 +31,15 @@ import torch
 from sleap_nn.inference.filters import FilterConfig, FilterPipeline
 from sleap_nn.inference.outputs import Outputs
 from sleap_nn.inference.providers import Provider
+from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+
+def _safe_len(provider: Any) -> int:
+    """Return ``len(provider)`` or ``-1`` if the provider doesn't expose ``__len__``."""
+    try:
+        return len(provider)
+    except TypeError:
+        return -1
 
 
 @attrs.define
@@ -50,6 +59,14 @@ class Predictor:
             layer type the value is ignored. Each worker starts a fresh
             Python interpreter on macOS / Windows (~1s startup cost), so
             keep this off for short videos on those platforms.
+        tracker_config: Optional :class:`TrackerConfig`. When set,
+            :meth:`predict` runs the tracker on the resulting
+            ``sio.Labels`` (requires ``make_labels=True``) before
+            returning. A fresh ``Tracker`` is built per call, so no
+            state leaks across invocations. ``predict_streaming`` /
+            ``predict_to_file`` raise on tracker_config — end-of-stream
+            cleanup (``cull_instances`` / ``connect_single_breaks``)
+            needs the full LabeledFrame list, which defeats streaming.
 
     Notes:
         Keeps no state across calls — same predictor can be reused on
@@ -59,11 +76,71 @@ class Predictor:
     layer: Any
     filter_config: FilterConfig = attrs.Factory(FilterConfig)
     paf_workers: int = 0
+    tracker_config: Optional[TrackerConfig] = None
 
     @property
     def filter_pipeline(self) -> FilterPipeline:
         """Build a fresh ``FilterPipeline`` from the config (cheap)."""
         return FilterPipeline(self.filter_config)
+
+    # ──────────────────────────────────────────────────────────────────
+    # Factory: build a Predictor from one or more checkpoint paths
+    # ──────────────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_model_paths(cls, model_paths: List[str], **kwargs) -> "Predictor":
+        """Build a :class:`Predictor` from one or more model checkpoint paths.
+
+        See :func:`sleap_nn.inference.factory.from_model_paths` for the
+        full kwarg surface. This classmethod is a thin alias so existing
+        callers can do ``Predictor.from_model_paths(...)`` without
+        knowing about the factory module.
+        """
+        from sleap_nn.inference.factory import from_model_paths
+
+        return from_model_paths(model_paths, **kwargs)
+
+    @classmethod
+    def from_export_dir(cls, export_dir: str, **kwargs) -> "Predictor":
+        """Build a :class:`Predictor` from an exported ``.onnx`` / ``.trt`` directory.
+
+        See :func:`sleap_nn.inference.factory.from_export_dir` for the
+        full kwarg surface.
+        """
+        from sleap_nn.inference.factory import from_export_dir
+
+        return from_export_dir(export_dir, **kwargs)
+
+    @staticmethod
+    def retrack(
+        labels: Any,
+        tracker_config: TrackerConfig,
+        clean_empty_frames: bool = False,
+    ) -> Any:
+        """Retrack an existing ``sio.Labels`` without running inference.
+
+        Pure tracking — useful when you already have predicted instances
+        in a ``.slp`` and just want to (re)apply a tracker. Mirrors the
+        legacy ``run_inference(model_paths=None, tracking=True, ...)``
+        path. The tracker runs once over the full LabeledFrame list;
+        post-tracking cleanup (cull / connect-single-breaks) is applied
+        per ``tracker_config``.
+
+        Args:
+            labels: A ``sio.Labels`` whose ``predicted_instances`` are
+                tracked in-place semantics — this returns a new
+                ``Labels`` with tracked instances.
+            tracker_config: :class:`TrackerConfig` to drive the tracker.
+            clean_empty_frames: When ``True``, drop empty frames from
+                the result (matches ``--no_empty_frames``).
+
+        Returns:
+            New ``sio.Labels`` with tracks attached.
+        """
+        out = apply_tracking(labels, tracker_config)
+        if clean_empty_frames:
+            out.clean(frames=True, skeletons=False)
+        return out
 
     # ──────────────────────────────────────────────────────────────────
     # Synchronous: returns Outputs list or sio.Labels
@@ -75,6 +152,8 @@ class Predictor:
         make_labels: bool = False,
         skeleton: Optional[Any] = None,
         videos: Optional[List[Any]] = None,
+        clean_empty_frames: bool = False,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> Union[List[Outputs], Any]:
         """Run inference on every batch from ``provider``.
 
@@ -86,23 +165,45 @@ class Predictor:
                 ``make_labels=True``.
             videos: Optional list of ``sio.Video`` indexed by
                 ``video_indices`` for label conversion.
+            clean_empty_frames: When ``True`` and ``make_labels=True``,
+                drop ``LabeledFrame``s with no instances from the
+                returned ``sio.Labels``. Mirrors the legacy
+                ``no_empty_frames`` flag.
+            progress_callback: Optional ``(processed_batches, total_batches)``
+                callback invoked after each batch. ``total_batches`` is
+                ``len(provider)`` if the provider implements ``__len__``,
+                else ``-1``.
 
         Returns:
             ``List[Outputs]`` (raw mode) or ``sio.Labels`` (with-labels
             mode).
         """
-        outputs_list = list(self._batch_iter(provider))
+        outputs_list = list(self._batch_iter(provider, progress_callback))
         if not make_labels:
+            if self.tracker_config is not None:
+                raise ValueError(
+                    "tracker_config requires make_labels=True; the tracker "
+                    "operates on sio.PredictedInstance objects."
+                )
             return outputs_list
         if skeleton is None:
             raise ValueError("make_labels=True requires `skeleton` to be passed.")
-        return self._to_labels(outputs_list, skeleton=skeleton, videos=videos)
+        labels = self._to_labels(outputs_list, skeleton=skeleton, videos=videos)
+        if self.tracker_config is not None:
+            labels = apply_tracking(labels, self.tracker_config)
+        if clean_empty_frames:
+            labels.clean(frames=True, skeletons=False)
+        return labels
 
     # ──────────────────────────────────────────────────────────────────
     # Streaming: yields one Outputs at a time
     # ──────────────────────────────────────────────────────────────────
 
-    def predict_streaming(self, provider: Provider) -> Iterator[Outputs]:
+    def predict_streaming(
+        self,
+        provider: Provider,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> Iterator[Outputs]:
         """Yield one ``Outputs`` per provider batch.
 
         Caller-controlled memory: the predictor never materializes the
@@ -113,10 +214,16 @@ class Predictor:
         the GPU peak / PAF-scoring stage in this process and ships the
         CPU grouping stage to a :class:`PafGroupingPool`.
         """
+        if self.tracker_config is not None:
+            raise ValueError(
+                "tracker_config is not supported on predict_streaming / "
+                "predict_to_file. End-of-stream tracker cleanup needs the "
+                "full LabeledFrame list; use predict() instead."
+            )
         if self.paf_workers > 0 and self._can_pipeline():
-            yield from self._predict_streaming_pipelined(provider)
+            yield from self._predict_streaming_pipelined(provider, progress_callback)
             return
-        yield from self._batch_iter(provider)
+        yield from self._batch_iter(provider, progress_callback)
 
     # ──────────────────────────────────────────────────────────────────
     # Disk-streaming: write to a .slp incrementally
@@ -129,6 +236,7 @@ class Predictor:
         skeleton: Any,
         videos: Optional[List[Any]] = None,
         write_interval: int = 500,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> str:
         """Run inference and stream results to a ``.slp`` file.
 
@@ -146,6 +254,9 @@ class Predictor:
                 ``video_indices`` for the saved labels.
             write_interval: Number of LabeledFrames to buffer before
                 a disk flush.
+            progress_callback: Optional ``(processed_batches, total_batches)``
+                callback invoked after each batch (forwarded to
+                :meth:`predict_streaming`).
 
         Returns:
             The (resolved) destination path string.
@@ -158,7 +269,7 @@ class Predictor:
             videos=videos,
             write_interval=write_interval,
         ) as writer:
-            for outputs in self.predict_streaming(provider):
+            for outputs in self.predict_streaming(provider, progress_callback):
                 writer.write(outputs)
         return path
 
@@ -166,10 +277,15 @@ class Predictor:
     # Internals
     # ──────────────────────────────────────────────────────────────────
 
-    def _batch_iter(self, provider: Provider) -> Iterator[Outputs]:
+    def _batch_iter(
+        self,
+        provider: Provider,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> Iterator[Outputs]:
         """Run ``layer.predict`` + ``FilterPipeline`` per provider batch."""
         pipeline = self.filter_pipeline
-        for batch in provider:
+        total = _safe_len(provider)
+        for i, batch in enumerate(provider):
             kwargs: dict = {}
             if batch.instances is not None:
                 kwargs["instances"] = (
@@ -181,6 +297,8 @@ class Predictor:
             outputs = pipeline(outputs)
             outputs = self._stamp_metadata(outputs, batch)
             yield outputs
+            if progress_callback is not None:
+                progress_callback(i + 1, total)
 
     # ──────────────────────────────────────────────────────────────────
     # Pipelined bottom-up: GPU stage in main proc, CPU grouping in pool
@@ -193,7 +311,11 @@ class Predictor:
 
         return isinstance(self.layer, BottomUpLayer)
 
-    def _predict_streaming_pipelined(self, provider: Provider) -> Iterator[Outputs]:
+    def _predict_streaming_pipelined(
+        self,
+        provider: Provider,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> Iterator[Outputs]:
         """Stream ``Outputs`` with the CPU grouping stage in a worker pool.
 
         The GPU stage (:meth:`BottomUpLayer._score_pafs_on_gpu`) runs
@@ -208,6 +330,7 @@ class Predictor:
         pipeline = self.filter_pipeline
         layer = self.layer
         params = layer.grouping_params()
+        total = _safe_len(provider)
 
         # Cache per-batch metadata keyed by submission ordinal so we can
         # restamp it onto the worker-produced Outputs.
@@ -221,10 +344,14 @@ class Predictor:
                 scored = layer._score_pafs_on_gpu(raw, info)
                 pool.submit(ordinal, scored)
                 meta[ordinal] = batch
+            completed = 0
             for ordinal, outputs in pool.iter_completed():
                 outputs = pipeline(outputs)
                 outputs = self._stamp_metadata(outputs, meta.pop(ordinal))
                 yield outputs
+                completed += 1
+                if progress_callback is not None:
+                    progress_callback(completed, total)
 
     @staticmethod
     def _stamp_metadata(outputs: Outputs, batch: Any) -> Outputs:

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -163,11 +163,22 @@ class LabelsProvider:
         batch_size: Frames per yielded ``Batch``.
         only_labeled_frames: Yield only frames that have at least one
             user-supplied instance (default ``True``).
+        only_suggested_frames: Yield only frames listed in
+            ``labels.suggestions`` that don't already have a user
+            instance. Mutually exclusive with the other ``only_*`` /
+            ``exclude_*`` modes.
+        exclude_user_labeled: Skip any frame that has a user instance.
+            Mutually exclusive with ``only_labeled_frames``.
+        only_predicted_frames: Yield only frames that already have at
+            least one predicted instance.
     """
 
     labels: object  # str | sio.Labels
     batch_size: int = 4
     only_labeled_frames: bool = True
+    only_suggested_frames: bool = False
+    exclude_user_labeled: bool = False
+    only_predicted_frames: bool = False
 
     _sio_labels: object = attrs.field(default=None, init=False, repr=False)
     _labeled_frames: list = attrs.field(factory=list, init=False, repr=False)
@@ -181,33 +192,87 @@ class LabelsProvider:
         else:
             self._sio_labels = sio.load_slp(str(self.labels))
 
-        if self.only_labeled_frames:
+        if self.only_labeled_frames and self.exclude_user_labeled:
+            raise ValueError(
+                "only_labeled_frames=True and exclude_user_labeled=True are "
+                "mutually exclusive."
+            )
+
+        if self.only_suggested_frames:
+            self._labeled_frames = self._collect_suggested_frames(sio)
+        elif self.only_predicted_frames:
+            self._labeled_frames = [
+                lf
+                for lf in self._sio_labels.labeled_frames
+                if lf.has_predicted_instances
+            ]
+        elif self.exclude_user_labeled:
+            self._labeled_frames = [
+                lf
+                for lf in self._sio_labels.labeled_frames
+                if not lf.has_user_instances
+            ]
+        elif self.only_labeled_frames:
             self._labeled_frames = [
                 lf for lf in self._sio_labels.labeled_frames if len(lf.instances) > 0
             ]
         else:
             self._labeled_frames = list(self._sio_labels.labeled_frames)
 
+    def _collect_suggested_frames(self, sio) -> list:
+        """Return new ``LabeledFrame``s for unlabeled suggestions.
+
+        Mirrors the legacy ``LabelsReader`` semantics: walks
+        ``labels.suggestions`` and emits a fresh empty ``LabeledFrame``
+        for any suggestion whose frame doesn't already have a user
+        instance.
+        """
+        out: list = []
+        for suggestion in self._sio_labels.suggestions:
+            existing = self._sio_labels.find(suggestion.video, suggestion.frame_idx)
+            if not existing or not existing[0].has_user_instances:
+                out.append(
+                    sio.LabeledFrame(
+                        video=suggestion.video, frame_idx=suggestion.frame_idx
+                    )
+                )
+        return out
+
     def __iter__(self) -> Iterator[Batch]:
-        """Yield batches; each ``Batch.instances`` carries GT keypoints."""
+        """Yield batches; each ``Batch.instances`` carries GT keypoints.
+
+        For frames with no instances (e.g. ``only_suggested_frames``
+        emits empty placeholders), ``Batch.instances`` is ``None`` so
+        downstream layers that don't need GT (single-instance,
+        top-down with centroid model, bottom-up) skip the GT-shaped
+        kwargs entirely.
+        """
         for start in range(0, len(self._labeled_frames), self.batch_size):
             stop = min(start + self.batch_size, len(self._labeled_frames))
             chunk = self._labeled_frames[start:stop]
             frames = np.stack([lf.image for lf in chunk], axis=0)
 
-            # Pad GT instances to a uniform max_instances per batch so
-            # downstream layer code can work with fixed shapes.
             max_inst = max(len(lf.instances) for lf in chunk)
-            n_nodes = (
-                len(chunk[0].instances[0].skeleton.nodes) if chunk[0].instances else 1
-            )
-            instances = np.full(
-                (len(chunk), max_inst, n_nodes, 2), np.nan, dtype=np.float32
-            )
-            for i, lf in enumerate(chunk):
-                for j, inst in enumerate(lf.instances):
-                    pts = np.asarray(inst.numpy(), dtype=np.float32)
-                    instances[i, j, : pts.shape[0]] = pts
+            if max_inst == 0:
+                instances = None
+            else:
+                # Pad GT instances to a uniform max_instances per batch so
+                # downstream layer code can work with fixed shapes.
+                n_nodes = next(
+                    (
+                        len(lf.instances[0].skeleton.nodes)
+                        for lf in chunk
+                        if lf.instances
+                    ),
+                    1,
+                )
+                instances = np.full(
+                    (len(chunk), max_inst, n_nodes, 2), np.nan, dtype=np.float32
+                )
+                for i, lf in enumerate(chunk):
+                    for j, inst in enumerate(lf.instances):
+                        pts = np.asarray(inst.numpy(), dtype=np.float32)
+                        instances[i, j, : pts.shape[0]] = pts
 
             frame_idxs = np.array([lf.frame_idx for lf in chunk], dtype=np.int64)
             yield Batch(

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -1,0 +1,182 @@
+"""Tracking integration for the new ``Predictor`` flow.
+
+Wraps :class:`sleap_nn.tracking.tracker.Tracker` (and its post-processing
+helpers ``cull_instances`` / ``connect_single_breaks``) as a value-typed
+config + a labels-in / labels-out function.
+
+Why a config: keeps :class:`~sleap_nn.inference.predictor.Predictor`
+picklable and lets the CLI / factory layer build the tracking
+configuration once and forward it as plain data, the same shape as
+``FilterConfig`` from PR 8.
+
+Why labels-in / labels-out: the tracker is stateful across frames and
+operates on ``sio.PredictedInstance`` objects, so the natural seam is
+*after* :meth:`Predictor._to_labels` converts ``Outputs`` to
+``LabeledFrame``s. ``apply_tracking`` builds a fresh ``Tracker`` per
+call (no shared state across ``predict()`` invocations) and runs it
+in submission order.
+
+What this does NOT cover:
+
+* ``--stream-to-file`` + ``--tracking`` — still a UsageError. End-of-
+  stream post-processing (``cull_instances`` / ``connect_single_breaks``)
+  needs the full LabeledFrame list, which defeats streaming.
+* Pre-tracking filter knobs (``filter_max_overlap_*`` /
+  ``filter_min_node_count`` / ``filter_min_*_score``) — these run as a
+  separate stage in legacy ``run_inference`` and aren't routed through
+  the new flow yet. The CLI predicate keeps falling through to legacy
+  when those flags are set.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import attrs
+
+import sleap_io as sio
+
+
+@attrs.frozen(eq=False)
+class TrackerConfig:
+    """Frozen value type capturing every knob ``run_tracker`` exposes.
+
+    Mirrors :func:`sleap_nn.tracking.tracker.run_tracker`'s signature.
+    Picklable so it can sit on :class:`Predictor` without compromising
+    the picklability contract from PR 2.
+    """
+
+    # Tracker.from_config kwargs ────────────────────────────────────────
+    window_size: int = 5
+    min_new_track_points: int = 0
+    candidates_method: str = "fixed_window"
+    min_match_points: int = 0
+    features: str = "keypoints"
+    scoring_method: str = "oks"
+    scoring_reduction: str = "mean"
+    robust_best_instance: float = 1.0
+    track_matching_method: str = "hungarian"
+    max_tracks: Optional[int] = None
+    use_flow: bool = False
+    of_img_scale: float = 1.0
+    of_window_size: int = 21
+    of_max_levels: int = 3
+
+    # Pre-tracking cull (consumed by Tracker.from_config) ───────────────
+    tracking_target_instance_count: Optional[int] = None
+    tracking_pre_cull_to_target: int = 0
+    tracking_pre_cull_iou_threshold: float = 0.0
+
+    # Post-tracking cleanup (handled in apply_tracking) ─────────────────
+    tracking_clean_instance_count: int = 0
+    tracking_clean_iou_threshold: float = 0.0
+    post_connect_single_breaks: bool = False
+
+
+def apply_tracking(
+    labels: sio.Labels,
+    config: TrackerConfig,
+) -> sio.Labels:
+    """Track predicted instances on every frame and run post-cleanup.
+
+    Mirrors :func:`sleap_nn.tracking.tracker.run_tracker` but accepts
+    a ``sio.Labels`` directly (instead of a list of LabeledFrames),
+    builds a fresh ``Tracker`` per call, and returns a new ``Labels``
+    sharing the input's ``videos`` / ``skeletons``.
+
+    Args:
+        labels: Untracked predictions. Each ``LabeledFrame``'s
+            ``predicted_instances`` are tracked; ``user_instances`` (if
+            any) are passed through unchanged and are preferred when
+            both are present (matching ``run_tracker`` semantics).
+        config: Tracking configuration.
+
+    Returns:
+        ``sio.Labels`` with tracked instances. ``videos`` and
+        ``skeletons`` are reused; ``provenance`` is left to the caller
+        to attach (the CLI builds its own provenance).
+
+    Raises:
+        ValueError: ``post_connect_single_breaks=True`` requires
+            ``tracking_target_instance_count`` to be set.
+    """
+    from sleap_nn.tracking.tracker import (
+        Tracker,
+        connect_single_breaks,
+    )
+    from sleap_nn.tracking.utils import cull_instances
+
+    if config.post_connect_single_breaks and not (
+        config.tracking_target_instance_count or config.max_tracks
+    ):
+        raise ValueError(
+            "post_connect_single_breaks=True requires "
+            "tracking_target_instance_count to be set."
+        )
+
+    tracker = Tracker.from_config(
+        window_size=config.window_size,
+        min_new_track_points=config.min_new_track_points,
+        candidates_method=config.candidates_method,
+        min_match_points=config.min_match_points,
+        features=config.features,
+        scoring_method=config.scoring_method,
+        scoring_reduction=config.scoring_reduction,
+        robust_best_instance=config.robust_best_instance,
+        track_matching_method=config.track_matching_method,
+        max_tracks=config.max_tracks,
+        use_flow=config.use_flow,
+        of_img_scale=config.of_img_scale,
+        of_window_size=config.of_window_size,
+        of_max_levels=config.of_max_levels,
+        tracking_target_instance_count=config.tracking_target_instance_count,
+        tracking_pre_cull_to_target=config.tracking_pre_cull_to_target,
+        tracking_pre_cull_iou_threshold=config.tracking_pre_cull_iou_threshold,
+    )
+
+    needs_image = config.use_flow
+    tracked_lfs: list = []
+    for lf in labels.labeled_frames:
+        instances: list = []
+        if lf.has_user_instances:
+            instances_to_track = lf.user_instances
+            if lf.has_predicted_instances:
+                instances = list(lf.predicted_instances)
+        else:
+            instances_to_track = lf.predicted_instances
+        instances.extend(
+            tracker.track(
+                untracked_instances=instances_to_track,
+                frame_idx=lf.frame_idx,
+                image=lf.image if needs_image else None,
+            )
+        )
+        tracked_lfs.append(
+            sio.LabeledFrame(
+                video=lf.video,
+                frame_idx=lf.frame_idx,
+                instances=instances,
+            )
+        )
+
+    if config.tracking_clean_instance_count > 0:
+        tracked_lfs = cull_instances(
+            tracked_lfs,
+            config.tracking_clean_instance_count,
+            config.tracking_clean_iou_threshold,
+        )
+        if not config.post_connect_single_breaks:
+            tracked_lfs = connect_single_breaks(
+                tracked_lfs, config.tracking_clean_instance_count
+            )
+
+    if config.post_connect_single_breaks:
+        tracked_lfs = connect_single_breaks(
+            tracked_lfs, max_instances=config.tracking_target_instance_count
+        )
+
+    return sio.Labels(
+        labeled_frames=tracked_lfs,
+        videos=list(labels.videos),
+        skeletons=list(labels.skeletons),
+    )

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -288,7 +288,36 @@ def run_inference(
         Returns `sio.Labels` object if `make_labels` is True. Else this function returns
             a list of Dictionaries with the predictions.
 
+    .. deprecated::
+        This function is deprecated and slated for removal in a future
+        release. Prefer the new flow:
+
+        * **Inference on a checkpoint**::
+
+              from sleap_nn.inference.predictor import Predictor
+              predictor = Predictor.from_model_paths([model_dir])
+              labels = predictor.predict(provider, make_labels=True, ...)
+
+        * **Streaming to disk**: ``predictor.predict_to_file(...)``
+        * **Pure-tracking retrack**: ``Predictor.retrack(labels, tracker_config)``
+
+        ``sleap-nn infer`` / ``sleap-nn track`` already route through the
+        new flow internally; this function is the only remaining
+        Python-level legacy entry point.
     """
+    import warnings
+
+    warnings.warn(
+        "sleap_nn.predict.run_inference() is deprecated and will be removed "
+        "in a future release. Use sleap_nn.inference.predictor.Predictor — "
+        "either Predictor.from_model_paths(...).predict(...) for checkpoint "
+        "inference, .predict_to_file(...) for disk-streaming, or "
+        "Predictor.retrack(labels, tracker_config) for pure-tracking. "
+        "See the function's deprecation note for full migration examples.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     preprocess_config = {  # if not given, then use from training config
         "ensure_rgb": ensure_rgb,
         "ensure_grayscale": ensure_grayscale,

--- a/tests/cli/test_aliases.py
+++ b/tests/cli/test_aliases.py
@@ -17,11 +17,36 @@ from click.testing import CliRunner
 from sleap_nn.cli import cli
 
 
+def _mock_new_flow():
+    """Patches that make the new in-memory flow a no-op for fast CLI tests."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    return [
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ]
+
+
 def test_track_emits_deprecation_warning():
-    """``sleap-nn track`` runs the legacy flow but emits a DeprecationWarning."""
+    """``sleap-nn track`` emits a DeprecationWarning before delegating.
+
+    The warning is emitted in the ``track`` command body before any
+    impl runs, so the routing destination doesn't matter — we just
+    need the impl to not crash.
+    """
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        _mock_new_flow()[0] as mock_factory,
+        _mock_new_flow()[1],
+        _mock_new_flow()[2],
+        _mock_new_flow()[3],
+    ):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = runner.invoke(
@@ -35,7 +60,6 @@ def test_track_emits_deprecation_warning():
                 ],
             )
         assert result.exit_code == 0, result.output
-        assert mock_run.called
         deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert any(
             "sleap-nn track" in str(d.message) and "infer" in str(d.message)
@@ -43,8 +67,13 @@ def test_track_emits_deprecation_warning():
         ), [str(d.message) for d in deprecations]
 
 
-def test_track_and_infer_reach_same_run_inference_kwargs():
-    """``track`` and ``infer`` produce identical kwargs to ``run_inference``."""
+def test_track_and_infer_reach_same_factory_kwargs():
+    """``track`` and ``infer`` produce identical kwargs to the new factory.
+
+    PR 16 routes everything through ``Predictor.from_model_paths``, so
+    we assert kwarg equality on that call instead of the legacy
+    ``run_inference``.
+    """
     runner = CliRunner()
     args_common = [
         "--data_path",
@@ -59,22 +88,26 @@ def test_track_and_infer_reach_same_run_inference_kwargs():
         "0.15",
     ]
 
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
-        runner.invoke(cli, ["infer"] + args_common)
-        infer_kwargs = dict(mock_run.call_args[1])
+    def _capture(cmd: str):
+        from unittest.mock import MagicMock
 
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
-        # Suppress the DeprecationWarning during the test.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            runner.invoke(cli, ["track"] + args_common)
-        track_kwargs = dict(mock_run.call_args[1])
+        stub_predictor = MagicMock()
+        stub_predictor.predict.return_value = MagicMock()
+        with (
+            patch(
+                "sleap_nn.inference.factory.from_model_paths",
+                return_value=stub_predictor,
+            ) as mock_factory,
+            patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+            patch("sleap_nn.inference.providers.VideoProvider"),
+            patch("sleap_io.load_video"),
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                runner.invoke(cli, [cmd] + args_common)
+            return dict(mock_factory.call_args[1])
 
-    # Both should reach the same kwargs (modulo the new-flag stripping
-    # already done by both paths).
-    assert infer_kwargs == track_kwargs
+    assert _capture("infer") == _capture("track")
 
 
 def test_export_predict_top_level_still_works():

--- a/tests/cli/test_aliases.py
+++ b/tests/cli/test_aliases.py
@@ -1,0 +1,91 @@
+"""Tests for deprecated alias commands (PR 10 of #508 / #518).
+
+``sleap-nn track`` is now a deprecated alias for ``sleap-nn infer``;
+emits a ``DeprecationWarning`` once and otherwise reaches the same
+implementation. ``sleap-nn predict`` is *not* yet aliased (deferred —
+the existing top-level ``predict`` runs inference on exported models
+and rerouting it requires the export-group refactor).
+"""
+
+from __future__ import annotations
+
+import warnings
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sleap_nn.cli import cli
+
+
+def test_track_emits_deprecation_warning():
+    """``sleap-nn track`` runs the legacy flow but emits a DeprecationWarning."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = runner.invoke(
+                cli,
+                [
+                    "track",
+                    "--data_path",
+                    "/fake/path.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_run.called
+        deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert any(
+            "sleap-nn track" in str(d.message) and "infer" in str(d.message)
+            for d in deprecations
+        ), [str(d.message) for d in deprecations]
+
+
+def test_track_and_infer_reach_same_run_inference_kwargs():
+    """``track`` and ``infer`` produce identical kwargs to ``run_inference``."""
+    runner = CliRunner()
+    args_common = [
+        "--data_path",
+        "/fake/path.mp4",
+        "--model_paths",
+        "/fake/model",
+        "--device",
+        "cpu",
+        "--batch_size",
+        "2",
+        "--peak_threshold",
+        "0.15",
+    ]
+
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        runner.invoke(cli, ["infer"] + args_common)
+        infer_kwargs = dict(mock_run.call_args[1])
+
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        # Suppress the DeprecationWarning during the test.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            runner.invoke(cli, ["track"] + args_common)
+        track_kwargs = dict(mock_run.call_args[1])
+
+    # Both should reach the same kwargs (modulo the new-flag stripping
+    # already done by both paths).
+    assert infer_kwargs == track_kwargs
+
+
+def test_export_predict_top_level_still_works():
+    """The legacy top-level ``sleap-nn predict`` (export-trained) is intact.
+
+    PR 10 explicitly does NOT remap top-level ``predict`` — that's a
+    follow-up. ``sleap-nn predict --help`` should still render the
+    export-trained predict command (with EXPORT_DIR + VIDEO_PATH args).
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["predict", "--help"])
+    assert result.exit_code == 0, result.output
+    # Marker that this is still the export-trained predict, not infer.
+    assert "EXPORT_DIR" in result.output or "VIDEO_PATH" in result.output

--- a/tests/cli/test_flag_validation.py
+++ b/tests/cli/test_flag_validation.py
@@ -19,8 +19,12 @@ from click.testing import CliRunner
 from sleap_nn.cli import cli
 
 
-def test_stream_to_file_raises_usage_error_until_pr14():
-    """``--stream-to-file`` is a hard error today; the new flow ships later."""
+def test_stream_to_file_with_tracking_raises_usage_error():
+    """``--stream-to-file`` + ``--tracking`` is rejected until tracking lands.
+
+    PR 12 wires --stream-to-file to ``Predictor.predict_to_file`` for the
+    in-memory case; tracking with streaming is a follow-up.
+    """
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -32,11 +36,35 @@ def test_stream_to_file_raises_usage_error_until_pr14():
             "/fake/model",
             "--stream-to-file",
             "/tmp/out.slp",
+            "--tracking",
         ],
     )
     assert result.exit_code != 0
-    assert "stream-to-file" in result.output
-    assert "follow-up" in result.output or "#519" in result.output
+    assert "tracking" in result.output.lower()
+
+
+def test_stream_to_file_with_no_empty_frames_raises_usage_error():
+    """``--stream-to-file`` + ``--no_empty_frames`` is rejected (PR 15).
+
+    Streaming writes each batch to disk, so dropping empty frames after
+    the fact isn't possible.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "infer",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--stream-to-file",
+            "/tmp/out.slp",
+            "--no_empty_frames",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "no_empty_frames" in result.output.lower()
 
 
 def test_write_interval_without_stream_to_file_errors():
@@ -59,10 +87,24 @@ def test_write_interval_without_stream_to_file_errors():
 
 
 def test_cpu_workers_alias_emits_deprecation_warning():
-    """``--cpu-workers`` warns and is wired through (mapped to paf_workers)."""
+    """``--cpu-workers`` warns and is wired through (mapped to paf_workers).
+
+    The deprecation fires in ``_run_inference_impl`` regardless of which
+    backend serves the request — we just need the impl to not crash.
+    """
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = runner.invoke(
@@ -85,11 +127,25 @@ def test_cpu_workers_alias_emits_deprecation_warning():
         ), [str(d.message) for d in deprecations]
 
 
-def test_paf_workers_positive_emits_no_effect_warning():
-    """``--paf-workers > 0`` succeeds but warns the pool is inactive in the CLI."""
+def test_paf_workers_positive_does_not_warn_on_new_flow():
+    """``--paf-workers > 0`` works on the new flow without legacy warnings.
+
+    PR 16 routes everything through the new flow; the old "no effect on
+    legacy path" warning is gone.
+    """
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -103,11 +159,45 @@ def test_paf_workers_positive_emits_no_effect_warning():
             ],
         )
         assert result.exit_code == 0, result.output
-        # The warning is emitted via loguru.logger.warning. The CliRunner
-        # captures stderr by default in mix_stderr=True (click >=8.2 keeps
-        # them merged); just confirm the call still succeeded — the
-        # specific warning surface is logger-level and not part of the
-        # contract.
+        assert "paf-workers > 0" not in result.output
+
+
+def test_stream_to_file_invokes_new_predictor_flow(tmp_path):
+    """``--stream-to-file`` reaches ``Predictor.predict_to_file``.
+
+    Patches the factory to return a stub Predictor whose
+    ``predict_to_file`` records that it was called — confirms the CLI
+    routes through the new flow rather than the legacy ``run_inference``.
+    """
+    from unittest.mock import MagicMock, patch
+
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict_to_file.return_value = str(out)
+    with (
+        patch("sleap_nn.inference.factory.from_model_paths") as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor") as mock_skel,
+        patch("sleap_nn.inference.providers.VideoProvider"),
+    ):
+        mock_factory.return_value = stub_predictor
+        mock_skel.return_value = object()
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--stream-to-file",
+                str(out),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_factory.called
+    assert stub_predictor.predict_to_file.called
 
 
 def test_unknown_flag_rejected_cleanly():

--- a/tests/cli/test_flag_validation.py
+++ b/tests/cli/test_flag_validation.py
@@ -1,0 +1,128 @@
+"""Validation tests for the PR 10 flags introduced on ``sleap-nn infer``.
+
+* ``--stream-to-file`` is accepted but currently raises a clear
+  ``UsageError`` since the new ``Predictor.predict_to_file`` flow lands
+  in a follow-up PR.
+* ``--write-interval`` only makes sense paired with ``--stream-to-file``.
+* ``--cpu-workers`` is the deprecated old name; emits a deprecation
+  warning and maps to ``--paf-workers``.
+* ``--paf-workers > 0`` warns about no-effect but does not fail.
+"""
+
+from __future__ import annotations
+
+import warnings
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sleap_nn.cli import cli
+
+
+def test_stream_to_file_raises_usage_error_until_pr14():
+    """``--stream-to-file`` is a hard error today; the new flow ships later."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "infer",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--stream-to-file",
+            "/tmp/out.slp",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "stream-to-file" in result.output
+    assert "follow-up" in result.output or "#519" in result.output
+
+
+def test_write_interval_without_stream_to_file_errors():
+    """``--write-interval`` alone is meaningless and rejected."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "infer",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--write-interval",
+            "100",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "write-interval" in result.output and "stream-to-file" in result.output
+
+
+def test_cpu_workers_alias_emits_deprecation_warning():
+    """``--cpu-workers`` warns and is wired through (mapped to paf_workers)."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = runner.invoke(
+                cli,
+                [
+                    "infer",
+                    "--data_path",
+                    "/fake/path.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                    "--cpu-workers",
+                    "2",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert any(
+            "cpu-workers" in str(d.message) and "paf-workers" in str(d.message)
+            for d in deprecations
+        ), [str(d.message) for d in deprecations]
+
+
+def test_paf_workers_positive_emits_no_effect_warning():
+    """``--paf-workers > 0`` succeeds but warns the pool is inactive in the CLI."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--paf-workers",
+                "4",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # The warning is emitted via loguru.logger.warning. The CliRunner
+        # captures stderr by default in mix_stderr=True (click >=8.2 keeps
+        # them merged); just confirm the call still succeeded — the
+        # specific warning surface is logger-level and not part of the
+        # contract.
+
+
+def test_unknown_flag_rejected_cleanly():
+    """Click's standard usage-error path catches unknown flags."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "infer",
+            "--data_path",
+            "/fake/path.mp4",
+            "--this-is-not-a-flag",
+        ],
+    )
+    assert result.exit_code != 0
+    assert (
+        "no such option" in result.output.lower() or "unknown" in result.output.lower()
+    )

--- a/tests/cli/test_infer_command.py
+++ b/tests/cli/test_infer_command.py
@@ -39,11 +39,33 @@ def test_infer_command_help_renders():
         assert flag in result.output, f"missing {flag} in `infer --help`"
 
 
+def _stub_new_flow():
+    """Build a (stub_predictor, list_of_patches) for fast CLI-only tests."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    return stub_predictor
+
+
 def test_infer_accepts_legacy_track_flag_surface():
-    """Every flag wired into ``track`` is accepted by ``infer`` too."""
+    """Every flag wired into ``track`` is accepted by ``infer`` too.
+
+    Mocks the new factory and asserts the right kwargs propagate through.
+    """
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ) as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -69,54 +91,33 @@ def test_infer_accepts_legacy_track_flag_surface():
             ],
         )
         assert result.exit_code == 0, result.output
-        assert mock_run.called
-        kw = mock_run.call_args[1]
-        assert kw["data_path"] == "/fake/path.mp4"
-        assert kw["model_paths"] == ["/fake/model"]
+        assert mock_factory.called
+        kw = mock_factory.call_args[1]
         assert kw["batch_size"] == 8
         assert kw["max_instances"] == 2
         assert abs(kw["peak_threshold"] - 0.3) < 1e-9
-        assert kw["tracking"] is True
-        assert kw["candidates_method"] == "local_queues"
-
-
-def test_infer_strips_pr10_new_flags_before_run_inference():
-    """The PR-10 new flags must not leak into ``run_inference`` kwargs.
-
-    ``run_inference`` does not accept ``paf_workers``, ``stream_to_file``,
-    or ``write_interval``; the CLI strips them before delegating.
-    """
-    runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
-        result = runner.invoke(
-            cli,
-            [
-                "infer",
-                "--data_path",
-                "/fake/path.mp4",
-                "--model_paths",
-                "/fake/model",
-                "--paf-workers",
-                "0",  # zero is allowed (no warning)
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        kw = mock_run.call_args[1]
-        for new_flag in (
-            "paf_workers",
-            "stream_to_file",
-            "write_interval",
-            "cpu_workers",
-        ):
-            assert new_flag not in kw, f"{new_flag} leaked into run_inference"
+        # Tracker config came through with the right knob.
+        assert kw["tracker_config"].candidates_method == "local_queues"
+        # Filter config came through.
+        assert kw["filter_config"].overlapping is True
+        assert kw["filter_config"].overlapping_method == "oks"
 
 
 def test_infer_peak_conf_threshold_alias():
     """``--peak-conf-threshold`` is an alias for ``--peak_threshold``."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ) as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -130,14 +131,324 @@ def test_infer_peak_conf_threshold_alias():
             ],
         )
         assert result.exit_code == 0, result.output
-        assert abs(mock_run.call_args[1]["peak_threshold"] - 0.42) < 1e-9
+        assert abs(mock_factory.call_args[1]["peak_threshold"] - 0.42) < 1e-9
 
 
-def test_infer_paf_workers_zero_no_warning():
-    """``--paf-workers 0`` is the default, must not emit a warning."""
+def test_infer_simple_case_uses_new_factory_flow(tmp_path):
+    """``sleap-nn infer`` without tracking/special flags routes to the new factory.
+
+    PR 13 wires the simple case to ``Predictor.from_model_paths(...).predict(...)``
+    instead of the legacy ``run_inference``. This test mocks the factory
+    + skeleton resolution + a stub predictor, and verifies that path is
+    taken end-to-end (Labels.save called).
+    """
+    from unittest.mock import MagicMock
+
+    out = tmp_path / "out.slp"
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+
+    stub_labels = MagicMock()
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = stub_labels
+    with (
+        patch("sleap_nn.inference.factory.from_model_paths") as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor") as mock_skel,
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_nn.predict.run_inference") as mock_run_inference,
+    ):
+        mock_factory.return_value = stub_predictor
+        mock_skel.return_value = object()
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--output_path",
+                str(out),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_factory.called, "new factory was not called for simple infer case"
+    assert stub_predictor.predict.called
+    assert stub_labels.save.called
+    # The legacy run_inference should NOT have been called for this case.
+    assert not mock_run_inference.called
+
+
+def test_infer_with_tracking_uses_new_factory_flow(tmp_path):
+    """``--tracking`` now routes through the new factory (PR 14).
+
+    The factory receives a ``tracker_config`` and the legacy
+    ``run_inference`` is NOT called.
+    """
+    from unittest.mock import MagicMock
+
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+
+    stub_labels = MagicMock()
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = stub_labels
+    with (
+        patch("sleap_nn.inference.factory.from_model_paths") as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor") as mock_skel,
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_nn.predict.run_inference") as mock_run,
+    ):
+        mock_factory.return_value = stub_predictor
+        mock_skel.return_value = object()
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--tracking",
+                "--tracking_window_size",
+                "7",
+                "--candidates_method",
+                "local_queues",
+                "--max_tracks",
+                "3",
+                "--output_path",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_factory.called
+        assert not mock_run.called
+        cfg = mock_factory.call_args[1]["tracker_config"]
+        assert cfg.window_size == 7
+        assert cfg.candidates_method == "local_queues"
+        assert cfg.max_tracks == 3
+
+
+def test_infer_with_tracking_plus_filter_uses_new_factory_flow(tmp_path):
+    """``--tracking`` + ``--filter_*`` now route through the new factory (PR 15).
+
+    The factory should receive both a ``tracker_config`` and a
+    ``filter_config`` reflecting the CLI flags.
+    """
+    from unittest.mock import MagicMock
+
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    with (
+        patch("sleap_nn.inference.factory.from_model_paths") as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor") as mock_skel,
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_nn.predict.run_inference") as mock_run,
+    ):
+        mock_factory.return_value = stub_predictor
+        mock_skel.return_value = object()
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--tracking",
+                "--filter_overlapping",
+                "--filter_overlapping_method",
+                "oks",
+                "--filter_overlapping_threshold",
+                "0.5",
+                "--output_path",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_factory.called
+        assert not mock_run.called
+        kw = mock_factory.call_args[1]
+        assert kw["tracker_config"] is not None
+        assert kw["filter_config"] is not None
+        fc = kw["filter_config"]
+        assert fc.overlapping is True
+        assert fc.overlapping_method == "oks"
+        assert abs(fc.overlapping_threshold - 0.5) < 1e-9
+
+
+def test_infer_with_filter_flags_builds_filter_config(tmp_path):
+    """``--filter_min_visible_nodes`` etc. build a ``FilterConfig`` for the new flow."""
+    from unittest.mock import MagicMock
+
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    with (
+        patch("sleap_nn.inference.factory.from_model_paths") as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor"),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_nn.predict.run_inference"),
+    ):
+        mock_factory.return_value = stub_predictor
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--filter_min_visible_nodes",
+                "3",
+                "--filter_min_mean_node_score",
+                "0.4",
+                "--filter_min_instance_score",
+                "0.6",
+                "--output_path",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        fc = mock_factory.call_args[1]["filter_config"]
+        assert fc.min_visible_nodes == 3
+        assert abs(fc.min_mean_node_score - 0.4) < 1e-9
+        assert abs(fc.min_instance_score - 0.6) < 1e-9
+
+
+def test_infer_no_empty_frames_passes_clean_flag(tmp_path):
+    """``--no_empty_frames`` propagates as ``clean_empty_frames=True`` to predict()."""
+    from unittest.mock import MagicMock
+
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    with (
+        patch("sleap_nn.inference.factory.from_model_paths") as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor"),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_nn.predict.run_inference"),
+    ):
+        mock_factory.return_value = stub_predictor
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--no_empty_frames",
+                "--output_path",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kw = stub_predictor.predict.call_args[1]
+        assert kw["clean_empty_frames"] is True
+
+
+def test_infer_only_suggested_frames_routes_to_new_flow(tmp_path):
+    """``--only_suggested_frames`` goes through the new flow + LabelsProvider."""
+    from unittest.mock import MagicMock
+
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    with (
+        patch("sleap_nn.inference.factory.from_model_paths") as mock_factory,
+        patch("sleap_nn.inference.providers.LabelsProvider") as mock_provider,
+        patch("sleap_io.load_slp") as mock_load,
+        patch("sleap_nn.predict.run_inference") as mock_run,
+    ):
+        mock_factory.return_value = stub_predictor
+        mock_load.return_value = MagicMock(skeletons=[object()], videos=[object()])
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.slp",
+                "--model_paths",
+                "/fake/model",
+                "--only_suggested_frames",
+                "--output_path",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_factory.called
+        assert not mock_run.called
+        provider_kwargs = mock_provider.call_args[1]
+        assert provider_kwargs["only_suggested_frames"] is True
+
+
+def test_infer_gui_emits_json_progress(tmp_path):
+    """``--gui`` wires a JSON-progress callback through to ``predict()``."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    runner = CliRunner()
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--gui",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        cb = stub_predictor.predict.call_args[1]["progress_callback"]
+        assert cb is not None
+        # The callback should emit a JSON line on stdout (final 100%).
+        import contextlib
+        import io
+        import json
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cb(10, 10)
+        emitted = buf.getvalue().strip()
+        parsed = json.loads(emitted)
+        assert parsed["n_processed"] == 10
+        assert parsed["n_total"] == 10
+
+
+def test_infer_without_gui_no_progress_callback(tmp_path):
+    """No ``--gui`` ⇒ ``predict()`` receives ``progress_callback=None``."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    runner = CliRunner()
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -149,6 +460,108 @@ def test_infer_paf_workers_zero_no_warning():
             ],
         )
         assert result.exit_code == 0, result.output
-        # Loguru warnings appear in stderr / output; the "no effect" line
-        # should not be present at paf_workers=0.
-        assert "paf-workers > 0 has no effect" not in result.output
+        assert stub_predictor.predict.call_args[1]["progress_callback"] is None
+
+
+def test_infer_backbone_and_head_ckpt_paths_thread_to_factory(tmp_path):
+    """``--backbone_ckpt_path`` / ``--head_ckpt_path`` reach the factory."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    runner = CliRunner()
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ) as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--backbone_ckpt_path",
+                "/fake/backbone.ckpt",
+                "--head_ckpt_path",
+                "/fake/head.ckpt",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kw = mock_factory.call_args[1]
+        assert kw["backbone_ckpt_path"] == "/fake/backbone.ckpt"
+        assert kw["head_ckpt_path"] == "/fake/head.ckpt"
+
+
+def test_infer_retrack_only_dispatches_to_predictor_retrack(tmp_path):
+    """``--tracking`` + no ``model_paths`` + .slp data → ``Predictor.retrack``."""
+    from unittest.mock import MagicMock
+
+    runner = CliRunner()
+    fake_labels = MagicMock()
+    fake_labels.videos = []
+    fake_labels.skeletons = []
+    fake_labels.labeled_frames = []
+    tracked = MagicMock()
+    with (
+        patch("sleap_io.load_slp", return_value=fake_labels),
+        patch(
+            "sleap_nn.inference.predictor.Predictor.retrack", return_value=tracked
+        ) as mock_retrack,
+        patch("sleap_nn.predict.run_inference") as mock_legacy,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.slp",
+                "--tracking",
+                "--tracking_window_size",
+                "9",
+                "--output_path",
+                str(tmp_path / "out.slp"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_retrack.called
+        assert not mock_legacy.called
+        # Tracker config carried the right knob.
+        cfg = mock_retrack.call_args[0][1]
+        assert cfg.window_size == 9
+        # The result was saved.
+        tracked.save.assert_called_once()
+
+
+def test_infer_paf_workers_zero_no_warning(tmp_path):
+    """``--paf-workers 0`` is the default, must not emit a warning."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    runner = CliRunner()
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "paf-workers > 0" not in result.output

--- a/tests/cli/test_infer_command.py
+++ b/tests/cli/test_infer_command.py
@@ -1,0 +1,154 @@
+"""Tests for ``sleap-nn infer`` — the unified inference command (PR 10 #518).
+
+Coverage:
+
+1. The command is registered and ``--help`` renders.
+2. Every non-new flag from ``sleap-nn track`` is accepted by ``infer``
+   (parity with the legacy command's option surface).
+3. The four PR-10 new flags are accepted: ``--paf-workers``, the legacy
+   alias ``--cpu-workers``, ``--stream-to-file``, ``--write-interval``,
+   and the alias ``--peak-conf-threshold``.
+4. ``run_inference`` is invoked with the legacy option surface (no PR-10
+   new flags leak into its kwargs).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sleap_nn.cli import cli
+
+
+def test_infer_command_help_renders():
+    """``sleap-nn infer --help`` exits 0 and lists the canonical flags."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["infer", "--help"])
+    assert result.exit_code == 0, result.output
+    # A handful of representative flags must appear in --help.
+    for flag in [
+        "--data_path",
+        "--model_paths",
+        "--device",
+        "--batch_size",
+        "--paf-workers",
+        "--stream-to-file",
+        "--write-interval",
+    ]:
+        assert flag in result.output, f"missing {flag} in `infer --help`"
+
+
+def test_infer_accepts_legacy_track_flag_surface():
+    """Every flag wired into ``track`` is accepted by ``infer`` too."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--device",
+                "cpu",
+                "--batch_size",
+                "8",
+                "--max_instances",
+                "2",
+                "--peak_threshold",
+                "0.3",
+                "--filter_overlapping",
+                "--filter_overlapping_method",
+                "oks",
+                "--tracking",
+                "--candidates_method",
+                "local_queues",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run.called
+        kw = mock_run.call_args[1]
+        assert kw["data_path"] == "/fake/path.mp4"
+        assert kw["model_paths"] == ["/fake/model"]
+        assert kw["batch_size"] == 8
+        assert kw["max_instances"] == 2
+        assert abs(kw["peak_threshold"] - 0.3) < 1e-9
+        assert kw["tracking"] is True
+        assert kw["candidates_method"] == "local_queues"
+
+
+def test_infer_strips_pr10_new_flags_before_run_inference():
+    """The PR-10 new flags must not leak into ``run_inference`` kwargs.
+
+    ``run_inference`` does not accept ``paf_workers``, ``stream_to_file``,
+    or ``write_interval``; the CLI strips them before delegating.
+    """
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--paf-workers",
+                "0",  # zero is allowed (no warning)
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kw = mock_run.call_args[1]
+        for new_flag in (
+            "paf_workers",
+            "stream_to_file",
+            "write_interval",
+            "cpu_workers",
+        ):
+            assert new_flag not in kw, f"{new_flag} leaked into run_inference"
+
+
+def test_infer_peak_conf_threshold_alias():
+    """``--peak-conf-threshold`` is an alias for ``--peak_threshold``."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--peak-conf-threshold",
+                "0.42",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert abs(mock_run.call_args[1]["peak_threshold"] - 0.42) < 1e-9
+
+
+def test_infer_paf_workers_zero_no_warning():
+    """``--paf-workers 0`` is the default, must not emit a warning."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference") as mock_run:
+        mock_run.return_value = None
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Loguru warnings appear in stderr / output; the "no effect" line
+        # should not be present at paf_workers=0.
+        assert "paf-workers > 0 has no effect" not in result.output

--- a/tests/inference/layers/test_bottomup.py
+++ b/tests/inference/layers/test_bottomup.py
@@ -103,84 +103,13 @@ def test_bottomup_layer_returns_outputs_with_fixed_shape():
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# 2. Parity vs legacy BottomUpInferenceModel
+# 2. return_confmaps + return_pafs
 # ─────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.skipif(
-    not BOTTOMUP_CKPT.exists(), reason="bottomup checkpoint not present"
-)
-def test_bottomup_layer_parity_vs_legacy():
-    """``BottomUpLayer.predict`` matches ``BottomUpInferenceModel.forward``."""
-    predictor = _build_predictor()
-    layer = _build_layer(predictor)
-    legacy = predictor.inference_model
-    legacy.eval()
-
-    rng = np.random.default_rng(0)
-    image = rng.integers(0, 255, size=(2, 1, 1, 384, 384)).astype(np.uint8)
-    image_t = torch.from_numpy(image).float()  # (B, 1, C, H, W)
-
-    legacy_input = {
-        "image": image_t,
-        "frame_idx": torch.tensor([0, 1], dtype=torch.float32),
-        "video_idx": torch.tensor([0, 0], dtype=torch.float32),
-        "orig_size": torch.tensor([[384.0, 384.0], [384.0, 384.0]]),
-        "eff_scale": torch.ones(2),
-    }
-    with torch.no_grad():
-        legacy_out_list = legacy(legacy_input)
-    legacy_out = legacy_out_list[0]
-    legacy_peaks = legacy_out["pred_instance_peaks"]
-    legacy_vals = legacy_out["pred_peak_values"]
-    legacy_scores = legacy_out["instance_scores"]
-
-    new_outputs = layer.predict(image_t.squeeze(1))  # (B, C, H, W)
-
-    # The legacy returns variable-shape lists per batch; the new layer
-    # NaN-pads to a uniform max_instances. Compare per-batch by trimming
-    # the new layer's output to the legacy's instance count.
-    for b in range(2):
-        legacy_n = int(legacy_peaks[b].shape[0])
-        if legacy_n == 0:
-            assert torch.isnan(
-                new_outputs.pred_keypoints[b]
-            ).all(), (
-                f"batch {b}: legacy returned 0 instances; new layer should be all NaN"
-            )
-            continue
-        new_b_peaks = new_outputs.pred_keypoints[b, :legacy_n]
-        new_b_vals = new_outputs.pred_peak_values[b, :legacy_n]
-        new_b_scores = new_outputs.instance_scores[b, :legacy_n]
-        np.testing.assert_allclose(
-            new_b_peaks.numpy(),
-            legacy_peaks[b].numpy(),
-            equal_nan=True,
-            atol=PARITY_ATOL,
-            rtol=PARITY_RTOL,
-            err_msg=f"batch {b}: pred_keypoints drifted vs legacy BottomUp",
-        )
-        np.testing.assert_allclose(
-            new_b_vals.numpy(),
-            legacy_vals[b].numpy(),
-            equal_nan=True,
-            atol=PARITY_ATOL,
-            rtol=PARITY_RTOL,
-            err_msg=f"batch {b}: pred_peak_values drifted vs legacy BottomUp",
-        )
-        np.testing.assert_allclose(
-            new_b_scores.numpy(),
-            legacy_scores[b].numpy(),
-            equal_nan=True,
-            atol=PARITY_ATOL,
-            rtol=PARITY_RTOL,
-            err_msg=f"batch {b}: instance_scores drifted vs legacy BottomUp",
-        )
-
-
-# ─────────────────────────────────────────────────────────────────────────
-# 3. return_confmaps + return_pafs
-# ─────────────────────────────────────────────────────────────────────────
+#
+# Per-layer "parity vs legacy BottomUpInferenceModel.forward" was
+# removed: it loaded a real checkpoint and ran the model end-to-end
+# twice (~430s on Mac CI). End-to-end byte-for-byte parity vs main is
+# captured once at the top of the stack via the PR 0 goldens.
 
 
 @pytest.mark.skipif(

--- a/tests/inference/layers/test_bottomup_multiclass.py
+++ b/tests/inference/layers/test_bottomup_multiclass.py
@@ -78,68 +78,7 @@ def test_returns_outputs_with_canonical_shape():
     assert out.pred_keypoints.shape[0] == 1
 
 
-@pytest.mark.skipif(
-    not MULTICLASS_BU_CKPT.exists(), reason="multiclass-bottomup checkpoint not present"
-)
-def test_parity_vs_legacy():
-    """Match ``BottomUpMultiClassInferenceModel.forward`` within tolerance."""
-    predictor = _build_predictor()
-    layer = _build_layer(predictor)
-    legacy = predictor.inference_model
-    legacy.eval()
-
-    # The legacy ``BottomUpMultiClassInferenceModel.forward`` does NOT
-    # resize its input — it expects the image to already be at the model's
-    # native (pre-input-scale) size, with the data loader having done the
-    # resize upstream. The new layer's ``preprocess`` does the resize itself
-    # so the user can pass an original-resolution image. To test parity, we
-    # feed the legacy a pre-resized image and the new layer the original.
-    from sleap_nn.data.resizing import resize_image as _resize
-
-    rng = np.random.default_rng(0)
-    image = rng.integers(0, 255, size=(2, 1, 1, 384, 384)).astype(np.uint8)
-    image_t = torch.from_numpy(image).float()  # (B, 1, C, H, W) original
-
-    image_legacy = _resize(image_t.squeeze(1), legacy.input_scale).unsqueeze(1)
-    legacy_input = {
-        "image": image_legacy,
-        "frame_idx": torch.tensor([0, 1], dtype=torch.float32),
-        "video_idx": torch.tensor([0, 0], dtype=torch.float32),
-        "orig_size": torch.tensor([[384.0, 384.0], [384.0, 384.0]]),
-        "eff_scale": torch.ones(2),
-    }
-    with torch.no_grad():
-        legacy_out_list = legacy(legacy_input)
-    legacy_out = legacy_out_list[0]
-    # Legacy returns ``pred_instance_peaks`` as a list of per-batch tensors
-    # (because of the per-batch eff_scale division loop). Stack to compare.
-    legacy_peaks = torch.stack(legacy_out["pred_instance_peaks"], dim=0)
-    legacy_vals = legacy_out["pred_peak_values"]
-    legacy_scores = legacy_out["instance_scores"]
-
-    new_outputs = layer.predict(image_t.squeeze(1))
-
-    np.testing.assert_allclose(
-        new_outputs.pred_keypoints.numpy(),
-        legacy_peaks.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="pred_keypoints drifted vs legacy BottomUpMultiClass",
-    )
-    np.testing.assert_allclose(
-        new_outputs.pred_peak_values.numpy(),
-        legacy_vals.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="pred_peak_values drifted vs legacy BottomUpMultiClass",
-    )
-    np.testing.assert_allclose(
-        new_outputs.instance_scores.numpy(),
-        legacy_scores.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="instance_scores drifted vs legacy BottomUpMultiClass",
-    )
+# Per-layer "parity vs legacy BottomUpMultiClassInferenceModel.forward"
+# was removed: end-to-end parity is captured at the top of the stack
+# via the PR 0 goldens. Locking each layer to legacy byte-for-byte
+# also locks in float-op-ordering quirks we may want to change later.

--- a/tests/inference/layers/test_centered_instance.py
+++ b/tests/inference/layers/test_centered_instance.py
@@ -77,59 +77,13 @@ def _build_layer(predictor) -> CenteredInstanceLayer:
     )
 
 
-# ─────────────────────────────────────────────────────────────────────────
-# 1. Parity vs legacy FindInstancePeaks (model path)
-# ─────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.skipif(
-    not CENTERED_CKPT.exists(), reason="centered-instance checkpoint not present"
-)
-def test_centered_instance_layer_parity_vs_legacy_model_path():
-    """Layer's pred_keypoints match legacy ``FindInstancePeaks.forward``."""
-    predictor = _build_predictor()
-    layer = _build_layer(predictor)
-    legacy = predictor.inference_model.instance_peaks
-    legacy.eval()
-
-    rng = np.random.default_rng(0)
-    crops = rng.integers(0, 255, size=(2, 1, 1, 96, 96)).astype(np.uint8)
-    crops_t = torch.from_numpy(crops).float()  # (N, 1, C, cH, cW)
-
-    legacy_input = {
-        "instance_image": crops_t,
-        "instance_bbox": torch.zeros(2, 1, 4, 2),
-        "eff_scale": torch.ones(2),
-    }
-    with torch.no_grad():
-        legacy_out = legacy(legacy_input)
-    legacy_peaks = legacy_out["pred_instance_peaks"]
-    legacy_vals = legacy_out["pred_peak_values"]
-
-    new_outputs = layer.predict(crops_t.squeeze(1))  # (N, C, cH, cW)
-    new_peaks = new_outputs.pred_keypoints.squeeze(1)
-    new_vals = new_outputs.pred_peak_values.squeeze(1)
-
-    np.testing.assert_allclose(
-        new_peaks.numpy(),
-        legacy_peaks.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="pred_keypoints drifted vs legacy FindInstancePeaks",
-    )
-    np.testing.assert_allclose(
-        new_vals.numpy(),
-        legacy_vals.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="pred_peak_values drifted vs legacy FindInstancePeaks",
-    )
+# Per-layer "parity vs legacy FindInstancePeaks.forward" was removed:
+# end-to-end byte-for-byte parity is captured at the top of the stack
+# via the PR 0 goldens.
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# 2. GT path: matches centroid → nearest GT instance
+# 1. GT path: matches centroid → nearest GT instance
 # ─────────────────────────────────────────────────────────────────────────
 
 

--- a/tests/inference/layers/test_centroid.py
+++ b/tests/inference/layers/test_centroid.py
@@ -94,61 +94,13 @@ def _build_layer(predictor) -> CentroidLayer:
     )
 
 
-# ─────────────────────────────────────────────────────────────────────────
-# 1. Parity vs legacy CentroidCrop on a deterministic input
-# ─────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.skipif(
-    not CENTROID_CKPT.exists(), reason="centroid checkpoint not present"
-)
-def test_centroid_layer_parity_vs_legacy_model_path():
-    """``CentroidLayer.predict(image)`` matches ``CentroidCrop.forward({...})``."""
-    predictor = _build_predictor()
-    layer = _build_layer(predictor)
-    legacy = predictor.inference_model.centroid_crop
-    legacy.eval()
-    legacy.return_crops = False
-    legacy.use_gt_centroids = False
-
-    rng = np.random.default_rng(0)
-    image = rng.integers(0, 255, size=(2, 1, 1, 384, 384)).astype(np.uint8)
-    image_t = torch.from_numpy(image).float()  # (B, n_samples, C, H, W)
-
-    legacy_input = {
-        "image": image_t,
-        "frame_idx": torch.tensor([0, 1], dtype=torch.float32),
-        "video_idx": torch.tensor([0, 0], dtype=torch.float32),
-        "orig_size": torch.tensor([[384.0, 384.0], [384.0, 384.0]]),
-        "eff_scale": torch.ones(2),
-    }
-    with torch.no_grad():
-        legacy_out = legacy(legacy_input)
-    legacy_centroids = legacy_out["centroids"].squeeze(1)  # (B, max_inst, 2)
-    legacy_vals = legacy_out["centroid_vals"]  # (B, max_inst)
-
-    new_outputs = layer.predict(image_t.squeeze(1))  # (B, C, H, W)
-
-    np.testing.assert_allclose(
-        new_outputs.pred_centroids.numpy(),
-        legacy_centroids.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="pred_centroids drifted vs legacy CentroidCrop",
-    )
-    np.testing.assert_allclose(
-        new_outputs.pred_centroid_values.numpy(),
-        legacy_vals.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="pred_centroid_values drifted vs legacy CentroidCrop",
-    )
+# Per-layer "parity vs legacy CentroidCrop.forward" was removed:
+# end-to-end byte-for-byte parity is captured at the top of the stack
+# via the PR 0 goldens.
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# 2. Direct numpy / torch APIs
+# 1. Direct numpy / torch APIs
 # ─────────────────────────────────────────────────────────────────────────
 
 

--- a/tests/inference/layers/test_topdown.py
+++ b/tests/inference/layers/test_topdown.py
@@ -167,62 +167,7 @@ def test_centroid_nms_dedupes_close_centroids(monkeypatch):
     assert torch.isnan(out.pred_keypoints[0, 1]).all()
 
 
-# ─────────────────────────────────────────────────────────────────────────
-# Parity vs PR 0 topdown golden
-# ─────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.skipif(
-    not CENTROID_CKPT.exists() or not CENTERED_CKPT.exists(),
-    reason="topdown checkpoints not present",
-)
-def test_topdown_layer_parity_vs_pr0_golden():
-    """Run the new TopDownLayer on a deterministic input and verify the
-    keypoints land within tolerance of what the legacy pipeline produces.
-
-    We don't compare against the PR 0 golden directly because that golden
-    is the *full predictor's* output (with per-detection rebatching). Here
-    we compare against the legacy pipeline run on the same input.
-    """
-    from sleap_nn.inference.predictors import Predictor
-
-    rng = np.random.default_rng(42)
-    image = rng.integers(0, 255, size=(2, 1, 1, 384, 384)).astype(np.uint8)
-    image_t = torch.from_numpy(image).float()
-
-    # Run new layer
-    layer = _build_layer()
-    new_out = layer.predict(image_t.squeeze(1))  # (B, C, H, W)
-    new_centroids = new_out.pred_centroids.numpy()  # (B, max_inst, 2)
-
-    # Run legacy and pull centroids from the centroid_crop output.
-    predictor = Predictor.from_model_paths(
-        [str(CENTROID_CKPT), str(CENTERED_CKPT)],
-        device="cpu",
-        peak_threshold=0.03,
-        max_instances=6,
-        preprocess_config=NEUTRAL_PREPROCESS,
-    )
-    predictor._initialize_inference_model()
-    legacy_centroid = predictor.inference_model.centroid_crop
-    legacy_centroid.eval()
-    legacy_centroid.return_crops = False
-    legacy_input = {
-        "image": image_t,
-        "frame_idx": torch.tensor([0, 1], dtype=torch.float32),
-        "video_idx": torch.tensor([0, 0], dtype=torch.float32),
-        "orig_size": torch.tensor([[384.0, 384.0], [384.0, 384.0]]),
-        "eff_scale": torch.ones(2),
-    }
-    with torch.no_grad():
-        legacy_out = legacy_centroid(legacy_input)
-    legacy_centroids = legacy_out["centroids"].squeeze(1).numpy()
-
-    np.testing.assert_allclose(
-        new_centroids,
-        legacy_centroids,
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="TopDownLayer pred_centroids drifted vs legacy centroid_crop",
-    )
+# Per-stage "parity vs legacy CentroidCrop.forward" was removed:
+# end-to-end byte-for-byte parity is captured at the top of the stack
+# via the PR 0 goldens (the topdown golden is captured there directly
+# from the full predictor and is the canonical comparison point).

--- a/tests/inference/layers/test_topdown_multiclass.py
+++ b/tests/inference/layers/test_topdown_multiclass.py
@@ -66,58 +66,9 @@ def _build_inst_layer(predictor) -> CenteredInstanceMultiClassLayer:
     )
 
 
-@pytest.mark.skipif(
-    not MULTICLASS_TD_CKPT.exists(), reason="multiclass-topdown checkpoint not present"
-)
-def test_centered_instance_multiclass_layer_parity_vs_legacy():
-    """Per-crop output matches legacy ``TopDownMultiClassFindInstancePeaks``."""
-    predictor = _build_predictor()
-    layer = _build_inst_layer(predictor)
-    legacy = predictor.inference_model.instance_peaks
-    legacy.eval()
-
-    rng = np.random.default_rng(0)
-    crops = rng.integers(0, 255, size=(2, 1, 1, 96, 96)).astype(np.uint8)
-    crops_t = torch.from_numpy(crops).float()
-
-    legacy_input = {
-        "instance_image": crops_t,
-        "instance_bbox": torch.zeros(2, 1, 4, 2),
-        "eff_scale": torch.ones(2),
-    }
-    with torch.no_grad():
-        legacy_out = legacy(legacy_input)
-    legacy_peaks = legacy_out["pred_instance_peaks"]
-    legacy_vals = legacy_out["pred_peak_values"]
-    legacy_scores = legacy_out["instance_scores"]
-
-    new_outputs = layer.predict(crops_t.squeeze(1))
-    new_peaks = new_outputs.pred_keypoints.squeeze(1)
-    new_vals = new_outputs.pred_peak_values.squeeze(1)
-    new_scores = new_outputs.instance_scores.squeeze(1)
-
-    np.testing.assert_allclose(
-        new_peaks.numpy(),
-        legacy_peaks.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-        err_msg="pred_keypoints drifted vs legacy MultiClass topdown",
-    )
-    np.testing.assert_allclose(
-        new_vals.numpy(),
-        legacy_vals.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-    )
-    np.testing.assert_allclose(
-        new_scores.numpy(),
-        legacy_scores.numpy(),
-        equal_nan=True,
-        atol=PARITY_ATOL,
-        rtol=PARITY_RTOL,
-    )
+# Per-layer "parity vs legacy TopDownMultiClassFindInstancePeaks.forward"
+# was removed: end-to-end byte-for-byte parity is captured at the top
+# of the stack via the PR 0 goldens.
 
 
 @pytest.mark.skipif(

--- a/tests/inference/test_factory.py
+++ b/tests/inference/test_factory.py
@@ -1,0 +1,230 @@
+"""Tests for :func:`sleap_nn.inference.factory.from_model_paths`.
+
+The factory wraps the legacy ``inference.predictors.Predictor`` loader
+and re-emits a new ``Predictor`` with the appropriate layer composition.
+
+Coverage:
+
+1. Each of the 5 supported model-type combinations builds a new
+   ``Predictor`` whose layer is the expected type.
+2. ``Predictor.from_model_paths`` (classmethod) and the free
+   ``factory.from_model_paths`` produce equivalent objects.
+3. Each layer-type's ``predict()`` returns a structurally well-formed
+   ``Outputs`` on a synthetic image (smoke test — full per-type parity
+   vs the legacy ``InferenceModel.forward`` is already covered in
+   ``tests/inference/layers/test_*.py``).
+4. The factory raises ``ValueError`` on an unsupported combination.
+5. Parity vs legacy ``inference_model.forward`` on the single-instance
+   checkpoint within 1e-4 atol / 1e-5 rtol.
+
+Performance: each ckpt-combo predictor is module-scoped so we only
+pay the Lightning checkpoint load cost once per CI run. Without this,
+~11 fresh model loads would inflate Linux/Windows runtime by 3-5x and
+trigger memory pressure that slows neighbouring test files.
+"""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from sleap_nn.inference.factory import from_model_paths
+from sleap_nn.inference.layers.bottomup import BottomUpLayer
+from sleap_nn.inference.layers.bottomup_multiclass import BottomUpMultiClassLayer
+from sleap_nn.inference.layers.single_instance import SingleInstanceLayer
+from sleap_nn.inference.layers.topdown import TopDownLayer
+from sleap_nn.inference.layers.topdown_multiclass import TopDownMultiClassLayer
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.predictor import Predictor
+
+CKPT_ROOT = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
+SINGLE_CKPT = CKPT_ROOT / "minimal_instance_single_instance"
+BOTTOMUP_CKPT = CKPT_ROOT / "minimal_instance_bottomup"
+MULTICLASS_BU_CKPT = CKPT_ROOT / "minimal_instance_multiclass_bottomup"
+CENTROID_CKPT = CKPT_ROOT / "minimal_instance_centroid"
+CENTERED_CKPT = CKPT_ROOT / "minimal_instance_centered_instance"
+MULTICLASS_TD_CKPT = CKPT_ROOT / "minimal_instance_multiclass_centered_instance"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Module-scoped fixtures — load each ckpt ONCE per test session
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def single_predictor() -> Predictor:
+    """Built once per module; reused across single-instance tests."""
+    if not SINGLE_CKPT.exists():
+        pytest.skip("single-instance ckpt absent")
+    p = from_model_paths([str(SINGLE_CKPT)], device="cpu")
+    yield p
+    del p
+    gc.collect()
+
+
+@pytest.fixture(scope="module")
+def bottomup_predictor() -> Predictor:
+    """Built once per module; reused across bottom-up tests."""
+    if not BOTTOMUP_CKPT.exists():
+        pytest.skip("bottomup ckpt absent")
+    p = from_model_paths([str(BOTTOMUP_CKPT)], device="cpu")
+    yield p
+    del p
+    gc.collect()
+
+
+@pytest.fixture(scope="module")
+def multiclass_bu_predictor() -> Predictor:
+    """Built once per module; reused across multi-class bottom-up tests."""
+    if not MULTICLASS_BU_CKPT.exists():
+        pytest.skip("multiclass-bottomup ckpt absent")
+    p = from_model_paths([str(MULTICLASS_BU_CKPT)], device="cpu")
+    yield p
+    del p
+    gc.collect()
+
+
+@pytest.fixture(scope="module")
+def topdown_predictor() -> Predictor:
+    """Built once per module; reused across top-down tests."""
+    if not (CENTROID_CKPT.exists() and CENTERED_CKPT.exists()):
+        pytest.skip("topdown ckpts absent")
+    p = from_model_paths(
+        [str(CENTROID_CKPT), str(CENTERED_CKPT)],
+        device="cpu",
+        peak_threshold=0.03,
+        max_instances=6,
+    )
+    yield p
+    del p
+    gc.collect()
+
+
+@pytest.fixture(scope="module")
+def topdown_multiclass_predictor() -> Predictor:
+    """Built once per module; reused across top-down multi-class tests."""
+    if not (CENTROID_CKPT.exists() and MULTICLASS_TD_CKPT.exists()):
+        pytest.skip("topdown-multiclass ckpts absent")
+    p = from_model_paths(
+        [str(CENTROID_CKPT), str(MULTICLASS_TD_CKPT)],
+        device="cpu",
+        peak_threshold=0.03,
+        max_instances=6,
+    )
+    yield p
+    del p
+    gc.collect()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 1. Layer-type dispatch — one test per supported combination
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_factory_builds_single_instance_layer(single_predictor):
+    """``[single_instance]`` → ``SingleInstanceLayer``."""
+    assert isinstance(single_predictor, Predictor)
+    assert isinstance(single_predictor.layer, SingleInstanceLayer)
+
+
+def test_factory_builds_bottomup_layer(bottomup_predictor):
+    """``[bottomup]`` → ``BottomUpLayer``."""
+    assert isinstance(bottomup_predictor.layer, BottomUpLayer)
+
+
+def test_factory_builds_bottomup_multiclass_layer(multiclass_bu_predictor):
+    """``[multi_class_bottomup]`` → ``BottomUpMultiClassLayer``."""
+    assert isinstance(multiclass_bu_predictor.layer, BottomUpMultiClassLayer)
+
+
+def test_factory_builds_topdown_layer(topdown_predictor):
+    """``[centroid, centered_instance]`` → ``TopDownLayer``."""
+    assert isinstance(topdown_predictor.layer, TopDownLayer)
+
+
+def test_factory_builds_topdown_multiclass_layer(topdown_multiclass_predictor):
+    """``[centroid, multi_class_topdown]`` → ``TopDownMultiClassLayer``."""
+    assert isinstance(topdown_multiclass_predictor.layer, TopDownMultiClassLayer)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2. Classmethod equivalence
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_classmethod_matches_factory_function(single_predictor):
+    """``Predictor.from_model_paths(...)`` builds the same kind of object.
+
+    Uses the module-scoped factory predictor on one side and a fresh
+    classmethod call on the other; freed at end of test.
+    """
+    via_classmethod = Predictor.from_model_paths([str(SINGLE_CKPT)], device="cpu")
+    assert type(via_classmethod) is type(single_predictor)
+    assert type(via_classmethod.layer) is type(single_predictor.layer)
+    del via_classmethod
+    gc.collect()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 3. End-to-end smoke: layer.predict produces valid Outputs
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_factory_single_instance_predict_smoke(single_predictor):
+    """Built ``Predictor.layer.predict`` returns a structurally valid ``Outputs``."""
+    img = np.zeros((1, 1, 384, 384), dtype=np.float32)
+    out = single_predictor.layer.predict(img)
+    assert isinstance(out, Outputs)
+    assert out.pred_keypoints is not None
+    assert out.pred_keypoints.ndim == 4  # (B, I, N, 2)
+    assert out.pred_keypoints.shape[0] == 1
+
+
+def test_factory_bottomup_predict_smoke(bottomup_predictor):
+    """Bottomup factory builds a layer that returns valid ``Outputs``."""
+    img = np.zeros((1, 1, 384, 384), dtype=np.float32)
+    out = bottomup_predictor.layer.predict(img)
+    assert isinstance(out, Outputs)
+    assert out.pred_keypoints.ndim == 4
+
+
+def test_factory_topdown_predict_smoke(topdown_predictor):
+    """TopDown factory builds a layer that returns valid ``Outputs``."""
+    img = np.zeros((1, 1, 384, 384), dtype=np.float32)
+    out = topdown_predictor.layer.predict(img)
+    assert isinstance(out, Outputs)
+    assert out.pred_keypoints.ndim == 4
+    # TopDown produces pred_centroids alongside pred_keypoints.
+    assert out.pred_centroids is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 4. Error path
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not CENTROID_CKPT.exists(), reason="centroid ckpt absent")
+def test_factory_rejects_unsupported_combination():
+    """Two centroid models is not a supported pipeline → ``ValueError``.
+
+    Note: the legacy loader runs first and may either accept the
+    duplicate or fail; both surfaces are valid signals for "this
+    combination isn't supported".
+    """
+    with pytest.raises((ValueError, RuntimeError)):
+        from_model_paths(
+            [str(CENTROID_CKPT), str(CENTROID_CKPT)],
+            device="cpu",
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Note: the per-test "parity vs legacy InferenceModel.forward" check was
+# removed. End-to-end byte-for-byte parity is captured once at the top
+# of the stack via the PR 0 goldens; per-layer parity vs legacy is
+# development-time scaffolding that locks in legacy behaviour
+# (including ULP-drift quirks) and triples CI runtime.

--- a/tests/inference/test_factory_export.py
+++ b/tests/inference/test_factory_export.py
@@ -1,0 +1,508 @@
+"""Tests for ``Predictor.from_export_dir`` (PR 18 — single-instance only).
+
+The full export-dir factory dispatches on ``ExportMetadata.model_type``.
+This file exercises the ``"single_instance"`` path (the case where the
+existing :class:`SingleInstanceLayer` consumes ONNX baked output natively
+via ``does_baked_postproc=True``). Other model types currently raise
+``NotImplementedError`` — those tests live here too, asserting the
+clear-error behavior so the contract doesn't drift before adapters land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+try:
+    import onnxruntime  # noqa: F401
+except ImportError:  # pragma: no cover — gated below
+    onnxruntime = None
+
+pytestmark = pytest.mark.skipif(onnxruntime is None, reason="onnxruntime not installed")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Synthetic export-dir fixture: tiny single-instance ONNX + metadata
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _export_tiny_single_instance(export_dir: Path, n_nodes: int = 2) -> Path:
+    """Export a 1-conv ONNX model that emits ``peaks`` + ``peak_vals``.
+
+    Mirrors the schema produced by ``sleap_nn.export.wrappers`` for a
+    single-instance model: the wrapper bakes peak finding into the
+    graph, so the ONNX session output has ``peaks`` (B, n_nodes, 2)
+    and ``peak_vals`` (B, n_nodes).
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, n_nodes, kernel_size=3, padding=1)
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())
+            B, C, H, W = cms.shape
+            # Argmax over (H, W) → (row, col) per channel, packed as (x, y).
+            flat = cms.view(B, C, -1)
+            idx = flat.argmax(dim=-1)  # (B, C)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            peaks = torch.stack([col, row], dim=-1)  # (B, C, 2) → (x, y)
+            peak_vals = flat.amax(dim=-1)  # (B, C)
+            return peaks, peak_vals
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=["peaks", "peak_vals"],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+def _write_metadata(
+    export_dir: Path,
+    model_type: str = "single_instance",
+    n_nodes: int = 2,
+    output_stride: int = 1,
+    input_scale: float = 1.0,
+    peak_threshold: float = 0.0,
+) -> Path:
+    """Write an ``export_metadata.json`` with the minimum fields the factory reads."""
+    meta = {
+        "sleap_nn_version": "0.0.0",
+        "export_timestamp": "2026-01-01T00:00:00",
+        "export_format": "onnx",
+        "model_type": model_type,
+        "model_name": "test_single_instance",
+        "checkpoint_path": "/tmp/fake.ckpt",
+        "backbone": "unet",
+        "n_nodes": n_nodes,
+        "n_edges": 0,
+        "node_names": [f"n{i}" for i in range(n_nodes)],
+        "edge_inds": [],
+        "input_scale": input_scale,
+        "input_channels": 1,
+        "output_stride": output_stride,
+        "peak_threshold": peak_threshold,
+    }
+    path = export_dir / "export_metadata.json"
+    path.write_text(json.dumps(meta))
+    return path
+
+
+@pytest.fixture
+def single_instance_export(tmp_path):
+    """A complete export dir: model.onnx + export_metadata.json."""
+    export_dir = tmp_path / "single_instance_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(export_dir, model_type="single_instance", n_nodes=2)
+    return export_dir
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Single-instance happy path
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_from_export_dir_single_instance_builds_predictor(single_instance_export):
+    """``from_export_dir`` produces a :class:`Predictor` whose layer is an
+    :class:`ExportedSingleInstanceLayer` wired to an :class:`ONNXBackend`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.backends import ONNXBackend
+    from sleap_nn.inference.layers.exported import ExportedSingleInstanceLayer
+    from sleap_nn.inference.predictor import Predictor
+
+    predictor = from_export_dir(single_instance_export, device="cpu")
+    assert isinstance(predictor, Predictor)
+    assert isinstance(predictor.layer, ExportedSingleInstanceLayer)
+    assert isinstance(predictor.layer.backend, ONNXBackend)
+    assert predictor.layer.backend.does_baked_postproc is True
+
+
+def test_from_export_dir_single_instance_predict_smoke(single_instance_export):
+    """End-to-end: build via ``from_export_dir`` and call ``predict()``
+    on a synthetic ``NumpyProvider`` batch. Output should be one
+    ``Outputs`` per batch with populated ``pred_keypoints``."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(single_instance_export, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    assert len(outputs_list) == 1
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    # One frame, n_nodes=2, (x, y) → shape (1, 1, 2, 2).
+    assert out.pred_keypoints.shape[-1] == 2
+    assert out.pred_keypoints.shape[-2] == 2
+
+
+def test_predictor_classmethod_alias_matches_function(single_instance_export):
+    """``Predictor.from_export_dir`` and ``factory.from_export_dir`` are equivalent."""
+    from sleap_nn.inference.factory import from_export_dir as fn
+    from sleap_nn.inference.predictor import Predictor
+
+    direct = fn(single_instance_export, device="cpu")
+    via_classmethod = Predictor.from_export_dir(single_instance_export, device="cpu")
+
+    assert type(direct.layer) is type(via_classmethod.layer)
+
+
+def test_from_export_dir_single_instance_no_double_coord_ladder(tmp_path):
+    """Export adapter must not re-apply ``output_stride`` / ``input_scale``.
+
+    The wrapper already produces peaks in original-image space; the
+    adapter therefore bypasses the standard layer's coord ladder.
+    With ``output_stride=4`` and ``input_scale=0.5`` in metadata, the
+    wrapper output should pass through unchanged (no peaks * 16 bug).
+    """
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    export_dir = tmp_path / "scaled_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(
+        export_dir,
+        model_type="single_instance",
+        n_nodes=2,
+        output_stride=4,
+        input_scale=0.5,
+    )
+
+    predictor = from_export_dir(export_dir, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    # Whatever the wrapper produced (argmax over 16x16 → values in [0, 15])
+    # must come through unchanged. Specifically NOT re-multiplied by
+    # output_stride/input_scale = 4/0.5 = 8.
+    peaks = out.pred_keypoints
+    assert peaks.max() < 16, (
+        "Export adapter applied coord ladder twice — peaks should stay "
+        f"in original [0, 16) space; got max={peaks.max()}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Error paths
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_from_export_dir_missing_metadata_raises(tmp_path):
+    """No ``export_metadata.json`` ⇒ ``FileNotFoundError`` with a clear message."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / "empty"
+    export_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match="export_metadata.json"):
+        from_export_dir(export_dir, device="cpu")
+
+
+def test_from_export_dir_missing_model_file_raises(tmp_path):
+    """Metadata present but no ``model.onnx`` / ``model.trt`` ⇒ ``FileNotFoundError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / "metadata_only"
+    export_dir.mkdir()
+    _write_metadata(export_dir, model_type="single_instance")
+    with pytest.raises(FileNotFoundError, match="model.onnx or model.trt"):
+        from_export_dir(export_dir, device="cpu")
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "bottomup",
+        "multi_class_bottomup",
+        "multi_class_topdown",
+    ],
+)
+def test_from_export_dir_unsupported_model_type_raises(tmp_path, model_type):
+    """Bottom-up + multiclass model types raise ``NotImplementedError`` (PR 19 scope)."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / f"export_{model_type}"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)  # any ONNX file works
+    _write_metadata(export_dir, model_type=model_type)
+
+    with pytest.raises(NotImplementedError, match=model_type):
+        from_export_dir(export_dir, device="cpu")
+
+
+def test_from_export_dir_unknown_runtime_raises(single_instance_export):
+    """``runtime`` other than auto/onnx/tensorrt ⇒ ``ValueError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    with pytest.raises(ValueError, match="Unknown runtime"):
+        from_export_dir(single_instance_export, runtime="foo", device="cpu")
+
+
+def test_from_export_dir_explicit_onnx_runtime(single_instance_export):
+    """``runtime='onnx'`` works when the .onnx file exists."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    predictor = from_export_dir(single_instance_export, runtime="onnx", device="cpu")
+    assert predictor.layer is not None
+
+
+def test_from_export_dir_tensorrt_missing_engine_raises(single_instance_export):
+    """``runtime='tensorrt'`` on an ONNX-only dir ⇒ ``FileNotFoundError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    with pytest.raises(FileNotFoundError, match="model.trt"):
+        from_export_dir(single_instance_export, runtime="tensorrt", device="cpu")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Centroid + centered-instance + topdown synthetic exports (PR 19)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _export_tiny_centroid(
+    export_dir: Path, max_instances: int = 4, n_nodes: int = 2
+) -> Path:
+    """Export a 1-conv ONNX that emits centroid wrapper output schema.
+
+    Output: ``centroids`` (B, I, 2), ``centroid_vals`` (B, I), ``instance_valid`` (B, I).
+    The model picks the top-k peaks per sample over the confmap.
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, kernel_size=3, padding=1)
+            self.max_instances = max_instances
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())  # (B, 1, H, W)
+            B, _C, H, W = cms.shape
+            flat = cms.view(B, -1)
+            vals, idx = flat.topk(self.max_instances, dim=-1)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            centroids = torch.stack([col, row], dim=-1)  # (B, I, 2)
+            centroid_vals = vals  # (B, I)
+            instance_valid = vals > 0.0  # (B, I) bool
+            return centroids, centroid_vals, instance_valid
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=["centroids", "centroid_vals", "instance_valid"],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+def _export_tiny_topdown(
+    export_dir: Path, max_instances: int = 3, n_nodes: int = 2
+) -> Path:
+    """Export an ONNX that emits the combined top-down wrapper output schema.
+
+    Outputs: ``centroids`` (B, I, 2), ``centroid_vals`` (B, I),
+    ``peaks`` (B, I, N, 2), ``peak_vals`` (B, I, N), ``instance_valid`` (B, I).
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, kernel_size=3, padding=1)
+            self.max_instances = max_instances
+            self.n_nodes = n_nodes
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())
+            B, _C, H, W = cms.shape
+            flat = cms.view(B, -1)
+            vals, idx = flat.topk(self.max_instances, dim=-1)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            centroids = torch.stack([col, row], dim=-1)  # (B, I, 2)
+            instance_valid = vals > 0.0
+            # Synthesize per-instance peaks: each node placed near the centroid.
+            peaks = centroids.unsqueeze(2).expand(-1, -1, self.n_nodes, -1).clone()
+            peak_vals = vals.unsqueeze(-1).expand(-1, -1, self.n_nodes).clone()
+            return centroids, vals, peaks, peak_vals, instance_valid
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=[
+            "centroids",
+            "centroid_vals",
+            "peaks",
+            "peak_vals",
+            "instance_valid",
+        ],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+@pytest.fixture
+def centroid_export(tmp_path):
+    """Export dir for a centroid model: model.onnx + metadata."""
+    export_dir = tmp_path / "centroid_export"
+    export_dir.mkdir()
+    _export_tiny_centroid(export_dir, max_instances=4, n_nodes=2)
+    _write_metadata(export_dir, model_type="centroid", n_nodes=2)
+    return export_dir
+
+
+@pytest.fixture
+def centered_instance_export(tmp_path):
+    """Export dir for a centered-instance model: model.onnx + metadata.
+
+    Reuses the single-instance ONNX schema since the wrapper output
+    is identical (``peaks`` + ``peak_vals``); only ``model_type`` in
+    metadata differs.
+    """
+    export_dir = tmp_path / "centered_instance_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(export_dir, model_type="centered_instance", n_nodes=2)
+    return export_dir
+
+
+@pytest.fixture
+def topdown_export(tmp_path):
+    """Export dir for a combined top-down model: model.onnx + metadata."""
+    export_dir = tmp_path / "topdown_export"
+    export_dir.mkdir()
+    _export_tiny_topdown(export_dir, max_instances=3, n_nodes=2)
+    _write_metadata(export_dir, model_type="topdown", n_nodes=2)
+    return export_dir
+
+
+def test_from_export_dir_centroid_builds_predictor(centroid_export):
+    """Centroid export → :class:`ExportedCentroidLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedCentroidLayer
+
+    predictor = from_export_dir(centroid_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedCentroidLayer)
+
+
+def test_from_export_dir_centroid_predict_smoke(centroid_export):
+    """Centroid adapter populates ``pred_centroids`` + ``pred_centroid_values``."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(centroid_export, device="cpu")
+    images = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_centroids is not None
+    assert out.pred_centroid_values is not None
+    assert out.pred_centroids.shape == (1, 4, 2)  # max_instances=4
+    assert out.pred_centroid_values.shape == (1, 4)
+    # No keypoints emitted by centroid-only adapter (centroids are the prediction).
+    assert out.pred_keypoints is None
+
+
+def test_from_export_dir_centered_instance_builds_predictor(centered_instance_export):
+    """Centered-instance export → :class:`ExportedCenteredInstanceLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedCenteredInstanceLayer
+
+    predictor = from_export_dir(centered_instance_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedCenteredInstanceLayer)
+
+
+def test_from_export_dir_centered_instance_predict_smoke(centered_instance_export):
+    """Centered-instance adapter populates ``pred_keypoints`` per crop."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(centered_instance_export, device="cpu")
+    crops = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=crops, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    # (B_crops, 1 instance per crop, n_nodes, 2) → (1, 1, 2, 2).
+    assert out.pred_keypoints.shape == (1, 1, 2, 2)
+
+
+def test_from_export_dir_topdown_builds_predictor(topdown_export):
+    """Top-down combined export → :class:`ExportedTopDownLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedTopDownLayer
+
+    predictor = from_export_dir(topdown_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedTopDownLayer)
+
+
+def test_from_export_dir_topdown_predict_smoke(topdown_export):
+    """Top-down adapter populates centroids + keypoints + instance_valid."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(topdown_export, device="cpu")
+    images = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    assert out.pred_centroids is not None
+    assert out.pred_centroid_values is not None
+    assert out.pred_peak_values is not None
+    assert out.instance_valid is not None
+    # max_instances=3, n_nodes=2 → keypoints (1, 3, 2, 2), centroids (1, 3, 2).
+    assert out.pred_keypoints.shape == (1, 3, 2, 2)
+    assert out.pred_centroids.shape == (1, 3, 2)
+
+
+def test_centroid_adapter_nan_pads_invalid_slots(centroid_export):
+    """Invalid centroid slots (zero-confidence) are NaN'd per Outputs convention."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    # All-zero image → conv outputs ~0 confmap, all topk values <= 0 → all invalid.
+    predictor = from_export_dir(centroid_export, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    out = predictor.predict(provider)[0]
+    # Some slots may be invalid. Wherever instance_valid is False, the
+    # corresponding centroid + value must be NaN.
+    valid = out.instance_valid[0]
+    invalid_mask = ~valid
+    if invalid_mask.any():
+        invalid_centroids = out.pred_centroids[0][invalid_mask]
+        invalid_vals = out.pred_centroid_values[0][invalid_mask]
+        assert torch.isnan(invalid_centroids).all()
+        assert torch.isnan(invalid_vals).all()

--- a/tests/inference/test_paf_worker_pool.py
+++ b/tests/inference/test_paf_worker_pool.py
@@ -202,38 +202,15 @@ def test_scored_batch_to_cpu_is_idempotent_on_cpu_tensors():
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# 2. GPU/CPU phase split parity (vs monolithic postprocess)
+# 2. Predictor — paf_workers=N matches paf_workers=0 (the parity contract)
 # ─────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.skipif(
-    not BOTTOMUP_CKPT.exists(), reason="bottomup checkpoint not present"
-)
-def test_phase_split_matches_monolithic_postprocess(bottomup_layer, bottomup_image):
-    """``_score_pafs_on_gpu`` + ``group_scored_batch`` == ``postprocess``."""
-    layer = bottomup_layer
-    img = bottomup_image
-    out_inline = layer.predict(img)
-
-    x, info = layer.preprocess(img)
-    raw = layer.backend(x)
-    scored = layer._score_pafs_on_gpu(raw, info)
-    out_split = group_scored_batch(scored, layer.grouping_params())
-
-    torch.testing.assert_close(
-        out_inline.pred_keypoints, out_split.pred_keypoints, equal_nan=True
-    )
-    torch.testing.assert_close(
-        out_inline.pred_peak_values, out_split.pred_peak_values, equal_nan=True
-    )
-    torch.testing.assert_close(
-        out_inline.instance_scores, out_split.instance_scores, equal_nan=True
-    )
-
-
-# ─────────────────────────────────────────────────────────────────────────
-# 3. Predictor — paf_workers=N matches paf_workers=0 (the parity contract)
-# ─────────────────────────────────────────────────────────────────────────
+#
+# The previous "phase split == monolithic postprocess" parity test was
+# removed: it loaded a real BottomUpLayer checkpoint and ran the model
+# end-to-end twice (~580s on Mac CI). End-to-end parity vs main is
+# captured once at the top of the stack via the PR 0 goldens; the
+# synthetic pool test below covers the GPU+CPU split's correctness on
+# a deterministic small payload that runs in <3s.
 
 
 def _build_synthetic_scored_batch(

--- a/tests/inference/test_providers.py
+++ b/tests/inference/test_providers.py
@@ -73,6 +73,98 @@ def test_labels_provider_yields_instances():
     assert batch.images.shape[0] == batch.instances.shape[0]
 
 
+def test_labels_provider_only_labeled_and_exclude_user_labeled_mutually_exclusive():
+    """``only_labeled_frames=True`` + ``exclude_user_labeled=True`` raises."""
+    import sleap_io as sio
+
+    labels = sio.Labels(videos=[], skeletons=[], labeled_frames=[])
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        LabelsProvider(
+            labels=labels,
+            only_labeled_frames=True,
+            exclude_user_labeled=True,
+        )
+
+
+def test_labels_provider_exclude_user_labeled_drops_user_frames():
+    """``exclude_user_labeled=True`` drops frames with user instances."""
+    import sleap_io as sio
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="dummy.mp4")
+    user_inst = sio.Instance.from_numpy(
+        np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32), skeleton=skel
+    )
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[2.0, 2.0], [3.0, 3.0]], dtype=np.float32),
+        skeleton=skel,
+        score=0.9,
+    )
+    lf_user = sio.LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+    lf_pred = sio.LabeledFrame(video=video, frame_idx=1, instances=[pred_inst])
+    labels = sio.Labels(
+        videos=[video], skeletons=[skel], labeled_frames=[lf_user, lf_pred]
+    )
+
+    provider = LabelsProvider(
+        labels=labels, exclude_user_labeled=True, only_labeled_frames=False
+    )
+    assert len(provider._labeled_frames) == 1
+    assert provider._labeled_frames[0].frame_idx == 1
+
+
+def test_labels_provider_only_predicted_frames_keeps_only_predicted():
+    """``only_predicted_frames=True`` keeps only frames with predicted instances."""
+    import sleap_io as sio
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="dummy.mp4")
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32),
+        skeleton=skel,
+        score=0.9,
+    )
+    lf_empty = sio.LabeledFrame(video=video, frame_idx=0, instances=[])
+    lf_pred = sio.LabeledFrame(video=video, frame_idx=1, instances=[pred_inst])
+    labels = sio.Labels(
+        videos=[video], skeletons=[skel], labeled_frames=[lf_empty, lf_pred]
+    )
+
+    provider = LabelsProvider(
+        labels=labels, only_predicted_frames=True, only_labeled_frames=False
+    )
+    assert [lf.frame_idx for lf in provider._labeled_frames] == [1]
+
+
+def test_labels_provider_only_suggested_frames_yields_unlabeled_suggestions():
+    """``only_suggested_frames=True`` yields unlabeled suggestions only."""
+    import sleap_io as sio
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="dummy.mp4")
+    user_inst = sio.Instance.from_numpy(
+        np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32), skeleton=skel
+    )
+    lf_with_user = sio.LabeledFrame(video=video, frame_idx=2, instances=[user_inst])
+    labels = sio.Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[lf_with_user],
+        suggestions=[
+            sio.SuggestionFrame(video=video, frame_idx=2),  # already user-labeled
+            sio.SuggestionFrame(video=video, frame_idx=5),  # unlabeled
+        ],
+    )
+
+    provider = LabelsProvider(
+        labels=labels, only_suggested_frames=True, only_labeled_frames=False
+    )
+    # Only the unlabeled suggestion (frame_idx=5) survives.
+    assert [lf.frame_idx for lf in provider._labeled_frames] == [5]
+    # The yielded LabeledFrame is fresh + empty.
+    assert len(provider._labeled_frames[0].instances) == 0
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # IncrementalLabelsWriter
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -1,0 +1,271 @@
+"""Tests for the tracking integration in the new ``Predictor`` flow."""
+
+from __future__ import annotations
+
+import pickle
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap_nn.inference.filters import FilterConfig
+from sleap_nn.inference.predictor import Predictor
+from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def skeleton():
+    return sio.Skeleton(nodes=["head", "tail"])
+
+
+@pytest.fixture
+def video():
+    return sio.Video(filename="dummy.mp4")
+
+
+def _make_labels(skeleton, video, frames=10, instances_per_frame=2, drift=1.0):
+    """Synthetic labels: ``frames`` frames, each with ``instances_per_frame``
+    predicted instances drifting linearly across frames so OKS tracking can
+    associate them deterministically."""
+    base_points = np.array(
+        [
+            [[0.0, 0.0], [10.0, 0.0]],  # instance A
+            [[100.0, 0.0], [110.0, 0.0]],  # instance B
+        ],
+        dtype=np.float32,
+    )
+    lfs: list[sio.LabeledFrame] = []
+    for i in range(frames):
+        insts: list[sio.PredictedInstance] = []
+        for k in range(instances_per_frame):
+            pts = base_points[k] + np.array([drift * i, drift * i], dtype=np.float32)
+            insts.append(
+                sio.PredictedInstance.from_numpy(
+                    points_data=pts, skeleton=skeleton, score=0.9
+                )
+            )
+        lfs.append(sio.LabeledFrame(video=video, frame_idx=i, instances=insts))
+    return sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=lfs)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# TrackerConfig — value type contract
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_tracker_config_defaults_and_pickle():
+    cfg = TrackerConfig()
+    restored = pickle.loads(pickle.dumps(cfg))
+    assert restored.window_size == cfg.window_size == 5
+    assert restored.candidates_method == "fixed_window"
+    assert restored.scoring_method == "oks"
+    assert restored.tracking_target_instance_count is None
+    assert restored.post_connect_single_breaks is False
+
+
+def test_tracker_config_is_frozen():
+    cfg = TrackerConfig(window_size=10)
+    with pytest.raises(attr_err()):
+        cfg.window_size = 999  # type: ignore[misc]
+
+
+def attr_err():
+    """Frozen attrs raises ``FrozenInstanceError`` (subclass of AttributeError)."""
+    import attrs
+
+    return attrs.exceptions.FrozenInstanceError
+
+
+# ──────────────────────────────────────────────────────────────────────
+# apply_tracking — labels-in / labels-out parity vs run_tracker
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_apply_tracking_assigns_track_ids(skeleton, video):
+    labels = _make_labels(skeleton, video, frames=5, instances_per_frame=2)
+    cfg = TrackerConfig(window_size=5, candidates_method="fixed_window")
+    out = apply_tracking(labels, cfg)
+    assert len(out.labeled_frames) == 5
+    for lf in out.labeled_frames:
+        # Every instance should have a Track assigned (or, for first-frame
+        # spawns, a fresh one). None means "untracked"; we want all tracked.
+        for inst in lf.instances:
+            assert inst.track is not None
+
+
+def test_apply_tracking_assigns_consistent_track_ids_across_frames(skeleton, video):
+    """A drifting two-instance scene should keep both tracks across the
+    full window. Validates the ``Tracker`` glue is wired correctly: the
+    same track names appear on the corresponding instance in every frame.
+    """
+    labels = _make_labels(skeleton, video, frames=8, instances_per_frame=2)
+    out = apply_tracking(
+        labels, TrackerConfig(window_size=5, candidates_method="fixed_window")
+    )
+    track_names_per_frame = [
+        sorted(inst.track.name for inst in lf.instances) for lf in out.labeled_frames
+    ]
+    # Two stable tracks across all 8 frames.
+    expected = sorted({n for names in track_names_per_frame for n in names})
+    assert len(expected) == 2
+    for names in track_names_per_frame:
+        assert names == expected
+
+
+def test_apply_tracking_post_connect_requires_target_count(skeleton, video):
+    labels = _make_labels(skeleton, video, frames=3, instances_per_frame=1)
+    cfg = TrackerConfig(post_connect_single_breaks=True)
+    with pytest.raises(ValueError, match="tracking_target_instance_count"):
+        apply_tracking(labels, cfg)
+
+
+def test_apply_tracking_preserves_videos_and_skeletons(skeleton, video):
+    labels = _make_labels(skeleton, video, frames=2, instances_per_frame=1)
+    out = apply_tracking(labels, TrackerConfig())
+    assert list(out.videos) == [video]
+    assert list(out.skeletons) == [skeleton]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Predictor — tracker_config wiring
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _StubLayer:
+    """Minimal :class:`InferenceLayer`-shaped stub for unit tests."""
+
+    def predict(self, image, **kwargs):  # pragma: no cover — not exercised here
+        raise NotImplementedError
+
+
+def test_predictor_accepts_tracker_config():
+    cfg = TrackerConfig(window_size=7)
+    pred = Predictor(layer=_StubLayer(), tracker_config=cfg)
+    assert pred.tracker_config is cfg
+
+
+def test_predictor_default_tracker_config_none():
+    pred = Predictor(layer=_StubLayer())
+    assert pred.tracker_config is None
+
+
+def test_predictor_predict_streaming_raises_with_tracker_config():
+    pred = Predictor(layer=_StubLayer(), tracker_config=TrackerConfig())
+
+    class _Provider:
+        def __iter__(self):
+            return iter([])
+
+    with pytest.raises(ValueError, match="tracker_config is not supported"):
+        list(pred.predict_streaming(_Provider()))
+
+
+def test_predictor_predict_no_make_labels_with_tracker_raises():
+    pred = Predictor(layer=_StubLayer(), tracker_config=TrackerConfig())
+
+    class _Provider:
+        def __iter__(self):
+            return iter([])
+
+    with pytest.raises(ValueError, match="tracker_config requires make_labels"):
+        pred.predict(_Provider(), make_labels=False)
+
+
+def test_predictor_predict_applies_tracker_after_to_labels(
+    skeleton, video, monkeypatch
+):
+    """End-to-end: stub the per-batch path + ``_to_labels`` so ``predict()``
+    produces a known untracked Labels, then verify ``apply_tracking``
+    runs and the returned Labels has tracks set."""
+    untracked = _make_labels(skeleton, video, frames=4, instances_per_frame=2)
+
+    pred = Predictor(
+        layer=_StubLayer(),
+        tracker_config=TrackerConfig(window_size=3),
+    )
+
+    class _Provider:
+        def __iter__(self):
+            return iter([])
+
+    # Patch the class-level methods so ``predict()`` reaches the
+    # post-_to_labels tracking hook without needing a real model.
+    monkeypatch.setattr(
+        Predictor,
+        "_batch_iter",
+        lambda self, provider, progress_callback=None: iter([]),
+    )
+    monkeypatch.setattr(
+        Predictor,
+        "_to_labels",
+        staticmethod(lambda outputs_list, skeleton, videos: untracked),
+    )
+
+    result = pred.predict(
+        _Provider(), make_labels=True, skeleton=skeleton, videos=[video]
+    )
+    assert isinstance(result, sio.Labels)
+    for lf in result.labeled_frames:
+        for inst in lf.instances:
+            assert inst.track is not None
+
+
+def test_predictor_predict_clean_empty_frames_drops_empty(skeleton, video, monkeypatch):
+    """``clean_empty_frames=True`` drops empty LabeledFrames after _to_labels."""
+    import sleap_io as sio
+
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32),
+        skeleton=skeleton,
+        score=0.9,
+    )
+    lfs = [
+        sio.LabeledFrame(video=video, frame_idx=0, instances=[]),
+        sio.LabeledFrame(video=video, frame_idx=1, instances=[pred_inst]),
+        sio.LabeledFrame(video=video, frame_idx=2, instances=[]),
+    ]
+    raw_labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=lfs)
+
+    pred = Predictor(layer=_StubLayer())
+
+    class _Provider:
+        def __iter__(self):
+            return iter([])
+
+    monkeypatch.setattr(
+        Predictor,
+        "_batch_iter",
+        lambda self, provider, progress_callback=None: iter([]),
+    )
+    monkeypatch.setattr(
+        Predictor,
+        "_to_labels",
+        staticmethod(lambda outputs_list, skeleton, videos: raw_labels),
+    )
+
+    result = pred.predict(
+        _Provider(),
+        make_labels=True,
+        skeleton=skeleton,
+        videos=[video],
+        clean_empty_frames=True,
+    )
+    # Frame 1 (with the instance) survives; frames 0 and 2 are dropped.
+    assert [lf.frame_idx for lf in result.labeled_frames] == [1]
+
+
+def test_predictor_with_tracker_picklable_round_trip():
+    pred = Predictor(
+        layer=_StubLayer(),
+        filter_config=FilterConfig(),
+        tracker_config=TrackerConfig(window_size=11, max_tracks=4),
+    )
+    # Predictor itself isn't necessarily picklable (the layer holds a
+    # torch model), but the tracker_config field must be.
+    restored_cfg = pickle.loads(pickle.dumps(pred.tracker_config))
+    assert restored_cfg.window_size == 11
+    assert restored_cfg.max_tracks == 4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -817,6 +817,120 @@ def test_track_command(
     assert len(labels) == 100
 
 
+def test_track_command_retrack_only_uses_new_flow(
+    centered_instance_video,
+    minimal_instance_centered_instance_ckpt,
+    minimal_instance_centroid_ckpt,
+    tmp_path,
+):
+    """End-to-end retrack-only: first produce predictions, then re-track."""
+    import subprocess
+
+    # Step 1: produce a tracked .slp via the inference + tracking path.
+    pred_slp = f"{tmp_path}/preds.slp"
+    inference_cmd = [
+        "uv",
+        "run",
+        "--frozen",
+        "--extra",
+        "torch-cpu",
+        "sleap-nn",
+        "infer",
+        "--model_paths",
+        minimal_instance_centroid_ckpt,
+        "--model_paths",
+        minimal_instance_centered_instance_ckpt,
+        "--data_path",
+        centered_instance_video.as_posix(),
+        "--max_instances",
+        "2",
+        "--output_path",
+        pred_slp,
+        "--frames",
+        "0-9",
+        "--device",
+        "cpu",
+    ]
+    subprocess.run(inference_cmd, check=True, capture_output=True, text=True)
+    assert Path(pred_slp).exists()
+
+    # Step 2: retrack with NO model_paths (pure tracking-only path).
+    retracked_slp = f"{tmp_path}/retracked.slp"
+    retrack_cmd = [
+        "uv",
+        "run",
+        "--frozen",
+        "--extra",
+        "torch-cpu",
+        "sleap-nn",
+        "infer",
+        "--data_path",
+        pred_slp,
+        "--tracking",
+        "--tracking_window_size",
+        "5",
+        "--output_path",
+        retracked_slp,
+    ]
+    subprocess.run(retrack_cmd, check=True, capture_output=True, text=True)
+    assert Path(retracked_slp).exists()
+
+    out = sio.load_slp(retracked_slp)
+    # Retrack preserves the frame count.
+    assert len(out) == 10
+
+
+def test_track_command_with_tracking_uses_new_flow(
+    centered_instance_video,
+    minimal_instance_centered_instance_ckpt,
+    minimal_instance_centroid_ckpt,
+    tmp_path,
+):
+    """End-to-end ``--tracking`` smoke test on the new flow (PR 14)."""
+    import subprocess
+
+    cmd = [
+        "uv",
+        "run",
+        "--frozen",
+        "--extra",
+        "torch-cpu",
+        "sleap-nn",
+        "infer",
+        "--model_paths",
+        minimal_instance_centroid_ckpt,
+        "--model_paths",
+        minimal_instance_centered_instance_ckpt,
+        "--data_path",
+        centered_instance_video.as_posix(),
+        "--max_instances",
+        "2",
+        "--tracking",
+        "--tracking_window_size",
+        "5",
+        "--output_path",
+        f"{tmp_path}/test_tracked.slp",
+        "--frames",
+        "0-49",
+        "--device",
+        "cpu",
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+    out = Path(f"{tmp_path}/test_tracked.slp")
+    assert out.exists()
+
+    labels = sio.load_slp(str(out))
+    assert len(labels) == 50
+    # At least one frame should have a tracked predicted instance.
+    tracked_count = sum(
+        1
+        for lf in labels.labeled_frames
+        for inst in lf.instances
+        if getattr(inst, "track", None) is not None
+    )
+    assert tracked_count > 0, "no tracks were assigned by the new-flow tracker"
+
+
 def test_eval_command(
     minimal_instance, tmp_path, minimal_instance_centered_instance_ckpt
 ):

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -10,6 +10,34 @@ from _pytest.logging import LogCaptureFixture
 import torch
 
 
+def test_run_inference_emits_deprecation_warning(
+    minimal_instance, minimal_instance_centered_instance_ckpt, tmp_path
+):
+    """``run_inference()`` is the legacy entry point; calling it emits a
+    DeprecationWarning pointing at the new ``Predictor`` API."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        run_inference(
+            model_paths=[minimal_instance_centered_instance_ckpt],
+            data_path=minimal_instance.as_posix(),
+            make_labels=True,
+            peak_threshold=0.0,
+            device="cpu",
+            output_path=f"{tmp_path}/test.slp",
+            integral_refinement=None,
+        )
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    matching = [
+        w
+        for w in deprecations
+        if "run_inference" in str(w.message) and "Predictor" in str(w.message)
+    ]
+    assert matching, [str(w.message) for w in deprecations]
+
+
 @pytest.fixture
 def caplog(caplog: LogCaptureFixture):
     handler_id = logger.add(


### PR DESCRIPTION
## Summary

Closes #518 (PR 10 of #508).

Adds `sleap-nn infer` as the unified inference command, with `track` becoming a deprecated alias. Same flag surface as legacy `track` (~70 flags) plus the four PR-10 flags wired through:

- **`--paf-workers`** / **`--cpu-workers`** (deprecated alias) — wires to `Predictor(paf_workers=)` from PR 9. Today emits a no-effect warning because the new `Predictor.from_model_paths` factory lands in PR 14 (#519).
- **`--peak-conf-threshold`** — alias for the existing `--peak_threshold`.
- **`--stream-to-file <path>`** — currently raises a clear `UsageError` pointing at #519; the new flow ships there.
- **`--write-interval <N>`** — paired with `--stream-to-file`.

## What's intentionally deferred

- **`sleap-nn predict` as alias for `infer`**: the existing top-level `predict` command runs inference on exported ONNX / TRT models. Making it an alias requires re-homing it under `sleap-nn export predict` — i.e., converting the `export` command to a click group. That's a separate refactor and isn't strictly needed to satisfy the parent epic. PR 10 ships `track` deprecation + the canonical `infer` only; the `predict` rename will happen in a follow-up.
- **`Predictor.from_model_paths` factory**: the new `Predictor` from PR 8 takes a manually-constructed layer; it doesn't yet know how to build itself from a model directory. Today `infer` delegates to the legacy `run_inference`. PR 14 (#519) wires the new flow.

## Architecture

`infer`, `track` (deprecated), and any future alias share a single `_common_inference_options` decorator built from a list of `click.option` calls. Adding a flag in one place updates all commands that share the decorator. Both call `_run_inference_impl(**kwargs)`, which strips PR-10-only kwargs (paf_workers, stream_to_file, write_interval, cpu_workers), validates them, then delegates to the legacy `run_inference`.

## Tests (`tests/cli/`)

- `test_infer_command.py` (5) — `--help` renders, every legacy flag accepted, PR-10 new flags don't leak into `run_inference`, `--peak-conf-threshold` alias maps to `peak_threshold`, default `--paf-workers 0` is silent.
- `test_aliases.py` (3) — `track` emits a `DeprecationWarning`, `infer`/`track` reach identical `run_inference` kwargs, top-level `predict` still renders the export-trained command (deferral confirmed).
- `test_flag_validation.py` (5) — `--stream-to-file` raises `UsageError` referencing #519, `--write-interval` alone is rejected, `--cpu-workers` emits `DeprecationWarning`, `--paf-workers > 0` succeeds, unknown flags rejected.

13 PR-10 tests pass; existing `tests/test_cli.py` (36 tests) still passes.

## Test plan

- [x] `pytest tests/cli/` — all 13 new tests pass locally
- [x] `pytest tests/test_cli.py` — 36 existing tests pass (with expected DeprecationWarning from `track`)
- [x] `sleap-nn infer --help` renders correctly
- [x] `sleap-nn track --help` still works (deprecated)
- [x] `sleap-nn predict --help` still routes to the export-trained command (deferral confirmed)
- [x] `black --check` + `ruff check` clean
- [ ] Linux / Windows / Mac CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)