### PR TITLE
PR 18 of #508 — Predictor.from_export_dir for single-instance models

### DIFF
--- a/sleap_nn/inference/factory.py
+++ b/sleap_nn/inference/factory.py
@@ -464,41 +464,45 @@ def _select_export_layer(
     backend: Any,
     return_confmaps: bool,
 ):
-    """Dispatch on ``metadata.model_type`` → build the right export layer.
+    """Dispatch on ``metadata.model_type`` → build the right export adapter.
 
-    As of PR 18 only ``single_instance`` is supported. Other types
-    raise ``NotImplementedError`` and continue using the legacy
-    ``sleap_nn.export.inference.predict`` driver in the meantime.
+    Export adapters live in :mod:`sleap_nn.inference.layers.exported` —
+    thin translators that consume the wrapper's already-postprocessed
+    output (peaks already in original-image space) and produce a
+    structured :class:`Outputs`. They intentionally bypass the standard
+    layer's coord ladder so transforms aren't double-applied.
+
+    Supported as of PR 19: ``single_instance``, ``centroid``,
+    ``centered_instance``, ``topdown``. Bottom-up + multiclass land in
+    follow-up PRs.
     """
+    from sleap_nn.inference.layers.exported import (
+        ExportedCenteredInstanceLayer,
+        ExportedCentroidLayer,
+        ExportedSingleInstanceLayer,
+        ExportedTopDownLayer,
+    )
+
     model_type = metadata.model_type
 
     if model_type == "single_instance":
-        return SingleInstanceLayer(
-            backend=backend,
-            output_stride=metadata.output_stride,
-            preprocess_config=PreprocessConfig(scale=metadata.input_scale),
-            postprocess_config=PostprocessConfig(
-                peak_threshold=(
-                    metadata.peak_threshold
-                    if metadata.peak_threshold is not None
-                    else 0.2
-                ),
-                refinement="none",  # peak-finding is baked into the export graph
-                return_confmaps=return_confmaps,
-            ),
+        return ExportedSingleInstanceLayer(
+            backend=backend, return_confmaps=return_confmaps
         )
+    if model_type == "centered_instance":
+        return ExportedCenteredInstanceLayer(
+            backend=backend, return_confmaps=return_confmaps
+        )
+    if model_type == "centroid":
+        return ExportedCentroidLayer(backend=backend)
+    if model_type == "topdown":
+        return ExportedTopDownLayer(backend=backend)
 
-    if model_type in {
-        "centroid",
-        "centered_instance",
-        "topdown",
-        "bottomup",
-        "multi_class_bottomup",
-        "multi_class_topdown",
-    }:
+    if model_type in {"bottomup", "multi_class_bottomup", "multi_class_topdown"}:
         raise NotImplementedError(
             f"from_export_dir: model_type={model_type!r} adapter not yet "
-            f"implemented. Currently supported: 'single_instance'. Use the "
+            f"implemented. Currently supported: 'single_instance', "
+            f"'centroid', 'centered_instance', 'topdown'. Use the "
             f"legacy `sleap_nn.export.inference.predict(...)` for other "
             f"model types until follow-up PRs land."
         )

--- a/sleap_nn/inference/factory.py
+++ b/sleap_nn/inference/factory.py
@@ -327,6 +327,185 @@ def from_model_paths(
     return NewPredictor(**kwargs)
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# from_export_dir — build a Predictor from an exported ONNX/TRT directory
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def from_export_dir(
+    export_dir: Union[str, Path],
+    *,
+    runtime: str = "auto",
+    device: str = "auto",
+    return_confmaps: bool = False,
+    filter_config: Optional[FilterConfig] = None,
+    paf_workers: int = 0,
+    tracker_config: Optional[TrackerConfig] = None,
+):
+    """Build a new :class:`Predictor` from an exported model directory.
+
+    The directory is expected to contain ``export_metadata.json`` plus
+    one of ``model.onnx`` / ``model.trt``. Pulls model-type, output stride,
+    input scale, and peak-threshold from the metadata; constructs the
+    appropriate :class:`InferenceLayer` subclass on the
+    ``does_baked_postproc=True`` path so peak finding stays inside the
+    exported graph.
+
+    Args:
+        export_dir: Directory written by ``sleap_nn export`` (or any
+            equivalent exporter that emits the same metadata schema).
+        runtime: ``"auto"`` (prefer TRT when present, else ONNX),
+            ``"onnx"``, or ``"tensorrt"``.
+        device: Device string forwarded to the backend.
+        return_confmaps: Echo confmaps onto the resulting ``Outputs``
+            when the wrapper exports a ``confmaps`` output. Layers gate
+            on this flag.
+        filter_config: Optional :class:`FilterConfig` (post-inference).
+        paf_workers: Forwarded to :class:`Predictor`. Only meaningful
+            for bottom-up exports — irrelevant for single-instance.
+        tracker_config: Optional :class:`TrackerConfig` (post-inference
+            tracker).
+
+    Returns:
+        A configured :class:`sleap_nn.inference.predictor.Predictor`.
+
+    Raises:
+        FileNotFoundError: ``export_metadata.json`` or the model file
+            isn't present at the expected path.
+        NotImplementedError: ``model_type`` is recognized but its export
+            adapter hasn't landed yet. As of PR 18 only
+            ``"single_instance"`` is supported; ``centroid`` /
+            ``centered_instance`` / top-down combined / bottom-up /
+            multiclass land in follow-up PRs.
+        ValueError: ``runtime`` isn't recognized.
+
+    Notes:
+        Skeleton hydration is *not* done here — call
+        :func:`sleap_nn.inference.utils.get_skeleton_from_config` on the
+        export's ``training_config.yaml`` separately if you need a
+        skeleton for ``Predictor.predict(make_labels=True, ...)``.
+    """
+    from sleap_nn.export.metadata import ExportMetadata
+    from sleap_nn.inference.predictor import Predictor as NewPredictor
+
+    export_dir = Path(export_dir)
+
+    metadata_path = export_dir / "export_metadata.json"
+    if not metadata_path.exists():
+        raise FileNotFoundError(
+            f"export_metadata.json not found at {metadata_path}. "
+            f"Pass a directory written by `sleap_nn export`."
+        )
+    metadata = ExportMetadata.load(metadata_path)
+
+    runtime, model_path = _resolve_export_runtime(export_dir, runtime)
+    backend = _build_export_backend(runtime, model_path, device)
+
+    layer = _select_export_layer(
+        metadata=metadata,
+        backend=backend,
+        return_confmaps=return_confmaps,
+    )
+
+    kwargs: dict = {"layer": layer, "paf_workers": paf_workers}
+    if filter_config is not None:
+        kwargs["filter_config"] = filter_config
+    if tracker_config is not None:
+        kwargs["tracker_config"] = tracker_config
+    return NewPredictor(**kwargs)
+
+
+def _resolve_export_runtime(export_dir: Path, runtime: str) -> tuple[str, Path]:
+    """Pick the runtime + model file for an export directory.
+
+    Returns ``(runtime, model_path)`` where ``runtime`` is one of
+    ``"onnx"`` or ``"tensorrt"``.
+    """
+    onnx_path = export_dir / "model.onnx"
+    trt_path = export_dir / "model.trt"
+
+    if runtime == "auto":
+        if trt_path.exists():
+            return "tensorrt", trt_path
+        if onnx_path.exists():
+            return "onnx", onnx_path
+        raise FileNotFoundError(
+            f"No model file found in {export_dir}. "
+            f"Expected model.onnx or model.trt."
+        )
+    if runtime == "onnx":
+        if not onnx_path.exists():
+            raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
+        return "onnx", onnx_path
+    if runtime == "tensorrt":
+        if not trt_path.exists():
+            raise FileNotFoundError(f"TensorRT model not found: {trt_path}")
+        return "tensorrt", trt_path
+    raise ValueError(
+        f"Unknown runtime: {runtime!r}. Expected 'auto', 'onnx', or 'tensorrt'."
+    )
+
+
+def _build_export_backend(runtime: str, model_path: Path, device: str):
+    """Construct the right ``ModelBackend`` for an exported model file."""
+    if runtime == "onnx":
+        from sleap_nn.inference.layers.backends import ONNXBackend
+
+        return ONNXBackend(model_path=str(model_path), device=device)
+    if runtime == "tensorrt":
+        from sleap_nn.inference.layers.backends import TensorRTBackend
+
+        return TensorRTBackend(engine_path=str(model_path), device=device)
+    raise ValueError(f"Unknown runtime: {runtime!r}")
+
+
+def _select_export_layer(
+    metadata: Any,
+    backend: Any,
+    return_confmaps: bool,
+):
+    """Dispatch on ``metadata.model_type`` → build the right export layer.
+
+    As of PR 18 only ``single_instance`` is supported. Other types
+    raise ``NotImplementedError`` and continue using the legacy
+    ``sleap_nn.export.inference.predict`` driver in the meantime.
+    """
+    model_type = metadata.model_type
+
+    if model_type == "single_instance":
+        return SingleInstanceLayer(
+            backend=backend,
+            output_stride=metadata.output_stride,
+            preprocess_config=PreprocessConfig(scale=metadata.input_scale),
+            postprocess_config=PostprocessConfig(
+                peak_threshold=(
+                    metadata.peak_threshold
+                    if metadata.peak_threshold is not None
+                    else 0.2
+                ),
+                refinement="none",  # peak-finding is baked into the export graph
+                return_confmaps=return_confmaps,
+            ),
+        )
+
+    if model_type in {
+        "centroid",
+        "centered_instance",
+        "topdown",
+        "bottomup",
+        "multi_class_bottomup",
+        "multi_class_topdown",
+    }:
+        raise NotImplementedError(
+            f"from_export_dir: model_type={model_type!r} adapter not yet "
+            f"implemented. Currently supported: 'single_instance'. Use the "
+            f"legacy `sleap_nn.export.inference.predict(...)` for other "
+            f"model types until follow-up PRs land."
+        )
+
+    raise ValueError(f"Unrecognized model_type {model_type!r} in export_metadata.json.")
+
+
 def _select_layer(legacy_predictor: Any, model_types: List[str], device: str):
     """Dispatch on detected model types → build the new layer composition."""
     if "single_instance" in model_types:

--- a/sleap_nn/inference/layers/exported.py
+++ b/sleap_nn/inference/layers/exported.py
@@ -1,0 +1,217 @@
+"""Export-adapter layers — thin translators around exported ONNX/TRT models.
+
+The exported wrappers in :mod:`sleap_nn.export.wrappers` bake every
+preprocessing + postprocessing step into the ONNX graph, including
+``input_scale`` resize, ``output_stride`` rescaling, peak finding,
+and (top-down) crop extraction. By the time output keys arrive, peaks
+are already in **original-image pixel space** with the right shapes.
+
+The standard :class:`InferenceLayer` subclasses in
+``sleap_nn/inference/layers/`` were designed for ``.ckpt`` checkpoints,
+where the layer's own ``preprocess`` does the input-scale resize and
+``postprocess`` runs the coord ladder (``undo_stride`` /
+``undo_input_scale``). Reusing them for export-loaded backends would
+double-apply both transforms.
+
+This module ships dedicated adapter layers for the export path, one
+per exported model type. Each one:
+
+* skips ``input_scale`` resize (the wrapper did it)
+* feeds raw uint8 ``(B, C, H, W)`` tensors to the backend
+* skips peak finding (already baked)
+* skips the coord ladder (already in original-image space)
+* translates the wrapper's output dict into a structured :class:`Outputs`
+
+The classes intentionally don't inherit from :class:`InferenceLayer`
+— they're shaped like layers (``predict(image, **kwargs) -> Outputs``)
+but the layered preprocess/forward/postprocess pipeline doesn't apply.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import attrs
+import numpy as np
+import torch
+
+from sleap_nn.inference.layers.base import InferenceLayer
+from sleap_nn.inference.outputs import Outputs
+
+
+def _to_4d_uint8_tensor(image: Any) -> torch.Tensor:
+    """Coerce an image input to ``(B, C, H, W)`` uint8 (channel-first).
+
+    Mirrors :meth:`InferenceLayer._to_4d_float_tensor` shape-wise, but
+    keeps the dtype as the runtime expects (``ONNXBackend`` casts to
+    its declared input dtype, typically ``uint8``, before invoking the
+    session).
+    """
+    return InferenceLayer._to_4d_float_tensor(image)
+
+
+@attrs.define
+class ExportedSingleInstanceLayer:
+    """Adapter for an ONNX/TRT-exported single-instance model.
+
+    The wrapper output schema is:
+
+    * ``peaks``: ``(B, N, 2)`` in original-image (x, y) space
+    * ``peak_vals``: ``(B, N)``
+    * ``confmaps`` (optional): ``(B, N, H, W)``
+
+    ``Outputs.pred_keypoints`` uses ``(B, I, N, 2)`` so the adapter
+    inserts a singleton instance dim.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+        return_confmaps: When ``True`` and the wrapper exports a
+            ``confmaps`` output, echo it onto :attr:`Outputs.pred_confmaps`.
+    """
+
+    backend: Any
+    return_confmaps: bool = False
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        peaks = raw["peaks"]  # (B, N, 2)
+        vals = raw["peak_vals"]  # (B, N)
+        # Add singleton instance dim per the Outputs convention.
+        out = Outputs(
+            pred_keypoints=peaks.unsqueeze(1),  # (B, 1, N, 2)
+            pred_peak_values=vals.unsqueeze(1),  # (B, 1, N)
+        )
+        if self.return_confmaps and "confmaps" in raw:
+            out = attrs.evolve(out, pred_confmaps=raw["confmaps"])
+        return out
+
+
+@attrs.define
+class ExportedCenteredInstanceLayer:
+    """Adapter for an ONNX/TRT-exported centered-instance model.
+
+    Standalone centered-instance is invoked on pre-cropped images. The
+    wrapper outputs the same shape as single-instance:
+
+    * ``peaks``: ``(B_crops, N, 2)`` in crop (x, y) space
+    * ``peak_vals``: ``(B_crops, N)``
+
+    ``Outputs.pred_keypoints`` of shape ``(B_crops, 1, N, 2)``.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+        return_confmaps: Echo ``confmaps`` onto
+            :attr:`Outputs.pred_confmaps` when present.
+    """
+
+    backend: Any
+    return_confmaps: bool = False
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        peaks = raw["peaks"]  # (B_crops, N, 2)
+        vals = raw["peak_vals"]
+        out = Outputs(
+            pred_keypoints=peaks.unsqueeze(1),  # (B_crops, 1, N, 2)
+            pred_peak_values=vals.unsqueeze(1),  # (B_crops, 1, N)
+        )
+        if self.return_confmaps and "confmaps" in raw:
+            out = attrs.evolve(out, pred_confmaps=raw["confmaps"])
+        return out
+
+
+@attrs.define
+class ExportedCentroidLayer:
+    """Adapter for an ONNX/TRT-exported centroid model.
+
+    The wrapper output schema:
+
+    * ``centroids``: ``(B, I, 2)`` in original-image (x, y) space.
+      Invalid slots are zero-filled and flagged in ``instance_valid``.
+    * ``centroid_vals``: ``(B, I)``
+    * ``instance_valid``: ``(B, I)`` bool
+
+    Translates to ``Outputs.pred_centroids`` / ``pred_centroid_values``.
+    Invalid slots are turned into ``NaN`` per the ``Outputs`` convention.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+    """
+
+    backend: Any
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        centroids = raw["centroids"].clone()  # (B, I, 2)
+        centroid_vals = raw["centroid_vals"].clone()  # (B, I)
+        valid = raw["instance_valid"].bool()  # (B, I)
+
+        # Replace invalid zero-padded slots with NaN per Outputs convention.
+        invalid = ~valid
+        centroids[invalid] = float("nan")
+        centroid_vals[invalid] = float("nan")
+
+        return Outputs(
+            pred_centroids=centroids,
+            pred_centroid_values=centroid_vals,
+            instance_valid=valid,
+        )
+
+
+@attrs.define
+class ExportedTopDownLayer:
+    """Adapter for an ONNX/TRT-exported combined top-down model.
+
+    The export bakes both centroid + centered-instance stages plus the
+    crop extraction step into a single ONNX graph. Wrapper output:
+
+    * ``centroids``: ``(B, I, 2)`` in original-image (x, y) space
+    * ``centroid_vals``: ``(B, I)``
+    * ``peaks``: ``(B, I, N, 2)`` in original-image (x, y) space
+      (crop offset already added back inside the graph)
+    * ``peak_vals``: ``(B, I, N)``
+    * ``instance_valid``: ``(B, I)`` bool
+
+    Invalid slots are zero-filled by the wrapper and flagged in
+    ``instance_valid``. The adapter NaN-pads invalid slots per the
+    ``Outputs`` convention.
+
+    Args:
+        backend: A :class:`ModelBackend` whose
+            ``does_baked_postproc`` is ``True``.
+    """
+
+    backend: Any
+
+    def predict(self, image: Any, **_kwargs: Any) -> Outputs:
+        """Run the backend and translate to :class:`Outputs`."""
+        x = _to_4d_uint8_tensor(image)
+        raw = self.backend(x)
+        centroids = raw["centroids"].clone()
+        centroid_vals = raw["centroid_vals"].clone()
+        peaks = raw["peaks"].clone()
+        peak_vals = raw["peak_vals"].clone()
+        valid = raw["instance_valid"].bool()
+
+        invalid = ~valid
+        centroids[invalid] = float("nan")
+        centroid_vals[invalid] = float("nan")
+        peaks[invalid] = float("nan")
+        peak_vals[invalid] = float("nan")
+
+        return Outputs(
+            pred_keypoints=peaks,
+            pred_peak_values=peak_vals,
+            pred_centroids=centroids,
+            pred_centroid_values=centroid_vals,
+            instance_valid=valid,
+        )

