### PR TITLE
Fix #583: inference-refactor CLI/streaming/feature follow-ups

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -957,14 +957,16 @@ def track(**kwargs):
     else:
         kwargs["frames"] = None
 
-    # Pop new-pipeline-only flags that track doesn't use
+    # Pop new-pipeline-only flags that track doesn't use. NOTE: `gui` is NOT
+    # popped — legacy run_inference accepts+honors it (predict.py sets
+    # predictor.gui, switching to JSON-per-line progress); popping it silently
+    # dropped `track --gui` GUI integration (#583).
     kwargs.pop("paf_workers", None)
     kwargs.pop("cpu_workers", None)
     kwargs.pop("stream_to_file", None)
     kwargs.pop("write_interval", None)
     kwargs.pop("centroid_only", None)
     kwargs.pop("centroid_peak_threshold", None)
-    kwargs.pop("gui", None)
 
     return run_inference(**kwargs)
 
@@ -1182,6 +1184,44 @@ def _build_tracker_config(kwargs: dict) -> "object":
     )
 
 
+def _scope_labels_to_video(labels, video_index: int, frames=None):
+    """Scope a ``Labels`` to one video (re-indexed to slot 0), optionally + frames.
+
+    Returns ``(scoped_labels, target_video)``. Raises ``click.UsageError`` for an
+    out-of-range ``video_index``. Carries the video's ``suggestions`` and the
+    source ``provenance`` so ``--video_index`` composes with
+    ``--only_suggested_frames`` / ``--frames`` and preserves input lineage
+    (legacy parity, #583).
+    """
+    import sleap_io as sio
+
+    if video_index >= len(labels.videos):
+        raise click.UsageError(
+            f"--video_index {video_index} is out of range: the .slp has "
+            f"{len(labels.videos)} video(s)."
+        )
+    target = labels.videos[video_index]
+    wanted = set(frames) if frames else None
+    lfs = [
+        lf
+        for lf in labels.find(video=target)
+        if wanted is None or lf.frame_idx in wanted
+    ]
+    suggestions = [
+        s
+        for s in (getattr(labels, "suggestions", None) or [])
+        if s.video is target and (wanted is None or s.frame_idx in wanted)
+    ]
+    scoped = sio.Labels(
+        videos=[target],
+        skeletons=labels.skeletons,
+        labeled_frames=lfs,
+        suggestions=suggestions,
+        provenance=dict(getattr(labels, "provenance", None) or {}),
+    )
+    return scoped, target
+
+
 def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     """Run the new ``predict()`` flow synchronously and save the resulting Labels.
 
@@ -1213,7 +1253,33 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
             "only_predicted_frames",
         )
     )
-    if src.suffix == ".slp" and has_slp_filters:
+    # Suffix for the auto-derived output filename when --video_index scopes a
+    # single video of a multi-video .slp (legacy parity, so per-video runs don't
+    # collide on one output path). Stays None for the non-video_index case. #583.
+    scoped_video_name = None
+    video_index = kwargs.get("video_index")
+    if src.suffix == ".slp" and video_index is not None:
+        import sleap_io as sio
+
+        # Scope to the requested video (re-indexed to slot 0 so its frames map to
+        # videos[0] and avoid an out-of-range video index in packaging). The
+        # frames pass through a pre-built LabelsProvider, so the real Video is not
+        # re-attached on output (same as the has_slp_filters path); the output is
+        # video-name-suffixed instead. Carries suggestions + the --frames filter.
+        scoped, target_video = _scope_labels_to_video(
+            sio.load_slp(str(src)), video_index, frames=kwargs.get("frames")
+        )
+        source = LabelsProvider(
+            labels=scoped,
+            batch_size=kwargs.get("batch_size", 4),
+            only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
+            only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
+            exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
+            only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
+        )
+        _vfn = getattr(target_video, "filename", None)
+        scoped_video_name = Path(str(_vfn)).stem if _vfn else f"video_{video_index}"
+    elif src.suffix == ".slp" and has_slp_filters:
         source = LabelsProvider(
             labels=str(src),
             batch_size=kwargs.get("batch_size", 4),
@@ -1253,7 +1319,20 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         "anchor_part": kwargs.get("anchor_part"),
         "frames": kwargs.get("frames"),
         "clean_empty_frames": bool(kwargs.get("no_empty_frames")),
-        "output_path": kwargs.get("output_path") or f"{src}.slp",
+        "output_path": (
+            kwargs.get("output_path")
+            or (
+                f"{src.with_suffix('')}.{scoped_video_name}.predictions.slp"
+                if scoped_video_name is not None
+                else f"{src}.slp"
+            )
+        ),
+        # Bottom-up PAF grouping knobs (inert for non-bottom-up models). #583.
+        "max_edge_length_ratio": kwargs.get("max_edge_length_ratio", 0.25),
+        "dist_penalty_weight": kwargs.get("dist_penalty_weight", 1.0),
+        "n_points": kwargs.get("n_points", 10),
+        "min_instance_peaks": kwargs.get("min_instance_peaks", 0),
+        "min_line_scores": kwargs.get("min_line_scores", 0.25),
     }
     preprocess_config = _build_preprocess_config(kwargs)
     if preprocess_config is not None:
@@ -1269,10 +1348,19 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     filter_config = _build_filter_config(kwargs)
     if filter_config is not None:
         predict_kwargs["filter_config"] = filter_config
+
     if kwargs.get("gui"):
         predict_kwargs["progress_callback"] = _gui_progress_callback()
+        return predict(source, **predict_kwargs)
 
-    return predict(source, **predict_kwargs)
+    # Non-gui: show a Rich progress bar (parity with legacy `track`'s default
+    # progress UX; the plumbing was wired but no callback was attached). #583.
+    cb, progress = _rich_progress_callback()
+    predict_kwargs["progress_callback"] = cb
+    try:
+        return predict(source, **predict_kwargs)
+    finally:
+        progress.stop()
 
 
 def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
@@ -1290,19 +1378,13 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
 
     labels = sio.load_slp(str(src))
 
-    # video_index filter (optional)
+    # Scope by --video_index (raises on out-of-range, like the inference paths)
+    # and/or --frames, carrying suggestions + the source provenance. #583.
     video_index = kwargs.get("video_index")
-    if video_index is not None and video_index < len(labels.videos):
-        target_video = labels.videos[video_index]
-        labels = sio.Labels(
-            videos=labels.videos,
-            skeletons=labels.skeletons,
-            labeled_frames=labels.find(video=target_video),
-        )
-
-    # frames filter (optional)
     frames = kwargs.get("frames")
-    if frames:
+    if video_index is not None:
+        labels, _ = _scope_labels_to_video(labels, video_index, frames=frames)
+    elif frames:
         wanted = set(frames)
         labels = sio.Labels(
             videos=labels.videos,
@@ -1310,13 +1392,31 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
             labeled_frames=[
                 lf for lf in labels.labeled_frames if lf.frame_idx in wanted
             ],
+            suggestions=labels.suggestions,
+            provenance=dict(getattr(labels, "provenance", None) or {}),
         )
 
+    import attrs as _attrs
+
+    from sleap_nn.inference.provenance import build_tracking_only_provenance
+
     tracker_config = _build_tracker_config(kwargs)
+    _start = datetime.now()
     out = predictor_cls.retrack(
         labels,
         tracker_config,
         clean_empty_frames=bool(kwargs.get("no_empty_frames")),
+    )
+    # Attach tracking-only provenance to the retracked .slp (legacy parity —
+    # apply_tracking leaves provenance to the caller, and the legacy track path
+    # set it; the new retrack flow previously saved with empty provenance). #583.
+    out.provenance = build_tracking_only_provenance(
+        input_labels=labels,
+        input_path=str(src),
+        start_time=_start,
+        end_time=datetime.now(),
+        tracking_params=_attrs.asdict(tracker_config),
+        frames_processed=len(out.labeled_frames),
     )
     output_path = kwargs.get("output_path") or f"{src}.slp"
     out.save(output_path)
@@ -1359,6 +1459,53 @@ def _gui_progress_callback():
         state["last"] = now
 
     return cb
+
+
+def _rich_progress_callback():
+    """Build a Rich progress bar callback for the non-``--gui`` ``infer`` path.
+
+    Returns ``(callback, progress)`` where ``callback(processed, total)`` has
+    the per-batch signature the new pipeline uses. The ``Progress`` is started
+    immediately (so "Predicting..." shows right away) and the caller MUST stop
+    it in a ``finally`` block so the bar closes cleanly on success or error.
+    A ``total <= 0`` (length-less provider) renders an indeterminate bar.
+
+    ``rich`` is imported lazily so it doesn't slow ``--help``; the columns
+    mirror the legacy ``track`` look-and-feel without importing the heavy
+    legacy ``predictors`` module. Progress is counted in batches (the new
+    callback reports batches, not frames). #583.
+    """
+    from rich.progress import (
+        BarColumn,
+        MofNCompleteColumn,
+        Progress,
+        TaskProgressColumn,
+        TimeElapsedColumn,
+        TimeRemainingColumn,
+    )
+
+    progress = Progress(
+        "[progress.description]{task.description}",
+        BarColumn(),
+        TaskProgressColumn(),
+        MofNCompleteColumn(),
+        "ETA:",
+        TimeRemainingColumn(),
+        "Elapsed:",
+        TimeElapsedColumn(),
+        refresh_per_second=4,
+    )
+    task = progress.add_task("Predicting...", total=None)
+    progress.start()
+    state = {"total_set": False}
+
+    def cb(processed: int, total: int) -> None:
+        if not state["total_set"] and total and total > 0:
+            progress.update(task, total=total)
+            state["total_set"] = True
+        progress.update(task, completed=processed)
+
+    return cb, progress
 
 
 def _run_stream_to_file(
@@ -1408,6 +1555,12 @@ def _run_stream_to_file(
         "return_confmaps": False,
         "anchor_part": kwargs.get("anchor_part"),
         "paf_workers": paf_workers,
+        # Bottom-up PAF grouping knobs (inert for non-bottom-up models). #583.
+        "max_edge_length_ratio": kwargs.get("max_edge_length_ratio", 0.25),
+        "dist_penalty_weight": kwargs.get("dist_penalty_weight", 1.0),
+        "n_points": kwargs.get("n_points", 10),
+        "min_instance_peaks": kwargs.get("min_instance_peaks", 0),
+        "min_line_scores": kwargs.get("min_line_scores", 0.25),
     }
     preprocess_config = _build_preprocess_config(kwargs)
     if preprocess_config is not None:
@@ -1425,7 +1578,25 @@ def _run_stream_to_file(
     predictor = Predictor.from_model_paths(kwargs["model_paths"], **factory_kwargs)
 
     src = Path(data_path)
-    if src.suffix == ".slp":
+    video_index = kwargs.get("video_index")
+    if src.suffix == ".slp" and video_index is not None:
+        # Scope streaming inference to the requested video of a multi-video .slp
+        # (re-indexed to videos[0] so frames map correctly). Carries suggestions
+        # + the --frames filter. #583.
+        import sleap_io as sio
+
+        scoped, _target_video = _scope_labels_to_video(
+            sio.load_slp(str(src)), video_index, frames=kwargs.get("frames")
+        )
+        provider = LabelsProvider(
+            labels=scoped,
+            batch_size=kwargs.get("batch_size", 4),
+            only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
+            only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
+            exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
+            only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
+        )
+    elif src.suffix == ".slp":
         provider = LabelsProvider(
             labels=str(src),
             batch_size=kwargs.get("batch_size", 4),
@@ -1443,12 +1614,25 @@ def _run_stream_to_file(
             input_format=kwargs.get("video_input_format"),
         )
 
-    return predictor.predict_to_file(
-        provider,
-        path=str(stream_to_file),
-        write_interval=write_interval,
-        progress_callback=_gui_progress_callback() if kwargs.get("gui") else None,
-    )
+    if kwargs.get("gui"):
+        return predictor.predict_to_file(
+            provider,
+            path=str(stream_to_file),
+            write_interval=write_interval,
+            progress_callback=_gui_progress_callback(),
+        )
+
+    # Non-gui: Rich progress bar, stopped cleanly in finally (#583).
+    cb, progress = _rich_progress_callback()
+    try:
+        return predictor.predict_to_file(
+            provider,
+            path=str(stream_to_file),
+            write_interval=write_interval,
+            progress_callback=cb,
+        )
+    finally:
+        progress.stop()
 
 
 def _common_inference_options(f):
@@ -1572,7 +1756,15 @@ def _common_inference_options(f):
         click.option("--n_points", type=int, default=10),
         click.option("--min_instance_peaks", type=float, default=0),
         click.option("--min_line_scores", type=float, default=0.25),
-        click.option("--queue_maxsize", type=int, default=32),
+        click.option(
+            "--queue_maxsize",
+            type=int,
+            default=32,
+            hidden=True,
+            help="[no-op] Retained for CLI compatibility; ignored by the new "
+            "inference pipeline (which has no frame-buffer queue). The legacy "
+            "`sleap-nn track` path still honors it.",
+        ),
         click.option("--crop_size", type=int, default=None),
         click.option(
             "--peak_threshold",
@@ -1652,9 +1844,10 @@ def _common_inference_options(f):
             type=str,
             default=None,
             help=(
-                "Stream predictions incrementally to this .slp path "
-                "(memory stays O(write-interval)). Triggers the new "
-                "Predictor.predict_to_file flow."
+                "Write predictions to this .slp path via the new "
+                "Predictor.predict_to_file flow. Heavy intermediate tensors "
+                "(confmaps/PAFs) are dropped per batch; the .slp is written "
+                "once at the end."
             ),
         ),
         click.option(
@@ -1663,8 +1856,8 @@ def _common_inference_options(f):
             type=int,
             default=None,
             help=(
-                "Number of LabeledFrames to buffer before flushing to "
-                "disk when --stream-to-file is set. Default: 500."
+                "How often (in frames) to slim+convert buffered outputs to "
+                "LabeledFrames when --stream-to-file is set. Default: 500."
             ),
         ),
     ]

--- a/sleap_nn/inference/layers/topdown.py
+++ b/sleap_nn/inference/layers/topdown.py
@@ -330,6 +330,15 @@ class TopDownLayer:
         # the same class slot.
         full_class_inds = None
         full_tracking_scores = None
+        full_class_vectors = None
+        # Whether the caller requested the raw class vectors on the output
+        # (predict-time return_class_vectors override, #583). Without scattering
+        # them here, the composed top-down output silently dropped them.
+        want_class_vectors = getattr(
+            getattr(self.centered_instance_layer, "postprocess_config", None),
+            "return_class_vectors",
+            False,
+        )
         if stage2_out.pred_class_probs is not None:
             from sleap_nn.inference.ops.identity import get_class_inds_from_vectors
 
@@ -342,6 +351,11 @@ class TopDownLayer:
             )
             # Raw per-crop softmax vectors aligned with ``valid_idx`` rows.
             crop_class_vectors = stage2_out.pred_class_probs.squeeze(1)  # (n_valid, C)
+            if want_class_vectors:
+                n_classes = int(crop_class_vectors.shape[-1])
+                full_class_vectors = torch.full(
+                    (B, max_inst, n_classes), float("nan"), device=device
+                )
             crop_b = valid_idx[:, 0]
             crop_i = valid_idx[:, 1]
             for b in torch.unique(crop_b):
@@ -357,6 +371,8 @@ class TopDownLayer:
                     -1, n_cls_nodes
                 )
                 full_tracking_scores[b, inst_slots] = cls_probs
+                if full_class_vectors is not None:
+                    full_class_vectors[b, inst_slots] = vecs.to(device)
 
         return Outputs(
             pred_keypoints=full_kpts,
@@ -368,6 +384,7 @@ class TopDownLayer:
             instance_tracking_scores=full_tracking_scores,
             instance_bboxes=full_bboxes,
             pred_class_inds=full_class_inds,
+            pred_class_vectors=full_class_vectors,
             crops=full_crops,
         )
 

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -288,6 +288,11 @@ def _build_bottomup(
     max_instances: Optional[int],
     return_confmaps: bool,
     preprocess_config: Any,
+    max_edge_length_ratio: float = 0.25,
+    dist_penalty_weight: float = 1.0,
+    n_points: int = 10,
+    min_instance_peaks: Union[int, float] = 0,
+    min_line_scores: float = 0.25,
 ) -> LoadedAssets:
     module, config, backbone_type = _load_lightning_module(
         BottomUpLightningModule,
@@ -301,6 +306,9 @@ def _build_bottomup(
 
     preprocess_config = _resolve_preprocess_config(preprocess_config, config)
 
+    # Thread the bottom-up PAF grouping knobs from the CLI/API into the scorer
+    # (legacy ran_inference set these on the live scorer; the new infer flow
+    # silently dropped them). #583.
     paf_scorer = PAFScorer.from_config(
         config=OmegaConf.create(
             {
@@ -308,6 +316,11 @@ def _build_bottomup(
                 "pafs": config.model_config.head_configs.bottomup["pafs"],
             }
         ),
+        max_edge_length_ratio=max_edge_length_ratio,
+        dist_penalty_weight=dist_penalty_weight,
+        n_points=n_points,
+        min_instance_peaks=min_instance_peaks,
+        min_line_scores=min_line_scores,
     )
 
     inference_model = BottomUpInferenceModel(
@@ -674,8 +687,19 @@ def load_model_assets(
     return_confmaps: bool = False,
     preprocess_config: Optional["DictConfig"] = None,
     anchor_part: Optional[str] = None,
+    max_edge_length_ratio: float = 0.25,
+    dist_penalty_weight: float = 1.0,
+    n_points: int = 10,
+    min_instance_peaks: Union[int, float] = 0,
+    min_line_scores: float = 0.25,
 ) -> tuple[LoadedAssets, List[str]]:
     """Load checkpoints and build inference models.
