### PR TITLE
Fix WandBRenderer peak_values shape for centroid case

### DIFF
--- a/sleap_nn/training/utils.py
+++ b/sleap_nn/training/utils.py
@@ -505,10 +505,16 @@ class WandBRenderer:
         box_data = []
 
         # Normalize shape to (instances, nodes, 2)
+        if peak_values is not None:
+            peak_values = np.asarray(peak_values)
         if peaks.ndim == 2:
             peaks = peaks[np.newaxis, ...]
-            if peak_values is not None and peak_values.ndim == 1:
+
+        if peak_values is not None and peak_values.ndim == 1:
+            if peaks.shape[0] == 1 and peak_values.shape[0] == peaks.shape[1]:
                 peak_values = peak_values[np.newaxis, ...]
+            elif peaks.shape[1] == 1 and peak_values.shape[0] == peaks.shape[0]:
+                peak_values = peak_values[:, np.newaxis]
 
         # Convert box_size from pixels to percent
         box_w_pct = self.box_size / img_w

--- a/tests/training/test_training_utils.py
+++ b/tests/training/test_training_utils.py
@@ -479,6 +479,24 @@ class TestWandBRenderer:
         assert boxes[0]["scores"]["confidence"] == pytest.approx(0.95, rel=0.01)
         assert "(0.95)" in boxes[0]["box_caption"]
 
+    def test_peaks_to_boxes_with_centroid_confidence(self):
+        """Handles centroid confidences with one value per predicted instance."""
+        renderer = WandBRenderer()
+        peaks = np.array([[[10.0, 20.0]], [[30.0, 40.0]]])
+        peak_values = np.array([0.95, 0.87])
+        node_names = ["centroid"]
+        img_w, img_h = 100, 100
+
+        boxes = renderer._peaks_to_boxes(
+            peaks, node_names, img_w, img_h, peak_values=peak_values, is_gt=False
+        )
+
+        assert len(boxes) == 2
+        assert boxes[0]["scores"]["confidence"] == pytest.approx(0.95, rel=0.01)
+        assert boxes[1]["scores"]["confidence"] == pytest.approx(0.87, rel=0.01)
+        assert "(0.95)" in boxes[0]["box_caption"]
+        assert "(0.87)" in boxes[1]["box_caption"]
+
     def test_peaks_to_boxes_skips_nan(self):
         """Skips NaN coordinates."""
         renderer = WandBRenderer()


### PR DESCRIPTION
### Summary

I got a WandB mismatching shape error when logging visualisations after training a centroid model. I fixed it with Codex (model 5.5), reviewed, and it's a pretty straightforward fix of a bit more elaborate shape normalisation which seems sensible.

### More detailed error info

<details>
<summary>WandB error in stdout</summary>

```python3
Traceback (most recent call last):
  File "/sleap/.uv/bin/sleap-nn", line 10, in <module>
    sys.exit(cli())
             ~~~^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/rich_click/rich_command.py", line 402, in __call__
    return super().__call__(*args, **kwargs)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/rich_click/rich_command.py", line 216, in main
    rv = self.invoke(ctx)
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 1902, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/cli.py", line 534, in train
    run_training(config=cfg, train_labels=train_labels, val_labels=val_labels)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/train.py", line 44, in run_training
    trainer.train()
    ~~~~~~~~~~~~~^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/training/model_trainer.py", line 1333, in train
    self.trainer.fit(
    ~~~~~~~~~~~~~~~~^
        self.lightning_model,
        ^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        ckpt_path=self.config.trainer_config.resume_ckpt_path,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 584, in fit
    call._call_and_handle_interrupt(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self,
        ^^^^^
    ...<6 lines>...
        weights_only,
        ^^^^^^^^^^^^^
    )
    ^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/trainer/call.py", line 49, in _call_and_handle_interrupt
    return trainer_fn(*args, **kwargs)
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 630, in _fit_impl
    self._run(model, ckpt_path=ckpt_path, weights_only=weights_only)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 1079, in _run
    results = self._run_stage()
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 1123, in _run_stage
    self.fit_loop.run()
    ~~~~~~~~~~~~~~~~~^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/loops/fit_loop.py", line 218, in run
    self.on_advance_end()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/loops/fit_loop.py", line 478, in on_advance_end
    call._call_callback_hooks(trainer, "on_train_epoch_end", monitoring_callbacks=False)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/lightning/pytorch/trainer/call.py", line 228, in _call_callback_hooks
    fn(trainer, trainer.lightning_module, *args, **kwargs)
    ~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/training/callbacks.py", line 760, in on_train_epoch_end
    self._log_wandb_viz(val_data, "val", epoch, wandb_logger)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/training/callbacks.py", line 685, in _log_wandb_viz
    img = renderer.render(data, caption=f"{prefix.title()} Epoch {epoch}")
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/training/utils.py", line 397, in render
    return self._render_with_boxes(data, caption)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/training/utils.py", line 462, in _render_with_boxes
    pred_box_data = self._peaks_to_boxes(
        data.pred_peaks,
    ...<4 lines>...
        is_gt=False,
    )
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/training/utils.py", line 546, in _peaks_to_boxes
    conf = float(peak_values[inst_idx, node_idx])
                 ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
Traceback (most recent call last):
  File "/sleap/configs/sleap_pipeline_v3/run_scripts/run_job.py", line 120, in <module>
    main()
    ~~~~^^
  File "/sleap/configs/sleap_pipeline_v3/run_scripts/run_job.py", line 78, in main
    run(["sleap-nn", "train", "--config", job["train_config"]], args.dry_run)
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/configs/sleap_pipeline_v3/run_scripts/run_job.py", line 27, in run
    subprocess.run(cmd, check=True)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/python/install/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['sleap-nn', 'train', '--config', '/sleap/outputs/runs/r010_centroid_recall/configs/convnext_tiny_centroid_none.yaml']' returned non-zero exit status 1.
```

</details>

**Note:** This section was generated with the help of Claude.

It seems that `_peaks_to_boxes` in `WandBRenderer` assumed 1-D `peak_values` meant one confidence per node for a single instance. Centroid models produce one confidence per instance (since there's only one node). With multiple predicted instances, peak_values shape was (N_instances,) but the old reshape turned it into (1, N_instances) — then indexing [inst_idx, node_idx] crashed.

This pull request improves the handling of confidence values in the `_peaks_to_boxes` utility and adds a new test to ensure correct behavior when centroid confidences are provided per predicted instance.

**Bugfixes and Improvements:**

* Improved normalization of `peak_values` in `_peaks_to_boxes` to correctly handle cases where confidence values are provided as a 1D array, ensuring alignment with the shape of `peaks` for both single and multiple instance scenarios.

**Testing:**

* Added a new test `test_peaks_to_boxes_with_centroid_confidence` to verify that per-instance centroid confidences are handled correctly, including checks for correct assignment of confidence scores and captions in the output boxes.

### PR integration with the existing codebase

The commit was originally applied and used with sleap-nn v0.1.3, but from what I can see ([comparing v0.1.3 tag with main of talmolab/sleap-nn](https://github.com/talmolab/sleap-nn/compare/v0.1.3...main)), the PR doesn't seem to interfere with changes made to sleap-nn in the meantime. I applied the PR to my repo fork with a patched `ci.yml` to disable codecov and run the standard sleap-nn tests which it passed (https://github.com/davorvr/sleap-nn/pull/3).