### PR TITLE
Fix #582: inference-refactor parity/correctness follow-ups

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -822,8 +822,8 @@ def train(
 @click.option(
     "--candidates_method",
     type=str,
-    default=None,
-    help="Either of `fixed_window` or `local_queues`. In fixed window method, candidates from the last `window_size` frames. In local queues, last `window_size` instances for each track ID is considered for matching against the current detection. Defaults to `fixed_window`, or to `local_queues` when `--max_tracks` is set (since `max_tracks` is only honored by `local_queues`).",
+    default="fixed_window",
+    help="Either of `fixed_window` or `local_queues`. In fixed window method, candidates from the last `window_size` frames. In local queues, last `window_size` instances for each track ID is considered for matching against the current detection.",
 )
 @click.option(
     "--min_match_points",
@@ -1605,7 +1605,10 @@ def _common_inference_options(f):
         click.option("--integral_refinement", type=str, default="integral"),
         click.option("--tracking_window_size", type=int, default=5),
         click.option("--min_new_track_points", type=int, default=0),
-        click.option("--candidates_method", type=str, default="fixed_window"),
+        # Default None (not "fixed_window") so _build_tracker_config can tell
+        # "user didn't choose a method" from an explicit choice, and default it
+        # to local_queues when --max_tracks is set (#582).
+        click.option("--candidates_method", type=str, default=None),
         click.option("--min_match_points", type=int, default=0),
         click.option("--features", type=str, default="keypoints"),
         click.option("--scoring_method", type=str, default="oks"),

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -822,8 +822,8 @@ def train(
 @click.option(
     "--candidates_method",
     type=str,
-    default="fixed_window",
-    help="Either of `fixed_window` or `local_queues`. In fixed window method, candidates from the last `window_size` frames. In local queues, last `window_size` instances for each track ID is considered for matching against the current detection.",
+    default=None,
+    help="Either of `fixed_window` or `local_queues`. In fixed window method, candidates from the last `window_size` frames. In local queues, last `window_size` instances for each track ID is considered for matching against the current detection. Defaults to `fixed_window`, or to `local_queues` when `--max_tracks` is set (since `max_tracks` is only honored by `local_queues`).",
 )
 @click.option(
     "--min_match_points",
@@ -1117,32 +1117,68 @@ def _build_filter_config(kwargs: dict) -> "object":
 
 
 def _build_tracker_config(kwargs: dict) -> "object":
-    """Build a :class:`TrackerConfig` from the CLI ``--tracking_*`` flags."""
+    """Build a :class:`TrackerConfig` from the CLI ``--tracking_*`` flags.
+
+    Replicates the legacy ``run_inference`` edge-layer defaulting (see
+    ``sleap_nn/predict.py`` pre-#530) so the new ``infer`` flow behaves
+    identically (#582):
+
+    * ``--max_tracks`` with no ``--candidates_method`` defaults the method to
+      ``local_queues`` (``max_tracks`` is silently ignored by ``fixed_window``).
+    * ``--post_connect_single_breaks`` / ``--tracking_pre_cull_to_target`` with
+      only ``--max_instances`` (no explicit ``--tracking_target_instance_count``)
+      derive the target count from ``max_instances`` instead of crashing /
+      silently no-op'ing.
+    * ``--post_connect_single_breaks`` with no ``--max_tracks`` derives
+      ``max_tracks`` from ``max_instances`` (legacy track-only default).
+    """
     from sleap_nn.inference.tracking import TrackerConfig
+
+    max_instances = kwargs.get("max_instances")
+    target = kwargs.get("tracking_target_instance_count")
+    max_tracks = kwargs.get("max_tracks")
+    pre_cull = kwargs.get("tracking_pre_cull_to_target", 0)
+    pcsb = kwargs.get("post_connect_single_breaks", False)
+
+    # Default candidates_method to local_queues when max_tracks is set but the
+    # user did not explicitly choose a method (the click default is None).
+    candidates_method = kwargs.get("candidates_method")
+    if candidates_method is None:
+        candidates_method = "local_queues" if max_tracks is not None else "fixed_window"
+
+    # Legacy: post_connect_single_breaks defaults max_tracks from max_instances.
+    if pcsb and max_tracks is None:
+        max_tracks = max_instances
+
+    # Legacy: post_connect / pre_cull derive the target count from max_instances
+    # when not given explicitly (leaves target=None when both are None, so the
+    # apply_tracking gate raises exactly as legacy did).
+    if (pcsb or pre_cull) and target is None:
+        target = max_instances
 
     return TrackerConfig(
         window_size=kwargs.get("tracking_window_size", 5),
         min_new_track_points=kwargs.get("min_new_track_points", 0),
-        candidates_method=kwargs.get("candidates_method", "fixed_window"),
+        candidates_method=candidates_method,
         min_match_points=kwargs.get("min_match_points", 0),
         features=kwargs.get("features", "keypoints"),
         scoring_method=kwargs.get("scoring_method", "oks"),
         scoring_reduction=kwargs.get("scoring_reduction", "mean"),
         robust_best_instance=kwargs.get("robust_best_instance", 1.0),
         track_matching_method=kwargs.get("track_matching_method", "hungarian"),
-        max_tracks=kwargs.get("max_tracks"),
+        max_tracks=max_tracks,
         use_flow=kwargs.get("use_flow", False),
         of_img_scale=kwargs.get("of_img_scale", 1.0),
         of_window_size=kwargs.get("of_window_size", 21),
         of_max_levels=kwargs.get("of_max_levels", 3),
-        tracking_target_instance_count=kwargs.get("tracking_target_instance_count"),
-        tracking_pre_cull_to_target=kwargs.get("tracking_pre_cull_to_target", 0),
+        tracking_target_instance_count=target,
+        tracking_pre_cull_to_target=pre_cull,
         tracking_pre_cull_iou_threshold=kwargs.get(
             "tracking_pre_cull_iou_threshold", 0.0
         ),
         tracking_clean_instance_count=kwargs.get("tracking_clean_instance_count", 0),
         tracking_clean_iou_threshold=kwargs.get("tracking_clean_iou_threshold", 0.0),
-        post_connect_single_breaks=kwargs.get("post_connect_single_breaks", False),
+        post_connect_single_breaks=pcsb,
     )
 
 

--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -74,6 +74,13 @@ def generate_centroids(
     Returns:
         The centroids of the instances. The output will be of shape (..., 2),
         reducing the rank of the input by 1. NaNs will be ignored in the calculation.
+
+    Note:
+        The missing/occluded-anchor fallback is the mean of visible nodes
+        (``find_points_mean``). Pre-#530 this was the bounding-box midpoint
+        (``find_points_bbox_midpoint``). The two modes are tracked for a future
+        revisit in https://github.com/talmolab/sleap-nn/issues/586 — keep this
+        consistent with the centroid target generated during training.
     """
     if anchor_ind is not None:
         centroids = points[..., anchor_ind, :].clone()

--- a/sleap_nn/inference/layers/bottomup.py
+++ b/sleap_nn/inference/layers/bottomup.py
@@ -192,6 +192,12 @@ class BottomUpLayer(InferenceLayer):
 
         The result is picklable and can be sent to a worker process.
         """
+        # Prefer a predict-time override (set on ``postprocess_config`` by
+        # ``Predictor._postprocess_overrides``) over the build-time value
+        # carried on ``self.max_instances`` (#582).
+        max_instances = getattr(self.postprocess_config, "max_instances", None)
+        if max_instances is None:
+            max_instances = self.max_instances
         return GroupingParams(
             paf_scorer_kwargs={
                 "part_names": list(self.paf_scorer.part_names),
@@ -203,7 +209,7 @@ class BottomUpLayer(InferenceLayer):
                 "min_instance_peaks": self.paf_scorer.min_instance_peaks,
                 "min_line_scores": self.paf_scorer.min_line_scores,
             },
-            max_instances=self.max_instances,
+            max_instances=max_instances,
             return_confmaps=self.postprocess_config.return_confmaps,
             return_pafs=self.postprocess_config.return_pafs,
             return_paf_graph=self.postprocess_config.return_paf_graph,

--- a/sleap_nn/inference/layers/bottomup_multiclass.py
+++ b/sleap_nn/inference/layers/bottomup_multiclass.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 import attrs
+import numpy as np
 import torch
 
 from sleap_nn.inference.layers.backends.base import ModelBackend
@@ -31,6 +32,11 @@ class BottomUpMultiClassLayer(InferenceLayer):
         cms_output_stride: Stride for ``MultiInstanceConfmapsHead``.
         class_maps_output_stride: Stride for ``ClassMapsHead``.
         max_stride: Max stride the model requires for input divisibility.
+        max_instances: Cap on instances per frame. Since each instance slot is
+            a fixed class index, the cap is applied by NaN-masking the
+            lowest-scoring class slots (not by reordering), preserving the
+            ``slot == class`` identity used for track assignment (legacy parity,
+            #582).
         preprocess_config / postprocess_config: Standard knobs.
         class_names: Ordered class names from
             ``multi_class_bottomup.class_maps.classes``. Used by the predictor
@@ -44,6 +50,7 @@ class BottomUpMultiClassLayer(InferenceLayer):
         cms_output_stride: int,
         class_maps_output_stride: int,
         max_stride: int = 1,
+        max_instances: Optional[int] = None,
         preprocess_config: Optional[PreprocessConfig] = None,
         postprocess_config: Optional[PostprocessConfig] = None,
         class_names: Optional[List[str]] = None,
@@ -58,6 +65,7 @@ class BottomUpMultiClassLayer(InferenceLayer):
         )
         self.cms_output_stride = cms_output_stride
         self.class_maps_output_stride = class_maps_output_stride
+        self.max_instances = max_instances
         self.class_names = list(class_names) if class_names is not None else None
 
     # ──────────────────────────────────────────────────────────────────
@@ -110,6 +118,25 @@ class BottomUpMultiClassLayer(InferenceLayer):
         instance_scores = torch.nanmean(peak_scores, dim=-1)
         instance_tracking_scores = torch.nanmean(class_probs, dim=-1)
 
+        # Cap instances per frame by NaN-masking the lowest-scoring class slots,
+        # preserving slot==class identity (legacy parity — legacy sorted by
+        # score and truncated to max_instances after class assignment). A
+        # predict-time override (postprocess_config) takes precedence over the
+        # build-time value (#582).
+        max_instances = getattr(self.postprocess_config, "max_instances", None)
+        if max_instances is None:
+            max_instances = self.max_instances
+        if max_instances is not None:
+            instances, peak_scores, instance_scores, instance_tracking_scores = (
+                self._cap_instances_by_score(
+                    instances,
+                    peak_scores,
+                    instance_scores,
+                    instance_tracking_scores,
+                    max_instances,
+                )
+            )
+
         outputs = Outputs(
             pred_keypoints=instances,
             pred_peak_values=peak_scores,
@@ -122,3 +149,42 @@ class BottomUpMultiClassLayer(InferenceLayer):
         if self.postprocess_config.return_class_maps:
             outputs = attrs.evolve(outputs, pred_class_maps=class_maps.detach())
         return outputs
+
+    @staticmethod
+    def _cap_instances_by_score(
+        instances: torch.Tensor,
+        peak_scores: torch.Tensor,
+        instance_scores: torch.Tensor,
+        instance_tracking_scores: torch.Tensor,
+        max_instances: int,
+    ) -> tuple:
+        """NaN-mask the lowest-scoring class slots beyond ``max_instances``.
+
+        Per frame, the present classes are those with a non-NaN
+        ``instance_score`` (a class with no assigned peaks has an all-NaN peak
+        row → NaN score). When more than ``max_instances`` classes are present,
+        the lowest-scoring ones are masked out (keypoints / peak values /
+        scores set to NaN) so the frame yields at most ``max_instances``
+        instances, while every surviving instance keeps its original class slot
+        (and therefore its track). Mirrors the legacy top-N-by-score truncation
+        without reordering.
+        """
+        B = instance_scores.shape[0]
+        for b in range(B):
+            scores_b = instance_scores[b]  # (n_classes,)
+            valid = ~torch.isnan(scores_b)
+            n_valid = int(valid.sum().item())
+            if n_valid <= max_instances:
+                continue
+            # Rank present classes by score (descending) and keep the top
+            # ``max_instances``. NaN scores sort last via argsort, matching the
+            # legacy ``np.argsort(scores)[::-1]`` selection.
+            order = np.argsort(scores_b.detach().cpu().numpy())[::-1]
+            keep = torch.as_tensor(order[:max_instances].copy(), dtype=torch.long)
+            drop_mask = torch.ones(scores_b.shape[0], dtype=torch.bool)
+            drop_mask[keep] = False
+            instances[b, drop_mask] = float("nan")
+            peak_scores[b, drop_mask] = float("nan")
+            instance_scores[b, drop_mask] = float("nan")
+            instance_tracking_scores[b, drop_mask] = float("nan")
+        return instances, peak_scores, instance_scores, instance_tracking_scores

--- a/sleap_nn/inference/layers/centered_instance.py
+++ b/sleap_nn/inference/layers/centered_instance.py
@@ -83,6 +83,7 @@ class CenteredInstanceLayer(InferenceLayer):
         crops: ImageInput,
         centroids: Optional[torch.Tensor] = None,
         instances: Optional[torch.Tensor] = None,
+        centroid_vals: Optional[torch.Tensor] = None,
     ) -> Outputs:
         """Run keypoint prediction.
 
@@ -95,6 +96,10 @@ class CenteredInstanceLayer(InferenceLayer):
                 nearest GT instance.
             instances: ``(B, max_inst, n_nodes, 2)`` GT keypoints from a
                 LabelsReader. Required on the GT path.
+            centroid_vals: ``(B, max_inst)`` centroid confidences from the
+                centroid model. Carried through as the instance score on the
+                GT path (legacy parity — legacy reported ``score=centroid_val``);
+                falls back to all-ones when not provided.
 
         Returns:
             ``Outputs`` populated with ``pred_keypoints`` and
@@ -107,7 +112,7 @@ class CenteredInstanceLayer(InferenceLayer):
                     "to be passed (the layer matches each centroid to its "
                     "nearest GT instance)."
                 )
-            return self._predict_from_gt(centroids, instances)
+            return self._predict_from_gt(centroids, instances, centroid_vals)
         return super().predict(crops)
 
     # ──────────────────────────────────────────────────────────────────
@@ -115,13 +120,20 @@ class CenteredInstanceLayer(InferenceLayer):
     # ──────────────────────────────────────────────────────────────────
 
     def _predict_from_gt(
-        self, centroids: torch.Tensor, instances: torch.Tensor
+        self,
+        centroids: torch.Tensor,
+        instances: torch.Tensor,
+        centroid_vals: Optional[torch.Tensor] = None,
     ) -> Outputs:
         """Match each centroid to its nearest GT instance; return GT keypoints.
 
         Mirrors the legacy ``FindInstancePeaksGroundTruth.forward`` matching:
         for each centroid, find the GT instance whose nearest keypoint to
         the centroid is closest, then emit that instance's keypoints.
+
+        When ``centroid_vals`` is given, those confidences are reported as the
+        per-instance score (and ``pred_centroid_values``), matching legacy
+        ``score=centroid_val``; otherwise both fall back to all-ones.
         """
         # ``centroids``: (B, max_inst, 2) — already in image-space.
         # ``instances``: (B, max_inst, n_nodes, 2) — GT keypoints.
@@ -162,11 +174,22 @@ class CenteredInstanceLayer(InferenceLayer):
             matched_vals,
         )
 
+        # Report the real centroid confidence as the instance score (legacy
+        # parity — legacy used score=centroid_val). Fall back to all-ones when
+        # the caller didn't supply centroid_vals. NaN-padded centroid slots get
+        # a NaN score so empty slots don't report a spurious value.
+        if centroid_vals is not None:
+            cvals = centroid_vals.to(device=device, dtype=torch.float32)
+        else:
+            cvals = torch.ones(B, max_inst, device=device)
+        cvals = torch.where(nan_centroid, torch.full_like(cvals, float("nan")), cvals)
+
         return Outputs(
             pred_keypoints=matched_kpts,
             pred_peak_values=matched_vals,
             pred_centroids=centroids,
-            pred_centroid_values=torch.ones(B, max_inst, device=device),
+            pred_centroid_values=cvals,
+            instance_scores=cvals,
         )
 
     # ──────────────────────────────────────────────────────────────────

--- a/sleap_nn/inference/layers/exported.py
+++ b/sleap_nn/inference/layers/exported.py
@@ -39,15 +39,32 @@ from sleap_nn.inference.layers.base import InferenceLayer
 from sleap_nn.inference.outputs import Outputs
 
 
-def _to_4d_uint8_tensor(image: Any) -> torch.Tensor:
-    """Coerce an image input to ``(B, C, H, W)`` uint8 (channel-first).
+def _to_4d_tensor_for_export(image: Any) -> torch.Tensor:
+    """Coerce an image input to ``(B, C, H, W)`` channel-first, preserving dtype.
 
-    Mirrors :meth:`InferenceLayer._to_4d_float_tensor` shape-wise, but
-    keeps the dtype as the runtime expects (``ONNXBackend`` casts to
-    its declared input dtype, typically ``uint8``, before invoking the
-    session).
+    Uses the dtype-preserving :meth:`InferenceLayer._to_4d_tensor` so a uint8
+    input stays uint8 (matching the legacy exporter's uint8 NCHW fast path)
+    instead of being force-cast to float32. Each backend re-casts to its
+    engine's declared input dtype: ``ONNXBackend`` via ``np.astype`` and
+    ``TensorRTBackend`` via ``x.to(...)``, so any input dtype is accepted.
     """
-    return InferenceLayer._to_4d_float_tensor(image)
+    return InferenceLayer._to_4d_tensor(image)
+
+
+def _raw_to_cpu(raw: dict) -> dict:
+    """Move every tensor in a backend output dict to CPU.
+
+    The grouping-based adapters build index/output tensors on the default
+    (CPU) device and index them with masks derived from the backend output.
+    ``ONNXBackend`` returns CPU tensors, but ``TensorRTBackend`` returns CUDA
+    tensors, which makes those mixed-device index/assign ops crash on a GPU
+    host (invisible to CPU-only CI). Legacy export inference moved all engine
+    outputs to CPU before grouping; mirror that here (#582). No-op on CPU.
+    """
+    return {
+        k: (v.detach().cpu() if isinstance(v, torch.Tensor) else v)
+        for k, v in raw.items()
+    }
 
 
 @attrs.define
@@ -75,7 +92,7 @@ class ExportedSingleInstanceLayer:
 
     def predict(self, image: Any, **_kwargs: Any) -> Outputs:
         """Run the backend and translate to :class:`Outputs`."""
-        x = _to_4d_uint8_tensor(image)
+        x = _to_4d_tensor_for_export(image)
         raw = self.backend(x)
         peaks = raw["peaks"]  # (B, N, 2)
         vals = raw["peak_vals"]  # (B, N)
@@ -113,7 +130,7 @@ class ExportedCenteredInstanceLayer:
 
     def predict(self, image: Any, **_kwargs: Any) -> Outputs:
         """Run the backend and translate to :class:`Outputs`."""
-        x = _to_4d_uint8_tensor(image)
+        x = _to_4d_tensor_for_export(image)
         raw = self.backend(x)
         peaks = raw["peaks"]  # (B_crops, N, 2)
         vals = raw["peak_vals"]
@@ -143,13 +160,19 @@ class ExportedCentroidLayer:
     Args:
         backend: A :class:`ModelBackend` whose
             ``does_baked_postproc`` is ``True``.
+        anchor_ind: Skeleton node index the centroid represents (resolved
+            from ``ExportMetadata.anchor_part``). Read at packaging time by
+            ``Predictor._packaging_anchor_ind`` so the centroid lands on the
+            configured anchor node rather than node 0 (#582). ``None`` (old
+            exports without ``anchor_part``) keeps the node-0 behavior.
     """
 
     backend: Any
+    anchor_ind: Optional[int] = None
 
     def predict(self, image: Any, **_kwargs: Any) -> Outputs:
         """Run the backend and translate to :class:`Outputs`."""
-        x = _to_4d_uint8_tensor(image)
+        x = _to_4d_tensor_for_export(image)
         raw = self.backend(x)
         centroids = raw["centroids"].clone()  # (B, I, 2)
         centroid_vals = raw["centroid_vals"].clone()  # (B, I)
@@ -202,6 +225,11 @@ class ExportedBottomUpLayer:
         min_instance_peaks: Drop assembled instances with fewer peaks.
         min_line_scores: Per-edge match threshold (forwarded to
             :class:`PAFScorer`).
+        peak_conf_threshold: Optional runtime peak-confidence threshold. When
+            set, PAF candidate connections whose src or dst peak confidence is
+            ``<= peak_conf_threshold`` are dropped before grouping (legacy
+            parity for the runtime threshold override, #582). ``None`` keeps
+            every candidate the wrapper emitted.
     """
 
     backend: Any
@@ -212,15 +240,16 @@ class ExportedBottomUpLayer:
     max_instances: Optional[int] = None
     min_instance_peaks: float = 0
     min_line_scores: float = 0.25
+    peak_conf_threshold: Optional[float] = None
 
     def predict(self, image: Any, **_kwargs: Any) -> Outputs:
         """Run the backend, translate to ``ScoredBatch``, run CPU grouping."""
         from sleap_nn.inference.preprocess_info import PreprocInfo
         from sleap_nn.inference.streaming import GroupingParams, group_scored_batch
 
-        x = _to_4d_uint8_tensor(image)
+        x = _to_4d_tensor_for_export(image)
         B, _C, H, W = x.shape
-        raw = self.backend(x)
+        raw = _raw_to_cpu(self.backend(x))
 
         info = PreprocInfo(
             original_size=(H, W),
@@ -314,6 +343,14 @@ class ExportedBottomUpLayer:
                 src_compact = global_to_compact[src_global]
                 dst_compact = global_to_compact[dst_global]
                 ok = (src_compact >= 0) & (dst_compact >= 0)
+                # Runtime peak-confidence gate: drop candidate connections whose
+                # src/dst peak confidence is below the threshold (legacy parity,
+                # #582). The wrapper already baked a peak threshold, so this can
+                # only tighten further.
+                if self.peak_conf_threshold is not None:
+                    pv_flat = peak_vals[b].reshape(-1)
+                    thr = self.peak_conf_threshold
+                    ok = ok & (pv_flat[src_global] > thr) & (pv_flat[dst_global] > thr)
                 if not ok.any():
                     continue
                 sample_edge_inds.append(
@@ -374,7 +411,7 @@ class ExportedTopDownLayer:
 
     def predict(self, image: Any, **_kwargs: Any) -> Outputs:
         """Run the backend and translate to :class:`Outputs`."""
-        x = _to_4d_uint8_tensor(image)
+        x = _to_4d_tensor_for_export(image)
         raw = self.backend(x)
         centroids = raw["centroids"].clone()
         centroid_vals = raw["centroid_vals"].clone()
@@ -430,8 +467,8 @@ class ExportedTopDownMultiClassLayer:
         """Run the backend, run softmax + Hungarian, build :class:`Outputs`."""
         from sleap_nn.inference.ops.identity import get_class_inds_from_vectors
 
-        x = _to_4d_uint8_tensor(image)
-        raw = self.backend(x)
+        x = _to_4d_tensor_for_export(image)
+        raw = _raw_to_cpu(self.backend(x))
 
         centroids = raw["centroids"]
         centroid_vals = raw["centroid_vals"]
@@ -520,8 +557,8 @@ class ExportedBottomUpMultiClassLayer:
         """Run the backend, flatten + group peaks by class, build ``Outputs``."""
         from sleap_nn.inference.ops.identity import group_class_peaks
 
-        x = _to_4d_uint8_tensor(image)
-        raw = self.backend(x)
+        x = _to_4d_tensor_for_export(image)
+        raw = _raw_to_cpu(self.backend(x))
 
         peaks = raw["peaks"]  # (B, n_nodes, k, 2)
         peak_vals = raw["peak_vals"]  # (B, n_nodes, k)

--- a/sleap_nn/inference/layers/exported.py
+++ b/sleap_nn/inference/layers/exported.py
@@ -546,12 +546,18 @@ class ExportedBottomUpMultiClassLayer:
         n_classes: Number of identity classes (= ``I`` in the output).
         input_scale: Wrapper's baked-in ``input_scale``. Used to
             unscale predicted points back to original-image space.
+        peak_conf_threshold: Optional runtime peak-confidence threshold.
+            When set, peaks whose confidence is ``<= peak_conf_threshold``
+            are dropped before class grouping (legacy parity — the legacy
+            exported multi-class bottom-up path gated peaks the same way,
+            #582). ``None`` keeps every peak the wrapper emitted.
     """
 
     backend: Any
     n_nodes: int
     n_classes: int
     input_scale: float = 1.0
+    peak_conf_threshold: Optional[float] = None
 
     def predict(self, image: Any, **_kwargs: Any) -> Outputs:
         """Run the backend, flatten + group peaks by class, build ``Outputs``."""
@@ -563,6 +569,9 @@ class ExportedBottomUpMultiClassLayer:
         peaks = raw["peaks"]  # (B, n_nodes, k, 2)
         peak_vals = raw["peak_vals"]  # (B, n_nodes, k)
         peak_mask = raw["peak_mask"].bool()  # (B, n_nodes, k)
+        # Runtime peak-confidence gate before class grouping (legacy parity).
+        if self.peak_conf_threshold is not None:
+            peak_mask = peak_mask & (peak_vals > self.peak_conf_threshold)
         class_probs_raw = raw["class_probs"]  # (B, n_nodes, k, n_classes)
 
         B, n_nodes, k, _ = peaks.shape

--- a/sleap_nn/inference/layers/topdown.py
+++ b/sleap_nn/inference/layers/topdown.py
@@ -121,7 +121,10 @@ class TopDownLayer:
                     "TopDownLayer with use_gt_peaks=True requires `instances`."
                 )
             return self.centered_instance_layer.predict(
-                crops=None, centroids=centroids, instances=instances
+                crops=None,
+                centroids=centroids,
+                instances=instances,
+                centroid_vals=centroid_vals,
             )
 
         # Stage 2: crop + run centered-instance model + un-crop.

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -340,6 +340,7 @@ def _build_bottomup_multiclass(
     peak_threshold: float,
     integral_refinement: str,
     integral_patch_size: int,
+    max_instances: Optional[int],
     return_confmaps: bool,
     preprocess_config: Any,
 ) -> LoadedAssets:
@@ -371,6 +372,7 @@ def _build_bottomup_multiclass(
         skeletons=skeletons,
         bottomup_config=config,
         backbone_type=backbone_type,
+        max_instances=max_instances,
     )
 
 
@@ -719,7 +721,9 @@ def load_model_assets(
 
     elif "multi_class_bottomup" in model_types:
         path = model_paths[model_types.index("multi_class_bottomup")]
-        assets = _build_bottomup_multiclass(path, **common_kwargs)
+        assets = _build_bottomup_multiclass(
+            path, max_instances=max_instances, **common_kwargs
+        )
 
     elif (
         "centroid" in model_types

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -65,6 +65,11 @@ class LoadedAssets:
     centroid_config: Optional["DictConfig"] = None
     confmap_config: Optional["DictConfig"] = None
 
+    # Cap on instances per frame. Threaded through to the bottom-up grouping
+    # stage (the legacy ``BottomUpInferenceModel`` has no such field, so the
+    # value is carried on the assets and read by ``_build_bottomup_layer``).
+    max_instances: Optional[int] = None
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Per-checkpoint helpers (shared across all model types)
@@ -322,6 +327,7 @@ def _build_bottomup(
         skeletons=skeletons,
         bottomup_config=config,
         backbone_type=backbone_type,
+        max_instances=max_instances,
     )
 
 

--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -478,9 +478,24 @@ class Outputs:
                 if self.video_indices is not None
                 else 0
             )
+            # Map the per-frame video index to its Video. For genuine multi-video
+            # output, an out-of-range index is a provider/packaging mismatch and
+            # must be loud rather than silently wrapping onto the wrong video
+            # (the old `% len(videos)` masked exactly that bug). The single-video
+            # / placeholder case stays lenient (#582).
+            if video_idx < len(videos):
+                video = videos[video_idx]
+            elif len(videos) == 1:
+                video = videos[0]
+            else:
+                raise IndexError(
+                    f"video_index {video_idx} is out of range for {len(videos)} "
+                    "videos; the provider emitted a video index with no matching "
+                    "video."
+                )
             labeled_frames.append(
                 sio.LabeledFrame(
-                    video=videos[video_idx % len(videos)] if videos else None,
+                    video=video,
                     frame_idx=frame_idx,
                     instances=instances,
                 )

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -140,7 +140,11 @@ def _build_bottomup_layer(predictor: Any, device: str) -> BottomUpLayer:
         paf_scorer=inf.paf_scorer,
         cms_output_stride=inf.cms_output_stride,
         pafs_output_stride=inf.pafs_output_stride,
-        max_instances=getattr(inf, "max_instances", None),
+        # ``max_instances`` is carried on the LoadedAssets (the legacy
+        # ``BottomUpInferenceModel`` has no such field), so read it from the
+        # assets, not the inference model — otherwise the cap is silently
+        # dropped for the from_model_paths path (#582).
+        max_instances=getattr(predictor, "max_instances", None),
         max_stride=max_stride,
         max_peaks_per_node=inf.max_peaks_per_node,
         preprocess_config=PreprocessConfig(
@@ -239,7 +243,16 @@ def _build_centered_instance_layer(
 
 
 def _build_centroid_layer_gt_only(assets: Any, backend: Any) -> CentroidLayer:
-    """Build a ``CentroidLayer`` that reads centroids from GT (no model forward)."""
+    """Build a ``CentroidLayer`` that reads centroids from GT (no model forward).
+
+    Populates the sizematcher fields (``max_height`` / ``max_width`` /
+    ``ensure_rgb`` / ``ensure_grayscale``) from the resolved preprocess config so
+    the centered-instance-only (GT-centroid) path sizematches each frame the same
+    way the model path does. Dropping them diverged from legacy whenever the
+    centered-instance config set max_height/max_width (#582). ``scale`` stays 1.0:
+    the GT path only re-applies max_height/max_width (not input_scale), and the
+    centered-instance layer applies its own input_scale to the crops.
+    """
     centroid_model = assets.inference_model.centroid_crop
     return CentroidLayer(
         backend=backend,
@@ -248,7 +261,13 @@ def _build_centroid_layer_gt_only(assets: Any, backend: Any) -> CentroidLayer:
         max_stride=1,
         anchor_ind=getattr(centroid_model, "anchor_ind", None),
         use_gt_centroids=True,
-        preprocess_config=PreprocessConfig(scale=1.0),
+        preprocess_config=PreprocessConfig(
+            scale=1.0,
+            max_height=_pp_field(assets, "max_height"),
+            max_width=_pp_field(assets, "max_width"),
+            ensure_rgb=_pp_field(assets, "ensure_rgb"),
+            ensure_grayscale=_pp_field(assets, "ensure_grayscale"),
+        ),
         postprocess_config=PostprocessConfig(),
     )
 
@@ -419,6 +438,7 @@ def _select_export_layer(
     max_instances: Optional[int] = None,
     min_instance_peaks: float = 0,
     min_line_scores: float = 0.25,
+    peak_conf_threshold: Optional[float] = None,
 ):
     """Dispatch on ``metadata.model_type`` to build the right export adapter."""
     from sleap_nn.inference.layers.exported import (
@@ -442,7 +462,21 @@ def _select_export_layer(
             backend=backend, return_confmaps=return_confmaps
         )
     if model_type == "centroid":
-        return ExportedCentroidLayer(backend=backend)
+        # Resolve the configured anchor node so the centroid lands on it at
+        # packaging time, mirroring legacy export inference (#582). Old exports
+        # without `anchor_part` keep anchor_ind=None (node-0 fallback).
+        anchor_part = getattr(metadata, "anchor_part", None)
+        anchor_ind = None
+        if anchor_part is not None:
+            node_names = list(getattr(metadata, "node_names", []) or [])
+            if anchor_part in node_names:
+                anchor_ind = node_names.index(anchor_part)
+            else:
+                raise ValueError(
+                    f"Anchor part {anchor_part!r} not found in export node_names: "
+                    f"{node_names}."
+                )
+        return ExportedCentroidLayer(backend=backend, anchor_ind=anchor_ind)
     if model_type == "topdown":
         return ExportedTopDownLayer(backend=backend)
     if model_type == "bottomup":
@@ -460,6 +494,7 @@ def _select_export_layer(
             max_instances=max_instances,
             min_instance_peaks=min_instance_peaks,
             min_line_scores=min_line_scores,
+            peak_conf_threshold=peak_conf_threshold,
         )
     if model_type in ("multi_class_topdown", "multi_class_topdown_combined"):
         if metadata.n_classes is None:
@@ -646,6 +681,7 @@ class Predictor:
         max_instances: Optional[int] = None,
         min_instance_peaks: float = 0,
         min_line_scores: float = 0.25,
+        peak_conf_threshold: Optional[float] = None,
     ) -> "Predictor":
         """Build a :class:`Predictor` from an exported ONNX/TensorRT directory.
 
@@ -662,6 +698,12 @@ class Predictor:
             max_instances: Cap on instances per frame (bottom-up).
             min_instance_peaks: Min peaks for a valid instance (bottom-up).
             min_line_scores: Per-edge match threshold (bottom-up).
+            peak_conf_threshold: Runtime peak-confidence threshold for the
+                exported bottom-up path. Gates PAF candidate connections by the
+                src/dst peak confidence (legacy parity). Defaults to the
+                threshold baked at export time (``metadata.peak_threshold``).
+                Note the wrapper already bakes a peak threshold during peak
+                finding, so this can only *tighten* beyond the baked value.
         """
         from sleap_nn.export.metadata import ExportMetadata
 
@@ -678,6 +720,13 @@ class Predictor:
         runtime, model_path = _resolve_export_runtime(export_dir, runtime)
         backend = _build_export_backend(runtime, model_path, device)
 
+        # Default the runtime peak-confidence threshold to the value baked at
+        # export time, matching legacy export inference (#582).
+        resolved_peak_conf = (
+            peak_conf_threshold
+            if peak_conf_threshold is not None
+            else getattr(metadata, "peak_threshold", None)
+        )
         layer = _select_export_layer(
             metadata=metadata,
             backend=backend,
@@ -685,6 +734,7 @@ class Predictor:
             max_instances=max_instances,
             min_instance_peaks=min_instance_peaks,
             min_line_scores=min_line_scores,
+            peak_conf_threshold=resolved_peak_conf,
         )
 
         skeleton = _skeleton_from_export(export_dir, metadata)
@@ -820,6 +870,24 @@ class Predictor:
             )
             videos = list(source.videos) if source.videos else None
             return provider, videos
+
+        if isinstance(source, (list, tuple)):
+            # Multi-source input: predict([v1, v2, v3]) -> one merged Labels with
+            # monotonically increasing per-frame video_indices (#582). Recurse to
+            # reuse per-type dispatch, then concatenate. Per-source frame
+            # selection is not expressible for a flat list, so `frames` is not
+            # applied here (build providers explicitly if you need it).
+            from sleap_nn.inference.providers import MultiVideoProvider
+
+            if len(source) == 0:
+                raise ValueError("predict() received an empty list of sources.")
+            sub_providers: list = []
+            all_videos: list = []
+            for sub in source:
+                sub_provider, sub_videos = self._make_provider(sub, **provider_kwargs)
+                sub_providers.append(sub_provider)
+                all_videos.extend(sub_videos if sub_videos else [None])
+            return MultiVideoProvider(providers=sub_providers), all_videos
 
         if hasattr(source, "__iter__"):
             return source, None
@@ -1086,7 +1154,13 @@ class Predictor:
             )
         from sleap_nn.inference.writer import IncrementalLabelsWriter
 
-        provider, _ = self._make_provider(source, frames=frames)
+        provider, derived = self._make_provider(source, frames=frames)
+        # Preserve the real source video(s) on the streamed .slp instead of the
+        # 'unknown' placeholder. Mirrors the in-memory predict() path; for a
+        # pre-built Provider source `derived` is None so the caller-supplied
+        # `videos` (possibly None) is used (#582).
+        if videos is None:
+            videos = derived
         with IncrementalLabelsWriter(
             path=path,
             skeleton=self.skeleton,
@@ -1252,8 +1326,9 @@ class Predictor:
     def _packaging_anchor_ind(self) -> Optional[int]:
         """Anchor-node slot for centroid-only output packaging."""
         from sleap_nn.inference.layers.centroid import CentroidLayer
+        from sleap_nn.inference.layers.exported import ExportedCentroidLayer
 
-        if isinstance(self.layer, CentroidLayer):
+        if isinstance(self.layer, (CentroidLayer, ExportedCentroidLayer)):
             return self.layer.anchor_ind
         return None
 

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -515,6 +515,7 @@ def _select_export_layer(
             n_nodes=int(metadata.n_nodes),
             n_classes=int(metadata.n_classes),
             input_scale=float(metadata.input_scale),
+            peak_conf_threshold=peak_conf_threshold,
         )
 
     raise ValueError(f"Unrecognized model_type {model_type!r} in export_metadata.json.")
@@ -721,12 +722,13 @@ class Predictor:
         backend = _build_export_backend(runtime, model_path, device)
 
         # Default the runtime peak-confidence threshold to the value baked at
-        # export time, matching legacy export inference (#582).
-        resolved_peak_conf = (
-            peak_conf_threshold
-            if peak_conf_threshold is not None
-            else getattr(metadata, "peak_threshold", None)
-        )
+        # export time, falling back to legacy's 0.2 when the metadata carries no
+        # baked threshold (matches legacy export inference, #582).
+        if peak_conf_threshold is not None:
+            resolved_peak_conf = peak_conf_threshold
+        else:
+            meta_thr = getattr(metadata, "peak_threshold", None)
+            resolved_peak_conf = meta_thr if meta_thr is not None else 0.2
         layer = _select_export_layer(
             metadata=metadata,
             backend=backend,
@@ -883,11 +885,26 @@ class Predictor:
                 raise ValueError("predict() received an empty list of sources.")
             sub_providers: list = []
             all_videos: list = []
+            video_offsets: list = []
             for sub in source:
                 sub_provider, sub_videos = self._make_provider(sub, **provider_kwargs)
                 sub_providers.append(sub_provider)
-                all_videos.extend(sub_videos if sub_videos else [None])
-            return MultiVideoProvider(providers=sub_providers), all_videos
+                # Each source starts at the current end of the merged video
+                # list; its own (possibly multi-video) indices are offset by
+                # this. Substitute a placeholder when a sub-source has no
+                # derivable video so frames never reference a None video
+                # (unserializable) — matches the writer's placeholder.
+                video_offsets.append(len(all_videos))
+                if sub_videos:
+                    all_videos.extend(sub_videos)
+                else:
+                    all_videos.append(sio.Video(filename="unknown", backend=None))
+            return (
+                MultiVideoProvider(
+                    providers=sub_providers, video_offsets=video_offsets
+                ),
+                all_videos,
+            )
 
         if hasattr(source, "__iter__"):
             return source, None

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -178,6 +178,7 @@ def _build_bottomup_multiclass_layer(
         cms_output_stride=inf.cms_output_stride,
         class_maps_output_stride=inf.class_maps_output_stride,
         max_stride=max_stride,
+        max_instances=getattr(predictor, "max_instances", None),
         class_names=_multiclass_class_names(predictor, "multi_class_bottomup"),
         preprocess_config=PreprocessConfig(
             scale=inf.input_scale,

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -309,33 +309,47 @@ class LabelsProvider:
 
 @attrs.define
 class MultiVideoProvider:
-    """Concatenate several providers, re-stamping per-source video indices.
+    """Concatenate several providers, OFFSETTING per-source video indices.
 
     Wraps an ordered list of already-built providers (one per input source)
-    and yields their batches in order, OVERRIDING each batch's
-    ``video_indices`` with the source ordinal (0 for the first source's
-    batches, 1 for the second, ...). Single-source providers each emit their
-    own 0-based ``video_indices`` (e.g. :class:`VideoProvider` hardcodes
-    zeros), so they must be replaced — not offset — to attribute every frame
-    to the correct video in a merged multi-video ``.slp`` (#582).
+    and yields their batches in order, shifting each batch's
+    ``video_indices`` by that source's starting global video index. Each
+    sub-provider emits its own local video indices (``VideoProvider`` always
+    0; a ``LabelsProvider`` over a multi-video ``.slp`` emits per-frame
+    0..N-1), so adding the per-source offset attributes every frame to the
+    correct video in the merged multi-video ``.slp`` — and supports both
+    single-video and multi-video sources in the list (#582).
 
     Args:
         providers: Ordered list of per-source :class:`Provider` instances.
             Build these via ``Predictor._make_provider`` so source-type
             dispatch stays in one place.
+        video_offsets: Parallel list giving each source's starting index
+            into the merged ``videos`` list (i.e. the cumulative video count
+            of the preceding sources). Defaults to ``0, 1, 2, ...`` (one
+            video per source) when omitted.
     """
 
     providers: list
+    video_offsets: Optional[list] = None
+
+    def _offsets(self) -> list:
+        if self.video_offsets is not None:
+            return list(self.video_offsets)
+        return list(range(len(self.providers)))
 
     def __iter__(self) -> Iterator[Batch]:
-        """Yield each sub-provider's batches with the source ordinal stamped."""
-        for source_idx, provider in enumerate(self.providers):
+        """Yield each sub-provider's batches with its video offset applied."""
+        offsets = self._offsets()
+        for provider, offset in zip(self.providers, offsets):
             for batch in provider:
                 n = int(batch.images.shape[0])
-                yield attrs.evolve(
-                    batch,
-                    video_indices=np.full(n, source_idx, dtype=np.int64),
-                )
+                if batch.video_indices is not None:
+                    local = np.asarray(batch.video_indices, dtype=np.int64)
+                    vid = local + offset
+                else:
+                    vid = np.full(n, offset, dtype=np.int64)
+                yield attrs.evolve(batch, video_indices=vid)
 
     def __len__(self) -> int:
         """Total batches across all sub-providers (or ``-1`` if any unknown)."""

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -212,11 +212,26 @@ class LabelsProvider:
                 if not lf.has_user_instances
             ]
         elif self.only_labeled_frames:
+            # Keep only frames with >=1 USER (ground-truth) instance, and drop
+            # predicted-only frames. Legacy LabelsReader restricted GT to user
+            # instances; using lf.instances here would feed PredictedInstances
+            # into the GT-centroid / GT-peaks paths (#582).
             self._labeled_frames = [
-                lf for lf in self._sio_labels.labeled_frames if len(lf.instances) > 0
+                lf for lf in self._sio_labels.labeled_frames if lf.has_user_instances
             ]
         else:
             self._labeled_frames = list(self._sio_labels.labeled_frames)
+
+    def _frame_instances(self, lf) -> list:
+        """Instances to expose as GT for a frame.
+
+        In ``only_labeled_frames`` mode (the GT-fallback paths), expose only the
+        USER instances so PredictedInstances are never treated as ground truth
+        (legacy parity, #582). All other modes expose every instance.
+        """
+        if self.only_labeled_frames:
+            return list(lf.user_instances)
+        return list(lf.instances)
 
     def _collect_suggested_frames(self, sio) -> list:
         """Return new ``LabeledFrame``s for unlabeled suggestions.
@@ -251,25 +266,22 @@ class LabelsProvider:
             chunk = self._labeled_frames[start:stop]
             frames = np.stack([lf.image for lf in chunk], axis=0)
 
-            max_inst = max(len(lf.instances) for lf in chunk)
+            inst_lists = [self._frame_instances(lf) for lf in chunk]
+            max_inst = max(len(insts) for insts in inst_lists)
             if max_inst == 0:
                 instances = None
             else:
                 # Pad GT instances to a uniform max_instances per batch so
                 # downstream layer code can work with fixed shapes.
                 n_nodes = next(
-                    (
-                        len(lf.instances[0].skeleton.nodes)
-                        for lf in chunk
-                        if lf.instances
-                    ),
+                    (len(insts[0].skeleton.nodes) for insts in inst_lists if insts),
                     1,
                 )
                 instances = np.full(
                     (len(chunk), max_inst, n_nodes, 2), np.nan, dtype=np.float32
                 )
-                for i, lf in enumerate(chunk):
-                    for j, inst in enumerate(lf.instances):
+                for i, insts in enumerate(inst_lists):
+                    for j, inst in enumerate(insts):
                         pts = np.asarray(inst.numpy(), dtype=np.float32)
                         instances[i, j, : pts.shape[0]] = pts
 
@@ -293,6 +305,47 @@ class LabelsProvider:
         """Number of batches over the (filtered) labeled-frame list."""
         n = len(self._labeled_frames)
         return (n + self.batch_size - 1) // self.batch_size
+
+
+@attrs.define
+class MultiVideoProvider:
+    """Concatenate several providers, re-stamping per-source video indices.
+
+    Wraps an ordered list of already-built providers (one per input source)
+    and yields their batches in order, OVERRIDING each batch's
+    ``video_indices`` with the source ordinal (0 for the first source's
+    batches, 1 for the second, ...). Single-source providers each emit their
+    own 0-based ``video_indices`` (e.g. :class:`VideoProvider` hardcodes
+    zeros), so they must be replaced — not offset — to attribute every frame
+    to the correct video in a merged multi-video ``.slp`` (#582).
+
+    Args:
+        providers: Ordered list of per-source :class:`Provider` instances.
+            Build these via ``Predictor._make_provider`` so source-type
+            dispatch stays in one place.
+    """
+
+    providers: list
+
+    def __iter__(self) -> Iterator[Batch]:
+        """Yield each sub-provider's batches with the source ordinal stamped."""
+        for source_idx, provider in enumerate(self.providers):
+            for batch in provider:
+                n = int(batch.images.shape[0])
+                yield attrs.evolve(
+                    batch,
+                    video_indices=np.full(n, source_idx, dtype=np.int64),
+                )
+
+    def __len__(self) -> int:
+        """Total batches across all sub-providers (or ``-1`` if any unknown)."""
+        total = 0
+        for provider in self.providers:
+            n = len(provider)
+            if n < 0:
+                return -1
+            total += n
+        return total
 
 
 @attrs.define

--- a/sleap_nn/inference/streaming.py
+++ b/sleap_nn/inference/streaming.py
@@ -28,6 +28,7 @@ from concurrent.futures import Future, ProcessPoolExecutor
 from typing import Any, Iterator, List, Optional, Tuple
 
 import attrs
+import numpy as np
 import torch
 
 from sleap_nn.inference.outputs import Outputs
@@ -221,8 +222,12 @@ def group_scored_batch(scored: ScoredBatch, params: GroupingParams) -> Outputs:
             params.max_instances is not None
             and int(instances_b.shape[0]) > max_instances
         ):
-            sort_key = torch.nan_to_num(scores_b, nan=float("-inf"))
-            order = torch.argsort(sort_key, descending=True)
+            # Top-N by instance score, descending. Replicate legacy exactly
+            # (``np.argsort(instance_scores)[::-1][:max]``) so tie-order and
+            # NaN handling match the legacy live + export truncation. scores_b
+            # is already CPU here (group_instances returns CPU tensors).
+            order_np = np.argsort(scores_b.detach().cpu().numpy())[::-1]
+            order = torch.from_numpy(order_np.copy())
             instances_b = instances_b[order]
             vals_b = vals_b[order]
             scores_b = scores_b[order]

--- a/sleap_nn/inference/streaming.py
+++ b/sleap_nn/inference/streaming.py
@@ -211,6 +211,21 @@ def group_scored_batch(scored: ScoredBatch, params: GroupingParams) -> Outputs:
         instances_b = predicted_instances[b]  # (n_b, n_nodes, 2)
         vals_b = predicted_peak_scores[b]  # (n_b, n_nodes)
         scores_b = predicted_instance_scores[b]  # (n_b,)
+        # When an explicit cap is set and there are more instances than the
+        # cap, keep the TOP-N by instance score (legacy parity — both the live
+        # predictors.py path and the export top-k select by score descending),
+        # not the first-N in grouping/assembly order. Only reorder when we are
+        # actually truncating, so uncapped output keeps its assembly order
+        # (preserves the parity goldens). NaN scores sort last.
+        if (
+            params.max_instances is not None
+            and int(instances_b.shape[0]) > max_instances
+        ):
+            sort_key = torch.nan_to_num(scores_b, nan=float("-inf"))
+            order = torch.argsort(sort_key, descending=True)
+            instances_b = instances_b[order]
+            vals_b = vals_b[order]
+            scores_b = scores_b[order]
         n = min(int(instances_b.shape[0]), max_instances)
         if n == 0:
             continue

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -30,11 +30,14 @@ What this does NOT cover:
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 import attrs
 
 import sleap_io as sio
+
+logger = logging.getLogger(__name__)
 
 
 @attrs.frozen(eq=False)
@@ -106,12 +109,27 @@ def apply_tracking(
     )
     from sleap_nn.tracking.utils import cull_instances
 
-    if config.post_connect_single_breaks and not (
-        config.tracking_target_instance_count or config.max_tracks
-    ):
+    # Both post_connect_single_breaks and a non-zero pre-cull target require an
+    # explicit tracking_target_instance_count (legacy parity — max_tracks was
+    # NEVER accepted as a substitute; the CLI edge layer derives the target from
+    # --max_instances before this point, see cli._build_tracker_config). #582.
+    if (
+        config.post_connect_single_breaks or config.tracking_pre_cull_to_target
+    ) and not config.tracking_target_instance_count:
         raise ValueError(
-            "post_connect_single_breaks=True requires "
-            "tracking_target_instance_count to be set."
+            "post_connect_single_breaks=True and tracking_pre_cull_to_target "
+            "require tracking_target_instance_count to be set."
+        )
+
+    # max_tracks is only honored by the local_queues candidate maker; the
+    # fixed_window default silently ignores it. The CLI auto-switches to
+    # local_queues, but a library caller can still hit this — warn rather than
+    # silently drop the cap (#582).
+    if config.max_tracks is not None and config.candidates_method == "fixed_window":
+        logger.warning(
+            "max_tracks=%s is set but candidates_method='fixed_window' ignores "
+            "it. Use candidates_method='local_queues' to honor max_tracks.",
+            config.max_tracks,
         )
 
     tracker = Tracker.from_config(

--- a/sleap_nn/inference/writer.py
+++ b/sleap_nn/inference/writer.py
@@ -56,6 +56,9 @@ class IncrementalLabelsWriter:
     _buffer: List[Any] = attrs.field(factory=list, init=False, repr=False)
     _all_frames: List[Any] = attrs.field(factory=list, init=False, repr=False)
     _closed: bool = attrs.field(default=False, init=False, repr=False)
+    _resolved_videos: Optional[List[Any]] = attrs.field(
+        default=None, init=False, repr=False
+    )
 
     @property
     def tmp_path(self) -> Path:
@@ -90,7 +93,7 @@ class IncrementalLabelsWriter:
             self._flush()
 
     def _resolve_videos(self) -> List[Any]:
-        """Return a list of Videos for label conversion.
+        """Return a list of Videos for label conversion (memoized).
 
         ``sio.Labels.save`` cannot serialize ``LabeledFrame`` objects
         whose ``video`` is ``None``, so when the caller didn't supply a
@@ -98,14 +101,25 @@ class IncrementalLabelsWriter:
         ``Video`` placeholder. The placeholder serializes cleanly and
         stays loadable via ``sio.load_slp``; users typically rebind a
         real ``Video`` after load.
+
+        The result is computed once and cached so ``write()`` (per batch)
+        and ``_finalize()`` share the **same** ``Video`` object(s). Minting
+        a fresh placeholder per call produced N+1 distinct videos, so every
+        frame referenced a ``Video`` absent from the saved ``Labels.videos``
+        list — a corrupt multi-video ``.slp`` (#582).
         """
         import sleap_io as sio
+
+        if self._resolved_videos is not None:
+            return self._resolved_videos
 
         if self.videos:
             real = [v for v in self.videos if v is not None]
             if real:
-                return real
-        return [sio.Video(filename="unknown", backend=None)]
+                self._resolved_videos = real
+                return self._resolved_videos
+        self._resolved_videos = [sio.Video(filename="unknown", backend=None)]
+        return self._resolved_videos
 
     def close(self) -> None:
         """Flush the remaining buffer + atomic-rename ``.tmp`` → final path.

--- a/tests/cli/test_infer_command.py
+++ b/tests/cli/test_infer_command.py
@@ -477,3 +477,88 @@ def test_infer_paf_workers_zero_no_warning(tmp_path):
         )
         assert result.exit_code == 0, result.output
         assert "paf-workers > 0" not in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #582 — candidates_method defaulting (infer auto-switch + track regression)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_infer_max_tracks_auto_switches_to_local_queues():
+    """`infer --max_tracks N` with no explicit method defaults to local_queues.
+
+    Drives the real CLI wiring (#582): the infer option default is None so
+    _build_tracker_config can switch fixed_window -> local_queues for max_tracks.
+    """
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict", return_value=MagicMock()
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--tracking",
+                "--max_tracks",
+                "3",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        cfg = mock_predict.call_args[1]["tracker_config"]
+        assert cfg.candidates_method == "local_queues"
+        assert cfg.max_tracks == 3
+
+
+def test_infer_explicit_fixed_window_with_max_tracks_respected():
+    """An explicit `--candidates_method fixed_window` is not overridden (#582)."""
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict", return_value=MagicMock()
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--tracking",
+                "--candidates_method",
+                "fixed_window",
+                "--max_tracks",
+                "3",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_predict.call_args[1]["tracker_config"].candidates_method == (
+            "fixed_window"
+        )
+
+
+def test_track_command_candidates_method_defaults_fixed_window():
+    """Legacy `track --tracking` keeps the fixed_window default (no None crash).
+
+    Regression guard for #582: the new flow's option was changed to default
+    None, which must NOT leak into the legacy `track` command (its option must
+    stay 'fixed_window', else run_inference -> Tracker.from_config(None) crashes).
+    """
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference", return_value=MagicMock()) as mock_run:
+        result = runner.invoke(
+            cli,
+            [
+                "track",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--tracking",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args[1]["candidates_method"] == "fixed_window"

--- a/tests/data/test_instance_centroids.py
+++ b/tests/data/test_instance_centroids.py
@@ -68,8 +68,9 @@ def test_generate_centroids_missing_anchor_node_fallback():
     the bbox midpoint) on the per-instance missing-anchor path — distinct from
     the ``anchor_ind=None`` path. Uses a skewed instance (one far node) so the
     mean and the bbox midpoint differ, locking the intended behavior (#582).
-    This is a shared module (training + GT-centroid inference); see the #582 PR
-    discussion for the intent confirmation.
+    This is a shared module (training + GT-centroid inference) kept consistent
+    between the two; the bbox-midpoint vs mean-of-visible choice is tracked in
+    #586 for a later revisit.
     """
     # 4 nodes; anchor (index 0) is NaN. Visible nodes (0,0),(0,0),(12,12).
     points = torch.tensor(

--- a/tests/data/test_instance_centroids.py
+++ b/tests/data/test_instance_centroids.py
@@ -61,6 +61,27 @@ def test_generate_centroids_anchor_none_uses_mean_of_visible_nodes():
     assert not torch.allclose(centroids, bbox_mid)
 
 
+def test_generate_centroids_missing_anchor_node_fallback():
+    """A NaN (occluded) anchor node falls back to the mean of visible nodes.
+
+    Pins the post-#530 anchor-fallback convention (mean of visible nodes, not
+    the bbox midpoint) on the per-instance missing-anchor path — distinct from
+    the ``anchor_ind=None`` path. Uses a skewed instance (one far node) so the
+    mean and the bbox midpoint differ, locking the intended behavior (#582).
+    This is a shared module (training + GT-centroid inference); see the #582 PR
+    discussion for the intent confirmation.
+    """
+    # 4 nodes; anchor (index 0) is NaN. Visible nodes (0,0),(0,0),(12,12).
+    points = torch.tensor(
+        [[[float("nan"), float("nan")], [0.0, 0.0], [0.0, 0.0], [12.0, 12.0]]]
+    )
+    centroids = generate_centroids(points, anchor_ind=0)
+    # mean of visible = (4, 4); bbox midpoint would be (6, 6).
+    torch.testing.assert_close(centroids, torch.tensor([[4.0, 4.0]]))
+    bbox_mid = find_points_bbox_midpoint(points)
+    assert not torch.allclose(centroids, bbox_mid)
+
+
 def test_find_points_mean_ignores_nan():
     """`find_points_mean` excludes NaN nodes; all-NaN → NaN."""
     points = torch.tensor(

--- a/tests/inference/test_issue_582.py
+++ b/tests/inference/test_issue_582.py
@@ -35,6 +35,7 @@ from sleap_nn.inference.streaming import (
 
 CKPT_ROOT = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
 BOTTOMUP_CKPT = CKPT_ROOT / "minimal_instance_bottomup"
+MULTICLASS_BOTTOMUP_CKPT = CKPT_ROOT / "minimal_instance_multiclass_bottomup"
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -156,6 +157,69 @@ def test_bottomup_predict_time_max_instances_override():
         predictor.layer.postprocess_config, max_instances=2
     )
     assert predictor.layer.grouping_params().max_instances == 2
+
+
+def test_multiclass_bottomup_cap_masks_lowest_score_keeping_class_slots():
+    """max_instances masks lowest-scoring CLASS slots, preserving slot==class."""
+    from sleap_nn.inference.layers.bottomup_multiclass import BottomUpMultiClassLayer
+
+    # 1 frame, 3 classes, 1 node.
+    instances = torch.tensor(
+        [[[[0.0, 0.0]], [[10.0, 10.0]], [[20.0, 20.0]]]]
+    )  # (1, 3, 1, 2)
+    peak_scores = torch.tensor([[[0.3], [0.9], [0.6]]])  # (1, 3, 1)
+    instance_scores = torch.tensor([[0.3, 0.9, 0.6]])
+    tracking_scores = torch.tensor([[0.3, 0.9, 0.6]])
+
+    inst, _pv, isc, _ts = BottomUpMultiClassLayer._cap_instances_by_score(
+        instances.clone(),
+        peak_scores.clone(),
+        instance_scores.clone(),
+        tracking_scores.clone(),
+        max_instances=1,
+    )
+    # Class 1 (score 0.9) survives in its own slot; classes 0 and 2 masked.
+    assert torch.isnan(isc[0, 0]) and torch.isnan(isc[0, 2])
+    assert float(isc[0, 1]) == pytest.approx(0.9)
+    assert not torch.isnan(inst[0, 1]).any()
+    assert torch.isnan(inst[0, 0]).all() and torch.isnan(inst[0, 2]).all()
+
+
+def test_multiclass_bottomup_cap_noop_when_present_within_cap():
+    """A class with no peaks (NaN score) doesn't count toward the cap."""
+    from sleap_nn.inference.layers.bottomup_multiclass import BottomUpMultiClassLayer
+
+    instances = torch.tensor([[[[0.0, 0.0]], [[1.0, 1.0]], [[2.0, 2.0]]]])
+    peak_scores = torch.tensor([[[0.3], [float("nan")], [0.9]]])
+    instance_scores = torch.tensor([[0.3, float("nan"), 0.9]])
+    tracking_scores = torch.tensor([[0.3, float("nan"), 0.9]])
+
+    inst, _pv, isc, _ts = BottomUpMultiClassLayer._cap_instances_by_score(
+        instances.clone(),
+        peak_scores.clone(),
+        instance_scores.clone(),
+        tracking_scores.clone(),
+        max_instances=2,
+    )
+    # Only 2 present classes (0 and 2) <= cap -> nothing masked.
+    assert float(isc[0, 0]) == pytest.approx(0.3)
+    assert float(isc[0, 2]) == pytest.approx(0.9)
+    assert not torch.isnan(inst[0, 0]).any()
+
+
+@pytest.mark.skipif(
+    not MULTICLASS_BOTTOMUP_CKPT.exists(),
+    reason="multiclass bottomup checkpoint asset not present",
+)
+def test_from_model_paths_threads_max_instances_to_multiclass_bottomup_layer():
+    """max_instances reaches the BottomUpMultiClassLayer (#582)."""
+    predictor = Predictor.from_model_paths(
+        [str(MULTICLASS_BOTTOMUP_CKPT)],
+        device="cpu",
+        peak_threshold=0.2,
+        max_instances=1,
+    )
+    assert predictor.layer.max_instances == 1
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/inference/test_issue_582.py
+++ b/tests/inference/test_issue_582.py
@@ -1,0 +1,639 @@
+"""Regression tests for issue #582 (post-#530 parity/correctness follow-ups).
+
+Covers the five clusters fixed for #582:
+
+* Bottom-up ``max_instances`` (build-time + predict-time override + top-N-by-score
+  truncation).
+* Multi-video support (``MultiVideoProvider``, writer video memoization,
+  ``predict_to_file`` video attribution, out-of-range video-index guard).
+* Exported ONNX/TRT parity (centroid anchor resolution, CPU-normalized grouping,
+  dtype-preserving helper, ``peak_conf_threshold`` threading).
+* Tracking target-count / ``max_tracks`` defaulting + gate tightening.
+* GT-centroid / centered-instance minors (sizematcher, user-instance GT filter,
+  GT centroid-confidence score).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+import sleap_io as sio
+
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.predictor import Predictor, _select_export_layer
+from sleap_nn.inference.preprocess_info import PreprocInfo
+from sleap_nn.inference.streaming import (
+    GroupingParams,
+    ScoredBatch,
+    group_scored_batch,
+)
+
+CKPT_ROOT = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
+BOTTOMUP_CKPT = CKPT_ROOT / "minimal_instance_bottomup"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cluster 1 — bottom-up max_instances (findings 20, 21, 52)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _two_instance_scored_batch() -> ScoredBatch:
+    """A single-sample ScoredBatch that groups into TWO instances.
+
+    Instance A (peaks near x=0) has LOW peak confidence; instance B (near
+    x=100) has HIGH confidence. Their assembly order is independent of score,
+    so a correct top-N-by-score truncation keeps B.
+    """
+    # peaks: [A0, B0, A1, B1]; channels [0, 0, 1, 1].
+    cms_peaks = [torch.tensor([[0.0, 0.0], [100.0, 0.0], [0.0, 10.0], [100.0, 10.0]])]
+    cms_peak_vals = [torch.tensor([0.3, 0.9, 0.3, 0.9])]
+    cms_peak_channel_inds = [torch.tensor([0, 0, 1, 1], dtype=torch.int32)]
+    # Candidate connections: A0->A1 (idx 0->2) and B0->B1 (idx 1->3).
+    # The PAF instance score is driven by the line score, so give instance B
+    # (assembled second) the HIGHER score to prove top-N-by-score reordering.
+    edge_inds = [torch.tensor([0, 0], dtype=torch.int32)]
+    edge_peak_inds = [torch.tensor([[0, 2], [1, 3]], dtype=torch.int32)]
+    line_scores = [torch.tensor([0.40, 0.95])]
+    info = PreprocInfo(
+        original_size=(128, 128),
+        processed_size=(128, 128),
+        eff_scale=torch.ones(1),
+        input_scale=1.0,
+        output_stride=1,
+    )
+    return ScoredBatch(
+        cms_peaks=cms_peaks,
+        cms_peak_vals=cms_peak_vals,
+        cms_peak_channel_inds=cms_peak_channel_inds,
+        edge_inds=edge_inds,
+        edge_peak_inds=edge_peak_inds,
+        line_scores=line_scores,
+        info=info,
+        n_samples=1,
+        n_nodes=2,
+        skip_paf=False,
+    )
+
+
+def _grouping_params(max_instances):
+    return GroupingParams(
+        paf_scorer_kwargs={
+            "part_names": ["n0", "n1"],
+            "edges": [("n0", "n1")],
+            "pafs_stride": 1,
+            "max_edge_length_ratio": 2.0,
+            "dist_penalty_weight": 1.0,
+            "n_points": 5,
+            "min_instance_peaks": 0,
+            "min_line_scores": 0.0,
+        },
+        max_instances=max_instances,
+    )
+
+
+def test_group_scored_batch_uncapped_keeps_both_instances():
+    """With no cap, both assembled instances survive."""
+    out = group_scored_batch(_two_instance_scored_batch(), _grouping_params(None))
+    kpts = out.pred_keypoints[0]  # (max_inst, n_nodes, 2)
+    n_real = int((~torch.isnan(kpts).all(dim=(-1, -2))).sum())
+    assert n_real == 2
+
+
+def test_group_scored_batch_truncates_top_n_by_score():
+    """max_instances=1 keeps the TOP instance by score, not the first assembled.
+
+    Instance B (peaks near x=100) has higher confidence than A (near x=0), so
+    the surviving instance must be B regardless of grouping/assembly order
+    (legacy parity — findings 21/52).
+    """
+    out = group_scored_batch(_two_instance_scored_batch(), _grouping_params(1))
+    kpts = out.pred_keypoints[0]  # (1, n_nodes, 2)
+    real = kpts[~torch.isnan(kpts).all(dim=(-1, -2))]
+    assert real.shape[0] == 1
+    # The surviving instance is the high-confidence one (x ~= 100), not x ~= 0.
+    assert float(real[0, :, 0].mean()) > 50.0
+
+
+@pytest.mark.skipif(
+    not BOTTOMUP_CKPT.exists(), reason="bottomup checkpoint asset not present"
+)
+def test_from_model_paths_threads_max_instances_to_bottomup_layer():
+    """from_model_paths(max_instances=N) actually reaches the BottomUpLayer.
+
+    Finding 20: the value was dropped because loaders never set it on the
+    inference model. It is now carried on LoadedAssets and read by the layer
+    builder.
+    """
+    predictor = Predictor.from_model_paths(
+        [str(BOTTOMUP_CKPT)], device="cpu", peak_threshold=0.2, max_instances=1
+    )
+    assert predictor.layer.max_instances == 1
+    # grouping_params snapshots the effective cap.
+    assert predictor.layer.grouping_params().max_instances == 1
+
+
+@pytest.mark.skipif(
+    not BOTTOMUP_CKPT.exists(), reason="bottomup checkpoint asset not present"
+)
+def test_bottomup_predict_time_max_instances_override():
+    """A predict-time max_instances override is honored by grouping_params.
+
+    The override is written onto postprocess_config; grouping_params prefers it
+    over the build-time value (finding 20, per-call path).
+    """
+    import attrs
+
+    predictor = Predictor.from_model_paths(
+        [str(BOTTOMUP_CKPT)], device="cpu", peak_threshold=0.2
+    )
+    assert predictor.layer.grouping_params().max_instances is None
+    predictor.layer.postprocess_config = attrs.evolve(
+        predictor.layer.postprocess_config, max_instances=2
+    )
+    assert predictor.layer.grouping_params().max_instances == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cluster 2 — multi-video (findings 39, 48 + multi-source gap)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _StubBackend:
+    """Minimal object satisfying the ``ModelBackend`` runtime protocol.
+
+    The GT-peaks centered-instance path never calls the backend, but
+    construction validates ``isinstance(backend, ModelBackend)``.
+    """
+
+    device = "cpu"
+    does_baked_postproc = False
+
+    def __call__(self, x):  # pragma: no cover — never called on the GT path
+        return {}
+
+    def warmup(self, input_shape):  # pragma: no cover
+        return None
+
+
+class _StubLayer:
+    """Layer-shaped stub returning one constant instance per frame."""
+
+    def predict(self, image, **kwargs) -> Outputs:
+        b = int(image.shape[0])
+        return Outputs(
+            pred_keypoints=torch.zeros(b, 1, 2, 2),
+            pred_peak_values=torch.ones(b, 1, 2),
+            instance_scores=torch.ones(b, 1) * 0.9,
+        )
+
+
+def test_multivideo_provider_assigns_monotonic_video_indices():
+    """MultiVideoProvider re-stamps each source's batches with its ordinal."""
+    from sleap_nn.inference.providers import MultiVideoProvider, NumpyProvider
+
+    p0 = NumpyProvider(images=np.zeros((3, 1, 8, 8), dtype=np.float32), batch_size=2)
+    p1 = NumpyProvider(images=np.zeros((2, 1, 8, 8), dtype=np.float32), batch_size=2)
+    mvp = MultiVideoProvider(providers=[p0, p1])
+
+    seen = []
+    for batch in mvp:
+        seen.append(np.asarray(batch.video_indices))
+    flat = np.concatenate(seen)
+    # 3 frames from source 0, then 2 frames from source 1.
+    assert flat.tolist() == [0, 0, 0, 1, 1]
+    assert len(mvp) == len(p0) + len(p1)
+
+
+def test_incremental_writer_resolve_videos_is_memoized(tmp_path):
+    """_resolve_videos returns the SAME object across calls (finding 48)."""
+    from sleap_nn.inference.writer import IncrementalLabelsWriter
+
+    skel = sio.Skeleton(nodes=[sio.Node(name="n0")])
+    writer = IncrementalLabelsWriter(path=str(tmp_path / "o.slp"), skeleton=skel)
+    assert writer._resolve_videos() is writer._resolve_videos()
+
+
+def test_incremental_writer_shares_one_video_across_flushes(tmp_path):
+    """Per-flush writes share one Video, not N+1 placeholders (finding 48)."""
+    from sleap_nn.inference.writer import IncrementalLabelsWriter
+
+    skel = sio.Skeleton(nodes=[sio.Node(name="n0"), sio.Node(name="n1")])
+    out_path = tmp_path / "out.slp"
+    # write_interval=1 forces a flush per write -> 3 separate to_labels calls.
+    writer = IncrementalLabelsWriter(
+        path=str(out_path), skeleton=skel, write_interval=1
+    )
+    with writer:
+        for i in range(3):
+            writer.write(
+                Outputs(
+                    pred_keypoints=torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]]),
+                    pred_peak_values=torch.tensor([[[0.9, 0.9]]]),
+                    frame_indices=torch.tensor([i]),
+                    video_indices=torch.tensor([0]),
+                )
+            )
+    labels = sio.load_slp(str(out_path))
+    assert len(labels.videos) == 1
+    assert len({id(lf.video) for lf in labels.labeled_frames}) == 1
+    assert labels.labeled_frames[0].video in labels.videos
+
+
+def test_predict_to_file_attaches_source_videos(tmp_path, minimal_instance):
+    """predict_to_file preserves the real source video (finding 39)."""
+    predictor = Predictor(layer=_StubLayer())
+    skel = sio.Skeleton(nodes=[sio.Node(name="n0"), sio.Node(name="n1")])
+    out_path = tmp_path / "preds.slp"
+    predictor.predict_to_file(str(minimal_instance), path=str(out_path), skeleton=skel)
+    labels = sio.load_slp(str(out_path))
+    assert len(labels.videos) >= 1
+    # Not the backend-less 'unknown' placeholder.
+    assert all("unknown" not in str(v.filename) for v in labels.videos)
+
+
+def test_to_labels_out_of_range_video_index_raises():
+    """A video index with no matching video raises for genuine multi-video."""
+    v0, v1 = sio.Video(filename="a.mp4"), sio.Video(filename="b.mp4")
+    out = Outputs(
+        pred_keypoints=torch.zeros(1, 1, 2, 2),
+        pred_peak_values=torch.ones(1, 1, 2),
+        instance_scores=torch.ones(1, 1),
+        frame_indices=torch.tensor([0]),
+        video_indices=torch.tensor([5]),  # out of range for [v0, v1]
+    )
+    skel = sio.Skeleton(nodes=[sio.Node(name="n0"), sio.Node(name="n1")])
+    with pytest.raises(IndexError, match="out of range"):
+        out.to_labels(skeleton=skel, videos=[v0, v1])
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cluster 3 — exported ONNX/TRT parity (findings 29, 30, 31, 32)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_export_helper_preserves_dtype():
+    """_to_4d_tensor_for_export keeps uint8 as uint8 (finding 32)."""
+    from sleap_nn.inference.layers.exported import _to_4d_tensor_for_export
+
+    u = _to_4d_tensor_for_export(np.zeros((16, 16), dtype=np.uint8))
+    assert u.dtype == torch.uint8
+    assert tuple(u.shape) == (1, 1, 16, 16)
+    f = _to_4d_tensor_for_export(np.zeros((16, 16), dtype=np.float32))
+    assert f.dtype == torch.float32
+
+
+def test_raw_to_cpu_moves_tensors():
+    """_raw_to_cpu detaches+moves tensors to CPU and passes non-tensors (finding 30)."""
+    from sleap_nn.inference.layers.exported import _raw_to_cpu
+
+    out = _raw_to_cpu({"t": torch.zeros(3), "s": "scalar"})
+    assert out["t"].device.type == "cpu"
+    assert out["s"] == "scalar"
+
+
+def test_select_export_layer_resolves_centroid_anchor():
+    """Exported centroid anchor resolves from metadata.anchor_part (finding 29)."""
+    meta = SimpleNamespace(
+        model_type="centroid", anchor_part="n1", node_names=["n0", "n1"]
+    )
+    layer = _select_export_layer(metadata=meta, backend=None, return_confmaps=False)
+    assert layer.anchor_ind == 1
+
+
+def test_select_export_layer_missing_anchor_raises():
+    """A configured anchor_part absent from node_names raises (finding 29)."""
+    meta = SimpleNamespace(
+        model_type="centroid", anchor_part="nope", node_names=["n0", "n1"]
+    )
+    with pytest.raises(ValueError, match="not found"):
+        _select_export_layer(metadata=meta, backend=None, return_confmaps=False)
+
+
+def test_select_export_layer_no_anchor_part_keeps_node_zero():
+    """Old exports without anchor_part keep node-0 behavior (anchor_ind None)."""
+    meta = SimpleNamespace(
+        model_type="centroid", anchor_part=None, node_names=["n0", "n1"]
+    )
+    layer = _select_export_layer(metadata=meta, backend=None, return_confmaps=False)
+    assert layer.anchor_ind is None
+
+
+def test_packaging_anchor_ind_reads_exported_centroid():
+    """_packaging_anchor_ind honors ExportedCentroidLayer.anchor_ind (finding 29)."""
+    from sleap_nn.inference.layers.exported import ExportedCentroidLayer
+
+    p = Predictor(layer=ExportedCentroidLayer(backend=None, anchor_ind=2))
+    assert p._packaging_anchor_ind() == 2
+
+
+def test_select_export_layer_threads_peak_conf_threshold():
+    """from_export_dir's resolved peak_conf_threshold reaches the layer (finding 31)."""
+    meta = SimpleNamespace(
+        model_type="bottomup",
+        node_names=["n0", "n1"],
+        edge_inds=[(0, 1)],
+        max_peaks_per_node=5,
+        input_scale=1.0,
+        peak_threshold=0.2,
+    )
+    layer = _select_export_layer(
+        metadata=meta, backend=None, return_confmaps=False, peak_conf_threshold=0.5
+    )
+    assert layer.peak_conf_threshold == 0.5
+
+
+def _bottomup_export_raw(peak_val: float) -> dict:
+    """A minimal exported bottom-up wrapper output: 2 nodes, k=1, 1 edge, 1 cand."""
+    return {
+        "peaks": torch.tensor([[[[0.0, 0.0]], [[0.0, 10.0]]]]),  # (1,2,1,2)
+        "peak_vals": torch.tensor([[[peak_val], [peak_val]]]),  # (1,2,1)
+        "peak_mask": torch.ones(1, 2, 1, dtype=torch.bool),
+        "line_scores": torch.tensor([[[0.95]]]),  # (1,1,1)
+        "candidate_mask": torch.ones(1, 1, 1, dtype=torch.bool),
+    }
+
+
+class _FakeCudaBottomUpBackend:
+    """ModelBackend stub that returns the bottom-up wrapper dict on CUDA.
+
+    Reproduces the TensorRTBackend behavior (CUDA-resident outputs) so the
+    grouping adapter's CPU/CUDA tensor-mix crash (finding 30) is exercised on
+    a GPU host — CPU-only CI cannot see it.
+    """
+
+    device = "cuda"
+    does_baked_postproc = True
+
+    def __call__(self, x):
+        raw = _bottomup_export_raw(0.9)
+        return {k: v.to("cuda") for k, v in raw.items()}
+
+    def warmup(self, input_shape):  # pragma: no cover
+        return None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA to reproduce the device mix"
+)
+def test_exported_bottomup_grouping_handles_cuda_backend():
+    """Grouping adapter doesn't crash when the backend returns CUDA tensors.
+
+    Finding 30: index/output tensors were built on CPU and indexed by CUDA
+    masks. ``_raw_to_cpu`` normalizes to CPU first. Output stays on CPU.
+    """
+    from sleap_nn.inference.layers.exported import ExportedBottomUpLayer
+
+    layer = ExportedBottomUpLayer(
+        backend=_FakeCudaBottomUpBackend(),
+        node_names=["n0", "n1"],
+        edge_inds=[(0, 1)],
+        max_peaks_per_node=1,
+    )
+    out = layer.predict(np.zeros((1, 1, 32, 32), dtype=np.uint8))
+    assert out.pred_keypoints.device.type == "cpu"
+
+
+def test_exported_bottomup_peak_conf_threshold_gates_candidates():
+    """peak_conf_threshold above the peak vals drops the candidate (finding 31)."""
+    from sleap_nn.inference.layers.exported import ExportedBottomUpLayer
+
+    info = PreprocInfo(
+        original_size=(32, 32),
+        processed_size=(32, 32),
+        eff_scale=torch.ones(1),
+        input_scale=1.0,
+        output_stride=1,
+    )
+    # No threshold -> the candidate edge survives.
+    layer_open = ExportedBottomUpLayer(
+        backend=None,
+        node_names=["n0", "n1"],
+        edge_inds=[(0, 1)],
+        max_peaks_per_node=1,
+    )
+    scored_open = layer_open._build_scored_batch(_bottomup_export_raw(0.4), info)
+    assert int(scored_open.edge_inds[0].numel()) == 1
+
+    # Threshold above the peak vals -> candidate gated out.
+    layer_strict = ExportedBottomUpLayer(
+        backend=None,
+        node_names=["n0", "n1"],
+        edge_inds=[(0, 1)],
+        max_peaks_per_node=1,
+        peak_conf_threshold=0.5,
+    )
+    scored_strict = layer_strict._build_scored_batch(_bottomup_export_raw(0.4), info)
+    assert int(scored_strict.edge_inds[0].numel()) == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cluster 4 — tracking target-count / max_tracks (findings 56, 57, 58 + gap)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_build_tracker_config_defaults_target_from_max_instances():
+    """post_connect_single_breaks + max_instances derives the target (finding 56)."""
+    from sleap_nn.cli import _build_tracker_config
+
+    cfg = _build_tracker_config(
+        {"post_connect_single_breaks": True, "max_instances": 2}
+    )
+    assert cfg.tracking_target_instance_count == 2
+    # post_connect also defaults max_tracks from max_instances (legacy).
+    assert cfg.max_tracks == 2
+
+
+def test_build_tracker_config_pre_cull_defaults_target_from_max_instances():
+    """tracking_pre_cull_to_target + max_instances derives the target (finding 57)."""
+    from sleap_nn.cli import _build_tracker_config
+
+    cfg = _build_tracker_config({"tracking_pre_cull_to_target": 1, "max_instances": 3})
+    assert cfg.tracking_target_instance_count == 3
+
+
+def test_build_tracker_config_max_tracks_defaults_local_queues():
+    """max_tracks with no explicit method defaults to local_queues (gap)."""
+    from sleap_nn.cli import _build_tracker_config
+
+    cfg = _build_tracker_config({"max_tracks": 3})
+    assert cfg.candidates_method == "local_queues"
+    assert cfg.max_tracks == 3
+
+
+def test_build_tracker_config_explicit_fixed_window_respected():
+    """An explicit candidates_method is not overridden by max_tracks (gap)."""
+    from sleap_nn.cli import _build_tracker_config
+
+    cfg = _build_tracker_config({"max_tracks": 3, "candidates_method": "fixed_window"})
+    assert cfg.candidates_method == "fixed_window"
+
+
+def test_build_tracker_config_defaults_fixed_window_without_max_tracks():
+    """No max_tracks -> default candidates_method stays fixed_window (gap)."""
+    from sleap_nn.cli import _build_tracker_config
+
+    cfg = _build_tracker_config({})
+    assert cfg.candidates_method == "fixed_window"
+
+
+def _tracking_labels(skeleton, video, n=3):
+    lfs = []
+    for i in range(n):
+        inst = sio.PredictedInstance.from_numpy(
+            points_data=np.array([[0.0, 0.0], [10.0, 0.0]], dtype=np.float32),
+            skeleton=skeleton,
+            score=0.9,
+        )
+        lfs.append(sio.LabeledFrame(video=video, frame_idx=i, instances=[inst]))
+    return sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=lfs)
+
+
+def test_apply_tracking_post_connect_only_max_tracks_raises():
+    """max_tracks alone no longer satisfies the post_connect gate (finding 58)."""
+    from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+    skel = sio.Skeleton(nodes=["head", "tail"])
+    labels = _tracking_labels(skel, sio.Video(filename="d.mp4"))
+    cfg = TrackerConfig(post_connect_single_breaks=True, max_tracks=3)
+    with pytest.raises(ValueError, match="tracking_target_instance_count"):
+        apply_tracking(labels, cfg)
+
+
+def test_apply_tracking_pre_cull_requires_target():
+    """pre_cull without a target raises (legacy parity, finding 57)."""
+    from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+    skel = sio.Skeleton(nodes=["head", "tail"])
+    labels = _tracking_labels(skel, sio.Video(filename="d.mp4"))
+    cfg = TrackerConfig(tracking_pre_cull_to_target=1)
+    with pytest.raises(ValueError, match="tracking_target_instance_count"):
+        apply_tracking(labels, cfg)
+
+
+def test_apply_tracking_post_connect_with_target_succeeds():
+    """post_connect with an explicit target count runs (positive control)."""
+    from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+    skel = sio.Skeleton(nodes=["head", "tail"])
+    labels = _tracking_labels(skel, sio.Video(filename="d.mp4"))
+    cfg = TrackerConfig(
+        post_connect_single_breaks=True, tracking_target_instance_count=2
+    )
+    out = apply_tracking(labels, cfg)
+    assert len(out.labeled_frames) == 3
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cluster 5 — GT-centroid / centered-instance minors (findings 14, 16, 43)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_centered_instance_gt_carries_centroid_confidence():
+    """use_gt_peaks reports centroid confidence as the instance score (finding 14)."""
+    from sleap_nn.inference.layers.centered_instance import CenteredInstanceLayer
+
+    layer = CenteredInstanceLayer(
+        backend=_StubBackend(), output_stride=1, use_gt_peaks=True
+    )
+    centroids = torch.tensor([[[0.0, 0.0], [100.0, 0.0]]])  # (1, 2, 2)
+    instances = torch.tensor(
+        [[[[0.0, 0.0], [1.0, 1.0]], [[100.0, 0.0], [101.0, 1.0]]]]
+    )  # (1, 2, 2, 2)
+    cvals = torch.tensor([[0.7, 0.4]])
+    out = layer.predict(
+        crops=None, centroids=centroids, instances=instances, centroid_vals=cvals
+    )
+    assert torch.allclose(out.instance_scores, cvals)
+    assert torch.allclose(out.pred_centroid_values, cvals)
+
+
+def test_centered_instance_gt_score_falls_back_to_ones():
+    """Without centroid_vals the GT score stays all-ones (back-compat, finding 14)."""
+    from sleap_nn.inference.layers.centered_instance import CenteredInstanceLayer
+
+    layer = CenteredInstanceLayer(
+        backend=_StubBackend(), output_stride=1, use_gt_peaks=True
+    )
+    centroids = torch.tensor([[[0.0, 0.0]]])  # (1, 1, 2)
+    instances = torch.tensor([[[[0.0, 0.0], [1.0, 1.0]]]])  # (1, 1, 2, 2)
+    out = layer.predict(crops=None, centroids=centroids, instances=instances)
+    assert torch.allclose(out.instance_scores, torch.ones(1, 1))
+
+
+def test_centered_instance_gt_nan_centroid_gets_nan_score():
+    """NaN-padded centroid slots get a NaN score, not a spurious value."""
+    from sleap_nn.inference.layers.centered_instance import CenteredInstanceLayer
+
+    layer = CenteredInstanceLayer(
+        backend=_StubBackend(), output_stride=1, use_gt_peaks=True
+    )
+    centroids = torch.tensor([[[0.0, 0.0], [float("nan"), float("nan")]]])
+    instances = torch.tensor([[[[0.0, 0.0], [1.0, 1.0]], [[5.0, 5.0], [6.0, 6.0]]]])
+    cvals = torch.tensor([[0.8, 0.5]])
+    out = layer.predict(
+        crops=None, centroids=centroids, instances=instances, centroid_vals=cvals
+    )
+    assert float(out.instance_scores[0, 0]) == pytest.approx(0.8)
+    assert torch.isnan(out.instance_scores[0, 1])
+
+
+def _labels_with_user_and_predicted():
+    """Labels with one user-only, one predicted-only, and one mixed frame."""
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="d.mp4")
+    pts = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+    user = sio.Instance.from_numpy(points_data=pts, skeleton=skel)
+    pred = sio.PredictedInstance.from_numpy(
+        points_data=pts + 50, skeleton=skel, score=0.9
+    )
+    lf_user = sio.LabeledFrame(video=video, frame_idx=0, instances=[user])
+    lf_pred = sio.LabeledFrame(video=video, frame_idx=1, instances=[pred])
+    lf_mixed = sio.LabeledFrame(
+        video=video,
+        frame_idx=2,
+        instances=[
+            sio.Instance.from_numpy(points_data=pts, skeleton=skel),
+            sio.PredictedInstance.from_numpy(
+                points_data=pts + 50, skeleton=skel, score=0.9
+            ),
+        ],
+    )
+    return sio.Labels(
+        videos=[video], skeletons=[skel], labeled_frames=[lf_user, lf_pred, lf_mixed]
+    )
+
+
+def test_labels_provider_only_labeled_drops_predicted_only_frames():
+    """only_labeled_frames keeps only frames with user instances (finding 43)."""
+    from sleap_nn.inference.providers import LabelsProvider
+
+    provider = LabelsProvider(
+        labels=_labels_with_user_and_predicted(), only_labeled_frames=True
+    )
+    assert [lf.frame_idx for lf in provider._labeled_frames] == [0, 2]
+
+
+def test_labels_provider_frame_instances_excludes_predicted_in_gt_mode():
+    """In only_labeled_frames mode, GT excludes PredictedInstances (finding 43)."""
+    from sleap_nn.inference.providers import LabelsProvider
+
+    labels = _labels_with_user_and_predicted()
+    provider = LabelsProvider(labels=labels, only_labeled_frames=True)
+    mixed = [lf for lf in labels.labeled_frames if lf.frame_idx == 2][0]
+    # Only the single user instance is exposed as GT (not the predicted one).
+    assert len(provider._frame_instances(mixed)) == 1
+
+
+def test_labels_provider_non_gt_mode_keeps_all_instances():
+    """With only_labeled_frames=False every instance is exposed."""
+    from sleap_nn.inference.providers import LabelsProvider
+
+    labels = _labels_with_user_and_predicted()
+    provider = LabelsProvider(labels=labels, only_labeled_frames=False)
+    mixed = [lf for lf in labels.labeled_frames if lf.frame_idx == 2][0]
+    assert len(provider._frame_instances(mixed)) == 2


### PR DESCRIPTION
## Summary

Addresses the parity/correctness follow-ups tracked in **#582** from the adversarial audit of the #530 inference-pipeline refactor (epic #508). Single PR covering all five clusters. Built with a multi-agent investigate → implement → adversarial-verify loop; the verification pass caught and fixed 2 real bugs before this PR went up (see *Review notes* below).

### Bottom-up `max_instances` (findings 20, 21, 52)
- `from_model_paths(max_instances=N)` now actually caps bottom-up output. `max_instances` is carried on `LoadedAssets` and read by `_build_bottomup_layer` — the legacy `BottomUpInferenceModel` has no such field, so the value was silently dropped on the checkpoint path.
- The predict-time `predict(max_instances=N)` override is honored too (`grouping_params()` prefers the postprocess override over the build-time value).
- `group_scored_batch` truncates the **top-N by instance score** (legacy parity: `np.argsort(scores)[::-1][:N]`), not the first-N in grouping/assembly order. It only reorders when actually capping, so uncapped output (parity goldens) is byte-identical.

### Multi-video (findings 39, 48 + new `predict([list])`)
- New `MultiVideoProvider` + `Predictor.predict([v1, v2, v3])` list/tuple branch with correct per-frame `video_indices` (offset-based, so single- and multi-video sources both compose).
- `IncrementalLabelsWriter` memoizes its resolved video list → `write()` and `_finalize()` share one `Video` (was minting N+1 placeholder videos → corrupt multi-video `.slp`).
- `predict_to_file` forwards the auto-derived source videos to the writer (was dropping them → an "unknown" placeholder).
- `Outputs.to_labels` raises on an out-of-range video index for genuine multi-video output instead of silently wrapping onto the wrong video.

### Exported ONNX/TensorRT (findings 29, 30, 31, 32)
- `ExportedCentroidLayer` resolves the configured anchor node from `metadata.anchor_part` (was always node 0); `_packaging_anchor_ind` reads it.
- Grouping adapters CPU-normalize the backend output — `TensorRTBackend` returns CUDA tensors, which crashed the CPU index-tensor grouping on GPU hosts (invisible to CPU-only CI). Covered by a real-CUDA test.
- `peak_conf_threshold` threaded through `from_export_dir` → exported bottom-up **and** multi-class bottom-up adapters (legacy runtime gate, with legacy's 0.2 fallback when metadata carries no baked threshold).
- `_to_4d_uint8_tensor` renamed/fixed to preserve dtype (restores the uint8 fast path; the old name lied and force-cast to float32).

### Tracking (findings 56, 57, 58 + candidates-method default)
- `_build_tracker_config` replicates the legacy edge defaulting: derive target / `max_tracks` from `--max_instances` for `post_connect` / `pre_cull`, and default `candidates_method=local_queues` when `--max_tracks` is set (it's silently ignored by `fixed_window`).
- `apply_tracking` gate strictly requires `tracking_target_instance_count` (drops the `max_tracks` substitute that fed `None` into `connect_single_breaks` and crashed) and now also guards `pre_cull`; warns when `max_tracks` is set under `fixed_window`.

### GT-centroid / centered-instance (findings 14, 16, 43; 10 confirmed)
- Centered-instance-only (GT-centroid) path keeps the sizematcher (`max_height`/`max_width`) instead of dropping it.
- `LabelsProvider` `only_labeled_frames` restricts GT to **user** instances and drops predicted-only frames (legacy `LabelsReader` parity), without mutating the caller's `Labels`.
- GT-peaks path reports the real centroid confidence as the instance score.

## Decisions (resolved)

1. **Anchor fallback (finding 10) — keep mean-of-visible, tracked in #586.** #530 deliberately changed `generate_centroids`' missing/occluded-anchor fallback from **bbox-midpoint → mean-of-visible-nodes** in a module **shared by training and GT-centroid inference**. We keep the mean-of-visible behavior so inference matches the centroid target used in training, and filed **#586** to revisit the two modes (and possibly make them configurable) later. Locked with an explicit NaN-anchor regression test; `generate_centroids` + the test reference #586.

2. **Multi-class bottom-up `max_instances` — now implemented (fully closes the cluster).** Threaded through `loaders._build_bottomup_multiclass` → `LoadedAssets` → the layer, and applied in `BottomUpMultiClassLayer.postprocess` by NaN-**masking** the lowest-scoring class slots (not reordering), preserving the `slot == class` identity #530 restored. Honors the predict-time override too. Multi-class identity parity tests still pass.

## Review notes (caught by the adversarial verification pass, fixed here)
- **Tracking**: the first cut changed the `--candidates_method` default on the *legacy `track`* command's option (would have crashed `track --tracking` with `Tracker.from_config(None)`) while the new `infer` flow used a separate option — so the auto-switch was dead code. Fixed: reverted the `track` option, set the `infer` flow's option default to `None`, and added CLI-level regression tests for both.
- **Exported**: `peak_conf_threshold` was only threaded to the PAF bottom-up adapter, not multi-class bottom-up (legacy gated both) — now both, with the legacy 0.2 fallback.
- **Multi-video**: switched `MultiVideoProvider` from source-ordinal to cumulative-offset indices (handles a multi-video `.slp` as a list element) and substitute a placeholder video for any videoless sub-source (avoids an unserializable `None`-video frame).

## Test plan
- New `tests/inference/test_issue_582.py` (incl. a real-CUDA exported-grouping device test), CLI regression tests in `tests/cli/test_infer_command.py`, anchor-fallback regression in `tests/data/test_instance_centroids.py`.
- Full `tests/inference` suite: **465 passed / 14 skipped / 1 xfailed**; parity goldens + strong-parity preserved. `tests/tracking` + `tests/cli` green. `black --check` + `ruff` clean.
- Run on a CUDA box, so device-sensitive paths (exported grouping, top-down stage-2) were exercised on GPU — not just CPU CI.

Part of epic #508. Follow-ups #583 (CLI/streaming/features) and #584 (coverage + minors) are next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