+
+    The five bottom-up PAF grouping knobs (``max_edge_length_ratio``,
+    ``dist_penalty_weight``, ``n_points``, ``min_instance_peaks``,
+    ``min_line_scores``) are forwarded ONLY to the plain bottom-up builder
+    (legacy applied them only to ``BottomUpPredictor``); they are inert for
+    other model types.
 
     Returns:
         ``(loaded_assets, model_types)`` — *model_types* is the list of
@@ -717,7 +741,16 @@ def load_model_assets(
 
     elif "bottomup" in model_types:
         path = model_paths[model_types.index("bottomup")]
-        assets = _build_bottomup(path, max_instances=max_instances, **common_kwargs)
+        assets = _build_bottomup(
+            path,
+            max_instances=max_instances,
+            max_edge_length_ratio=max_edge_length_ratio,
+            dist_penalty_weight=dist_penalty_weight,
+            n_points=n_points,
+            min_instance_peaks=min_instance_peaks,
+            min_line_scores=min_line_scores,
+            **common_kwargs,
+        )
 
     elif "multi_class_bottomup" in model_types:
         path = model_paths[model_types.index("multi_class_bottomup")]

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -10,9 +10,13 @@ Three usage tiers:
   ``Outputs`` if ``make_labels=False``). Loads everything into memory;
   use for short videos / interactive sessions.
 * :meth:`predict_streaming` — yields one ``Outputs`` per batch as a
