### PR TITLE
chore: cap sleap-io at <0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "sleap-io>=0.7.0",
+    "sleap-io>=0.7.0,<0.8.0",
     "numpy",
     "torch",
     "torchvision>=0.20.0",


### PR DESCRIPTION
## Summary
- Add upper bound to `sleap-io` dependency: `>=0.7.0` → `>=0.7.0,<0.8.0`
- Prevents an unreviewed major bump from auto-resolving in

## Context
Follow-up to #550 (which bumped to `>=0.7.0` without an upper bound). Mirrors the prior pinning convention (`>=0.6.5,<0.7.0`).

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)