### PR TITLE
PR 16 of #508 — port remaining .ckpt-flow flags to new Predictor

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1033,21 +1033,12 @@ def _run_inference_impl(**kwargs):
             paf_workers=paf_workers,
         )
 
-    # ── In-memory new-flow path (PR 13) ────────────────────────────────
-    # When the requested flags don't need anything the legacy ``run_inference``
-    # alone can do (tracking, suggested-frame filtering, GUI progress reporter,
-    # backbone/head ckpt overrides), route through the new
-    # :func:`Predictor.from_model_paths(...).predict(...)` flow. The legacy
-    # path stays available as a fallback for everything else.
+    # ── In-memory new-flow path (PR 13–16) ─────────────────────────────
+    # As of PR 16 the new flow handles every documented flag, so this
+    # always routes here. The legacy ``run_inference`` body is kept for
+    # backward-compat external callers and is removed in PR 17.
     if _can_use_new_in_memory_flow(kwargs):
         return _run_in_memory_new_flow(kwargs, paf_workers=paf_workers)
-
-    if paf_workers > 0:
-        logger.warning(
-            "--paf-workers > 0 currently has no effect on the legacy "
-            "predict path; pass --stream-to-file or use a simpler config "
-            "(no tracking, no advanced frame filtering) to use the worker pool."
-        )
 
     return run_inference(**kwargs)
 
@@ -1055,23 +1046,26 @@ def _run_inference_impl(**kwargs):
 def _can_use_new_in_memory_flow(kwargs: dict) -> bool:
     """Return True iff the new factory + Predictor.predict can serve this call.
 
-    As of PR 15 the new flow handles: video / labels source, one or two
-    ``.ckpt`` model dirs, optional ``frames`` list, preprocess
-    overrides, ``--tracking`` (post-inference tracker via
-    :class:`TrackerConfig`), every ``--filter_*`` knob (via
-    :class:`FilterConfig`), and the four frame-selection knobs
-    (``only_suggested_frames`` / ``exclude_user_labeled`` /
-    ``only_predicted_frames`` / ``no_empty_frames``).
+    As of PR 16 the new flow handles every documented flag combination
+    that ``run_inference`` ever supported:
 
-    Still legacy: ``--gui`` (Qt progress reporter) and the layer-level
-    ``--backbone_ckpt_path`` / ``--head_ckpt_path`` overrides.
+    * Video or ``.slp`` source · one or more ``.ckpt`` model dirs
+    * ``--backbone_ckpt_path`` / ``--head_ckpt_path`` (threaded through
+      the factory's existing kwargs).
+    * ``--tracking`` + every tracking knob (via :class:`TrackerConfig`).
+    * Every ``--filter_*`` knob (via :class:`FilterConfig`).
+    * The four frame-selection flags (``only_suggested_frames`` /
+      ``exclude_user_labeled`` / ``only_predicted_frames`` /
+      ``no_empty_frames``).
+    * ``--gui`` (JSON progress emission via ``progress_callback``).
+    * Tracking-only retrack (no ``model_paths``, ``--tracking`` set,
+      ``.slp`` data path) — handled by :meth:`Predictor.retrack`.
+
+    The function returns ``True`` whenever any of these combinations is
+    requested. The legacy ``run_inference`` is no longer reached during
+    normal CLI use; the body is kept for one release as a deprecation
+    target and removed in PR 17.
     """
-    if kwargs.get("gui"):
-        return False
-    if kwargs.get("backbone_ckpt_path") or kwargs.get("head_ckpt_path"):
-        return False
-    if not kwargs.get("model_paths"):
-        return False
     return True
 
 
@@ -1166,17 +1160,22 @@ def _build_tracker_config(kwargs: dict) -> "object":
 def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     """Run the new ``Predictor`` flow synchronously and save the resulting Labels.
 
-    This is the in-memory counterpart to :func:`_run_stream_to_file`:
-    same factory, same providers, but ``predict()`` instead of
-    ``predict_to_file()`` so the result lives in memory until the final
-    ``Labels.save()`` call.
+    Routes to :meth:`Predictor.retrack` for the tracking-only retrack
+    case (no ``model_paths``, ``--tracking`` set, ``.slp`` data path);
+    otherwise builds a ``Predictor`` via the factory and calls
+    :meth:`Predictor.predict`.
     """
     from pathlib import Path
 
     import sleap_io as sio
 
     from sleap_nn.inference.factory import from_model_paths
+    from sleap_nn.inference.predictor import Predictor as NewPredictor
     from sleap_nn.inference.providers import LabelsProvider, VideoProvider
+
+    # ── Tracking-only retrack: no model_paths, --tracking on a .slp ────
+    if not kwargs.get("model_paths") and kwargs.get("tracking"):
+        return _run_retrack_only(kwargs, NewPredictor)
 
     factory_kwargs = {
         "device": _resolve_device(kwargs.get("device")),
@@ -1188,6 +1187,10 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         "anchor_part": kwargs.get("anchor_part"),
         "paf_workers": paf_workers,
     }
+    if kwargs.get("backbone_ckpt_path"):
+        factory_kwargs["backbone_ckpt_path"] = kwargs["backbone_ckpt_path"]
+    if kwargs.get("head_ckpt_path"):
+        factory_kwargs["head_ckpt_path"] = kwargs["head_ckpt_path"]
     if kwargs.get("tracking"):
         factory_kwargs["tracker_config"] = _build_tracker_config(kwargs)
     filter_config = _build_filter_config(kwargs)
@@ -1227,11 +1230,98 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         skeleton=skeleton,
         videos=videos,
         clean_empty_frames=bool(kwargs.get("no_empty_frames")),
+        progress_callback=_gui_progress_callback() if kwargs.get("gui") else None,
     )
 
     output_path = kwargs.get("output_path") or f"{src}.slp"
     labels.save(output_path)
     return labels