-  generator. Memory stays O(tracker_window).
-* :meth:`predict_to_file` — disk-streaming write of a ``.slp`` via
-  :class:`IncrementalLabelsWriter`. Memory stays O(write_interval).
+  generator; nothing is retained across batches, so memory stays
+  O(batch) (with ``paf_workers>0``, O(in-flight window)). Tracking is
+  not supported here (it needs the full frame list); use :meth:`predict`.
+* :meth:`predict_to_file` — buffered write of a ``.slp`` via
+  :class:`IncrementalLabelsWriter`. Heavy tensors are dropped per batch;
+  the (slimmed) ``LabeledFrame``s accumulate until finalize (see that
+  class for the memory note).
 """
 
 from __future__ import annotations
@@ -597,6 +601,11 @@ class Predictor:
         paf_workers: int = 0,
         tracker_config: Optional["TrackerConfig"] = None,
         centroid_only: bool = False,
+        max_edge_length_ratio: float = 0.25,
+        dist_penalty_weight: float = 1.0,
+        n_points: int = 10,
+        min_instance_peaks: Union[int, float] = 0,
+        min_line_scores: float = 0.25,
     ) -> "Predictor":
         """Build a :class:`Predictor` from one or more checkpoint paths.
 
@@ -622,6 +631,12 @@ class Predictor:
             tracker_config: :class:`TrackerConfig` for tracking.
             centroid_only: Force centroid-only output even when a
                 centered-instance model is among ``model_paths``.
+            max_edge_length_ratio: Bottom-up PAF max edge length ratio.
+            dist_penalty_weight: Bottom-up PAF distance penalty weight.
+            n_points: Bottom-up PAF line integration sample count.
+            min_instance_peaks: Bottom-up min peaks for a valid instance.
+            min_line_scores: Bottom-up per-edge match threshold. (These five
+                are applied only to plain bottom-up models.)
         """
         from sleap_nn.inference.loaders import load_model_assets
 
@@ -637,6 +652,11 @@ class Predictor:
             return_confmaps=return_confmaps,
             preprocess_config=preprocess_config,
             anchor_part=anchor_part,
+            max_edge_length_ratio=max_edge_length_ratio,
+            dist_penalty_weight=dist_penalty_weight,
+            n_points=n_points,
+            min_instance_peaks=min_instance_peaks,
+            min_line_scores=min_line_scores,
         )
 
         if centroid_only:
@@ -966,6 +986,10 @@ class Predictor:
         integral_patch_size: Optional[int] = None,
         return_confmaps: Optional[bool] = None,
         return_crops: Optional[bool] = None,
+        return_pafs: Optional[bool] = None,
+        return_paf_graph: Optional[bool] = None,
+        return_class_maps: Optional[bool] = None,
+        return_class_vectors: Optional[bool] = None,
     ) -> Union[List[Outputs], "sio.Labels"]:
         """Run inference on a source.
 
@@ -1002,6 +1026,14 @@ class Predictor:
             return_confmaps: Override whether to return confidence maps.
             return_crops: Override whether to return per-instance crops
                 (top-down only).
