### PR TITLE
Restrict Codecov upload to talmolab/sleap-nn (skip upload in forks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
           uv run --frozen --extra torch-cpu pytest --cov=sleap_nn --cov-report=xml --durations=-1 tests/
 
       - name: Upload coverage
+        if: github.repository == 'talmolab/sleap-nn' 
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
This change to the CI workflow configuration ensures that the coverage upload step only runs for the main repository and not for forks or external contributions.

- CI Workflow Update:
  * Added a conditional to the "Upload coverage" step in `.github/workflows/ci.yml` so that coverage is uploaded only when the repository is `talmolab/sleap-nn`.