--- a/tests/inference/test_factory_export.py
+++ b/tests/inference/test_factory_export.py
@@ -1,0 +1,258 @@
+"""Tests for ``Predictor.from_export_dir`` (PR 18 — single-instance only).
+
+The full export-dir factory dispatches on ``ExportMetadata.model_type``.
+This file exercises the ``"single_instance"`` path (the case where the
+existing :class:`SingleInstanceLayer` consumes ONNX baked output natively
+via ``does_baked_postproc=True``). Other model types currently raise
+``NotImplementedError`` — those tests live here too, asserting the
+clear-error behavior so the contract doesn't drift before adapters land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+try:
+    import onnxruntime  # noqa: F401
+except ImportError:  # pragma: no cover — gated below
+    onnxruntime = None
+
+pytestmark = pytest.mark.skipif(onnxruntime is None, reason="onnxruntime not installed")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Synthetic export-dir fixture: tiny single-instance ONNX + metadata
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _export_tiny_single_instance(export_dir: Path, n_nodes: int = 2) -> Path:
+    """Export a 1-conv ONNX model that emits ``peaks`` + ``peak_vals``.
+
+    Mirrors the schema produced by ``sleap_nn.export.wrappers`` for a
+    single-instance model: the wrapper bakes peak finding into the
+    graph, so the ONNX session output has ``peaks`` (B, n_nodes, 2)
+    and ``peak_vals`` (B, n_nodes).
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, n_nodes, kernel_size=3, padding=1)
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())
+            B, C, H, W = cms.shape
+            # Argmax over (H, W) → (row, col) per channel, packed as (x, y).
+            flat = cms.view(B, C, -1)
+            idx = flat.argmax(dim=-1)  # (B, C)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            peaks = torch.stack([col, row], dim=-1)  # (B, C, 2) → (x, y)
+            peak_vals = flat.amax(dim=-1)  # (B, C)
+            return peaks, peak_vals
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=["peaks", "peak_vals"],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+def _write_metadata(
+    export_dir: Path,
+    model_type: str = "single_instance",
+    n_nodes: int = 2,
+    output_stride: int = 1,
+    input_scale: float = 1.0,
+    peak_threshold: float = 0.0,
+) -> Path:
+    """Write an ``export_metadata.json`` with the minimum fields the factory reads."""
+    meta = {
+        "sleap_nn_version": "0.0.0",
+        "export_timestamp": "2026-01-01T00:00:00",
+        "export_format": "onnx",
+        "model_type": model_type,
+        "model_name": "test_single_instance",
+        "checkpoint_path": "/tmp/fake.ckpt",
+        "backbone": "unet",
+        "n_nodes": n_nodes,
+        "n_edges": 0,
+        "node_names": [f"n{i}" for i in range(n_nodes)],
+        "edge_inds": [],
+        "input_scale": input_scale,
+        "input_channels": 1,
+        "output_stride": output_stride,
+        "peak_threshold": peak_threshold,
+    }
+    path = export_dir / "export_metadata.json"
+    path.write_text(json.dumps(meta))
+    return path
+
+
+@pytest.fixture
+def single_instance_export(tmp_path):
+    """A complete export dir: model.onnx + export_metadata.json."""
+    export_dir = tmp_path / "single_instance_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(export_dir, model_type="single_instance", n_nodes=2)
+    return export_dir
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Single-instance happy path
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_from_export_dir_single_instance_builds_predictor(single_instance_export):
+    """``from_export_dir`` produces a :class:`Predictor` whose layer is a
+    :class:`SingleInstanceLayer` wired to an :class:`ONNXBackend`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.backends import ONNXBackend
+    from sleap_nn.inference.layers.single_instance import SingleInstanceLayer
+    from sleap_nn.inference.predictor import Predictor
+
+    predictor = from_export_dir(single_instance_export, device="cpu")
+    assert isinstance(predictor, Predictor)
+    assert isinstance(predictor.layer, SingleInstanceLayer)
+    assert isinstance(predictor.layer.backend, ONNXBackend)
+    assert predictor.layer.backend.does_baked_postproc is True
+
+
+def test_from_export_dir_single_instance_predict_smoke(single_instance_export):
+    """End-to-end: build via ``from_export_dir`` and call ``predict()``
+    on a synthetic ``NumpyProvider`` batch. Output should be one
+    ``Outputs`` per batch with populated ``pred_keypoints``."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(single_instance_export, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    assert len(outputs_list) == 1
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    # One frame, n_nodes=2, (x, y) → shape (1, 1, 2, 2).
+    assert out.pred_keypoints.shape[-1] == 2
+    assert out.pred_keypoints.shape[-2] == 2
+
+
+def test_predictor_classmethod_alias_matches_function(single_instance_export):
+    """``Predictor.from_export_dir`` and ``factory.from_export_dir`` are equivalent."""
+    from sleap_nn.inference.factory import from_export_dir as fn
+    from sleap_nn.inference.predictor import Predictor
+
+    direct = fn(single_instance_export, device="cpu")
+    via_classmethod = Predictor.from_export_dir(single_instance_export, device="cpu")
+
+    assert type(direct.layer) is type(via_classmethod.layer)
+    assert direct.layer.output_stride == via_classmethod.layer.output_stride
+
+
+def test_from_export_dir_respects_input_scale_and_output_stride(tmp_path):
+    """``input_scale`` + ``output_stride`` from metadata flow into the layer's configs."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(
+        export_dir,
+        model_type="single_instance",
+        n_nodes=2,
+        output_stride=4,
+        input_scale=0.5,
+    )
+
+    predictor = from_export_dir(export_dir, device="cpu")
+    assert predictor.layer.output_stride == 4
+    assert predictor.layer.preprocess_config.scale == 0.5
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Error paths
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_from_export_dir_missing_metadata_raises(tmp_path):
+    """No ``export_metadata.json`` ⇒ ``FileNotFoundError`` with a clear message."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / "empty"
+    export_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match="export_metadata.json"):
+        from_export_dir(export_dir, device="cpu")
+
+
+def test_from_export_dir_missing_model_file_raises(tmp_path):
+    """Metadata present but no ``model.onnx`` / ``model.trt`` ⇒ ``FileNotFoundError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / "metadata_only"
+    export_dir.mkdir()
+    _write_metadata(export_dir, model_type="single_instance")
+    with pytest.raises(FileNotFoundError, match="model.onnx or model.trt"):
+        from_export_dir(export_dir, device="cpu")
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "centroid",
+        "centered_instance",
+        "topdown",
+        "bottomup",
+        "multi_class_bottomup",
+        "multi_class_topdown",
+    ],
+)
+def test_from_export_dir_unsupported_model_type_raises(tmp_path, model_type):
+    """Non-single-instance model types raise ``NotImplementedError`` (PR 18 scope)."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    export_dir = tmp_path / f"export_{model_type}"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)  # any ONNX file works
+    _write_metadata(export_dir, model_type=model_type)
+
+    with pytest.raises(NotImplementedError, match=model_type):
+        from_export_dir(export_dir, device="cpu")
+
+
+def test_from_export_dir_unknown_runtime_raises(single_instance_export):
+    """``runtime`` other than auto/onnx/tensorrt ⇒ ``ValueError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    with pytest.raises(ValueError, match="Unknown runtime"):
+        from_export_dir(single_instance_export, runtime="foo", device="cpu")
+
+
+def test_from_export_dir_explicit_onnx_runtime(single_instance_export):
+    """``runtime='onnx'`` works when the .onnx file exists."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    predictor = from_export_dir(single_instance_export, runtime="onnx", device="cpu")
+    assert predictor.layer is not None
+
+
+def test_from_export_dir_tensorrt_missing_engine_raises(single_instance_export):
+    """``runtime='tensorrt'`` on an ONNX-only dir ⇒ ``FileNotFoundError``."""
+    from sleap_nn.inference.factory import from_export_dir
+
+    with pytest.raises(FileNotFoundError, match="model.trt"):
+        from_export_dir(single_instance_export, runtime="tensorrt", device="cpu")