+            return_pafs: Override whether to return part-affinity fields
+                (bottom-up).
+            return_paf_graph: Override whether to return the PAF graph
+                (bottom-up).
+            return_class_maps: Override whether to return class maps
+                (multi-class bottom-up).
+            return_class_vectors: Override whether to return class vectors
+                (multi-class top-down).
 
         Returns:
             ``sio.Labels`` (default) or ``List[Outputs]`` (when
@@ -1023,6 +1055,10 @@ class Predictor:
             integral_patch_size=integral_patch_size,
             return_confmaps=return_confmaps,
             return_crops=return_crops,
+            return_pafs=return_pafs,
+            return_paf_graph=return_paf_graph,
+            return_class_maps=return_class_maps,
+            return_class_vectors=return_class_vectors,
         ):
             outputs_list = list(self._batch_iter(provider, progress_callback))
         _prov_end = datetime.now()
@@ -1082,6 +1118,10 @@ class Predictor:
         integral_patch_size: Optional[int] = None,
         return_confmaps: Optional[bool] = None,
         return_crops: Optional[bool] = None,
+        return_pafs: Optional[bool] = None,
+        return_paf_graph: Optional[bool] = None,
+        return_class_maps: Optional[bool] = None,
+        return_class_vectors: Optional[bool] = None,
     ) -> Iterator[Outputs]:
         """Yield one ``Outputs`` per batch from ``source``.
 
@@ -1100,6 +1140,14 @@ class Predictor:
             return_confmaps: Override whether to return confidence maps.
             return_crops: Override whether to return per-instance crops
                 (top-down only).
+            return_pafs: Override whether to return part-affinity fields
+                (bottom-up).
+            return_paf_graph: Override whether to return the PAF graph
+                (bottom-up).
+            return_class_maps: Override whether to return class maps
+                (multi-class bottom-up).
+            return_class_vectors: Override whether to return class vectors
+                (multi-class top-down).
         """
         if self.tracker_config is not None:
             raise ValueError(
@@ -1117,6 +1165,10 @@ class Predictor:
             integral_patch_size=integral_patch_size,
             return_confmaps=return_confmaps,
             return_crops=return_crops,
+            return_pafs=return_pafs,
+            return_paf_graph=return_paf_graph,
+            return_class_maps=return_class_maps,
+            return_class_vectors=return_class_vectors,
         ):
             if self.paf_workers > 0 and self._can_pipeline():
                 yield from self._predict_streaming_pipelined(
@@ -1140,11 +1192,13 @@ class Predictor:
         write_interval: int = 500,
         progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> str:
-        """Run inference and stream results to a ``.slp`` file.
+        """Run inference and write results to a ``.slp`` file.
 
-        Memory stays O(``write_interval``) — outputs are slimmed and
-        converted to LabeledFrames per batch; heavy tensors are dropped
-        immediately.
+        Each batch's ``Outputs`` is slimmed and converted to LabeledFrames
+        immediately, so the heavy intermediate tensors (confmaps, PAFs) are
+        dropped right away. The slimmed LabeledFrames accumulate until the
+        file is finalized at close (see :class:`IncrementalLabelsWriter` for
+        the memory note).
 
         Args:
             source: ``sio.Video``, ``sio.Labels``, video path string, or
@@ -1170,6 +1224,8 @@ class Predictor:
                 "`skeleton=...` or build the Predictor via Predictor.from_model_paths() "
                 "which sets it automatically from the training config."
             )
+        from datetime import datetime
+
         from sleap_nn.inference.writer import IncrementalLabelsWriter
 
         provider, derived = self._make_provider(source, frames=frames)
@@ -1179,16 +1235,27 @@ class Predictor:
         # `videos` (possibly None) is used (#582).
         if videos is None:
             videos = derived
-        with IncrementalLabelsWriter(
+        writer = IncrementalLabelsWriter(
             path=path,
             skeleton=self.skeleton,
             videos=videos,
             write_interval=write_interval,
-        ) as writer:
+        )
+        _prov_start = datetime.now()
+        with writer:
             for outputs in self.predict_streaming(
                 provider, progress_callback=progress_callback
             ):
                 writer.write(outputs)
+            # Attach provenance before the context exit finalizes the .slp, so
+            # the streamed output carries lineage like the in-memory path (#583).
+            writer.provenance = self._build_inference_provenance(
+                source=source,
+                start_time=_prov_start,
+                end_time=datetime.now(),
+                n_frames=writer.frame_count,
+                inference_params={"batch_size": self.batch_size},
+            )
         return path
 
     # ──────────────────────────────────────────────────────────────────
@@ -1249,7 +1316,15 @@ class Predictor:
         params = layer.grouping_params()
         total = _safe_len(provider)
 
+        # Bound the number of in-flight batches so memory stays O(window),
+        # not O(whole video). Submitting every batch before draining (the old
+        # behavior) kept all ScoredBatch payloads + cached batches resident at
+        # once (#583). Keep a small multiple of n_workers in flight so workers
+        # stay fed; drain the OLDEST completed result (FIFO) before submitting
+        # more, preserving submission-order output.
+        max_in_flight = max(2 * self.paf_workers, self.paf_workers + 1)
         meta: dict[int, Any] = {}
+        completed = 0
         with PafGroupingPool(
             n_workers=self.paf_workers, grouping_params=params
         ) as pool:
@@ -1259,10 +1334,22 @@ class Predictor:
                 scored = layer._score_pafs_on_gpu(raw, info)
                 pool.submit(ordinal, scored)
                 meta[ordinal] = batch
-            completed = 0
-            for ordinal, outputs in pool.iter_completed():
+                while len(pool) >= max_in_flight:
+                    done_ordinal, outputs = pool.drain_one()
+                    outputs = pipeline(outputs)
+                    outputs = self._stamp_metadata(outputs, meta.pop(done_ordinal))
+                    yield outputs
+                    completed += 1
+                    if progress_callback is not None:
+                        progress_callback(completed, total)
+            # Drain the remaining in-flight batches.
+            while True:
+                result = pool.drain_one()
+                if result is None:
+                    break
+                done_ordinal, outputs = result
                 outputs = pipeline(outputs)
-                outputs = self._stamp_metadata(outputs, meta.pop(ordinal))
+                outputs = self._stamp_metadata(outputs, meta.pop(done_ordinal))
                 yield outputs
                 completed += 1
                 if progress_callback is not None:
@@ -1378,6 +1465,10 @@ class Predictor:
         integral_patch_size: Optional[int] = None,
         return_confmaps: Optional[bool] = None,
         return_crops: Optional[bool] = None,
