### PR TITLE
chore: bump to v0.2.0 and require sleap-io >=0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,11 @@ torch-cuda118 = ["torch", "torchvision>=0.20.0"]
 torch-cuda128 = ["torch", "torchvision>=0.20.0"]
 torch-cuda130 = ["torch", "torchvision>=0.20.0"]
 export = ["onnx>=1.15.0", "onnxruntime>=1.16.0", "onnxscript>=0.1.0"]
-export-gpu = ["onnx>=1.15.0", "onnxruntime-gpu>=1.16.0", "onnxscript>=0.1.0"]
+export-gpu = [
+    "onnx>=1.15.0",
+    "onnxruntime-gpu>=1.16.0; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64')",
+    "onnxscript>=0.1.0",
+]
 tensorrt = [
     "tensorrt>=10.13.0; sys_platform == 'linux' or sys_platform == 'win32'",
     "torch-tensorrt>=2.5.0; sys_platform == 'linux' or sys_platform == 'win32'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "sleap-io>=0.6.5,<0.7.0",
+    "sleap-io>=0.7.0",
     "numpy",
     "torch",
     "torchvision>=0.20.0",

--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -50,7 +50,7 @@ logger.add(
     colorize=False,
 )
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # Public API
 from sleap_nn.evaluation import load_metrics

--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -50,7 +50,7 @@ logger.add(
     colorize=False,
 )
 
-__version__ = "0.1.4"
+__version__ = "0.2.0"
 
 # Public API
 from sleap_nn.evaluation import load_metrics


### PR DESCRIPTION
## Summary
- Bump `sleap-nn` version: `0.1.3` → `0.2.0` (minor bump because the upstream `sleap-io` bump is API-breaking)
- Bump `sleap-io` dependency: `>=0.6.5,<0.7.0` → `>=0.7.0`
- Gate `onnxruntime-gpu` by platform marker so lockfile resolves on macOS / linux-aarch64

## Changes
- `sleap_nn/__init__.py`: `__version__` → `"0.2.0"`
- `pyproject.toml`: relax `sleap-io` pin; add platform marker to `export-gpu`'s `onnxruntime-gpu` (no wheels for macOS or linux-aarch64)
- `uv.lock`: regenerated against the new constraints

## Notes
sleap-io v0.7.0 is a major API release (unified annotation architecture, `User*`/`Predicted*` variants, new `BoundingBox` constructor signature, annotations no longer carry `video`/`frame_idx`). This PR catches any sleap-nn integration regressions in CI before publishing.

## Test plan
- [ ] CI passes on this branch
- [ ] `sleap-nn --version` reports `0.2.0` after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)