+
+
+def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
+    """Pure-tracking retrack of an existing ``.slp`` (no inference)."""
+    from pathlib import Path
+
+    import sleap_io as sio
+
+    src = Path(kwargs["data_path"])
+    if src.suffix != ".slp":
+        raise click.UsageError(
+            "Tracking-only mode requires --data_path to be a .slp file. "
+            "Pass --model_paths to run inference + tracking."
+        )
+
+    labels = sio.load_slp(str(src))
+
+    # video_index filter (optional)
+    video_index = kwargs.get("video_index")
+    if video_index is not None and video_index < len(labels.videos):
+        target_video = labels.videos[video_index]
+        labels = sio.Labels(
+            videos=labels.videos,
+            skeletons=labels.skeletons,
+            labeled_frames=labels.find(video=target_video),
+        )
+
+    # frames filter (optional)
+    frames = kwargs.get("frames")
+    if frames:
+        wanted = set(frames)
+        labels = sio.Labels(
+            videos=labels.videos,
+            skeletons=labels.skeletons,
+            labeled_frames=[
+                lf for lf in labels.labeled_frames if lf.frame_idx in wanted
+            ],
+        )
+
+    tracker_config = _build_tracker_config(kwargs)
+    out = predictor_cls.retrack(
+        labels,
+        tracker_config,
+        clean_empty_frames=bool(kwargs.get("no_empty_frames")),
+    )
+    output_path = kwargs.get("output_path") or f"{src}.slp"
+    out.save(output_path)
+    return out
+
+
+def _gui_progress_callback():
+    """Build a JSON-progress emitter compatible with the legacy ``--gui`` mode.
+
+    Emits one JSON line per batch with ``n_processed`` / ``n_total`` /
+    ``rate`` / ``eta``, throttled to ~4Hz so a downstream GUI process
+    can read progress via stdout. Matches the format used by the legacy
+    ``Predictor._predict_generator_gui`` exactly.
+    """
+    import json
+    from time import time as _now
+
+    state = {"start": _now(), "last": 0.0, "processed_at_last": 0}
+
+    def cb(processed: int, total: int) -> None:
+        now = _now()
+        is_last = total > 0 and processed >= total
+        if not is_last and (now - state["last"]) < 0.25:
+            return
+        elapsed = now - state["start"]
+        rate = processed / elapsed if elapsed > 0 else 0.0
+        remaining = max(total - processed, 0) if total > 0 else 0
+        eta = remaining / rate if rate > 0 else 0.0
+        print(
+            json.dumps(
+                {
+                    "n_processed": processed,
+                    "n_total": total if total > 0 else None,
+                    "rate": round(rate, 1),
+                    "eta": round(eta, 1),
+                }
+            ),
+            flush=True,
+        )
+        state["last"] = now
+
+    return cb
 
 
 def _run_stream_to_file(
@@ -1322,6 +1412,7 @@ def _run_stream_to_file(
         path=str(stream_to_file),
         skeleton=skeleton,
         write_interval=write_interval,
+        progress_callback=_gui_progress_callback() if kwargs.get("gui") else None,
     )
 
 

--- a/sleap_nn/inference/factory.py
+++ b/sleap_nn/inference/factory.py
@@ -327,6 +327,189 @@ def from_model_paths(
     return NewPredictor(**kwargs)
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# from_export_dir — build a Predictor from an exported ONNX/TRT directory
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def from_export_dir(
+    export_dir: Union[str, Path],
+    *,
+    runtime: str = "auto",
+    device: str = "auto",
+    return_confmaps: bool = False,
+    filter_config: Optional[FilterConfig] = None,
+    paf_workers: int = 0,
+    tracker_config: Optional[TrackerConfig] = None,
+):
+    """Build a new :class:`Predictor` from an exported model directory.
+
+    The directory is expected to contain ``export_metadata.json`` plus
+    one of ``model.onnx`` / ``model.trt``. Pulls model-type, output stride,
+    input scale, and peak-threshold from the metadata; constructs the
+    appropriate :class:`InferenceLayer` subclass on the
+    ``does_baked_postproc=True`` path so peak finding stays inside the
+    exported graph.
+
+    Args:
+        export_dir: Directory written by ``sleap_nn export`` (or any
+            equivalent exporter that emits the same metadata schema).
+        runtime: ``"auto"`` (prefer TRT when present, else ONNX),
+            ``"onnx"``, or ``"tensorrt"``.
+        device: Device string forwarded to the backend.
+        return_confmaps: Echo confmaps onto the resulting ``Outputs``
+            when the wrapper exports a ``confmaps`` output. Layers gate
+            on this flag.
+        filter_config: Optional :class:`FilterConfig` (post-inference).
+        paf_workers: Forwarded to :class:`Predictor`. Only meaningful
+            for bottom-up exports — irrelevant for single-instance.
+        tracker_config: Optional :class:`TrackerConfig` (post-inference
+            tracker).
+
+    Returns:
+        A configured :class:`sleap_nn.inference.predictor.Predictor`.
+
+    Raises:
+        FileNotFoundError: ``export_metadata.json`` or the model file
+            isn't present at the expected path.
+        NotImplementedError: ``model_type`` is recognized but its export
+            adapter hasn't landed yet. As of PR 18 only
+            ``"single_instance"`` is supported; ``centroid`` /
+            ``centered_instance`` / top-down combined / bottom-up /
+            multiclass land in follow-up PRs.
+        ValueError: ``runtime`` isn't recognized.
+
+    Notes:
+        Skeleton hydration is *not* done here — call
+        :func:`sleap_nn.inference.utils.get_skeleton_from_config` on the
+        export's ``training_config.yaml`` separately if you need a
+        skeleton for ``Predictor.predict(make_labels=True, ...)``.
+    """
+    from sleap_nn.export.metadata import ExportMetadata
+    from sleap_nn.inference.predictor import Predictor as NewPredictor
+
+    export_dir = Path(export_dir)
+
+    metadata_path = export_dir / "export_metadata.json"
+    if not metadata_path.exists():
+        raise FileNotFoundError(
+            f"export_metadata.json not found at {metadata_path}. "
+            f"Pass a directory written by `sleap_nn export`."
+        )
+    metadata = ExportMetadata.load(metadata_path)
+
+    runtime, model_path = _resolve_export_runtime(export_dir, runtime)
+    backend = _build_export_backend(runtime, model_path, device)
+
+    layer = _select_export_layer(
+        metadata=metadata,
+        backend=backend,
+        return_confmaps=return_confmaps,
+    )
+
+    kwargs: dict = {"layer": layer, "paf_workers": paf_workers}
+    if filter_config is not None:
+        kwargs["filter_config"] = filter_config
+    if tracker_config is not None:
+        kwargs["tracker_config"] = tracker_config
+    return NewPredictor(**kwargs)
+
+
+def _resolve_export_runtime(export_dir: Path, runtime: str) -> tuple[str, Path]:
+    """Pick the runtime + model file for an export directory.
+
+    Returns ``(runtime, model_path)`` where ``runtime`` is one of
+    ``"onnx"`` or ``"tensorrt"``.
+    """
+    onnx_path = export_dir / "model.onnx"
+    trt_path = export_dir / "model.trt"
+
+    if runtime == "auto":
+        if trt_path.exists():
+            return "tensorrt", trt_path
+        if onnx_path.exists():
+            return "onnx", onnx_path
+        raise FileNotFoundError(
+            f"No model file found in {export_dir}. "
+            f"Expected model.onnx or model.trt."
+        )
+    if runtime == "onnx":
+        if not onnx_path.exists():
+            raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
+        return "onnx", onnx_path
+    if runtime == "tensorrt":
+        if not trt_path.exists():
+            raise FileNotFoundError(f"TensorRT model not found: {trt_path}")
+        return "tensorrt", trt_path
+    raise ValueError(
+        f"Unknown runtime: {runtime!r}. Expected 'auto', 'onnx', or 'tensorrt'."
+    )
+
+
+def _build_export_backend(runtime: str, model_path: Path, device: str):
+    """Construct the right ``ModelBackend`` for an exported model file."""
+    if runtime == "onnx":
+        from sleap_nn.inference.layers.backends import ONNXBackend
+
+        return ONNXBackend(model_path=str(model_path), device=device)
+    if runtime == "tensorrt":
+        from sleap_nn.inference.layers.backends import TensorRTBackend
+
+        return TensorRTBackend(engine_path=str(model_path), device=device)
+    raise ValueError(f"Unknown runtime: {runtime!r}")
+
+
+def _select_export_layer(
+    metadata: Any,
+    backend: Any,
+    return_confmaps: bool,
+):
+    """Dispatch on ``metadata.model_type`` → build the right export adapter.
+
+    Export adapters live in :mod:`sleap_nn.inference.layers.exported` —
+    thin translators that consume the wrapper's already-postprocessed
+    output (peaks already in original-image space) and produce a
+    structured :class:`Outputs`. They intentionally bypass the standard
+    layer's coord ladder so transforms aren't double-applied.
+
+    Supported as of PR 19: ``single_instance``, ``centroid``,
+    ``centered_instance``, ``topdown``. Bottom-up + multiclass land in
+    follow-up PRs.
+    """
+    from sleap_nn.inference.layers.exported import (
+        ExportedCenteredInstanceLayer,
+        ExportedCentroidLayer,
+        ExportedSingleInstanceLayer,
+        ExportedTopDownLayer,
+    )
+
+    model_type = metadata.model_type
+
+    if model_type == "single_instance":
+        return ExportedSingleInstanceLayer(
+            backend=backend, return_confmaps=return_confmaps
+        )
+    if model_type == "centered_instance":
+        return ExportedCenteredInstanceLayer(
+            backend=backend, return_confmaps=return_confmaps
+        )
+    if model_type == "centroid":
+        return ExportedCentroidLayer(backend=backend)
+    if model_type == "topdown":
+        return ExportedTopDownLayer(backend=backend)
+
+    if model_type in {"bottomup", "multi_class_bottomup", "multi_class_topdown"}:
+        raise NotImplementedError(
+            f"from_export_dir: model_type={model_type!r} adapter not yet "
+            f"implemented. Currently supported: 'single_instance', "
+            f"'centroid', 'centered_instance', 'topdown'. Use the "
+            f"legacy `sleap_nn.export.inference.predict(...)` for other "
+            f"model types until follow-up PRs land."
+        )
+
+    raise ValueError(f"Unrecognized model_type {model_type!r} in export_metadata.json.")
+
+
 def _select_layer(legacy_predictor: Any, model_types: List[str], device: str):
     """Dispatch on detected model types → build the new layer composition."""
     if "single_instance" in model_types:

--- a/sleap_nn/inference/layers/exported.py
+++ b/sleap_nn/inference/layers/exported.py
@@ -1,0 +1,217 @@
+"""Export-adapter layers — thin translators around exported ONNX/TRT models.
+
+The exported wrappers in :mod:`sleap_nn.export.wrappers` bake every
+preprocessing + postprocessing step into the ONNX graph, including
+``input_scale`` resize, ``output_stride`` rescaling, peak finding,
+and (top-down) crop extraction. By the time output keys arrive, peaks
+are already in **original-image pixel space** with the right shapes.
+
+The standard :class:`InferenceLayer` subclasses in
+``sleap_nn/inference/layers/`` were designed for ``.ckpt`` checkpoints,
+where the layer's own ``preprocess`` does the input-scale resize and
+``postprocess`` runs the coord ladder (``undo_stride`` /
+``undo_input_scale``). Reusing them for export-loaded backends would
+double-apply both transforms.
+
+This module ships dedicated adapter layers for the export path, one
+per exported model type. Each one:
+
+* skips ``input_scale`` resize (the wrapper did it)
+* feeds raw uint8 ``(B, C, H, W)`` tensors to the backend
+* skips peak finding (already baked)
+* skips the coord ladder (already in original-image space)
+* translates the wrapper's output dict into a structured :class:`Outputs`
+
+The classes intentionally don't inherit from :class:`InferenceLayer`
+— they're shaped like layers (``predict(image, **kwargs) -> Outputs``)
+but the layered preprocess/forward/postprocess pipeline doesn't apply.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import attrs
+import numpy as np
+import torch
+
+from sleap_nn.inference.layers.base import InferenceLayer
+from sleap_nn.inference.outputs import Outputs
+
+
+def _to_4d_uint8_tensor(image: Any) -> torch.Tensor:
+    """Coerce an image input to ``(B, C, H, W)`` uint8 (channel-first).
+
+    Mirrors :meth:`InferenceLayer._to_4d_float_tensor` shape-wise, but
+    keeps the dtype as the runtime expects (``ONNXBackend`` casts to
+    its declared input dtype, typically ``uint8``, before invoking the
+    session).
+    """
+    return InferenceLayer._to_4d_float_tensor(image)
+
+
+@attrs.define
+class ExportedSingleInstanceLayer:
+    """Adapter for an ONNX/TRT-exported single-instance model.
+
+    The wrapper output schema is:
+
+    * ``peaks``: ``(B, N, 2)`` in original-image (x, y) space
+    * ``peak_vals``: ``(B, N)``
+    * ``confmaps`` (optional): ``(B, N, H, W)``
+
+    ``Outputs.pred_keypoints`` uses ``(B, I, N, 2)`` so the adapter
+    inserts a singleton instance dim.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+        return_confmaps: When ``True`` and the wrapper exports a
+            ``confmaps`` output, echo it onto :attr:`Outputs.pred_confmaps`.
+    """
+
+    backend: Any
+    return_confmaps: bool = False
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        peaks = raw["peaks"]  # (B, N, 2)
+        vals = raw["peak_vals"]  # (B, N)
+        # Add singleton instance dim per the Outputs convention.
+        out = Outputs(
+            pred_keypoints=peaks.unsqueeze(1),  # (B, 1, N, 2)
+            pred_peak_values=vals.unsqueeze(1),  # (B, 1, N)
+        )
+        if self.return_confmaps and "confmaps" in raw:
+            out = attrs.evolve(out, pred_confmaps=raw["confmaps"])
+        return out
+
+
+@attrs.define
+class ExportedCenteredInstanceLayer:
+    """Adapter for an ONNX/TRT-exported centered-instance model.
+
+    Standalone centered-instance is invoked on pre-cropped images. The
+    wrapper outputs the same shape as single-instance:
+
+    * ``peaks``: ``(B_crops, N, 2)`` in crop (x, y) space
+    * ``peak_vals``: ``(B_crops, N)``
+
+    ``Outputs.pred_keypoints`` of shape ``(B_crops, 1, N, 2)``.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+        return_confmaps: Echo ``confmaps`` onto
+            :attr:`Outputs.pred_confmaps` when present.
+    """
+
+    backend: Any
+    return_confmaps: bool = False
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        peaks = raw["peaks"]  # (B_crops, N, 2)
+        vals = raw["peak_vals"]
+        out = Outputs(
+            pred_keypoints=peaks.unsqueeze(1),  # (B_crops, 1, N, 2)
+            pred_peak_values=vals.unsqueeze(1),  # (B_crops, 1, N)
+        )
+        if self.return_confmaps and "confmaps" in raw:
+            out = attrs.evolve(out, pred_confmaps=raw["confmaps"])
+        return out
+
+
+@attrs.define
+class ExportedCentroidLayer:
+    """Adapter for an ONNX/TRT-exported centroid model.
+
+    The wrapper output schema:
+
+    * ``centroids``: ``(B, I, 2)`` in original-image (x, y) space.
+      Invalid slots are zero-filled and flagged in ``instance_valid``.
+    * ``centroid_vals``: ``(B, I)``
+    * ``instance_valid``: ``(B, I)`` bool
+
+    Translates to ``Outputs.pred_centroids`` / ``pred_centroid_values``.
+    Invalid slots are turned into ``NaN`` per the ``Outputs`` convention.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+    """
+
+    backend: Any
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        centroids = raw["centroids"].clone()  # (B, I, 2)
+        centroid_vals = raw["centroid_vals"].clone()  # (B, I)
+        valid = raw["instance_valid"].bool()  # (B, I)
+
+        # Replace invalid zero-padded slots with NaN per Outputs convention.
+        invalid = ~valid
+        centroids[invalid] = float("nan")
+        centroid_vals[invalid] = float("nan")
+
+        return Outputs(
+            pred_centroids=centroids,
+            pred_centroid_values=centroid_vals,
+            instance_valid=valid,
+        )
+
+
+@attrs.define
+class ExportedTopDownLayer:
+    """Adapter for an ONNX/TRT-exported combined top-down model.
+
+    The export bakes both centroid + centered-instance stages plus the
+    crop extraction step into a single ONNX graph. Wrapper output:
+
+    * ``centroids``: ``(B, I, 2)`` in original-image (x, y) space
+    * ``centroid_vals``: ``(B, I)``
+    * ``peaks``: ``(B, I, N, 2)`` in original-image (x, y) space
+      (crop offset already added back inside the graph)
+    * ``peak_vals``: ``(B, I, N)``
+    * ``instance_valid``: ``(B, I)`` bool
+
+    Invalid slots are zero-filled by the wrapper and flagged in
+    ``instance_valid``. The adapter NaN-pads invalid slots per the
+    ``Outputs`` convention.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+    """
+
+    backend: Any
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        centroids = raw["centroids"].clone()
+        centroid_vals = raw["centroid_vals"].clone()
+        peaks = raw["peaks"].clone()
+        peak_vals = raw["peak_vals"].clone()
+        valid = raw["instance_valid"].bool()
+
+        invalid = ~valid
+        centroids[invalid] = float("nan")
+        centroid_vals[invalid] = float("nan")
+        peaks[invalid] = float("nan")
+        peak_vals[invalid] = float("nan")
+
+        return Outputs(
+            pred_keypoints=peaks,
+            pred_peak_values=peak_vals,
+            pred_centroids=centroids,
+            pred_centroid_values=centroid_vals,
+            instance_valid=valid,
+        )

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -22,7 +22,7 @@ This commit ships the synchronous :meth:`predict`. Streaming +
 
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Callable, Iterator, List, Optional, Union
 
 import attrs
 import numpy as np
@@ -32,6 +32,14 @@ from sleap_nn.inference.filters import FilterConfig, FilterPipeline
 from sleap_nn.inference.outputs import Outputs
 from sleap_nn.inference.providers import Provider
 from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+
+def _safe_len(provider: Any) -> int:
+    """Return ``len(provider)`` or ``-1`` if the provider doesn't expose ``__len__``."""
+    try:
+        return len(provider)
+    except TypeError:
+        return -1
 
 
 @attrs.define
@@ -92,6 +100,48 @@ class Predictor:
 
         return from_model_paths(model_paths, **kwargs)
 
+    @classmethod
+    def from_export_dir(cls, export_dir: str, **kwargs) -> "Predictor":
+        """Build a :class:`Predictor` from an exported ``.onnx`` / ``.trt`` directory.
+
+        See :func:`sleap_nn.inference.factory.from_export_dir` for the
+        full kwarg surface.
+        """
+        from sleap_nn.inference.factory import from_export_dir
+
+        return from_export_dir(export_dir, **kwargs)
+
+    @staticmethod
+    def retrack(
+        labels: Any,
+        tracker_config: TrackerConfig,
+        clean_empty_frames: bool = False,
+    ) -> Any:
+        """Retrack an existing ``sio.Labels`` without running inference.
+
+        Pure tracking — useful when you already have predicted instances
+        in a ``.slp`` and just want to (re)apply a tracker. Mirrors the
+        legacy ``run_inference(model_paths=None, tracking=True, ...)``
+        path. The tracker runs once over the full LabeledFrame list;
+        post-tracking cleanup (cull / connect-single-breaks) is applied
+        per ``tracker_config``.
+
+        Args:
+            labels: A ``sio.Labels`` whose ``predicted_instances`` are
+                tracked in-place semantics — this returns a new
+                ``Labels`` with tracked instances.
+            tracker_config: :class:`TrackerConfig` to drive the tracker.
+            clean_empty_frames: When ``True``, drop empty frames from
+                the result (matches ``--no_empty_frames``).
+
+        Returns:
+            New ``sio.Labels`` with tracks attached.
+        """
+        out = apply_tracking(labels, tracker_config)
+        if clean_empty_frames:
+            out.clean(frames=True, skeletons=False)
+        return out
+
     # ──────────────────────────────────────────────────────────────────
     # Synchronous: returns Outputs list or sio.Labels
     # ──────────────────────────────────────────────────────────────────
@@ -103,6 +153,7 @@ class Predictor:
         skeleton: Optional[Any] = None,
         videos: Optional[List[Any]] = None,
         clean_empty_frames: bool = False,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> Union[List[Outputs], Any]:
         """Run inference on every batch from ``provider``.
 
@@ -118,12 +169,16 @@ class Predictor:
                 drop ``LabeledFrame``s with no instances from the
                 returned ``sio.Labels``. Mirrors the legacy
                 ``no_empty_frames`` flag.
+            progress_callback: Optional ``(processed_batches, total_batches)``
+                callback invoked after each batch. ``total_batches`` is
+                ``len(provider)`` if the provider implements ``__len__``,
+                else ``-1``.
 
         Returns:
             ``List[Outputs]`` (raw mode) or ``sio.Labels`` (with-labels
             mode).
         """
-        outputs_list = list(self._batch_iter(provider))
+        outputs_list = list(self._batch_iter(provider, progress_callback))
         if not make_labels:
             if self.tracker_config is not None:
                 raise ValueError(
@@ -144,7 +199,11 @@ class Predictor:
     # Streaming: yields one Outputs at a time
     # ──────────────────────────────────────────────────────────────────
 
-    def predict_streaming(self, provider: Provider) -> Iterator[Outputs]:
+    def predict_streaming(
+        self,
+        provider: Provider,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> Iterator[Outputs]:
         """Yield one ``Outputs`` per provider batch.
 
         Caller-controlled memory: the predictor never materializes the
@@ -162,9 +221,9 @@ class Predictor:
                 "full LabeledFrame list; use predict() instead."
             )
         if self.paf_workers > 0 and self._can_pipeline():
-            yield from self._predict_streaming_pipelined(provider)
+            yield from self._predict_streaming_pipelined(provider, progress_callback)
             return
-        yield from self._batch_iter(provider)
+        yield from self._batch_iter(provider, progress_callback)
 
     # ──────────────────────────────────────────────────────────────────
     # Disk-streaming: write to a .slp incrementally
@@ -177,6 +236,7 @@ class Predictor:
         skeleton: Any,
         videos: Optional[List[Any]] = None,
         write_interval: int = 500,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> str:
         """Run inference and stream results to a ``.slp`` file.
 
@@ -194,6 +254,9 @@ class Predictor:
                 ``video_indices`` for the saved labels.
             write_interval: Number of LabeledFrames to buffer before
                 a disk flush.
+            progress_callback: Optional ``(processed_batches, total_batches)``
+                callback invoked after each batch (forwarded to
+                :meth:`predict_streaming`).
 
         Returns:
             The (resolved) destination path string.
@@ -206,7 +269,7 @@ class Predictor:
             videos=videos,
             write_interval=write_interval,
         ) as writer:
-            for outputs in self.predict_streaming(provider):
+            for outputs in self.predict_streaming(provider, progress_callback):
                 writer.write(outputs)
         return path
 
@@ -214,10 +277,15 @@ class Predictor:
     # Internals
     # ──────────────────────────────────────────────────────────────────
 
-    def _batch_iter(self, provider: Provider) -> Iterator[Outputs]:
+    def _batch_iter(
+        self,
+        provider: Provider,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> Iterator[Outputs]:
         """Run ``layer.predict`` + ``FilterPipeline`` per provider batch."""
         pipeline = self.filter_pipeline
-        for batch in provider:
+        total = _safe_len(provider)
+        for i, batch in enumerate(provider):
             kwargs: dict = {}
             if batch.instances is not None:
                 kwargs["instances"] = (
@@ -229,6 +297,8 @@ class Predictor:
             outputs = pipeline(outputs)
             outputs = self._stamp_metadata(outputs, batch)
             yield outputs
+            if progress_callback is not None:
+                progress_callback(i + 1, total)
 
     # ──────────────────────────────────────────────────────────────────
     # Pipelined bottom-up: GPU stage in main proc, CPU grouping in pool
@@ -241,7 +311,11 @@ class Predictor:
 
         return isinstance(self.layer, BottomUpLayer)
 
-    def _predict_streaming_pipelined(self, provider: Provider) -> Iterator[Outputs]:
+    def _predict_streaming_pipelined(
+        self,
+        provider: Provider,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> Iterator[Outputs]:
         """Stream ``Outputs`` with the CPU grouping stage in a worker pool.
 
         The GPU stage (:meth:`BottomUpLayer._score_pafs_on_gpu`) runs
@@ -256,6 +330,7 @@ class Predictor:
         pipeline = self.filter_pipeline
         layer = self.layer
         params = layer.grouping_params()
+        total = _safe_len(provider)
 
         # Cache per-batch metadata keyed by submission ordinal so we can
         # restamp it onto the worker-produced Outputs.
@@ -269,10 +344,14 @@ class Predictor:
                 scored = layer._score_pafs_on_gpu(raw, info)
                 pool.submit(ordinal, scored)
                 meta[ordinal] = batch
+            completed = 0
             for ordinal, outputs in pool.iter_completed():
                 outputs = pipeline(outputs)
                 outputs = self._stamp_metadata(outputs, meta.pop(ordinal))
                 yield outputs
+                completed += 1
+                if progress_callback is not None:
+                    progress_callback(completed, total)
 
     @staticmethod
     def _stamp_metadata(outputs: Outputs, batch: Any) -> Outputs:

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -288,7 +288,36 @@ def run_inference(
         Returns `sio.Labels` object if `make_labels` is True. Else this function returns
             a list of Dictionaries with the predictions.
 
+    .. deprecated::
+        This function is deprecated and slated for removal in a future
+        release. Prefer the new flow:
+
+        * **Inference on a checkpoint**::
+
+              from sleap_nn.inference.predictor import Predictor
+              predictor = Predictor.from_model_paths([model_dir])
+              labels = predictor.predict(provider, make_labels=True, ...)
+
+        * **Streaming to disk**: ``predictor.predict_to_file(...)``
+        * **Pure-tracking retrack**: ``Predictor.retrack(labels, tracker_config)``
+
+        ``sleap-nn infer`` / ``sleap-nn track`` already route through the
+        new flow internally; this function is the only remaining
+        Python-level legacy entry point.
     """
+    import warnings
+
+    warnings.warn(
+        "sleap_nn.predict.run_inference() is deprecated and will be removed "
+        "in a future release. Use sleap_nn.inference.predictor.Predictor — "
+        "either Predictor.from_model_paths(...).predict(...) for checkpoint "
+        "inference, .predict_to_file(...) for disk-streaming, or "
+        "Predictor.retrack(labels, tracker_config) for pure-tracking. "
+        "See the function's deprecation note for full migration examples.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     preprocess_config = {  # if not given, then use from training config
         "ensure_rgb": ensure_rgb,
         "ensure_grayscale": ensure_grayscale,

--- a/tests/cli/test_aliases.py
+++ b/tests/cli/test_aliases.py
@@ -17,17 +17,36 @@ from click.testing import CliRunner
 from sleap_nn.cli import cli
 
 
-def test_track_emits_deprecation_warning():
-    """``sleap-nn track`` emits a DeprecationWarning.
+def _mock_new_flow():
+    """Patches that make the new in-memory flow a no-op for fast CLI tests."""
+    from unittest.mock import MagicMock
 
-    Adds ``--gui`` to force the legacy ``run_inference`` path (PR 13
-    routes simple cases to the new factory by default; PR 14 routes
-    ``--tracking`` through the new factory too — ``--gui`` is the
-    remaining legacy-only flag).
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    return [
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ]
+
+
+def test_track_emits_deprecation_warning():
+    """``sleap-nn track`` emits a DeprecationWarning before delegating.
+
+    The warning is emitted in the ``track`` command body before any
+    impl runs, so the routing destination doesn't matter — we just
+    need the impl to not crash.
     """
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        _mock_new_flow()[0] as mock_factory,
+        _mock_new_flow()[1],
+        _mock_new_flow()[2],
+        _mock_new_flow()[3],
+    ):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = runner.invoke(
@@ -38,11 +57,9 @@ def test_track_emits_deprecation_warning():
                     "/fake/path.mp4",
                     "--model_paths",
                     "/fake/model",
-                    "--gui",
                 ],
             )
         assert result.exit_code == 0, result.output
-        assert mock_run.called
         deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert any(
             "sleap-nn track" in str(d.message) and "infer" in str(d.message)
@@ -50,13 +67,12 @@ def test_track_emits_deprecation_warning():
         ), [str(d.message) for d in deprecations]
 
 
-def test_track_and_infer_reach_same_run_inference_kwargs():
-    """``track`` and ``infer`` produce identical kwargs to ``run_inference``.
+def test_track_and_infer_reach_same_factory_kwargs():
+    """``track`` and ``infer`` produce identical kwargs to the new factory.
 
-    Adds ``--gui`` to force the legacy ``run_inference`` path on both
-    sides; PR 13 routes simple cases through the new factory and PR 14
-    routes ``--tracking`` too, so ``--gui`` is the remaining
-    legacy-only flag that lets us assert kwarg equality.
+    PR 16 routes everything through ``Predictor.from_model_paths``, so
+    we assert kwarg equality on that call instead of the legacy
+    ``run_inference``.
     """
     runner = CliRunner()
     args_common = [
@@ -70,24 +86,28 @@ def test_track_and_infer_reach_same_run_inference_kwargs():
         "2",
         "--peak_threshold",
         "0.15",
-        "--gui",
     ]
 
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
-        runner.invoke(cli, ["infer"] + args_common)
-        infer_kwargs = dict(mock_run.call_args[1])
+    def _capture(cmd: str):
+        from unittest.mock import MagicMock
 
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            runner.invoke(cli, ["track"] + args_common)
-        track_kwargs = dict(mock_run.call_args[1])
+        stub_predictor = MagicMock()
+        stub_predictor.predict.return_value = MagicMock()
+        with (
+            patch(
+                "sleap_nn.inference.factory.from_model_paths",
+                return_value=stub_predictor,
+            ) as mock_factory,
+            patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+            patch("sleap_nn.inference.providers.VideoProvider"),
+            patch("sleap_io.load_video"),
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                runner.invoke(cli, [cmd] + args_common)
+            return dict(mock_factory.call_args[1])
 
-    # Both should reach the same kwargs (modulo the new-flag stripping
-    # already done by both paths).
-    assert infer_kwargs == track_kwargs
+    assert _capture("infer") == _capture("track")
 
 
 def test_export_predict_top_level_still_works():

--- a/tests/cli/test_flag_validation.py
+++ b/tests/cli/test_flag_validation.py
@@ -89,13 +89,22 @@ def test_write_interval_without_stream_to_file_errors():
 def test_cpu_workers_alias_emits_deprecation_warning():
     """``--cpu-workers`` warns and is wired through (mapped to paf_workers).
 
-    Forces the legacy path with ``--gui`` (PR 13/14 route simple +
-    tracking cases through the new factory which doesn't trip this
-    warning).
+    The deprecation fires in ``_run_inference_impl`` regardless of which
+    backend serves the request — we just need the impl to not crash.
     """
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = runner.invoke(
@@ -106,7 +115,6 @@ def test_cpu_workers_alias_emits_deprecation_warning():
                     "/fake/path.mp4",
                     "--model_paths",
                     "/fake/model",
-                    "--gui",
                     "--cpu-workers",
                     "2",
                 ],
@@ -119,11 +127,25 @@ def test_cpu_workers_alias_emits_deprecation_warning():
         ), [str(d.message) for d in deprecations]
 
 
-def test_paf_workers_positive_emits_no_effect_warning():
-    """``--paf-workers > 0`` succeeds on the legacy path with ``--gui``."""
+def test_paf_workers_positive_does_not_warn_on_new_flow():
+    """``--paf-workers > 0`` works on the new flow without legacy warnings.
+
+    PR 16 routes everything through the new flow; the old "no effect on
+    legacy path" warning is gone.
+    """
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -132,12 +154,12 @@ def test_paf_workers_positive_emits_no_effect_warning():
                 "/fake/path.mp4",
                 "--model_paths",
                 "/fake/model",
-                "--gui",
                 "--paf-workers",
                 "4",
             ],
         )
         assert result.exit_code == 0, result.output
+        assert "paf-workers > 0" not in result.output
 
 
 def test_stream_to_file_invokes_new_predictor_flow(tmp_path):

--- a/tests/cli/test_infer_command.py
+++ b/tests/cli/test_infer_command.py
@@ -39,16 +39,33 @@ def test_infer_command_help_renders():
         assert flag in result.output, f"missing {flag} in `infer --help`"
 
 
+def _stub_new_flow():
+    """Build a (stub_predictor, list_of_patches) for fast CLI-only tests."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    return stub_predictor
+
+
 def test_infer_accepts_legacy_track_flag_surface():
     """Every flag wired into ``track`` is accepted by ``infer`` too.
 
-    Uses ``--gui`` to force the legacy path so we can read the kwargs
-    directly off the ``run_inference`` mock; PR 15 routes
-    ``--tracking`` + ``--filter_*`` through the new factory.
+    Mocks the new factory and asserts the right kwargs propagate through.
     """
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ) as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -71,60 +88,36 @@ def test_infer_accepts_legacy_track_flag_surface():
                 "--tracking",
                 "--candidates_method",
                 "local_queues",
-                "--gui",
             ],
         )
         assert result.exit_code == 0, result.output
-        assert mock_run.called
-        kw = mock_run.call_args[1]
-        assert kw["data_path"] == "/fake/path.mp4"
-        assert kw["model_paths"] == ["/fake/model"]
+        assert mock_factory.called
+        kw = mock_factory.call_args[1]
         assert kw["batch_size"] == 8
         assert kw["max_instances"] == 2
         assert abs(kw["peak_threshold"] - 0.3) < 1e-9
-        assert kw["tracking"] is True
-        assert kw["candidates_method"] == "local_queues"
-
-
-def test_infer_strips_pr10_new_flags_before_run_inference():
-    """The PR-10 new flags must not leak into ``run_inference`` kwargs.
-
-    Forces the legacy path with ``--gui`` so ``run_inference`` is
-    called (PR 13/14 route simple+tracking cases through the new
-    factory; that path has its own kwarg surface and isn't tested here).
-    """
-    runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
-        result = runner.invoke(
-            cli,
-            [
-                "infer",
-                "--data_path",
-                "/fake/path.mp4",
-                "--model_paths",
-                "/fake/model",
-                "--gui",
-                "--paf-workers",
-                "0",  # zero is allowed (no warning)
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        kw = mock_run.call_args[1]
-        for new_flag in (
-            "paf_workers",
-            "stream_to_file",
-            "write_interval",
-            "cpu_workers",
-        ):
-            assert new_flag not in kw, f"{new_flag} leaked into run_inference"
+        # Tracker config came through with the right knob.
+        assert kw["tracker_config"].candidates_method == "local_queues"
+        # Filter config came through.
+        assert kw["filter_config"].overlapping is True
+        assert kw["filter_config"].overlapping_method == "oks"
 
 
 def test_infer_peak_conf_threshold_alias():
     """``--peak-conf-threshold`` is an alias for ``--peak_threshold``."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ) as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -133,13 +126,12 @@ def test_infer_peak_conf_threshold_alias():
                 "/fake/path.mp4",
                 "--model_paths",
                 "/fake/model",
-                "--gui",  # force legacy path so run_inference is called
                 "--peak-conf-threshold",
                 "0.42",
             ],
         )
         assert result.exit_code == 0, result.output
-        assert abs(mock_run.call_args[1]["peak_threshold"] - 0.42) < 1e-9
+        assert abs(mock_factory.call_args[1]["peak_threshold"] - 0.42) < 1e-9
 
 
 def test_infer_simple_case_uses_new_factory_flow(tmp_path):
@@ -399,15 +391,21 @@ def test_infer_only_suggested_frames_routes_to_new_flow(tmp_path):
         assert provider_kwargs["only_suggested_frames"] is True
 
 
-def test_infer_paf_workers_zero_no_warning():
-    """``--paf-workers 0`` is the default, must not emit a warning.
+def test_infer_gui_emits_json_progress(tmp_path):
+    """``--gui`` wires a JSON-progress callback through to ``predict()``."""
+    from unittest.mock import MagicMock
 
-    Uses ``--gui`` to force the legacy path where the no-effect
-    warning would fire if the flag were misused.
-    """
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference") as mock_run:
-        mock_run.return_value = None
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
         result = runner.invoke(
             cli,
             [
@@ -417,6 +415,152 @@ def test_infer_paf_workers_zero_no_warning():
                 "--model_paths",
                 "/fake/model",
                 "--gui",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        cb = stub_predictor.predict.call_args[1]["progress_callback"]
+        assert cb is not None
+        # The callback should emit a JSON line on stdout (final 100%).
+        import contextlib
+        import io
+        import json
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cb(10, 10)
+        emitted = buf.getvalue().strip()
+        parsed = json.loads(emitted)
+        assert parsed["n_processed"] == 10
+        assert parsed["n_total"] == 10
+
+
+def test_infer_without_gui_no_progress_callback(tmp_path):
+    """No ``--gui`` ⇒ ``predict()`` receives ``progress_callback=None``."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    runner = CliRunner()
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert stub_predictor.predict.call_args[1]["progress_callback"] is None
+
+
+def test_infer_backbone_and_head_ckpt_paths_thread_to_factory(tmp_path):
+    """``--backbone_ckpt_path`` / ``--head_ckpt_path`` reach the factory."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    runner = CliRunner()
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ) as mock_factory,
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--backbone_ckpt_path",
+                "/fake/backbone.ckpt",
+                "--head_ckpt_path",
+                "/fake/head.ckpt",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kw = mock_factory.call_args[1]
+        assert kw["backbone_ckpt_path"] == "/fake/backbone.ckpt"
+        assert kw["head_ckpt_path"] == "/fake/head.ckpt"
+
+
+def test_infer_retrack_only_dispatches_to_predictor_retrack(tmp_path):
+    """``--tracking`` + no ``model_paths`` + .slp data → ``Predictor.retrack``."""
+    from unittest.mock import MagicMock
+
+    runner = CliRunner()
+    fake_labels = MagicMock()
+    fake_labels.videos = []
+    fake_labels.skeletons = []
+    fake_labels.labeled_frames = []
+    tracked = MagicMock()
+    with (
+        patch("sleap_io.load_slp", return_value=fake_labels),
+        patch(
+            "sleap_nn.inference.predictor.Predictor.retrack", return_value=tracked
+        ) as mock_retrack,
+        patch("sleap_nn.predict.run_inference") as mock_legacy,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.slp",
+                "--tracking",
+                "--tracking_window_size",
+                "9",
+                "--output_path",
+                str(tmp_path / "out.slp"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_retrack.called
+        assert not mock_legacy.called
+        # Tracker config carried the right knob.
+        cfg = mock_retrack.call_args[0][1]
+        assert cfg.window_size == 9
+        # The result was saved.
+        tracked.save.assert_called_once()
+
+
+def test_infer_paf_workers_zero_no_warning(tmp_path):
+    """``--paf-workers 0`` is the default, must not emit a warning."""
+    from unittest.mock import MagicMock
+
+    stub_predictor = MagicMock()
+    stub_predictor.predict.return_value = MagicMock()
+    runner = CliRunner()
+    with (
+        patch(
+            "sleap_nn.inference.factory.from_model_paths", return_value=stub_predictor
+        ),
+        patch("sleap_nn.cli._skeleton_from_predictor", return_value=object()),
+        patch("sleap_nn.inference.providers.VideoProvider"),
+        patch("sleap_io.load_video"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
             ],
         )
         assert result.exit_code == 0, result.output

--- a/tests/inference/test_factory_export.py
+++ b/tests/inference/test_factory_export.py
@@ -1,0 +1,508 @@
+"""Tests for ``Predictor.from_export_dir`` (PR 18 — single-instance only).
+
+The full export-dir factory dispatches on ``ExportMetadata.model_type``.
+This file exercises the ``"single_instance"`` path (the case where the
+existing :class:`SingleInstanceLayer` consumes ONNX baked output natively
+via ``does_baked_postproc=True``). Other model types currently raise
+``NotImplementedError`` — those tests live here too, asserting the
+clear-error behavior so the contract doesn't drift before adapters land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+try:
+    import onnxruntime  # noqa: F401
+except ImportError:  # pragma: no cover — gated below
+    onnxruntime = None
+
+pytestmark = pytest.mark.skipif(onnxruntime is None, reason="onnxruntime not installed")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Synthetic export-dir fixture: tiny single-instance ONNX + metadata
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _export_tiny_single_instance(export_dir: Path, n_nodes: int = 2) -> Path:
+    """Export a 1-conv ONNX model that emits ``peaks`` + ``peak_vals``.
+
+    Mirrors the schema produced by ``sleap_nn.export.wrappers`` for a
+    single-instance model: the wrapper bakes peak finding into the
+    graph, so the ONNX session output has ``peaks`` (B, n_nodes, 2)
+    and ``peak_vals`` (B, n_nodes).
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, n_nodes, kernel_size=3, padding=1)
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())
+            B, C, H, W = cms.shape
+            # Argmax over (H, W) → (row, col) per channel, packed as (x, y).
+            flat = cms.view(B, C, -1)
+            idx = flat.argmax(dim=-1)  # (B, C)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            peaks = torch.stack([col, row], dim=-1)  # (B, C, 2) → (x, y)
+            peak_vals = flat.amax(dim=-1)  # (B, C)
+            return peaks, peak_vals
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=["peaks", "peak_vals"],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+def _write_metadata(
+    export_dir: Path,
+    model_type: str = "single_instance",
+    n_nodes: int = 2,
+    output_stride: int = 1,
+    input_scale: float = 1.0,
+    peak_threshold: float = 0.0,
+) -> Path:
+    """Write an ``export_metadata.json`` with the minimum fields the factory reads."""
+    meta = {
+        "sleap_nn_version": "0.0.0",
+        "export_timestamp": "2026-01-01T00:00:00",
+        "export_format": "onnx",
+        "model_type": model_type,
+        "model_name": "test_single_instance",
+        "checkpoint_path": "/tmp/fake.ckpt",
+        "backbone": "unet",
+        "n_nodes": n_nodes,
+        "n_edges": 0,
+        "node_names": [f"n{i}" for i in range(n_nodes)],
+        "edge_inds": [],
+        "input_scale": input_scale,
+        "input_channels": 1,
+        "output_stride": output_stride,
+        "peak_threshold": peak_threshold,
+    }
+    path = export_dir / "export_metadata.json"
+    path.write_text(json.dumps(meta))
+    return path
+
+
+@pytest.fixture
+def single_instance_export(tmp_path):
+    """A complete export dir: model.onnx + export_metadata.json."""
+    export_dir = tmp_path / "single_instance_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(export_dir, model_type="single_instance", n_nodes=2)
+    return export_dir
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Single-instance happy path
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_from_export_dir_single_instance_builds_predictor(single_instance_export):
+    """``from_export_dir`` produces a :class:`Predictor` whose layer is an
+    :class:`ExportedSingleInstanceLayer` wired to an :class:`ONNXBackend`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.backends import ONNXBackend
+    from sleap_nn.inference.layers.exported import ExportedSingleInstanceLayer
+    from sleap_nn.inference.predictor import Predictor
+
+    predictor = from_export_dir(single_instance_export, device="cpu")
+    assert isinstance(predictor, Predictor)
+    assert isinstance(predictor.layer, ExportedSingleInstanceLayer)
+    assert isinstance(predictor.layer.backend, ONNXBackend)
+    assert predictor.layer.backend.does_baked_postproc is True
+
+
+def test_from_export_dir_single_instance_predict_smoke(single_instance_export):
+    """End-to-end: build via ``from_export_dir`` and call ``predict()``
+    on a synthetic ``NumpyProvider`` batch. Output should be one
+    ``Outputs`` per batch with populated ``pred_keypoints``."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(single_instance_export, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    assert len(outputs_list) == 1
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    # One frame, n_nodes=2, (x, y) → shape (1, 1, 2, 2).
+    assert out.pred_keypoints.shape[-1] == 2
+    assert out.pred_keypoints.shape[-2] == 2
+
+
+def test_predictor_classmethod_alias_matches_function(single_instance_export):
+    """``Predictor.from_export_dir`` and ``factory.from_export_dir`` are equivalent."""
+    from sleap_nn.inference.factory import from_export_dir as fn
+    from sleap_nn.inference.predictor import Predictor
+
+    direct = fn(single_instance_export, device="cpu")
+    via_classmethod = Predictor.from_export_dir(single_instance_export, device="cpu")
+
+    assert type(direct.layer) is type(via_classmethod.layer)
+
+
+def test_from_export_dir_single_instance_no_double_coord_ladder(tmp_path):
+    """Export adapter must not re-apply ``output_stride`` / ``input_scale``.
+
+    The wrapper already produces peaks in original-image space; the
+    adapter therefore bypasses the standard layer's coord ladder.
+    With ``output_stride=4`` and ``input_scale=0.5`` in metadata, the
+    wrapper output should pass through unchanged (no peaks * 16 bug).
+    """
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    export_dir = tmp_path / "scaled_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(
+        export_dir,
+        model_type="single_instance",
+        n_nodes=2,
+        output_stride=4,
+        input_scale=0.5,
+    )
+
+    predictor = from_export_dir(export_dir, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    # Whatever the wrapper produced (argmax over 16x16 → values in [0, 15])
+    # must come through unchanged. Specifically NOT re-multiplied by
+    # output_stride/input_scale = 4/0.5 = 8.
+    peaks = out.pred_keypoints
+    assert peaks.max() < 16, (
+        "Export adapter applied coord ladder twice — peaks should stay "
+        f"in original [0, 16) space; got max={peaks.max()}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Error paths
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_from_export_dir_missing_metadata_raises(tmp_path):
+    """No ``export_metadata.json`` ⇒ ``FileNotFoundError`` with a clear message."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / "empty"
+    export_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match="export_metadata.json"):
+        from_export_dir(export_dir, device="cpu")
+
+
+def test_from_export_dir_missing_model_file_raises(tmp_path):
+    """Metadata present but no ``model.onnx`` / ``model.trt`` ⇒ ``FileNotFoundError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / "metadata_only"
+    export_dir.mkdir()
+    _write_metadata(export_dir, model_type="single_instance")
+    with pytest.raises(FileNotFoundError, match="model.onnx or model.trt"):
+        from_export_dir(export_dir, device="cpu")
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "bottomup",
+        "multi_class_bottomup",
+        "multi_class_topdown",
+    ],
+)
+def test_from_export_dir_unsupported_model_type_raises(tmp_path, model_type):
+    """Bottom-up + multiclass model types raise ``NotImplementedError`` (PR 19 scope)."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / f"export_{model_type}"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)  # any ONNX file works
+    _write_metadata(export_dir, model_type=model_type)
+
+    with pytest.raises(NotImplementedError, match=model_type):
+        from_export_dir(export_dir, device="cpu")
+
+
+def test_from_export_dir_unknown_runtime_raises(single_instance_export):
+    """``runtime`` other than auto/onnx/tensorrt ⇒ ``ValueError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    with pytest.raises(ValueError, match="Unknown runtime"):
+        from_export_dir(single_instance_export, runtime="foo", device="cpu")
+
+
+def test_from_export_dir_explicit_onnx_runtime(single_instance_export):
+    """``runtime='onnx'`` works when the .onnx file exists."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    predictor = from_export_dir(single_instance_export, runtime="onnx", device="cpu")
+    assert predictor.layer is not None
+
+
+def test_from_export_dir_tensorrt_missing_engine_raises(single_instance_export):
+    """``runtime='tensorrt'`` on an ONNX-only dir ⇒ ``FileNotFoundError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    with pytest.raises(FileNotFoundError, match="model.trt"):
+        from_export_dir(single_instance_export, runtime="tensorrt", device="cpu")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Centroid + centered-instance + topdown synthetic exports (PR 19)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _export_tiny_centroid(
+    export_dir: Path, max_instances: int = 4, n_nodes: int = 2
+) -> Path:
+    """Export a 1-conv ONNX that emits centroid wrapper output schema.
+
+    Output: ``centroids`` (B, I, 2), ``centroid_vals`` (B, I), ``instance_valid`` (B, I).
+    The model picks the top-k peaks per sample over the confmap.
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, kernel_size=3, padding=1)
+            self.max_instances = max_instances
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())  # (B, 1, H, W)
+            B, _C, H, W = cms.shape
+            flat = cms.view(B, -1)
+            vals, idx = flat.topk(self.max_instances, dim=-1)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            centroids = torch.stack([col, row], dim=-1)  # (B, I, 2)
+            centroid_vals = vals  # (B, I)
+            instance_valid = vals > 0.0  # (B, I) bool
+            return centroids, centroid_vals, instance_valid
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=["centroids", "centroid_vals", "instance_valid"],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+def _export_tiny_topdown(
+    export_dir: Path, max_instances: int = 3, n_nodes: int = 2
+) -> Path:
+    """Export an ONNX that emits the combined top-down wrapper output schema.
+
+    Outputs: ``centroids`` (B, I, 2), ``centroid_vals`` (B, I),
+    ``peaks`` (B, I, N, 2), ``peak_vals`` (B, I, N), ``instance_valid`` (B, I).
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, kernel_size=3, padding=1)
+            self.max_instances = max_instances
+            self.n_nodes = n_nodes
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())
+            B, _C, H, W = cms.shape
+            flat = cms.view(B, -1)
+            vals, idx = flat.topk(self.max_instances, dim=-1)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            centroids = torch.stack([col, row], dim=-1)  # (B, I, 2)
+            instance_valid = vals > 0.0
+            # Synthesize per-instance peaks: each node placed near the centroid.
+            peaks = centroids.unsqueeze(2).expand(-1, -1, self.n_nodes, -1).clone()
+            peak_vals = vals.unsqueeze(-1).expand(-1, -1, self.n_nodes).clone()
+            return centroids, vals, peaks, peak_vals, instance_valid
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=[
+            "centroids",
+            "centroid_vals",
+            "peaks",
+            "peak_vals",
+            "instance_valid",
+        ],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+@pytest.fixture
+def centroid_export(tmp_path):
+    """Export dir for a centroid model: model.onnx + metadata."""
+    export_dir = tmp_path / "centroid_export"
+    export_dir.mkdir()
+    _export_tiny_centroid(export_dir, max_instances=4, n_nodes=2)
+    _write_metadata(export_dir, model_type="centroid", n_nodes=2)
+    return export_dir
+
+
+@pytest.fixture
+def centered_instance_export(tmp_path):
+    """Export dir for a centered-instance model: model.onnx + metadata.
+
+    Reuses the single-instance ONNX schema since the wrapper output
+    is identical (``peaks`` + ``peak_vals``); only ``model_type`` in
+    metadata differs.
+    """
+    export_dir = tmp_path / "centered_instance_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(export_dir, model_type="centered_instance", n_nodes=2)
+    return export_dir
+
+
+@pytest.fixture
+def topdown_export(tmp_path):
+    """Export dir for a combined top-down model: model.onnx + metadata."""
+    export_dir = tmp_path / "topdown_export"
+    export_dir.mkdir()
+    _export_tiny_topdown(export_dir, max_instances=3, n_nodes=2)
+    _write_metadata(export_dir, model_type="topdown", n_nodes=2)
+    return export_dir
+
+
+def test_from_export_dir_centroid_builds_predictor(centroid_export):
+    """Centroid export → :class:`ExportedCentroidLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedCentroidLayer
+
+    predictor = from_export_dir(centroid_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedCentroidLayer)
+
+
+def test_from_export_dir_centroid_predict_smoke(centroid_export):
+    """Centroid adapter populates ``pred_centroids`` + ``pred_centroid_values``."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(centroid_export, device="cpu")
+    images = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_centroids is not None
+    assert out.pred_centroid_values is not None
+    assert out.pred_centroids.shape == (1, 4, 2)  # max_instances=4
+    assert out.pred_centroid_values.shape == (1, 4)
+    # No keypoints emitted by centroid-only adapter (centroids are the prediction).
+    assert out.pred_keypoints is None
+
+
+def test_from_export_dir_centered_instance_builds_predictor(centered_instance_export):
+    """Centered-instance export → :class:`ExportedCenteredInstanceLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedCenteredInstanceLayer
+
+    predictor = from_export_dir(centered_instance_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedCenteredInstanceLayer)
+
+
+def test_from_export_dir_centered_instance_predict_smoke(centered_instance_export):
+    """Centered-instance adapter populates ``pred_keypoints`` per crop."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(centered_instance_export, device="cpu")
+    crops = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=crops, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    # (B_crops, 1 instance per crop, n_nodes, 2) → (1, 1, 2, 2).
+    assert out.pred_keypoints.shape == (1, 1, 2, 2)
+
+
+def test_from_export_dir_topdown_builds_predictor(topdown_export):
+    """Top-down combined export → :class:`ExportedTopDownLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedTopDownLayer
+
+    predictor = from_export_dir(topdown_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedTopDownLayer)
+
+
+def test_from_export_dir_topdown_predict_smoke(topdown_export):
+    """Top-down adapter populates centroids + keypoints + instance_valid."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(topdown_export, device="cpu")
+    images = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    assert out.pred_centroids is not None
+    assert out.pred_centroid_values is not None
+    assert out.pred_peak_values is not None
+    assert out.instance_valid is not None
+    # max_instances=3, n_nodes=2 → keypoints (1, 3, 2, 2), centroids (1, 3, 2).
+    assert out.pred_keypoints.shape == (1, 3, 2, 2)
+    assert out.pred_centroids.shape == (1, 3, 2)
+
+
+def test_centroid_adapter_nan_pads_invalid_slots(centroid_export):
+    """Invalid centroid slots (zero-confidence) are NaN'd per Outputs convention."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    # All-zero image → conv outputs ~0 confmap, all topk values <= 0 → all invalid.
+    predictor = from_export_dir(centroid_export, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    out = predictor.predict(provider)[0]
+    # Some slots may be invalid. Wherever instance_valid is False, the
+    # corresponding centroid + value must be NaN.
+    valid = out.instance_valid[0]
+    invalid_mask = ~valid
+    if invalid_mask.any():
+        invalid_centroids = out.pred_centroids[0][invalid_mask]
+        invalid_vals = out.pred_centroid_values[0][invalid_mask]
+        assert torch.isnan(invalid_centroids).all()
+        assert torch.isnan(invalid_vals).all()

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -194,7 +194,11 @@ def test_predictor_predict_applies_tracker_after_to_labels(
 
     # Patch the class-level methods so ``predict()`` reaches the
     # post-_to_labels tracking hook without needing a real model.
-    monkeypatch.setattr(Predictor, "_batch_iter", lambda self, provider: iter([]))
+    monkeypatch.setattr(
+        Predictor,
+        "_batch_iter",
+        lambda self, provider, progress_callback=None: iter([]),
+    )
     monkeypatch.setattr(
         Predictor,
         "_to_labels",
@@ -232,7 +236,11 @@ def test_predictor_predict_clean_empty_frames_drops_empty(skeleton, video, monke
         def __iter__(self):
             return iter([])
 
-    monkeypatch.setattr(Predictor, "_batch_iter", lambda self, provider: iter([]))
+    monkeypatch.setattr(
+        Predictor,
+        "_batch_iter",
+        lambda self, provider, progress_callback=None: iter([]),
+    )
     monkeypatch.setattr(
         Predictor,
         "_to_labels",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -817,6 +817,69 @@ def test_track_command(
     assert len(labels) == 100
 
 
+def test_track_command_retrack_only_uses_new_flow(
+    centered_instance_video,
+    minimal_instance_centered_instance_ckpt,
+    minimal_instance_centroid_ckpt,
+    tmp_path,
+):
+    """End-to-end retrack-only: first produce predictions, then re-track."""
+    import subprocess
+
+    # Step 1: produce a tracked .slp via the inference + tracking path.
+    pred_slp = f"{tmp_path}/preds.slp"
+    inference_cmd = [
+        "uv",
+        "run",
+        "--frozen",
+        "--extra",
+        "torch-cpu",
+        "sleap-nn",
+        "infer",
+        "--model_paths",
+        minimal_instance_centroid_ckpt,
+        "--model_paths",
+        minimal_instance_centered_instance_ckpt,
+        "--data_path",
+        centered_instance_video.as_posix(),
+        "--max_instances",
+        "2",
+        "--output_path",
+        pred_slp,
+        "--frames",
+        "0-9",
+        "--device",
+        "cpu",
+    ]
+    subprocess.run(inference_cmd, check=True, capture_output=True, text=True)
+    assert Path(pred_slp).exists()
+
+    # Step 2: retrack with NO model_paths (pure tracking-only path).
+    retracked_slp = f"{tmp_path}/retracked.slp"
+    retrack_cmd = [
+        "uv",
+        "run",
+        "--frozen",
+        "--extra",
+        "torch-cpu",
+        "sleap-nn",
+        "infer",
+        "--data_path",
+        pred_slp,
+        "--tracking",
+        "--tracking_window_size",
+        "5",
+        "--output_path",
+        retracked_slp,
+    ]
+    subprocess.run(retrack_cmd, check=True, capture_output=True, text=True)
+    assert Path(retracked_slp).exists()
+
+    out = sio.load_slp(retracked_slp)
+    # Retrack preserves the frame count.
+    assert len(out) == 10
+
+
 def test_track_command_with_tracking_uses_new_flow(
     centered_instance_video,
     minimal_instance_centered_instance_ckpt,

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -10,6 +10,34 @@ from _pytest.logging import LogCaptureFixture
 import torch
 
 
+def test_run_inference_emits_deprecation_warning(
+    minimal_instance, minimal_instance_centered_instance_ckpt, tmp_path
+):
+    """``run_inference()`` is the legacy entry point; calling it emits a
+    DeprecationWarning pointing at the new ``Predictor`` API."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        run_inference(
+            model_paths=[minimal_instance_centered_instance_ckpt],
+            data_path=minimal_instance.as_posix(),
+            make_labels=True,
+            peak_threshold=0.0,
+            device="cpu",
+            output_path=f"{tmp_path}/test.slp",
+            integral_refinement=None,
+        )
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    matching = [
+        w
+        for w in deprecations
+        if "run_inference" in str(w.message) and "Predictor" in str(w.message)
+    ]
+    assert matching, [str(w.message) for w in deprecations]
+
+
 @pytest.fixture
 def caplog(caplog: LogCaptureFixture):
     handler_id = logger.add(


### PR DESCRIPTION
## Summary

After PR 15, three flags still forced ``sleap-nn infer`` / ``sleap-nn track`` to the legacy ``run_inference``: ``--gui``, ``--backbone_ckpt_path`` / ``--head_ckpt_path``, and the tracking-only retrack mode (no ``--model_paths`` + ``--tracking``). **PR 16 ports all three.**

After this PR, ``_can_use_new_in_memory_flow`` is a ``return True`` constant — every documented flag combination on ``sleap-nn infer`` / ``sleap-nn track`` routes through the new factory + ``Predictor.predict``.

## What ships

### `--gui` (JSON progress emission)

- New ``progress_callback: Optional[Callable[[int, int], None]]`` on ``Predictor.predict`` / ``predict_streaming`` / ``predict_to_file``, threaded into ``_batch_iter`` / ``_predict_streaming_pipelined``.
- ``cli._gui_progress_callback()`` builds a throttled JSON-emitter (``n_processed`` / ``n_total`` / ``rate`` / ``eta``, ~4Hz) that matches the legacy ``--gui`` line format byte-for-byte.
- Wired into both the in-memory and ``--stream-to-file`` paths.

### Tracking-only retrack

- New ``Predictor.retrack(labels, tracker_config, clean_empty_frames)`` staticmethod — pure tracking, no inference. Mirrors the legacy ``run_inference(model_paths=None, tracking=True, ...)`` path.
- ``_run_in_memory_new_flow`` dispatches to ``_run_retrack_only`` when ``--tracking`` is set without ``--model_paths``.
- Handles ``--video_index`` and ``--frames`` filters.

### `--backbone_ckpt_path` / `--head_ckpt_path`

- The factory's ``from_model_paths`` already accepted these kwargs; PR 16 just threads them through ``_run_in_memory_new_flow``'s ``factory_kwargs``.

### Routing

- ``_can_use_new_in_memory_flow`` now returns ``True`` always. Updated docstring lists every supported flag combination.

## Tests (5 new + 1 e2e)

| | |
|---|---|
| ``test_infer_gui_emits_json_progress`` | callback is wired, produces legacy-compat JSON |
| ``test_infer_without_gui_no_progress_callback`` | default is opt-out |
| ``test_infer_backbone_and_head_ckpt_paths_thread_to_factory`` | ckpt overrides reach the factory |
| ``test_infer_retrack_only_dispatches_to_predictor_retrack`` | no ``--model_paths`` + ``--tracking`` → ``Predictor.retrack`` |
| ``test_track_command_retrack_only_uses_new_flow`` (e2e) | inference-then-retrack subprocess |
| ``test_predict_main`` | the previously-broken ``--device auto`` + ``--no_empty_frames`` + ``--tracking`` Ubuntu case |

Updated existing tests that previously used ``--gui`` to force the legacy path. They now mock the new factory and assert kwargs there. ``test_paf_workers_positive_emits_no_effect_warning`` repurposed since the warning no longer exists.

## Local results

| | |
|---|---|
| ``tests/inference/`` (full) | 321 passed, 23 skipped (CUDA-gated) |
| ``tests/cli/`` | 24 passed |
| ``tests/test_cli.py`` | 37 passed |
| ``tests/test_predict.py::test_predict_main`` | passed |
| ``black --check sleap_nn tests`` | clean |
| ``ruff check sleap_nn/`` | clean |

## Out of scope (folded into PR 17)

The ``sleap-nn predict`` command (inference on **exported** ONNX/TRT models, defined in ``sleap_nn/export/cli.py``) is on a separate code path that never went through ``_run_inference_impl``. It still uses the legacy ``sleap_nn/export/inference.py`` driver. Adding a ``Predictor.from_export_dir`` factory entry + rewiring ``sleap-nn predict`` to it is folded into PR 17 alongside the deletion of the 1516-line legacy export driver.

## Test plan

- [x] Local: full inference + cli + e2e suites green
- [x] ``black --check`` + ``ruff check`` clean
- [ ] Linux / Windows / Mac CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)