+        return_pafs: Optional[bool] = None,
+        return_paf_graph: Optional[bool] = None,
+        return_class_maps: Optional[bool] = None,
+        return_class_vectors: Optional[bool] = None,
     ):
         """Context manager that temporarily overrides postprocess configs.
 
@@ -1398,6 +1489,10 @@ class Predictor:
                 integral_patch_size,
                 return_confmaps,
                 return_crops,
+                return_pafs,
+                return_paf_graph,
+                return_class_maps,
+                return_class_vectors,
             )
         )
         if not has_any:
@@ -1436,6 +1531,16 @@ class Predictor:
                     overrides["integral_patch_size"] = integral_patch_size
                 if return_confmaps is not None:
                     overrides["return_confmaps"] = return_confmaps
+                # The remaining intermediate-tensor toggles all live on
+                # PostprocessConfig; guard with hasattr defensively (#583).
+                for _name, _val in (
+                    ("return_pafs", return_pafs),
+                    ("return_paf_graph", return_paf_graph),
+                    ("return_class_maps", return_class_maps),
+                    ("return_class_vectors", return_class_vectors),
+                ):
+                    if _val is not None and hasattr(old_cfg, _name):
+                        overrides[_name] = _val
 
                 if overrides:
                     target.postprocess_config = attrs.evolve(old_cfg, **overrides)

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -51,6 +51,12 @@ def predict(
     anchor_part: Optional[str] = None,
     paf_workers: int = 0,
     centroid_only: bool = False,
+    # Bottom-up PAF grouping knobs (construction-time; plain bottom-up only)
+    max_edge_length_ratio: float = 0.25,
+    dist_penalty_weight: float = 1.0,
+    n_points: int = 10,
+    min_instance_peaks: float = 0,
+    min_line_scores: float = 0.25,
     # Prediction-time (can vary per call)
     frames: Optional[List[int]] = None,
     peak_threshold: Optional[float] = None,
@@ -61,6 +67,10 @@ def predict(
     integral_patch_size: Optional[int] = None,
     return_confmaps: bool = False,
     return_crops: bool = False,
+    return_pafs: bool = False,
+    return_paf_graph: bool = False,
+    return_class_maps: bool = False,
+    return_class_vectors: bool = False,
     # Filtering
     filter_config: Optional["FilterConfig"] = None,
     # Tracking
@@ -89,6 +99,12 @@ def predict(
         paf_workers: CPU worker processes for bottom-up PAF grouping.
         centroid_only: Force centroid-only output even when a
             centered-instance model is among ``model_paths``.
+        max_edge_length_ratio: Bottom-up PAF max edge length ratio.
+        dist_penalty_weight: Bottom-up PAF distance penalty weight.
+        n_points: Bottom-up PAF line integration sample count.
+        min_instance_peaks: Bottom-up min peaks for a valid instance.
+        min_line_scores: Bottom-up per-edge match threshold. (These five
+            apply only to plain bottom-up models.)
         frames: Frame indices to predict. ``None`` = all.
         peak_threshold: Override peak threshold for all stages.
         centroid_threshold: Override centroid-stage threshold (top-down).
@@ -98,6 +114,10 @@ def predict(
         integral_patch_size: Refinement patch size.
         return_confmaps: Keep confidence maps on Outputs.
         return_crops: Keep per-instance crops on Outputs (top-down).
+        return_pafs: Keep part-affinity fields on Outputs (bottom-up).
+        return_paf_graph: Keep the PAF graph on Outputs (bottom-up).
+        return_class_maps: Keep class maps on Outputs (multi-class bottom-up).
+        return_class_vectors: Keep class vectors on Outputs (multi-class top-down).
         filter_config: Post-inference :class:`FilterConfig`.
         tracker_config: :class:`TrackerConfig` for tracking.
         output_path: If set, save the Labels to this ``.slp`` path.
@@ -149,6 +169,13 @@ def predict(
             build_kwargs["anchor_part"] = anchor_part
         if centroid_only:
             build_kwargs["centroid_only"] = True
+        # Bottom-up PAF knobs configure the scorer at load time (#583); inert
+        # for non-bottom-up models (load_model_assets forwards them only there).
+        build_kwargs["max_edge_length_ratio"] = max_edge_length_ratio
+        build_kwargs["dist_penalty_weight"] = dist_penalty_weight
+        build_kwargs["n_points"] = n_points
+        build_kwargs["min_instance_peaks"] = min_instance_peaks
+        build_kwargs["min_line_scores"] = min_line_scores
         predictor = Predictor.from_model_paths(model_paths, **build_kwargs)
     else:
         predictor = Predictor.from_export_dir(export_dir, **build_kwargs)
@@ -168,6 +195,10 @@ def predict(
         integral_patch_size=integral_patch_size,
         return_confmaps=return_confmaps,
         return_crops=return_crops,
+        return_pafs=return_pafs,
+        return_paf_graph=return_paf_graph,
+        return_class_maps=return_class_maps,
+        return_class_vectors=return_class_vectors,
     )
 
     if output_path is not None:

--- a/sleap_nn/inference/streaming.py
+++ b/sleap_nn/inference/streaming.py
@@ -409,3 +409,21 @@ class PafGroupingPool:
         while self._pending:
             frame_idx, future = self._pending.pop(0)
             yield frame_idx, future.result()
+
+    def __len__(self) -> int:
+        """Number of submitted-but-not-yet-drained batches (in-flight depth)."""
+        return len(self._pending)
+
+    def drain_one(self) -> "Optional[Tuple[int, Outputs]]":
+        """Pop + block on the OLDEST pending batch (FIFO); ``None`` if empty.
+
+        Lets a caller interleave ``submit`` and drain to bound the number of
+        in-flight batches (true O(window) streaming) while preserving the same
+        submission-order yield as :meth:`iter_completed`. Because submission is
+        sequential on the main thread, the oldest future is always real, so
+        this never deadlocks.
+        """
+        if not self._pending:
+            return None
+        frame_idx, future = self._pending.pop(0)
+        return frame_idx, future.result()

--- a/sleap_nn/inference/writer.py
+++ b/sleap_nn/inference/writer.py
@@ -1,11 +1,12 @@
-"""``IncrementalLabelsWriter`` — disk-streaming write of a ``.slp``.
+"""``IncrementalLabelsWriter`` — buffered write of a ``.slp``.
 
 The legacy predictor accumulates every frame's predictions in memory
 before writing to disk. For long videos (100k frames × hundreds of MB
 of confmaps) that's an OOM risk. This writer accepts ``Outputs`` one
-batch at a time, accumulates ``LabeledFrame`` objects in a small ring,
-flushes them to disk every ``write_interval`` batches, and finalizes
-with an atomic rename so a crash mid-write doesn't corrupt the output.
+batch at a time and ``slim()``s each before converting to
+``LabeledFrame``s, so the heavy intermediate tensors (confmaps, PAFs)
+are dropped immediately — the dominant memory sink. It finalizes with
+an atomic rename so a crash mid-write doesn't corrupt the output.
 
 Two design constraints from the design doc:
 
@@ -14,10 +15,13 @@ Two design constraints from the design doc:
 * **Resume-friendly** — closed writers can be re-opened to append. Not
   implemented in this commit (deferred to a follow-up).
 
-Memory contract: at most ``write_interval`` ``LabeledFrame`` objects
-held in memory at once. ``Outputs`` from previous batches go through
-``slim()`` before being converted, so heavy intermediate tensors
-(confmaps, PAFs) are dropped.
+Memory note: ``Outputs`` are slim()-ed per write so heavy tensors are
+dropped right away. NOTE: until sleap-io exposes an incremental ``.slp``
+append surface, the (lightweight) ``LabeledFrame`` objects accumulate
+in memory and the ``.slp`` is written once at :meth:`close`/finalize —
+peak memory is therefore O(n_frames) of *slimmed* frames, not
+O(``write_interval``). ``write_interval`` currently controls only the
+slim/convert cadence, not a per-flush disk write.
 """
 
 from __future__ import annotations
@@ -37,8 +41,10 @@ class IncrementalLabelsWriter:
             rename on ``close()``.
         skeleton: ``sio.Skeleton`` for instance conversion.
         videos: Optional list of ``sio.Video`` indexed by ``video_indices``.
-        write_interval: Flush to disk every ``write_interval`` batches.
-            Smaller = lower memory, more I/O. Default 500 frames.
+        write_interval: Convert + slim buffered ``Outputs`` to
+            ``LabeledFrame``s every ``write_interval`` frames; the
+            consolidated ``.slp`` is written once at :meth:`close` (no
+            per-flush disk write until sleap-io supports incremental append).
 
     Usage::
 
