### PR TITLE
Warn when SizeMatcher silently resizes input frames

### DIFF
--- a/sleap_nn/data/resizing.py
+++ b/sleap_nn/data/resizing.py
@@ -102,6 +102,36 @@ def apply_resizer(image: torch.Tensor, instances: torch.Tensor, scale: float = 1
     return image, instances
 
 
+_SIZEMATCHER_WARNED_KEYS: set = set()
+
+
+def _warn_size_mismatch(
+    img_height: int, img_width: int, max_height: int, max_width: int
+) -> None:
+    """Emit a one-time warning per unique (input, target) size combination.
+
+    `apply_sizematcher` is called per frame, so dedup is required to avoid
+    flooding the log when every frame of a video hits the same size mismatch.
+    """
+    key = (int(img_height), int(img_width), int(max_height), int(max_width))
+    if key in _SIZEMATCHER_WARNED_KEYS:
+        return
+    _SIZEMATCHER_WARNED_KEYS.add(key)
+    direction = (
+        "downscaled"
+        if (img_height > max_height or img_width > max_width)
+        else "upscaled"
+    )
+    logger.warning(
+        f"Input image size ({img_height}x{img_width}, HxW) does not match "
+        f"the configured max_height/max_width ({max_height}x{max_width}); "
+        f"frames will be {direction} and padded on every call, which is "
+        f"slower than running on natively-sized inputs. To eliminate this "
+        f"overhead, set max_height/max_width in your config to match the "
+        f"input dimensions."
+    )
+
+
 def apply_sizematcher(
     image: torch.Tensor,
     max_height: Optional[int] = None,
@@ -115,6 +145,7 @@ def apply_sizematcher(
     if max_width is None:
         max_width = img_width
     if img_height != max_height or img_width != max_width:
+        _warn_size_mismatch(img_height, img_width, max_height, max_width)
         hratio = max_height / img_height
         wratio = max_width / img_width
 

--- a/tests/data/test_resizing.py
+++ b/tests/data/test_resizing.py
@@ -1,6 +1,7 @@
 import torch
 
 from sleap_nn.data.providers import process_lf
+from sleap_nn.data import resizing
 from sleap_nn.data.resizing import (
     apply_resizer,
     apply_pad_to_stride,
@@ -74,6 +75,8 @@ def test_apply_sizematcher(caplog, minimal_instance):
         max_instances=2,
     )
 
+    resizing._SIZEMATCHER_WARNED_KEYS.clear()
+
     image, _ = apply_sizematcher(ex["image"], 500, 500)
     assert image.shape == torch.Size([1, 1, 500, 500])
 
@@ -85,3 +88,47 @@ def test_apply_sizematcher(caplog, minimal_instance):
 
     image, eff = apply_sizematcher(ex["image"], 100, 480)
     assert image.shape == torch.Size([1, 1, 100, 480])
+
+
+def test_apply_sizematcher_warns_on_size_mismatch(caplog, minimal_instance):
+    """Size-mismatched frames (either direction) must warn about the slow path."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(
+        instances_list=lf.instances,
+        img=lf.image,
+        frame_idx=lf.frame_idx,
+        video_idx=0,
+        max_instances=2,
+    )
+
+    resizing._SIZEMATCHER_WARNED_KEYS.clear()
+    caplog.clear()
+    apply_sizematcher(ex["image"], 100, 480)  # 384x384 -> downscale
+    assert any("downscaled" in r.message and "slower" in r.message for r in caplog.records)
+
+    resizing._SIZEMATCHER_WARNED_KEYS.clear()
+    caplog.clear()
+    apply_sizematcher(ex["image"], 500, 500)  # 384x384 -> upscale
+    assert any("upscaled" in r.message and "slower" in r.message for r in caplog.records)
+
+
+def test_apply_sizematcher_warns_once_per_size(caplog, minimal_instance):
+    """Repeated calls with the same sizes should not flood the log."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    ex = process_lf(
+        instances_list=lf.instances,
+        img=lf.image,
+        frame_idx=lf.frame_idx,
+        video_idx=0,
+        max_instances=2,
+    )
+
+    resizing._SIZEMATCHER_WARNED_KEYS.clear()
+    caplog.clear()
+
+    for _ in range(5):
+        apply_sizematcher(ex["image"], 100, 480)
+    matches = [r for r in caplog.records if "100x480" in r.message]
+    assert len(matches) == 1

--- a/tests/data/test_resizing.py
+++ b/tests/data/test_resizing.py
@@ -105,12 +105,16 @@ def test_apply_sizematcher_warns_on_size_mismatch(caplog, minimal_instance):
     resizing._SIZEMATCHER_WARNED_KEYS.clear()
     caplog.clear()
     apply_sizematcher(ex["image"], 100, 480)  # 384x384 -> downscale
-    assert any("downscaled" in r.message and "slower" in r.message for r in caplog.records)
+    assert any(
+        "downscaled" in r.message and "slower" in r.message for r in caplog.records
+    )
 
     resizing._SIZEMATCHER_WARNED_KEYS.clear()
     caplog.clear()
     apply_sizematcher(ex["image"], 500, 500)  # 384x384 -> upscale
-    assert any("upscaled" in r.message and "slower" in r.message for r in caplog.records)
+    assert any(
+        "upscaled" in r.message and "slower" in r.message for r in caplog.records
+    )
 
 
 def test_apply_sizematcher_warns_once_per_size(caplog, minimal_instance):


### PR DESCRIPTION
## Summary
- `apply_sizematcher` previously rescaled and padded any frame whose dimensions didn't match `max_height`/`max_width` with no signal to the user. For video inference this is a per-frame cost — talmolab/sleap#2682 reports a ~2x throughput drop (38 → 20 fps) plus a GPU-utilization drop (~80% → ~45%) when the input video exceeds the configured size.
- Adds a deduped `logger.warning` from inside `apply_sizematcher` that names the input size, the configured `max_height`/`max_width`, and the resize direction (`upscaled`/`downscaled`). Dedup is keyed on the (input, target) size tuple so a uniform video produces a single warning, not one per frame.
- Centralizing the warning in `apply_sizematcher` covers all 5 call sites (`inference/predictors.py` and 4 in `data/custom_datasets.py`) — i.e., inference + training datasets.

## Test plan
- [x] `pytest tests/data/test_resizing.py` (5 passed) — including new `test_apply_sizematcher_warns_on_size_mismatch` (asserts both downscale and upscale paths warn) and `test_apply_sizematcher_warns_once_per_size` (asserts dedup so 5 calls with the same sizes produce 1 log record).
- [x] Manually run inference on a video whose height/width exceeds `max_height`/`max_width` and confirm a single warning lands in the log.
- [x] Run inference on a uniform-size video that matches the config and confirm no warning fires.

Closes talmolab/sleap#2682
