### PR TITLE
feat: expose --workspace-size-gb to export CLI (TensorRT)

### DIFF
--- a/sleap_nn/export/cli.py
+++ b/sleap_nn/export/cli.py
@@ -59,6 +59,12 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
     show_default=True,
     help="Minimum confidence threshold for peak detection (baked into ONNX graph).",
 )
+@click.option(
+    "--workspace-size-gb",
+    type=float,
+    default=None,
+    help="TensorRT builder workspace size in GB. Uses exporter default if unset.",
+)
 @click.option("--verify/--no-verify", default=True, show_default=True)
 def export(
     model_paths: tuple[Path, ...],
@@ -78,6 +84,7 @@ def export(
     device: str,
     precision: str,
     peak_threshold: float,
+    workspace_size_gb: Optional[float],
     verify: bool,
 ) -> None:
     """Export trained models to ONNX/TensorRT formats."""
@@ -118,6 +125,12 @@ def export(
     )
 
     fmt = fmt.lower()
+
+    trt_workspace_kwargs = (
+        {"workspace_size": int(workspace_size_gb * (1 << 30))}
+        if workspace_size_gb is not None
+        else {}
+    )
 
     if not model_paths:
         raise click.ClickException("Provide at least one model path to export.")
@@ -370,6 +383,7 @@ def export(
                 min_shape=trt_min_shape,
                 opt_shape=trt_opt_shape,
                 max_shape=trt_max_shape,
+                **trt_workspace_kwargs,
                 verbose=True,
             )
             # Update metadata for TensorRT
@@ -573,6 +587,7 @@ def export(
                 input_dtype=torch.uint8,
                 precision=precision,
                 max_shape=(max_batch_size, C, H * 2, W * 2),
+                **trt_workspace_kwargs,
                 verbose=True,
             )
             # Update metadata for TensorRT
@@ -778,6 +793,7 @@ def export(
                 input_dtype=torch.uint8,
                 precision=precision,
                 max_shape=(max_batch_size, C, H * 2, W * 2),
+                **trt_workspace_kwargs,
                 verbose=True,
             )
             trt_metadata = build_base_metadata(


### PR DESCRIPTION
This pull request adds support for specifying the TensorRT builder workspace size when exporting models via the CLI.

A larger workspace size enables the export of larger TensorRT models, and those that support larger maximum batch sizes. Larger batch size support is useful for GPUs with a larger amount of VRAM available, e.g. on computing clusters (in my case, 40 and 96 GB GPUs are available). Additionally, some models are too large for the 2 GB workspace size default - an error with a bottom-up model:

<details>

<summary>Bottom-up model export workspace size error</summary>

```python3
[05/10/2026-21:33:42] [TRT] [W] UNSUPPORTED_STATE: Skipping tactic 0 due to insufficient memory on requested size of 2147781632 detected for tactic 0x0000000000000000.
[05/10/2026-21:33:42] [TRT] [E] IBuilder::buildSerializedNetwork: Error Code 10: Internal Error (Could not find any implementation for node {ForeignNode[model.backbone.enc.features.1.0.block.2.weight + ONNXTRT_Broadcast_34.../model/backbone/enc/features.1/features.1.0/Add]}. In computeCosts at /_src/optimizer/common/tactic/optimizer.cpp:4265)
Traceback (most recent call last):
  File "/sleap/.uv/bin/sleap-nn", line 10, in <module>
    sys.exit(cli())
             ~~~^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/rich_click/rich_command.py", line 402, in __call__
    return super().__call__(*args, **kwargs)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/rich_click/rich_command.py", line 216, in main
    rv = self.invoke(ctx)
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 1902, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/export/cli.py", line 372, in export
    export_to_tensorrt(
    ~~~~~~~~~~~~~~~~~~^
        wrapper,
        ^^^^^^^^
    ...<8 lines>...
        verbose=True,
        ^^^^^^^^^^^^^
    )
    ^
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/export/exporters/tensorrt_exporter.py", line 78, in export_to_tensorrt
    return _export_tensorrt_onnx(
        model,
    ...<8 lines>...
        verbose,
    )
  File "/sleap/.uv/tools/sleap-nn/lib/python3.13/site-packages/sleap_nn/export/exporters/tensorrt_exporter.py", line 212, in _export_tensorrt_onnx
    raise RuntimeError("Failed to build TensorRT engine")
RuntimeError: Failed to build TensorRT engine
```

</details>

**TensorRT Export Customization:**

* Added a new `--workspace-size-gb` CLI option to `export` in `sleap_nn/export/cli.py`, allowing users to specify the TensorRT builder workspace size in gigabytes. If unset, the exporter uses its default value.
* Updated the `export` function signature and logic to accept and process the `workspace_size_gb` parameter, converting it to bytes and passing it as `workspace_size` to the TensorRT export calls.
* Modified all TensorRT export calls in the `export` function to accept the new workspace size argument via `**trt_workspace_kwargs`.