@@ -52,6 +58,9 @@ class IncrementalLabelsWriter:
     skeleton: Any
     videos: Optional[List[Any]] = None
     write_interval: int = 500
+    # Provenance dict attached to the finalized Labels. May be set after
+    # construction (e.g. once end-of-run timestamps are known). #583.
+    provenance: Optional[dict] = None
 
     _buffer: List[Any] = attrs.field(factory=list, init=False, repr=False)
     _all_frames: List[Any] = attrs.field(factory=list, init=False, repr=False)
@@ -64,6 +73,11 @@ class IncrementalLabelsWriter:
     def tmp_path(self) -> Path:
         """The intermediate ``.tmp`` path written to before atomic rename."""
         return Path(self.path).with_suffix(Path(self.path).suffix + ".tmp")
+
+    @property
+    def frame_count(self) -> int:
+        """Number of ``LabeledFrame``s buffered + accumulated so far."""
+        return len(self._all_frames) + len(self._buffer)
 
     def __enter__(self) -> "IncrementalLabelsWriter":
         """Context manager entry — return self."""
@@ -164,6 +178,7 @@ class IncrementalLabelsWriter:
             labeled_frames=self._all_frames,
             videos=videos,
             skeletons=[self.skeleton],
+            provenance=self.provenance or {},
         )
         tmp = self.tmp_path
         tmp.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/cli/test_infer_command.py
+++ b/tests/cli/test_infer_command.py
@@ -371,8 +371,12 @@ def test_infer_gui_emits_json_progress(tmp_path):
         assert parsed["n_total"] == 10
 
 
-def test_infer_without_gui_no_progress_callback(tmp_path):
-    """No ``--gui`` => ``predict()`` does not receive ``progress_callback``."""
+def test_infer_without_gui_attaches_rich_progress_callback(tmp_path):
+    """No ``--gui`` => ``predict()`` gets a (non-JSON) Rich progress callback (#583)."""
+    import io
+    import json
+    from contextlib import redirect_stdout
+
     runner = CliRunner()
     with patch(
         "sleap_nn.inference.run.predict",
@@ -389,8 +393,17 @@ def test_infer_without_gui_no_progress_callback(tmp_path):
             ],
         )
         assert result.exit_code == 0, result.output
-        # progress_callback should not be in kwargs (only added when --gui is set).
-        assert "progress_callback" not in mock_predict.call_args[1]
+        cb = mock_predict.call_args[1].get("progress_callback")
+        assert cb is not None and callable(cb)
+        # It is the Rich callback, NOT the --gui JSON emitter: driving it must
+        # not print a JSON line to stdout.
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cb(1, 4)
+        out = buf.getvalue().strip()
+        if out:
+            with __import__("pytest").raises(json.JSONDecodeError):
+                json.loads(out)
 
 
 def test_infer_backbone_and_head_ckpt_paths_thread_to_predict(tmp_path):