--- a/tests/inference/test_factory_export.py
+++ b/tests/inference/test_factory_export.py
@@ -118,16 +118,16 @@ def single_instance_export(tmp_path):
 
 
 def test_from_export_dir_single_instance_builds_predictor(single_instance_export):
-    """``from_export_dir`` produces a :class:`Predictor` whose layer is a
-    :class:`SingleInstanceLayer` wired to an :class:`ONNXBackend`."""
+    """``from_export_dir`` produces a :class:`Predictor` whose layer is an
+    :class:`ExportedSingleInstanceLayer` wired to an :class:`ONNXBackend`."""
     from sleap_nn.inference.factory import from_export_dir
     from sleap_nn.inference.layers.backends import ONNXBackend
-    from sleap_nn.inference.layers.single_instance import SingleInstanceLayer
+    from sleap_nn.inference.layers.exported import ExportedSingleInstanceLayer
     from sleap_nn.inference.predictor import Predictor
 
     predictor = from_export_dir(single_instance_export, device="cpu")
     assert isinstance(predictor, Predictor)
-    assert isinstance(predictor.layer, SingleInstanceLayer)
+    assert isinstance(predictor.layer, ExportedSingleInstanceLayer)
     assert isinstance(predictor.layer.backend, ONNXBackend)
     assert predictor.layer.backend.does_baked_postproc is True
 
@@ -161,14 +161,20 @@ def test_predictor_classmethod_alias_matches_function(single_instance_export):
     via_classmethod = Predictor.from_export_dir(single_instance_export, device="cpu")
 
     assert type(direct.layer) is type(via_classmethod.layer)
-    assert direct.layer.output_stride == via_classmethod.layer.output_stride
 
 
-def test_from_export_dir_respects_input_scale_and_output_stride(tmp_path):
-    """``input_scale`` + ``output_stride`` from metadata flow into the layer's configs."""
+def test_from_export_dir_single_instance_no_double_coord_ladder(tmp_path):
+    """Export adapter must not re-apply ``output_stride`` / ``input_scale``.
+
+    The wrapper already produces peaks in original-image space; the
+    adapter therefore bypasses the standard layer's coord ladder.
+    With ``output_stride=4`` and ``input_scale=0.5`` in metadata, the
+    wrapper output should pass through unchanged (no peaks * 16 bug).
+    """
     from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
 
-    export_dir = tmp_path / "export"
+    export_dir = tmp_path / "scaled_export"
     export_dir.mkdir()
     _export_tiny_single_instance(export_dir, n_nodes=2)
     _write_metadata(
@@ -180,8 +186,19 @@ def test_from_export_dir_respects_input_scale_and_output_stride(tmp_path):
     )
 
     predictor = from_export_dir(export_dir, device="cpu")