@@ -562,3 +575,218 @@ def test_track_command_candidates_method_defaults_fixed_window():
         )
         assert result.exit_code == 0, result.output
         assert mock_run.call_args[1]["candidates_method"] == "fixed_window"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #583 — CLI feature preservation
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_track_gui_forwards_to_run_inference():
+    """`track --gui` forwards gui=True to run_inference (no longer popped). #583."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference", return_value=MagicMock()) as mock_run:
+        result = runner.invoke(
+            cli,
+            [
+                "track",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--gui",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args[1]["gui"] is True
+
+
+def test_track_no_gui_defaults_false():
+    """Without --gui, track forwards gui=False."""
+    runner = CliRunner()
+    with patch("sleap_nn.predict.run_inference", return_value=MagicMock()) as mock_run:
+        result = runner.invoke(
+            cli,
+            ["track", "--data_path", "/fake/x.mp4", "--model_paths", "/fake/m"],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args[1]["gui"] is False
+
+
+def test_infer_paf_knobs_thread_to_predict():
+    """The 5 bottom-up PAF knobs reach run.predict (no longer silent no-ops). #583."""
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict", return_value=MagicMock()
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--max_edge_length_ratio",
+                "0.3",
+                "--dist_penalty_weight",
+                "2.0",
+                "--n_points",
+                "7",
+                "--min_instance_peaks",
+                "2",
+                "--min_line_scores",
+                "0.4",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kw = mock_predict.call_args[1]
+        assert abs(kw["max_edge_length_ratio"] - 0.3) < 1e-9
+        assert abs(kw["dist_penalty_weight"] - 2.0) < 1e-9
+        assert kw["n_points"] == 7
+        assert kw["min_instance_peaks"] == 2
+        assert abs(kw["min_line_scores"] - 0.4) < 1e-9
+
+
+def test_infer_queue_maxsize_accepted_but_not_forwarded():
+    """`--queue_maxsize` is accepted (compat) but never forwarded to predict. #583."""
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict", return_value=MagicMock()
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--queue_maxsize",
+                "64",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "queue_maxsize" not in mock_predict.call_args[1]
+
+
+def test_infer_queue_maxsize_hidden_in_help():
+    """The no-op --queue_maxsize is hidden from `infer --help`. #583."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["infer", "--help"])
+    assert result.exit_code == 0
+    assert "--queue_maxsize" not in result.output
+
+
+def test_infer_video_index_scopes_and_names_output():
+    """`infer --video_index 1` scopes to that video + suffixes the output. #583."""
+    import sleap_io as sio
+
+    from sleap_nn.inference.providers import LabelsProvider
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    v0 = sio.Video(filename="a.mp4")
+    v1 = sio.Video(filename="b.mp4")
+    fake = sio.Labels(videos=[v0, v1], skeletons=[skel], labeled_frames=[])
+
+    runner = CliRunner()
+    with (
+        patch("sleap_io.load_slp", return_value=fake),
+        patch("sleap_nn.inference.run.predict", return_value=MagicMock()) as mock_pred,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/x.slp",
+                "--model_paths",
+                "/fake/model",
+                "--video_index",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        source = mock_pred.call_args[0][0]
+        assert isinstance(source, LabelsProvider)
+        # Output filename is suffixed with the scoped video's name (legacy parity).
+        assert mock_pred.call_args[1]["output_path"].endswith("b.predictions.slp")
+
+
+def test_infer_video_index_out_of_range_errors():
+    """An out-of-range --video_index is a clear UsageError. #583."""
+    import sleap_io as sio
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    fake = sio.Labels(
+        videos=[sio.Video(filename="a.mp4")], skeletons=[skel], labeled_frames=[]
+    )
+    runner = CliRunner()
+    with (
+        patch("sleap_io.load_slp", return_value=fake),
+        patch("sleap_nn.inference.run.predict", return_value=MagicMock()),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/x.slp",
+                "--model_paths",
+                "/fake/model",
+                "--video_index",
+                "5",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "out of range" in result.output
+
+
+def test_infer_retrack_only_sets_tracking_provenance(tmp_path):
+    """Retrack-only writes tracking-only provenance to the saved .slp. #583."""
+    import numpy as np
+    import sleap_io as sio
+
+    skel = sio.Skeleton(nodes=["head", "tail"])
+    video = sio.Video(filename="d.mp4")
+    pts = np.array([[0.0, 0.0], [10.0, 0.0]], dtype=np.float32)
+    lfs = [
+        sio.LabeledFrame(
+            video=video,
+            frame_idx=i,
+            instances=[
+                sio.PredictedInstance.from_numpy(
+                    points_data=pts, skeleton=skel, score=0.9
+                )
+            ],
+        )
+        for i in range(3)
+    ]
+    fake = sio.Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=lfs,
+        provenance={"filename": "/path/preds.slp"},
+    )
+    out_path = tmp_path / "retracked.slp"
+    runner = CliRunner()
+    with patch("sleap_io.load_slp", return_value=fake):
+        result = runner.invoke(
+            cli,
+            [
+                "infer",
+                "--data_path",
+                "/fake/preds.slp",
+                "--tracking",
+                "--tracking_window_size",
+                "9",
+                "--output_path",
+                str(out_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+    reloaded = sio.load_slp(str(out_path))
+    assert reloaded.provenance.get("pipeline_type") == "tracking_only"
+    assert "sleap_nn_version" in reloaded.provenance
+    assert "tracking_start_timestamp" in reloaded.provenance
+    assert reloaded.provenance.get("tracking_config", {}).get("window_size") == 9

--- a/tests/inference/test_issue_583.py
+++ b/tests/inference/test_issue_583.py
@@ -1,0 +1,247 @@
+"""Regression tests for issue #583 (CLI/streaming/feature follow-ups).
+
+Library-level coverage (CLI-level tests live in tests/cli/test_infer_command.py):
+
+* Predict-time ``return_*`` intermediate-tensor overrides via
+  ``Predictor._postprocess_overrides``.
+* Streaming pool primitives (``PafGroupingPool.__len__`` / ``drain_one``) used
+  by the bounded pipelined-streaming path.
+* Streaming writer accumulate-until-finalize contract + provenance persistence.
+* The Rich progress-callback factory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import sleap_io as sio
+import torch
+
+from sleap_nn.inference.layers.configs import PostprocessConfig
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.predictor import Predictor
+from sleap_nn.inference.writer import IncrementalLabelsWriter
+
+CKPT_ROOT = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
+DATA_ROOT = Path(__file__).resolve().parents[1] / "assets" / "datasets"
+MC_TOPDOWN_CKPTS = [
+    CKPT_ROOT / "minimal_instance_centroid",
+    CKPT_ROOT / "minimal_instance_multiclass_centered_instance",
+]
+MC_TOPDOWN_VIDEO = DATA_ROOT / "centered_pair_small.mp4"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Predict-time return_* overrides (gap)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _PostprocStub:
+    """Minimal layer with a ``postprocess_config`` (so it is an override target)."""
+
+    def __init__(self):
+        self.postprocess_config = PostprocessConfig()
+
+
+def test_postprocess_overrides_thread_return_flags():
+    """Each return_* flag flips the layer's PostprocessConfig and restores (#583)."""
+    for name in (
+        "return_pafs",
+        "return_paf_graph",
+        "return_class_maps",
+        "return_class_vectors",
+    ):
+        predictor = Predictor(layer=_PostprocStub())
+        assert getattr(predictor.layer.postprocess_config, name) is False
+        with predictor._postprocess_overrides(**{name: True}):
+            assert getattr(predictor.layer.postprocess_config, name) is True
+        # Restored on exit.
+        assert getattr(predictor.layer.postprocess_config, name) is False
+
+
+def test_postprocess_overrides_no_args_is_noop():
+    """With no overrides the config object is untouched (has_any short-circuit)."""
+    predictor = Predictor(layer=_PostprocStub())
+    before = predictor.layer.postprocess_config
+    with predictor._postprocess_overrides():
+        pass
+    assert predictor.layer.postprocess_config is before
+
+
+@pytest.mark.skipif(
+    not (all(p.exists() for p in MC_TOPDOWN_CKPTS) and MC_TOPDOWN_VIDEO.exists()),
+    reason="multiclass top-down checkpoints / video not present",
+)
+def test_return_class_vectors_propagates_through_topdown_multiclass():
+    """return_class_vectors reaches Outputs for the composed multi-class top-down.
+
+    The flag flips the config but was dropped at the TopDownLayer composition;
+    _run_stage_2 now scatters the per-crop class vectors (#583 review).
+    """
+    from sleap_nn.inference.providers import VideoProvider
+
+    predictor = Predictor.from_model_paths(
+        [str(p) for p in MC_TOPDOWN_CKPTS],
+        device="cpu",
+        peak_threshold=0.03,
+        max_instances=6,
+    )
+    outs_on = list(
+        predictor.predict_streaming(
+            VideoProvider(video=str(MC_TOPDOWN_VIDEO), batch_size=2, frames=[0, 1]),
+            return_class_vectors=True,
+        )
+    )
+    assert any(o.pred_class_vectors is not None for o in outs_on)
+    # Default (no override) leaves it unset.
+    outs_off = list(
+        predictor.predict_streaming(
+            VideoProvider(video=str(MC_TOPDOWN_VIDEO), batch_size=2, frames=[0, 1])
+        )
+    )
+    assert all(o.pred_class_vectors is None for o in outs_off)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Streaming pool primitives (bounded pipelined streaming)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_paf_grouping_pool_len_and_drain_one_fifo():
+    """``__len__`` reflects pending depth; ``drain_one`` pops FIFO; None when empty."""
+    from concurrent.futures import Future
+
+    from sleap_nn.inference.streaming import GroupingParams, PafGroupingPool
+
+    pool = PafGroupingPool(
+        n_workers=1, grouping_params=GroupingParams(paf_scorer_kwargs={})
+    )
+    # Seed the pending queue with already-resolved futures (no executor needed):
+    # drain_one only pops the oldest and reads .result().
+    for i in range(3):
+        fut: Future = Future()
+        fut.set_result(f"out{i}")
+        pool._pending.append((i, fut))
+
+    assert len(pool) == 3
+    assert pool.drain_one() == (0, "out0")
+    assert pool.drain_one() == (1, "out1")
+    assert len(pool) == 1
+    assert pool.drain_one() == (2, "out2")
+    assert len(pool) == 0
+    assert pool.drain_one() is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Streaming writer: accumulate-until-finalize + provenance persistence
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _one_instance_outputs(frame_idx: int) -> Outputs:
+    return Outputs(
+        pred_keypoints=torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]]),
+        pred_peak_values=torch.tensor([[[0.9, 0.9]]]),
+        frame_indices=torch.tensor([frame_idx]),
+        video_indices=torch.tensor([0]),
+    )
+
+
+def test_incremental_writer_accumulates_until_finalize(tmp_path):
+    """flush != disk-write today: the .slp appears only at close (#583 docs)."""
+    skel = sio.Skeleton(nodes=[sio.Node(name="n0"), sio.Node(name="n1")])
+    out_path = tmp_path / "out.slp"
+    writer = IncrementalLabelsWriter(
+        path=str(out_path), skeleton=skel, write_interval=1
+    )
+    with writer:
+        for i in range(3):
+            writer.write(_one_instance_outputs(i))
+            # No final file mid-stream (write happens once at finalize).
+            assert not out_path.exists()
+        assert writer.frame_count == 3
+    assert out_path.exists()
+    assert len(sio.load_slp(str(out_path)).labeled_frames) == 3
+
+
+def test_incremental_writer_persists_provenance(tmp_path):
+    """A provenance dict set on the writer round-trips into the saved .slp (#583)."""
+    skel = sio.Skeleton(nodes=[sio.Node(name="n0"), sio.Node(name="n1")])
+    out_path = tmp_path / "out.slp"
+    writer = IncrementalLabelsWriter(
+        path=str(out_path),
+        skeleton=skel,
+        provenance={"sleap_nn_version": "x.y.z", "model_paths": ["/m"]},
+    )
+    with writer:
+        writer.write(_one_instance_outputs(0))
+    labels = sio.load_slp(str(out_path))
+    assert labels.provenance.get("sleap_nn_version") == "x.y.z"
+    assert labels.provenance.get("model_paths") == ["/m"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Rich progress callback factory
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_rich_progress_callback_returns_callable_and_progress():
+    """The factory yields a (callback, progress) pair; callback drives cleanly."""
+    from sleap_nn.cli import _rich_progress_callback
+
+    cb, progress = _rich_progress_callback()
+    try:
+        assert callable(cb)
+        # Unknown total (length-less provider) must not raise.
+        cb(1, -1)
+        cb(2, -1)
+        # Known total path.
+        cb(1, 4)
+        cb(4, 4)
+    finally:
+        progress.stop()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# --video_index scoping helper (composes with suggestions + frames; #583 review)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_scope_labels_to_video_carries_suggestions_frames_provenance():
+    """The scoping helper keeps the video's suggestions, applies --frames, and
+    preserves source provenance (review bug 66c)."""
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    v0, v1 = sio.Video(filename="a.mp4"), sio.Video(filename="b.mp4")
+    suggestions = [
+        sio.SuggestionFrame(video=v1, frame_idx=2),
+        sio.SuggestionFrame(video=v0, frame_idx=0),
+        sio.SuggestionFrame(video=v1, frame_idx=9),
+    ]
+    labels = sio.Labels(
+        videos=[v0, v1],
+        skeletons=[skel],
+        labeled_frames=[],
+        suggestions=suggestions,
+        provenance={"filename": "/orig.slp"},
+    )
+    scoped, target = _scope_labels_to_video(labels, 1, frames=[2])
+    assert target is v1
+    assert list(scoped.videos) == [v1]
+    # v1/frame2 kept; v1/frame9 dropped by --frames; v0 suggestion excluded.
+    assert [s.frame_idx for s in scoped.suggestions] == [2]
+    assert scoped.provenance.get("filename") == "/orig.slp"
+
+
+def test_scope_labels_to_video_out_of_range_raises():
+    """An out-of-range video_index raises a click UsageError."""
+    import click
+
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    labels = sio.Labels(
+        videos=[sio.Video(filename="a.mp4")], skeletons=[skel], labeled_frames=[]
+    )
+    with __import__("pytest").raises(click.UsageError):
+        _scope_labels_to_video(labels, 5)


### PR DESCRIPTION
## Summary

Addresses the CLI / streaming / feature follow-ups tracked in **#583** from the #530 inference-refactor review (epic #508). Builds on #582 (PR #585). Single PR, same investigate → implement → adversarial-verify workflow as #582.

### CLI feature preservation (Cluster I)
- **`track --gui` JSON progress restored** — `track()` was popping `gui` before calling the legacy `run_inference` (which honors it). Stop popping it; the legacy JSON-per-line GUI progress works again. (Verified the legacy emitter is still present.)
- **5 bottom-up PAF knobs wired** — `--max_edge_length_ratio`, `--dist_penalty_weight`, `--n_points`, `--min_instance_peaks`, `--min_line_scores` were accepted by `infer` but silently dropped. Threaded `run.predict → from_model_paths → load_model_assets → _build_bottomup → PAFScorer.from_config` (defaults match `PAFScorer`'s, and they're forwarded only to the plain bottom-up builder — legacy parity).
- **`--video_index` honored on `infer`** — was ignored on the inference path (only retrack used it). Now scopes a multi-video `.slp` to the requested video (re-indexed to `videos[0]`) and suffixes the auto-derived output filename with the video name (so per-video runs don't collide). Out-of-range index → clean `UsageError`. Applied to both the in-memory and `--stream-to-file` paths.
- **`--queue_maxsize` hidden + documented as a no-op** on `infer` (the new pipeline has no frame-buffer queue); the legacy `track` path still honors it.

### Streaming memory contract (Cluster M)
- **Bounded pipelined streaming** — `_predict_streaming_pipelined` submitted *every* batch (caching all `ScoredBatch` payloads + batches) before draining → O(whole video). Now interleaves submit/drain with a bounded in-flight window (`max(2·paf_workers, paf_workers+1)`), draining the oldest (FIFO) before submitting more → O(window). New `PafGroupingPool.__len__` / `drain_one()` primitives; FIFO yield order (and inline-parity) preserved.
- **Honest writer docstrings** — corrected the writer + predictor docstrings that overclaimed per-flush disk writes / `O(write_interval)`. The writer slims per batch (drops heavy tensors) but accumulates the lightweight `LabeledFrame`s and writes once at finalize — `O(n_frames)` of slimmed frames. (True incremental HDF5 append depends on a sleap-io surface; left as a follow-up.)

### Predict-time intermediate-tensor overrides
- Exposed `return_pafs` / `return_paf_graph` / `return_class_maps` / `return_class_vectors` as predict-time overrides on `Predictor.predict`, `predict_streaming`, and `run.predict` (mirroring the existing `return_confmaps`), threaded through `_postprocess_overrides`. The consuming layer decoders already read these `PostprocessConfig` fields, so the override takes effect end-to-end.

### Provenance for the other entry points
- `predict_to_file` (streaming) now attaches inference provenance to the saved `.slp` (new `IncrementalLabelsWriter.provenance` field → `sio.Labels(provenance=...)`).
- CLI retrack (`_run_retrack_only`) attaches tracking-only provenance (`build_tracking_only_provenance`, preserving the input labels' provenance). The in-memory `infer` path already had provenance (wired in #530) and is untouched.

### Rich progress bar
- `sleap-nn infer` / `predict` without `--gui` now shows a Rich progress bar (the `progress_callback` plumbing existed but the non-gui branch passed nothing). `--gui` still routes to the JSON emitter. The bar is started immediately and stopped in a `finally` so it closes cleanly on success or error; lazy `rich` import keeps `--help` fast. Progress is counted in batches.

## Test plan
- New `tests/inference/test_issue_583.py` (return_* overrides, pool `__len__`/`drain_one` FIFO, writer accumulate-until-finalize + provenance round-trip, Rich callback) + CLI regression tests in `tests/cli/test_infer_command.py` (`track --gui`, PAF knobs, `--video_index` scoping/naming/error, `--queue_maxsize` hidden, retrack provenance, Rich-not-JSON callback).
- Targeted suites green (`tests/cli` + `tests/inference/test_paf_worker_pool.py` PAF-pool parity preserved); `black` + `ruff` clean. Run on a CUDA box.

## Review notes (caught by the adversarial verification pass, fixed here)
- **`--video_index` composition** — the scoped `Labels` reconstruction dropped `suggestions` (broke `--video_index + --only_suggested_frames`) and ignored `--frames`. Fixed via a shared `_scope_labels_to_video` helper that carries suggestions, applies the frame filter, preserves provenance, and raises on out-of-range (also adopted by retrack).
- **`return_class_vectors`** — flipped the config but was inert for the only model it targets (multi-class top-down): `TopDownLayer._run_stage_2` didn't carry the per-crop class vectors into the composed `Outputs`. Now scattered into `(B, I, C)` (additive; multiclass identity parity tests still pass).

## Notes / minor calls (reviewable)
- Bottom-up PAF knobs apply only to plain bottom-up (legacy parity); inert for top-down/single/multiclass.
- `--video_index` output naming uses `{src}.{video_name}.predictions.slp` (legacy shape) only in the video_index case; the default single-output naming is unchanged.
- Progress is per **batch** (the new callback reports batches, not frames); no misleading "FPS" column.

Part of epic #508. Follow-up **#584** (test coverage + minor correctness) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