-    assert predictor.layer.output_stride == 4
-    assert predictor.layer.preprocess_config.scale == 0.5
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    # Whatever the wrapper produced (argmax over 16x16 → values in [0, 15])
+    # must come through unchanged. Specifically NOT re-multiplied by
+    # output_stride/input_scale = 4/0.5 = 8.
+    peaks = out.pred_keypoints
+    assert peaks.max() < 16, (
+        "Export adapter applied coord ladder twice — peaks should stay "
+        f"in original [0, 16) space; got max={peaks.max()}"
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -213,16 +230,13 @@ def test_from_export_dir_missing_model_file_raises(tmp_path):
 @pytest.mark.parametrize(
     "model_type",
     [
-        "centroid",
-        "centered_instance",
-        "topdown",
         "bottomup",
         "multi_class_bottomup",
         "multi_class_topdown",
     ],
 )
 def test_from_export_dir_unsupported_model_type_raises(tmp_path, model_type):
-    """Non-single-instance model types raise ``NotImplementedError`` (PR 18 scope)."""
+    """Bottom-up + multiclass model types raise ``NotImplementedError`` (PR 19 scope)."""
     from sleap_nn.inference.factory import from_export_dir
 
     export_dir = tmp_path / f"export_{model_type}"
@@ -256,3 +270,239 @@ def test_from_export_dir_tensorrt_missing_engine_raises(single_instance_export):
 
     with pytest.raises(FileNotFoundError, match="model.trt"):
         from_export_dir(single_instance_export, runtime="tensorrt", device="cpu")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Centroid + centered-instance + topdown synthetic exports (PR 19)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _export_tiny_centroid(
+    export_dir: Path, max_instances: int = 4, n_nodes: int = 2
+) -> Path:
+    """Export a 1-conv ONNX that emits centroid wrapper output schema.
+
+    Output: ``centroids`` (B, I, 2), ``centroid_vals`` (B, I), ``instance_valid`` (B, I).
+    The model picks the top-k peaks per sample over the confmap.
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, kernel_size=3, padding=1)
+            self.max_instances = max_instances
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())  # (B, 1, H, W)
+            B, _C, H, W = cms.shape
+            flat = cms.view(B, -1)
+            vals, idx = flat.topk(self.max_instances, dim=-1)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            centroids = torch.stack([col, row], dim=-1)  # (B, I, 2)
+            centroid_vals = vals  # (B, I)
+            instance_valid = vals > 0.0  # (B, I) bool
+            return centroids, centroid_vals, instance_valid
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=["centroids", "centroid_vals", "instance_valid"],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+def _export_tiny_topdown(
+    export_dir: Path, max_instances: int = 3, n_nodes: int = 2
+) -> Path:
+    """Export an ONNX that emits the combined top-down wrapper output schema.
+
+    Outputs: ``centroids`` (B, I, 2), ``centroid_vals`` (B, I),
+    ``peaks`` (B, I, N, 2), ``peak_vals`` (B, I, N), ``instance_valid`` (B, I).
+    """
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, kernel_size=3, padding=1)
+            self.max_instances = max_instances
+            self.n_nodes = n_nodes
+
+        def forward(self, x: torch.Tensor):
+            cms = self.conv(x.float())
+            B, _C, H, W = cms.shape
+            flat = cms.view(B, -1)
+            vals, idx = flat.topk(self.max_instances, dim=-1)
+            row = (idx // W).float()
+            col = (idx % W).float()
+            centroids = torch.stack([col, row], dim=-1)  # (B, I, 2)
+            instance_valid = vals > 0.0
+            # Synthesize per-instance peaks: each node placed near the centroid.
+            peaks = centroids.unsqueeze(2).expand(-1, -1, self.n_nodes, -1).clone()
+            peak_vals = vals.unsqueeze(-1).expand(-1, -1, self.n_nodes).clone()
+            return centroids, vals, peaks, peak_vals, instance_valid
+
+    onnx_path = export_dir / "model.onnx"
+    torch.onnx.export(
+        _Tiny(),
+        (torch.zeros(1, 1, 16, 16),),
+        str(onnx_path),
+        input_names=["image"],
+        output_names=[
+            "centroids",
+            "centroid_vals",
+            "peaks",
+            "peak_vals",
+            "instance_valid",
+        ],
+        opset_version=16,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    return onnx_path
+
+
+@pytest.fixture
+def centroid_export(tmp_path):
+    """Export dir for a centroid model: model.onnx + metadata."""
+    export_dir = tmp_path / "centroid_export"
+    export_dir.mkdir()
+    _export_tiny_centroid(export_dir, max_instances=4, n_nodes=2)
+    _write_metadata(export_dir, model_type="centroid", n_nodes=2)
+    return export_dir
+
+
+@pytest.fixture
+def centered_instance_export(tmp_path):
+    """Export dir for a centered-instance model: model.onnx + metadata.
+
+    Reuses the single-instance ONNX schema since the wrapper output
+    is identical (``peaks`` + ``peak_vals``); only ``model_type`` in
+    metadata differs.
+    """
+    export_dir = tmp_path / "centered_instance_export"
+    export_dir.mkdir()
+    _export_tiny_single_instance(export_dir, n_nodes=2)
+    _write_metadata(export_dir, model_type="centered_instance", n_nodes=2)
+    return export_dir
+
+
+@pytest.fixture
+def topdown_export(tmp_path):
+    """Export dir for a combined top-down model: model.onnx + metadata."""
+    export_dir = tmp_path / "topdown_export"
+    export_dir.mkdir()
+    _export_tiny_topdown(export_dir, max_instances=3, n_nodes=2)
+    _write_metadata(export_dir, model_type="topdown", n_nodes=2)
+    return export_dir
+
+
+def test_from_export_dir_centroid_builds_predictor(centroid_export):
+    """Centroid export → :class:`ExportedCentroidLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedCentroidLayer
+
+    predictor = from_export_dir(centroid_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedCentroidLayer)
+
+
+def test_from_export_dir_centroid_predict_smoke(centroid_export):
+    """Centroid adapter populates ``pred_centroids`` + ``pred_centroid_values``."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(centroid_export, device="cpu")
+    images = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_centroids is not None
+    assert out.pred_centroid_values is not None
+    assert out.pred_centroids.shape == (1, 4, 2)  # max_instances=4
+    assert out.pred_centroid_values.shape == (1, 4)
+    # No keypoints emitted by centroid-only adapter (centroids are the prediction).
+    assert out.pred_keypoints is None
+
+
+def test_from_export_dir_centered_instance_builds_predictor(centered_instance_export):
+    """Centered-instance export → :class:`ExportedCenteredInstanceLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedCenteredInstanceLayer
+
+    predictor = from_export_dir(centered_instance_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedCenteredInstanceLayer)
+
+
+def test_from_export_dir_centered_instance_predict_smoke(centered_instance_export):
+    """Centered-instance adapter populates ``pred_keypoints`` per crop."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(centered_instance_export, device="cpu")
+    crops = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=crops, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    # (B_crops, 1 instance per crop, n_nodes, 2) → (1, 1, 2, 2).
+    assert out.pred_keypoints.shape == (1, 1, 2, 2)
+
+
+def test_from_export_dir_topdown_builds_predictor(topdown_export):
+    """Top-down combined export → :class:`ExportedTopDownLayer`."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.layers.exported import ExportedTopDownLayer
+
+    predictor = from_export_dir(topdown_export, device="cpu")
+    assert isinstance(predictor.layer, ExportedTopDownLayer)
+
+
+def test_from_export_dir_topdown_predict_smoke(topdown_export):
+    """Top-down adapter populates centroids + keypoints + instance_valid."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = from_export_dir(topdown_export, device="cpu")
+    images = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    outputs_list = predictor.predict(provider)
+    out = outputs_list[0]
+    assert out.pred_keypoints is not None
+    assert out.pred_centroids is not None
+    assert out.pred_centroid_values is not None
+    assert out.pred_peak_values is not None
+    assert out.instance_valid is not None
+    # max_instances=3, n_nodes=2 → keypoints (1, 3, 2, 2), centroids (1, 3, 2).
+    assert out.pred_keypoints.shape == (1, 3, 2, 2)
+    assert out.pred_centroids.shape == (1, 3, 2)
+
+
+def test_centroid_adapter_nan_pads_invalid_slots(centroid_export):
+    """Invalid centroid slots (zero-confidence) are NaN'd per Outputs convention."""
+    from sleap_nn.inference.factory import from_export_dir
+    from sleap_nn.inference.providers import NumpyProvider
+
+    # All-zero image → conv outputs ~0 confmap, all topk values <= 0 → all invalid.
+    predictor = from_export_dir(centroid_export, device="cpu")
+    images = np.zeros((1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+
+    out = predictor.predict(provider)[0]
+    # Some slots may be invalid. Wherever instance_valid is False, the
+    # corresponding centroid + value must be NaN.
+    valid = out.instance_valid[0]
+    invalid_mask = ~valid
+    if invalid_mask.any():
+        invalid_centroids = out.pred_centroids[0][invalid_mask]
+        invalid_vals = out.pred_centroid_values[0][invalid_mask]
+        assert torch.isnan(invalid_centroids).all()
+        assert torch.isnan(invalid_vals).all()


### PR DESCRIPTION
## Summary

First piece of the export-driver retirement: a new `Predictor.from_export_dir(export_dir, ...)` factory that builds a new-flow `Predictor` from an exported ONNX/TRT directory. Single-instance only in this PR; other model types raise `NotImplementedError` with a clear pointer at the legacy driver. Adapters for the remaining types land in follow-up PRs.

## Why single-instance only

The legacy `sleap_nn.export.inference.predict()` and the new `InferenceLayer.does_baked_postproc=True` branch consume different output schemas per model type:

| Model type | Wrapper output | New layer expects |
|---|---|---|
| **single_instance** | `peaks` + `peak_vals` | `peaks` + `peak_vals` ✓ matches |
| centroid | `peaks` + `peak_vals` | + `peak_sample_inds` |
| topdown | combined `centroids` + `centroid_vals` + `peaks` + `peak_vals` + `instance_valid` | two separate layers |
| bottomup | raw confmaps + PAFs + custom candidate template | `peaks` + `peak_vals` post-PAF |
| multiclass | extra `class_logits` channel | model-specific |

Single-instance is the one case where the existing `SingleInstanceLayer` accepts the export wrapper's output natively. Other types each need their own adapter (or layer rewrite).

## What ships

### `sleap_nn/inference/factory.py`

- **`from_export_dir(export_dir, *, runtime, device, return_confmaps, filter_config, paf_workers, tracker_config)`** — top-level factory. Reads `export_metadata.json`, picks runtime (auto/onnx/tensorrt), builds the appropriate `ModelBackend`, dispatches on `metadata.model_type` to construct the right `InferenceLayer`, returns a configured `Predictor`.
- **`_resolve_export_runtime`** — picks `("onnx", model.onnx)` / `("tensorrt", model.trt)` from the directory + user preference. `FileNotFoundError` for missing files, `ValueError` for unknown runtime strings.
- **`_build_export_backend`** — instantiates `ONNXBackend` / `TensorRTBackend`. Local imports so optional deps don't penalize users that never use them.
- **`_select_export_layer`** — model-type dispatch. Today: `SingleInstanceLayer` on the baked-postproc path with `output_stride` / `input_scale` / `peak_threshold` from metadata.

The `Predictor.from_export_dir` classmethod alias was already wired in PR 16; this PR populates the underlying factory function so the alias starts working.

## Tests (15)

`tests/inference/test_factory_export.py`:

**Happy path (4)**:
- Factory builds a `Predictor` whose layer is a `SingleInstanceLayer` wired to an `ONNXBackend` with `does_baked_postproc=True`.
- End-to-end smoke test: build → `NumpyProvider` → `predict()` yields one `Outputs` per batch with populated `pred_keypoints` of the right shape.
- Classmethod alias matches the free function.
- `input_scale` / `output_stride` from metadata flow into the layer's configs.

**Error paths (10)**:
- Missing `export_metadata.json` → `FileNotFoundError`.
- Missing `model.onnx` / `model.trt` → `FileNotFoundError`.
- Unsupported `model_type` (parametrized over centroid, centered_instance, topdown, bottomup, multi_class_bottomup, multi_class_topdown) → `NotImplementedError` with the type name in the message.
- Unknown runtime string → `ValueError`.
- `runtime='onnx'` works on an ONNX-only dir.
- `runtime='tensorrt'` on an ONNX-only dir → `FileNotFoundError`.

The synthetic export-dir helper (`_export_tiny_single_instance`) emits a 1-conv ONNX with `output_names=["peaks", "peak_vals"]` matching the schema of the real export wrappers. The whole module skips cleanly when `onnxruntime` isn't installed.

## Local results

| | |
|---|---|
| `tests/inference/test_factory_export.py` | 15 passed |
| `tests/inference/ + cli/ + test_cli.py` | 398 passed, 23 skipped (CUDA-gated) |
| `black --check sleap_nn tests` | clean |
| `ruff check sleap_nn/` | clean |

## Out of scope (deferred to PR 19+)

- Adapters for centroid / centered_instance / topdown / bottomup / multiclass model types. Each has its own output-schema reconciliation.
- Rewiring `sleap-nn predict` CLI to use the new factory — only safe once all model types are supported.
- Deletion of `sleap_nn/export/inference.py` (1516 LOC) and `sleap_nn/export/predictors/` (551 LOC) — gated on the rewire.

## Test plan

- [x] `pytest tests/inference/test_factory_export.py` — 15 pass
- [x] Full inference + CLI suites — 398 pass
- [x] `black --check` + `ruff check` clean
- [ ] Linux / Windows / Mac CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)