### PR TITLE
Fix #584: inference-refactor test-coverage + minor-correctness follow-ups

### DIFF
--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -17,7 +17,11 @@ def find_points_mean(points: torch.Tensor) -> torch.Tensor:
         output row is NaN.
     """
     mask = ~torch.isnan(points)
-    counts = mask.any(dim=-1).sum(dim=-1, keepdim=True).clamp(min=1).to(points.dtype)
+    # Count non-NaN values PER AXIS so each coordinate's mean divides by the
+    # number of non-NaN values on that axis. Counting per-point (mask.any)
+    # biased the mean toward 0 when only one coordinate of a point was NaN
+    # (#584). For the common all-or-nothing-per-point case the two are equal.
+    counts = mask.sum(dim=-2).clamp(min=1).to(points.dtype)  # (..., 2)
     safe = torch.where(mask, points, torch.zeros_like(points))
     means = safe.sum(dim=-2) / counts
     all_nan = (~mask.any(dim=-1)).all(dim=-1, keepdim=True)

--- a/sleap_nn/inference/layers/base.py
+++ b/sleap_nn/inference/layers/base.py
@@ -326,11 +326,12 @@ class InferenceLayer(ABC):
         B, _C, H, W = x.shape
         orig_hw = (H, W)
 
-        # 1. Channel coercion.
-        if cfg.ensure_grayscale and x.shape[-3] != 1:
-            x = convert_to_grayscale(x)
-        elif cfg.ensure_rgb and x.shape[-3] != 3:
+        # 1. Channel coercion. Check ensure_rgb first to match legacy precedence
+        # when both are set (a misconfiguration PreprocessConfig now rejects). #584.
+        if cfg.ensure_rgb and x.shape[-3] != 3:
             x = convert_to_rgb(x)
+        elif cfg.ensure_grayscale and x.shape[-3] != 1:
+            x = convert_to_grayscale(x)
 
         # 2. Per-sample sizematcher → eff_scale.
         if cfg.max_height is not None or cfg.max_width is not None:

--- a/sleap_nn/inference/layers/bottomup.py
+++ b/sleap_nn/inference/layers/bottomup.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from typing import Optional
 
 import torch
+from loguru import logger
 
 from sleap_nn.inference.layers.backends.base import ModelBackend
 from sleap_nn.inference.layers.base import InferenceLayer
@@ -127,8 +128,18 @@ class BottomUpLayer(InferenceLayer):
         if self.max_peaks_per_node is not None:
             for ch_inds in cms_peak_channel_inds:
                 for ni in range(n_nodes):
-                    if int((ch_inds == ni).sum().item()) > self.max_peaks_per_node:
+                    n_peaks = int((ch_inds == ni).sum().item())
+                    if n_peaks > self.max_peaks_per_node:
                         skip_paf = True
+                        # Surface the skip (legacy logged it); an over-limit node
+                        # usually means an under-trained / noisy model (#584).
+                        logger.warning(
+                            "Skipping PAF scoring for a bottom-up batch: node "
+                            f"{ni} has {n_peaks} peaks "
+                            f"(max_peaks_per_node={self.max_peaks_per_node}). "
+                            "Instances will be all-NaN; the model may need more "
+                            "training or a higher peak threshold."
+                        )
                         break
                 if skip_paf:
                     break

--- a/sleap_nn/inference/layers/centered_instance.py
+++ b/sleap_nn/inference/layers/centered_instance.py
@@ -201,20 +201,17 @@ class CenteredInstanceLayer(InferenceLayer):
 
         Centered-instance returns one keypoint set per crop. The Outputs
         canonical shape is ``(B, I=1, N, 2)`` where ``I=1`` because the
-        crop is per-instance.
+        crop is per-instance. Always runs the torch decode path: this layer
+        is only built with a ``TorchBackend``; the exported path uses
+        :class:`ExportedCenteredInstanceLayer` (no double coord ladder; #584).
         """
-        if self.backend.does_baked_postproc:
-            peaks = raw_out["peaks"]
-            vals = raw_out["peak_vals"]
-            confmaps = raw_out.get("confmaps")
-        else:
-            confmaps = self._extract_confmaps(raw_out)
-            peaks, vals = find_global_peaks(
-                confmaps.detach(),
-                threshold=self.postprocess_config.peak_threshold,
-                refinement=self.postprocess_config.effective_refinement,
-                integral_patch_size=self.postprocess_config.integral_patch_size,
-            )
+        confmaps = self._extract_confmaps(raw_out)
+        peaks, vals = find_global_peaks(
+            confmaps.detach(),
+            threshold=self.postprocess_config.peak_threshold,
+            refinement=self.postprocess_config.effective_refinement,
+            integral_patch_size=self.postprocess_config.integral_patch_size,
+        )
 
         peaks = undo_stride(peaks, info.output_stride)
         peaks = undo_input_scale(peaks, info.input_scale)

--- a/sleap_nn/inference/layers/centroid.py
+++ b/sleap_nn/inference/layers/centroid.py
@@ -194,37 +194,23 @@ class CentroidLayer(InferenceLayer):
         returns ``(B, max_instances, 2)`` centroids and ``(B, max_instances)``
         values, NaN-padded where no detection.
         """
-        if self.backend.does_baked_postproc:
-            peaks = raw_out["peaks"]
-            peak_vals = raw_out["peak_vals"]
-            sample_inds = raw_out.get("peak_sample_inds")
-            confmaps = raw_out.get("confmaps")
-            if sample_inds is None:
-                raise KeyError(
-                    "baked-postproc backend must return peak_sample_inds for "
-                    "the centroid layer (multi-peak per sample)."
-                )
-        else:
-            confmaps = self._extract_confmaps(raw_out)
-            peaks, peak_vals, sample_inds, _channel_inds = find_local_peaks(
-                confmaps.detach(),
-                threshold=self.postprocess_config.peak_threshold,
-                refinement=self.postprocess_config.effective_refinement,
-                integral_patch_size=self.postprocess_config.integral_patch_size,
-            )
+        # Always the torch decode path: this layer is only built with a
+        # ``TorchBackend``; the exported path uses ``ExportedCentroidLayer``
+        # (so no double coord ladder, #584).
+        confmaps = self._extract_confmaps(raw_out)
+        peaks, peak_vals, sample_inds, _channel_inds = find_local_peaks(
+            confmaps.detach(),
+            threshold=self.postprocess_config.peak_threshold,
+            refinement=self.postprocess_config.effective_refinement,
+            integral_patch_size=self.postprocess_config.integral_patch_size,
+        )
 
         # Coord ladder: confmap → input pixels → original-image pixels.
         peaks = undo_stride(peaks, info.output_stride)
         peaks = undo_input_scale(peaks, info.input_scale)
 
-        B = (
-            info.processed_size and info.processed_size[0]
-        )  # not used; B from sample_inds
-        # Determine batch size from confmaps shape (always available on Torch).
-        if confmaps is not None:
-            B = int(confmaps.shape[0])
-        else:
-            B = int(sample_inds.max().item()) + 1 if sample_inds.numel() else 1
+        # Batch size from confmaps shape (always available on the torch path).
+        B = int(confmaps.shape[0])
 
         max_instances = self.max_instances or self._infer_max_instances(sample_inds)
         if max_instances == 0:

--- a/sleap_nn/inference/layers/configs.py
+++ b/sleap_nn/inference/layers/configs.py
@@ -27,8 +27,9 @@ class PreprocessConfig:
         max_height: Resize so height ≤ this (preserves aspect ratio). ``None``
             means no max.
         max_width: Same for width.
-        scale: Multiplicative input-scale factor applied via
-            :func:`apply_input_scale` after size matching. ``1.0`` is identity.
+        scale: Multiplicative input-scale factor applied (after size matching)
+            via :func:`sleap_nn.data.resizing.resize_image` (``tvf.resize``) on
+            the live ckpt path. ``1.0`` is identity.
         crop_size: Top-down stage 2 only — square crop side length.
     """
 
@@ -38,6 +39,14 @@ class PreprocessConfig:
     max_width: Optional[int] = None
     scale: float = 1.0
     crop_size: Optional[Tuple[int, int]] = None
+
+    def __attrs_post_init__(self) -> None:
+        """Reject the contradictory ``ensure_rgb=True`` + ``ensure_grayscale=True``."""
+        if self.ensure_rgb and self.ensure_grayscale:
+            raise ValueError(
+                "ensure_rgb and ensure_grayscale cannot both be True; choose one "
+                "(or leave both None to keep the source channel count)."
+            )
 
 
 @attrs.frozen

--- a/sleap_nn/inference/layers/single_instance.py
+++ b/sleap_nn/inference/layers/single_instance.py
@@ -71,22 +71,20 @@ class SingleInstanceLayer(InferenceLayer):
     def postprocess(self, raw_out: dict, info: PreprocInfo) -> Outputs:
         """Decode confmaps → keypoints, reverse coord ladder, build ``Outputs``.
 
-        On a baked-postproc backend (ONNX/TRT) ``raw_out`` already
-        contains ``peaks`` + ``peak_vals``; we skip ``find_global_peaks``
-        and only apply the coord ladder.
+        This layer always runs the torch decode path: it is only ever built
+        with a ``TorchBackend`` (``does_baked_postproc=False``). The exported
+        ONNX/TRT path uses the separate :class:`ExportedSingleInstanceLayer`
+        adapter, which returns already-final peaks without the coord ladder —
+        so this method must NOT special-case a baked backend (doing so would
+        double-apply the ladder; #584).
         """
-        if self.backend.does_baked_postproc:
-            peaks = raw_out["peaks"]
-            vals = raw_out["peak_vals"]
-            confmaps = raw_out.get("confmaps")
-        else:
-            confmaps = self._extract_confmaps(raw_out)
-            peaks, vals = find_global_peaks(
-                confmaps.detach(),
-                threshold=self.postprocess_config.peak_threshold,
-                refinement=self.postprocess_config.effective_refinement,
-                integral_patch_size=self.postprocess_config.integral_patch_size,
-            )
+        confmaps = self._extract_confmaps(raw_out)
+        peaks, vals = find_global_peaks(
+            confmaps.detach(),
+            threshold=self.postprocess_config.peak_threshold,
+            refinement=self.postprocess_config.effective_refinement,
+            integral_patch_size=self.postprocess_config.integral_patch_size,
+        )
 
         # Coord ladder: confmap pixels → input pixels → original-image pixels.
         peaks = undo_stride(peaks, info.output_stride)

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -448,6 +448,9 @@ def _build_topdown(
     # Resolve preprocess_config from both training configs. The confmap
     # config supplies crop_size (absent from centroid training configs),
     # so resolve centroid first, then confmap to fill remaining Nones.
+    # Capture whether the caller explicitly supplied a crop_size so the confmap
+    # default below does not override an intentional user value.
+    user_crop_size = preprocess_config.crop_size
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -456,6 +459,13 @@ def _build_topdown(
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, confmap_config
         )
+        # crop_size is a centered-instance property: force it from the confmap
+        # config so a stray non-null centroid crop_size can't win — but only
+        # when the caller didn't supply an explicit crop_size (legacy parity;
+        # #584).
+        confmap_crop = confmap_config.data_config.preprocessing.crop_size
+        if user_crop_size is None and confmap_crop is not None:
+            preprocess_config.crop_size = confmap_crop
 
     # Resolve anchor_ind
     if anchor_part is not None:
@@ -589,6 +599,9 @@ def _build_topdown_multiclass(
         )
         skeletons = get_skeleton_from_config(confmap_config.data_config.skeletons)
 
+    # Capture whether the caller explicitly supplied a crop_size so the confmap
+    # default below does not override an intentional user value.
+    user_crop_size = preprocess_config.crop_size
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -597,6 +610,13 @@ def _build_topdown_multiclass(
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, confmap_config
         )
+        # crop_size is a centered-instance property: force it from the confmap
+        # config so a stray non-null centroid crop_size can't win — but only
+        # when the caller didn't supply an explicit crop_size (legacy parity;
+        # #584).
+        confmap_crop = confmap_config.data_config.preprocessing.crop_size
+        if user_crop_size is None and confmap_crop is not None:
+            preprocess_config.crop_size = confmap_crop
 
     # Resolve anchor_ind
     if anchor_part is not None:
@@ -735,6 +755,12 @@ def load_model_assets(
         preprocess_config=preprocess_config,
     )
 
+    # Dispatch on detected model type. The order (bottomup checked before the
+    # topdown family) differs from legacy but is inert for parity: each model
+    # path is exactly one type and bottom-up is a single-stage model never
+    # combined with a centroid/centered-instance pair, so the branches are
+    # mutually exclusive (a mixed bottomup+topdown path list is not a supported
+    # workflow and falls through to the final ValueError). #584.
     if "single_instance" in model_types:
         path = model_paths[model_types.index("single_instance")]
         assets = _build_single_instance(path, **common_kwargs)

--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -160,6 +160,10 @@ class Outputs:
                 out[f.name] = val.detach().cpu().numpy()
             elif isinstance(val, tuple) and val and isinstance(val[0], torch.Tensor):
                 out[f.name] = tuple(t.detach().cpu().numpy() for t in val)
+            elif isinstance(val, PreprocInfo):
+                # Keep as a PreprocInfo (callers rely on this) but move its
+                # nested tensors to CPU (#584).
+                out[f.name] = val.cpu()
             else:
                 out[f.name] = val
         return out
@@ -186,6 +190,10 @@ class Outputs:
                 kwargs[f.name] = val.detach().cpu()
             elif isinstance(val, tuple) and val and isinstance(val[0], torch.Tensor):
                 kwargs[f.name] = tuple(t.detach().cpu() for t in val)
+            elif isinstance(val, PreprocInfo):
+                # Move the nested eff_scale / crop_offsets to CPU so the slimmed
+                # Outputs is genuinely pickle-safe for spawn workers (#584).
+                kwargs[f.name] = val.cpu()
             else:
                 kwargs[f.name] = val
         return Outputs(**kwargs)
@@ -203,6 +211,16 @@ class Outputs:
                 kwargs[f.name] = fn(val)
             elif isinstance(val, tuple) and val and isinstance(val[0], torch.Tensor):
                 kwargs[f.name] = tuple(fn(t) for t in val)
+            elif isinstance(val, PreprocInfo):
+                # Apply the same map to the nested tensors so .to(device)/.cpu()/
+                # .detach() carry PreprocInfo along (#584).
+                kwargs[f.name] = attrs.evolve(
+                    val,
+                    eff_scale=fn(val.eff_scale),
+                    crop_offsets=(
+                        fn(val.crop_offsets) if val.crop_offsets is not None else None
+                    ),
+                )
             else:
                 kwargs[f.name] = val
         return Outputs(**kwargs)

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1511,13 +1511,23 @@ class Predictor:
 
                 overrides: dict = {}
 
-                # Threshold routing for top-down
+                # Threshold routing for top-down. Use explicit None checks so an
+                # explicit 0.0 override ("accept all peaks") is honored rather
+                # than swallowed by a falsy `or` (#584).
                 if isinstance(self.layer, TopDownLayer):
                     is_centroid = target is self.layer.centroid_layer
                     if is_centroid:
-                        t = centroid_threshold or peak_threshold
+                        t = (
+                            centroid_threshold
+                            if centroid_threshold is not None
+                            else peak_threshold
+                        )
                     else:
-                        t = keypoint_threshold or peak_threshold
+                        t = (
+                            keypoint_threshold
+                            if keypoint_threshold is not None
+                            else peak_threshold
+                        )
                 else:
                     t = peak_threshold
 

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -80,9 +80,10 @@ import sys
 # ─────────────────────────────────────────────────────────────────────────
 # All public entry points in this module emit a ``DeprecationWarning`` so
 # external callers can migrate to ``sleap_nn.inference.predictor.Predictor``.
-# The loader module still uses these classes for checkpoint loading, so it
-# wraps its delegation calls in :func:`legacy_predictor_internal_use` to
-# suppress the warning while delegating.
+# :func:`legacy_predictor_internal_use` is a context manager that suppresses
+# that warning for code that still calls the legacy ``*Predictor`` classmethods
+# internally. (Note: ``sleap_nn.inference.loaders`` does NOT delegate to these
+# classmethods — it loads checkpoints directly — so it does not use it.)
 
 _LEGACY_INTERNAL_USE = threading.local()
 
@@ -102,11 +103,11 @@ _DEPRECATION_MESSAGE = (
 def legacy_predictor_internal_use():
     """Silence :class:`DeprecationWarning` from legacy ``*Predictor`` entries.
 
-    ``sleap_nn.inference.loaders`` still delegates Lightning checkpoint loading
-    to this module's ``from_trained_models`` classmethods. The new
-    ``Predictor.from_model_paths`` IS the migration path, so warning every
-    time it runs would be spurious noise. Wrap loader delegation calls with
-    this context manager.
+    For code that intentionally calls the legacy ``*Predictor.from_trained_models``
+    classmethods internally (so the warning would be spurious noise). Wrap such
+    calls with this context manager. ``sleap_nn.inference.loaders`` does NOT use
+    it — it loads checkpoints directly without going through the legacy
+    classmethods.
     """
     prev = getattr(_LEGACY_INTERNAL_USE, "active", False)
     _LEGACY_INTERNAL_USE.active = True

--- a/sleap_nn/inference/preprocess_info.py
+++ b/sleap_nn/inference/preprocess_info.py
@@ -31,8 +31,11 @@ class PreprocInfo:
             handed to the model.
         eff_scale: Per-sample size-matcher scale factor. Stored as a 1-D
             tensor ``(B,)``; broadcast against ``(B, ...)`` coords.
-        input_scale: Scalar applied via :func:`apply_input_scale` before the
-            forward pass. ``1.0`` is identity.
+        input_scale: Scalar input-scale factor. The live ckpt preprocess applies
+            it via :func:`sleap_nn.data.resizing.resize_image` (torchvision
+            ``tvf.resize``) in :meth:`InferenceLayer.preprocess`; the ops-level
+            :func:`sleap_nn.inference.ops.coord.apply_input_scale` is an
+            export/ONNX-only variant. ``1.0`` is identity.
         output_stride: Confmap → input-pixel stride. ``>= 1``.
         pad_amount: ``(pad_h, pad_w)`` padding added to reach a stride-aligned
             shape. Currently informational; not used in coord ops.
@@ -47,6 +50,24 @@ class PreprocInfo:
     output_stride: int = 1
     pad_amount: Tuple[int, int] = (0, 0)
     crop_offsets: Optional[torch.Tensor] = None
+
+    def cpu(self) -> "PreprocInfo":
+        """Return a copy with nested tensors detached + moved to CPU.
+
+        Frozen value type, so this returns a new instance. Used by
+        ``Outputs.slim()`` / ``.cpu()`` to honor the CPU/pickle-transport
+        contract (the nested ``eff_scale`` / ``crop_offsets`` were previously
+        left on-device, breaking spawn-based workers, #584).
+        """
+        return attrs.evolve(
+            self,
+            eff_scale=self.eff_scale.detach().cpu(),
+            crop_offsets=(
+                self.crop_offsets.detach().cpu()
+                if self.crop_offsets is not None
+                else None
+            ),
+        )
 
     def __repr__(self) -> str:
         """Compact summary — never prints tensor contents."""

--- a/sleap_nn/inference/streaming.py
+++ b/sleap_nn/inference/streaming.py
@@ -251,32 +251,40 @@ def group_scored_batch(scored: ScoredBatch, params: GroupingParams) -> Outputs:
             outputs, pred_pafs=scored.pafs.permute(0, 3, 1, 2).contiguous()
         )
     if params.return_paf_graph:
-        outputs = attrs.evolve(
-            outputs,
-            pred_paf_graph=(
-                (
-                    torch.cat(list(scored.cms_peaks), dim=0)
-                    if scored.cms_peaks
-                    else torch.empty(0, 2)
-                ),
-                (
-                    torch.cat(list(scored.edge_inds), dim=0)
-                    if scored.edge_inds
-                    else torch.empty(0, dtype=torch.int32)
-                ),
-                (
-                    torch.cat(list(scored.edge_peak_inds), dim=0)
-                    if scored.edge_peak_inds
-                    else torch.empty(0, 2, dtype=torch.int32)
-                ),
-                (
-                    torch.cat(list(scored.line_scores), dim=0)
-                    if scored.line_scores
-                    else torch.empty(0)
-                ),
-            ),
-        )
+        outputs = attrs.evolve(outputs, pred_paf_graph=_paf_graph_from_scored(scored))
     return outputs
+
+
+def _paf_graph_from_scored(scored: ScoredBatch) -> tuple:
+    """Build the ``(peaks, edge_inds, edge_peak_inds, line_scores)`` PAF graph.
+
+    Shared by the main grouping path and the ``skip_paf`` short-circuit so both
+    emit the same structure when ``return_paf_graph`` is set (legacy emitted it
+    on the skip path too; #584). On the skip path the edge lists are empty, so
+    the edge tensors resolve to the empty sentinels — matching legacy.
+    """
+    return (
+        (
+            torch.cat(list(scored.cms_peaks), dim=0)
+            if scored.cms_peaks
+            else torch.empty(0, 2)
+        ),
+        (
+            torch.cat(list(scored.edge_inds), dim=0)
+            if scored.edge_inds
+            else torch.empty(0, dtype=torch.int32)
+        ),
+        (
+            torch.cat(list(scored.edge_peak_inds), dim=0)
+            if scored.edge_peak_inds
+            else torch.empty(0, 2, dtype=torch.int32)
+        ),
+        (
+            torch.cat(list(scored.line_scores), dim=0)
+            if scored.line_scores
+            else torch.empty(0)
+        ),
+    )
 
 
 def _empty_outputs(
@@ -300,6 +308,10 @@ def _empty_outputs(
         outputs = attrs.evolve(
             outputs, pred_pafs=scored.pafs.permute(0, 3, 1, 2).contiguous()
         )
+    if params.return_paf_graph:
+        # Emit the (peaks + empty-edge) PAF graph the legacy skip path emitted
+        # so return_paf_graph isn't silently dropped on skip_paf (#584).
+        outputs = attrs.evolve(outputs, pred_paf_graph=_paf_graph_from_scored(scored))
     return outputs
 
 

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -569,28 +569,36 @@ def run_inference(
 
         logger.info(f"Using device: {device}")
 
-        # initializes the inference model
-        predictor = Predictor.from_model_paths(
-            model_paths,
-            backbone_ckpt_path=backbone_ckpt_path,
-            head_ckpt_path=head_ckpt_path,
-            peak_threshold=peak_threshold,
-            integral_refinement=integral_refinement,
-            integral_patch_size=integral_patch_size,
-            batch_size=batch_size,
-            max_instances=max_instances,
-            return_confmaps=return_confmaps,
-            device=device,
-            preprocess_config=OmegaConf.create(preprocess_config),
-            anchor_part=anchor_part,
-            filter_overlapping=filter_overlapping,
-            filter_overlapping_threshold=filter_overlapping_threshold,
-            filter_overlapping_method=filter_overlapping_method,
-            filter_min_visible_nodes=filter_min_visible_nodes,
-            filter_min_visible_node_fraction=filter_min_visible_node_fraction,
-            filter_min_mean_node_score=filter_min_mean_node_score,
-            filter_min_instance_score=filter_min_instance_score,
-        )
+        # initializes the inference model. run_inference already emits its own
+        # deprecation notice above, so suppress the nested DeprecationWarning the
+        # legacy Predictor.from_model_paths would raise — callers see one message
+        # instead of two (#584). Use the module's own threading-local guard
+        # (a module= warnings filter can't match it because the warning is
+        # issued with stacklevel pointing at the caller).
+        from sleap_nn.inference.predictors import legacy_predictor_internal_use
+
+        with legacy_predictor_internal_use():
+            predictor = Predictor.from_model_paths(
+                model_paths,
+                backbone_ckpt_path=backbone_ckpt_path,
+                head_ckpt_path=head_ckpt_path,
+                peak_threshold=peak_threshold,
+                integral_refinement=integral_refinement,
+                integral_patch_size=integral_patch_size,
+                batch_size=batch_size,
+                max_instances=max_instances,
+                return_confmaps=return_confmaps,
+                device=device,
+                preprocess_config=OmegaConf.create(preprocess_config),
+                anchor_part=anchor_part,
+                filter_overlapping=filter_overlapping,
+                filter_overlapping_threshold=filter_overlapping_threshold,
+                filter_overlapping_method=filter_overlapping_method,
+                filter_min_visible_nodes=filter_min_visible_nodes,
+                filter_min_visible_node_fraction=filter_min_visible_node_fraction,
+                filter_min_mean_node_score=filter_min_mean_node_score,
+                filter_min_instance_score=filter_min_instance_score,
+            )
 
         # Set GUI mode for progress output
         predictor.gui = gui

--- a/tests/inference/layers/backends/test_select_providers.py
+++ b/tests/inference/layers/backends/test_select_providers.py
@@ -1,0 +1,63 @@
+"""Tests for ``onnx_backend._select_providers`` (#584 — restores coverage lost
+when tests/export/test_onnx_predictor.py was deleted).
+
+``_select_providers`` is a pure function (device + available-providers list ->
+ordered provider list), so these tests need NO onnxruntime and run everywhere.
+"""
+
+from __future__ import annotations
+
+from sleap_nn.inference.layers.backends.onnx_backend import _select_providers
+
+ALL = ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]
+DML = ["DmlExecutionProvider", "CPUExecutionProvider"]
+CPU_ONLY = ["CPUExecutionProvider"]
+
+
+def test_cpu_and_host_select_cpu_only():
+    assert _select_providers("cpu", ALL) == ["CPUExecutionProvider"]
+    assert _select_providers("host", ALL) == ["CPUExecutionProvider"]
+
+
+def test_cuda_prefers_cuda_then_cpu_skipping_trt():
+    # CUDA/auto skip the ORT TensorRT EP (we ship a native TensorRTBackend).
+    assert _select_providers("cuda", ALL) == [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    assert _select_providers("cuda:0", ALL) == [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+
+
+def test_auto_matches_cuda_selection():
+    assert _select_providers("auto", ALL) == [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+
+
+def test_cuda_without_cuda_available_falls_back_to_cpu():
+    assert _select_providers("cuda", CPU_ONLY) == ["CPUExecutionProvider"]
+
+
+def test_directml_and_dml_alias():
+    assert _select_providers("directml", DML) == [
+        "DmlExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    assert _select_providers("dml", DML) == [
+        "DmlExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+
+
+def test_directml_falls_back_when_dml_absent():
+    # No DmlExecutionProvider available -> fall back to whatever is available.
+    assert _select_providers("dml", CPU_ONLY) == ["CPUExecutionProvider"]
+
+
+def test_unknown_device_returns_available_unchanged():
+    assert _select_providers("tpu", ALL) == ALL
+    assert _select_providers("weird-device", DML) == DML

--- a/tests/inference/ops/test_crops.py
+++ b/tests/inference/ops/test_crops.py
@@ -109,3 +109,24 @@ def test_crop_bboxes_border_case_differs_from_naive_trunc():
     legacy_tl_x = int(np.trunc(float(bbox[0, 0, 0]) + cw // 2)) - cw // 2
     assert naive_tl_x != legacy_tl_x  # the two strategies genuinely differ here
     np.testing.assert_array_equal(crop, legacy)
+
+
+def test_crop_bboxes_far_out_of_bounds_is_zero_filled():
+    """Far/extreme out-of-bounds crops are zero-filled (pins current behavior, #584).
+
+    The near-edge negative-fractional case is covered above; this pins the
+    far-OOB clamp so a future change to the shared crop op is caught.
+    """
+    h = w = 20
+    ch = cw = 6
+    image = _ramp_image(h, w)
+    # Centroids far outside the image on both sides.
+    centroids = torch.tensor(
+        [[1000.0, 1000.0], [-1000.0, -1000.0]], dtype=torch.float32
+    )
+    bboxes = make_centered_bboxes(centroids, ch, cw)
+    sample_inds = torch.zeros(centroids.shape[0], dtype=torch.long)
+    crops = crop_bboxes(image, bboxes, sample_inds).numpy()
+    assert crops.shape[0] == 2
+    # Entirely outside -> all-zero (no real pixels sampled).
+    np.testing.assert_array_equal(crops, np.zeros_like(crops))

--- a/tests/inference/test_issue_584.py
+++ b/tests/inference/test_issue_584.py
@@ -1,0 +1,210 @@
+"""Regression tests for issue #584 (coverage + minor-correctness follow-ups).
+
+Locks the minor-correctness fixes and fills the higher-value coverage gaps that
+don't already have a dedicated file (run.predict -> test_run.py; ONNX
+_select_providers -> test_select_providers.py; legacy loader -> test_loaders.py):
+
+* threshold 0.0-as-unset (#40), Outputs.slim() CPU contract (#47),
+  PreprocessConfig ensure_rgb/ensure_grayscale validator (#9),
+  find_points_mean per-axis NaN (#12), skip_paf pred_paf_graph (#51),
+  Predictor.retrack wrapper, crop far-OOB behavior is in test_crops.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+import sleap_io as sio
+
+from sleap_nn.data.instance_centroids import find_points_mean
+from sleap_nn.inference.layers.configs import PreprocessConfig
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.predictor import Predictor
+from sleap_nn.inference.preprocess_info import PreprocInfo
+from sleap_nn.inference.streaming import GroupingParams, ScoredBatch, group_scored_batch
+
+CKPT_ROOT = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
+CENTROID_CKPT = CKPT_ROOT / "minimal_instance_centroid"
+CENTERED_CKPT = CKPT_ROOT / "minimal_instance_centered_instance"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #9 — PreprocessConfig rejects ensure_rgb + ensure_grayscale both True
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_preprocess_config_rejects_both_rgb_and_grayscale():
+    """ensure_rgb=True + ensure_grayscale=True is a construction-time error (#584)."""
+    with pytest.raises(ValueError, match="cannot both be True"):
+        PreprocessConfig(ensure_rgb=True, ensure_grayscale=True)
+    # Single flags + neither are fine.
+    PreprocessConfig(ensure_rgb=True)
+    PreprocessConfig(ensure_grayscale=True)
+    PreprocessConfig()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #12 — find_points_mean counts non-NaN PER AXIS
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_find_points_mean_counts_per_axis():
+    """A single-axis NaN must not drag that axis's mean toward 0 (#584)."""
+    # p0=(0,4), p1=(10, NaN). x: both present -> mean 5; y: only p0 -> mean 4.
+    pts = torch.tensor([[0.0, 4.0], [10.0, float("nan")]])
+    out = find_points_mean(pts)
+    torch.testing.assert_close(out, torch.tensor([5.0, 4.0]))
+    # All-NaN slot stays NaN.
+    allnan = find_points_mean(
+        torch.tensor([[float("nan"), float("nan")], [float("nan"), float("nan")]])
+    )
+    assert torch.isnan(allnan).all()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #47 — Outputs.slim()/cpu() move PreprocInfo's nested tensors to CPU
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _outputs_with_info(device: str) -> Outputs:
+    info = PreprocInfo(
+        eff_scale=torch.tensor([1.0], device=device),
+        crop_offsets=torch.zeros(1, 2, device=device),
+    )
+    return Outputs(
+        pred_keypoints=torch.zeros(1, 1, 2, 2, device=device),
+        pred_peak_values=torch.ones(1, 1, 2, device=device),
+        preprocess_info=info,
+    )
+
+
+def test_slim_moves_preprocess_info_to_cpu():
+    """slim() returns a PreprocInfo whose nested tensors are CPU (#584)."""
+    slim = _outputs_with_info("cpu").slim()
+    assert isinstance(slim.preprocess_info, PreprocInfo)
+    assert slim.preprocess_info.eff_scale.device.type == "cpu"
+    assert slim.preprocess_info.crop_offsets.device.type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_slim_moves_cuda_preprocess_info_to_cpu():
+    """The leak case: a CUDA eff_scale/crop_offsets must land on CPU after slim."""
+    slim = _outputs_with_info("cuda").slim()
+    assert slim.preprocess_info.eff_scale.device.type == "cpu"
+    assert slim.preprocess_info.crop_offsets.device.type == "cpu"
+    # numpy() keeps a PreprocInfo but moves it to CPU too.
+    npd = _outputs_with_info("cuda").numpy()
+    assert npd["preprocess_info"].eff_scale.device.type == "cpu"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #51 — skip_paf still emits pred_paf_graph when requested
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_skip_paf_emits_pred_paf_graph():
+    """The skip_paf short-circuit honors return_paf_graph (legacy parity, #584)."""
+    info = PreprocInfo(
+        original_size=(64, 64),
+        processed_size=(64, 64),
+        eff_scale=torch.ones(1),
+        input_scale=1.0,
+        output_stride=1,
+    )
+    scored = ScoredBatch(
+        cms_peaks=[torch.tensor([[1.0, 2.0], [3.0, 4.0]])],
+        cms_peak_vals=[torch.tensor([0.9, 0.8])],
+        cms_peak_channel_inds=[torch.tensor([0, 1], dtype=torch.int32)],
+        edge_inds=[],  # skip path: no scored edges
+        edge_peak_inds=[],
+        line_scores=[],
+        info=info,
+        n_samples=1,
+        n_nodes=2,
+        skip_paf=True,
+    )
+    out = group_scored_batch(
+        scored, GroupingParams(paf_scorer_kwargs={}, return_paf_graph=True)
+    )
+    assert out.pred_paf_graph is not None
+    peaks, edge_inds, edge_peak_inds, line_scores = out.pred_paf_graph
+    assert peaks.shape == (2, 2)  # the found peaks survive
+    assert edge_inds.numel() == 0 and line_scores.numel() == 0  # no edges on skip
+    # Without the flag it stays None.
+    out2 = group_scored_batch(scored, GroupingParams(paf_scorer_kwargs={}))
+    assert out2.pred_paf_graph is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Predictor.retrack wrapper (coverage gap)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _predicted_labels(skeleton, video, frames, empty_last=False):
+    pts = np.array([[0.0, 0.0], [10.0, 0.0]], dtype=np.float32)
+    lfs = []
+    for i in range(frames):
+        insts = []
+        if not (empty_last and i == frames - 1):
+            insts = [
+                sio.PredictedInstance.from_numpy(
+                    points_data=pts + i, skeleton=skeleton, score=0.9
+                )
+            ]
+        lfs.append(sio.LabeledFrame(video=video, frame_idx=i, instances=insts))
+    return sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=lfs)
+
+
+def test_retrack_assigns_tracks():
+    """Predictor.retrack runs the tracker on existing predictions (#584)."""
+    from sleap_nn.inference.tracking import TrackerConfig
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    labels = _predicted_labels(skel, sio.Video(filename="d.mp4"), frames=3)
+    out = Predictor.retrack(labels, TrackerConfig(candidates_method="fixed_window"))
+    assert len(out.labeled_frames) == 3
+    assert all(
+        inst.track is not None for lf in out.labeled_frames for inst in lf.instances
+    )
+
+
+def test_retrack_clean_empty_frames_drops_empty():
+    """clean_empty_frames removes frames with no instances after tracking (#584)."""
+    from sleap_nn.inference.tracking import TrackerConfig
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    labels = _predicted_labels(
+        skel, sio.Video(filename="d.mp4"), frames=3, empty_last=True
+    )
+    out = Predictor.retrack(
+        labels,
+        TrackerConfig(candidates_method="fixed_window"),
+        clean_empty_frames=True,
+    )
+    assert all(len(lf.instances) > 0 for lf in out.labeled_frames)
+    assert len(out.labeled_frames) == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #40 — per-stage threshold 0.0 override is honored (top-down)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and CENTERED_CKPT.exists()),
+    reason="top-down checkpoints not present",
+)
+def test_topdown_centroid_threshold_zero_override_is_honored():
+    """centroid_threshold=0.0 reaches the centroid stage (not swallowed by `or`)."""
+    predictor = Predictor.from_model_paths(
+        [str(CENTROID_CKPT), str(CENTERED_CKPT)], device="cpu", peak_threshold=0.2
+    )
+    centroid_layer = predictor.layer.centroid_layer
+    with predictor._postprocess_overrides(centroid_threshold=0.0):
+        assert centroid_layer.postprocess_config.peak_threshold == 0.0
+    # Restored afterwards.
+    assert centroid_layer.postprocess_config.peak_threshold == 0.2

--- a/tests/inference/test_loaders.py
+++ b/tests/inference/test_loaders.py
@@ -258,3 +258,41 @@ def test_load_model_assets_unsupported_type(tmp_path):
     OmegaConf.save(fake_config, str(tmp_path / "training_config.yaml"))
     with pytest.raises((ValueError, KeyError)):
         load_model_assets([str(tmp_path)], device="cpu")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #584 — legacy SLEAP<=1.4 JSON-config loader path (is_legacy=True)
+# ─────────────────────────────────────────────────────────────────────────
+
+LEGACY_ROOT = Path(__file__).resolve().parents[1] / "assets" / "legacy_models"
+LEGACY_SINGLE = LEGACY_ROOT / "minimal_robot.UNet.single_instance"
+
+
+def test_load_training_config_detects_legacy_json():
+    """A SLEAP<=1.4 dir (training_config.json) is detected as legacy (#584)."""
+    if not LEGACY_SINGLE.exists():
+        pytest.skip("legacy SLEAP<=1.4 fixture not present")
+    _cfg, is_legacy = _load_training_config(str(LEGACY_SINGLE))
+    assert is_legacy is True
+
+
+def test_load_model_assets_legacy_single_instance():
+    """load_model_assets loads a SLEAP<=1.4 single-instance model end-to-end (#584).
+
+    Exercises the previously-untested is_legacy branch (JSON config +
+    TF->torch weight conversion).
+    """
+    if not LEGACY_SINGLE.exists():
+        pytest.skip("legacy SLEAP<=1.4 fixture not present")
+    try:
+        assets, model_types = load_model_assets([str(LEGACY_SINGLE)], device="cpu")
+    except ImportError as e:  # optional legacy-conversion deps missing
+        pytest.skip(f"legacy conversion deps unavailable: {e}")
+    try:
+        assert model_types == ["single_instance"]
+        assert isinstance(assets, LoadedAssets)
+        assert assets.inference_model is not None
+        assert assets.skeletons
+    finally:
+        del assets
+        gc.collect()

--- a/tests/inference/test_run.py
+++ b/tests/inference/test_run.py
@@ -1,0 +1,140 @@
+"""Direct unit tests for ``sleap_nn.inference.run.predict`` (#584 coverage gap).
+
+The CLI tests mock ``run.predict`` as the patch target, so its own body (the
+two source guards, build-kwargs assembly, the from_export_dir branch, and the
+output_path save) was never executed by fast tests. These tests run that body
+with ``Predictor`` mocked so no checkpoints are loaded.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sleap_nn.inference.run import predict
+
+
+def _mock_predictor():
+    """A Predictor stand-in whose predict() returns a MagicMock Labels."""
+    predictor = MagicMock()
+    predictor.predict.return_value = MagicMock(name="labels")
+    return predictor
+
+
+def test_predict_requires_exactly_one_source():
+    """Both or neither of model_paths/export_dir is a ValueError."""
+    with pytest.raises(ValueError, match="not both"):
+        predict("x.mp4", model_paths=["m"], export_dir="d")
+    with pytest.raises(ValueError, match="required"):
+        predict("x.mp4")
+
+
+def test_predict_model_paths_forwards_build_and_override_kwargs():
+    """from_model_paths gets construction kwargs (incl. PAF knobs); predict gets
+    the prediction-time overrides; conditional kwargs only when set (#584)."""
+    pred = _mock_predictor()
+    with patch(
+        "sleap_nn.inference.predictor.Predictor.from_model_paths",
+        return_value=pred,
+    ) as mock_factory:
+        predict(
+            "video.mp4",
+            model_paths=["/m"],
+            device="cpu",
+            batch_size=8,
+            paf_workers=2,
+            min_line_scores=0.4,
+            n_points=7,
+            peak_threshold=0.3,
+            max_instances=2,
+            return_pafs=True,
+        )
+    bk = mock_factory.call_args[1]
+    assert bk["device"] == "cpu"
+    assert bk["batch_size"] == 8
+    assert bk["paf_workers"] == 2
+    # PAF knobs threaded to construction.
+    assert abs(bk["min_line_scores"] - 0.4) < 1e-9
+    assert bk["n_points"] == 7
+    # Conditional kwargs absent when not provided.
+    assert "filter_config" not in bk
+    assert "tracker_config" not in bk
+    assert "anchor_part" not in bk
+    # Prediction-time overrides forwarded to predict().
+    pk = pred.predict.call_args[1]
+    assert abs(pk["peak_threshold"] - 0.3) < 1e-9
+    assert pk["max_instances"] == 2
+    assert pk["return_pafs"] is True
+
+
+def test_predict_forwards_conditional_kwargs_when_set():
+    """filter_config / tracker_config / anchor_part / centroid_only forwarded
+    only when non-None/truthy."""
+    from sleap_nn.inference.filters import FilterConfig
+    from sleap_nn.inference.tracking import TrackerConfig
+
+    pred = _mock_predictor()
+    fc, tc = FilterConfig(), TrackerConfig()
+    with patch(
+        "sleap_nn.inference.predictor.Predictor.from_model_paths",
+        return_value=pred,
+    ) as mock_factory:
+        predict(
+            "video.mp4",
+            model_paths=["/m"],
+            device="cpu",
+            filter_config=fc,
+            tracker_config=tc,
+            anchor_part="head",
+            centroid_only=True,
+        )
+    bk = mock_factory.call_args[1]
+    assert bk["filter_config"] is fc
+    assert bk["tracker_config"] is tc
+    assert bk["anchor_part"] == "head"
+    assert bk["centroid_only"] is True
+
+
+def test_predict_export_dir_branch():
+    """export_dir routes to from_export_dir (not from_model_paths)."""
+    pred = _mock_predictor()
+    with (
+        patch(
+            "sleap_nn.inference.predictor.Predictor.from_export_dir",
+            return_value=pred,
+        ) as mock_export,
+        patch("sleap_nn.inference.predictor.Predictor.from_model_paths") as mock_model,
+    ):
+        predict("video.mp4", export_dir="/exp", device="cpu")
+    assert mock_export.called
+    assert not mock_model.called
+
+
+def test_predict_saves_when_output_path_given(tmp_path):
+    """output_path triggers labels.save."""
+    pred = _mock_predictor()
+    out = tmp_path / "out.slp"
+    with patch(
+        "sleap_nn.inference.predictor.Predictor.from_model_paths",
+        return_value=pred,
+    ):
+        labels = predict(
+            "video.mp4", model_paths=["/m"], device="cpu", output_path=str(out)
+        )
+    labels.save.assert_called_once()
+
+
+def test_predict_device_auto_resolves(monkeypatch):
+    """device='auto' resolves to cpu when no accelerator is available."""
+    import torch
+
+    pred = _mock_predictor()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+    with patch(
+        "sleap_nn.inference.predictor.Predictor.from_model_paths",
+        return_value=pred,
+    ) as mock_factory:
+        predict("video.mp4", model_paths=["/m"], device="auto")
+    assert mock_factory.call_args[1]["device"] == "cpu"


### PR DESCRIPTION
## Summary

Addresses the test-coverage + minor-correctness + nit follow-ups tracked in **#584** from the #530 inference-refactor review (epic #508). Closes out the stack (after #582/PR #585 and #583/PR #587). Same investigate → implement → adversarial-verify workflow.

### Minor correctness (fix + test)
- **`0.0` threshold override honored** (#40): `_postprocess_overrides` used a falsy `or`, so an explicit `centroid_threshold=0.0`/`keypoint_threshold=0.0` ("accept all peaks") was silently dropped. Now uses `is not None`.
- **`Outputs.slim()` CPU contract** (#47): `slim()`/`cpu()`/`numpy()` left `PreprocInfo`'s nested `eff_scale`/`crop_offsets` on-device, breaking the documented pickle-safe-for-spawn contract. Added `PreprocInfo.cpu()` and wired it through `slim`/`_map`/`numpy`.
- **Dead `does_baked_postproc` double-transform removed** (#7): the branch in `SingleInstance`/`Centroid`/`CenteredInstance` `.postprocess` re-applied the coord ladder to already-final baked peaks. It's unreachable (these layers only run with `TorchBackend`; the exported path uses `Exported*Layer`), so the dead branch is deleted and the docstrings corrected.
- **`ensure_rgb`/`ensure_grayscale` precedence** (#9): check `ensure_rgb` first (legacy order) and reject the contradictory both-`True` config via a `PreprocessConfig` validator.

### Nits
- `find_points_mean` now counts non-NaN **per axis** (#12) — numerically identical for the common all-or-nothing-per-point case (no training/parity shift), correct for a single-axis NaN.
- `skip_paf` emits a user-facing warning again (#22, loguru) and no longer drops `pred_paf_graph` when `return_paf_graph` is set (#51; main + skip paths share a `_paf_graph_from_scored` helper).
- top-down `crop_size` is forced from the confmap config so a stray centroid `crop_size` can't win (#54); dead `B` in `CentroidLayer.postprocess` removed (#13); dispatch-order comment (#55); `legacy_predictor_internal_use` docstring corrected (#68); `run_inference` no longer emits a nested `DeprecationWarning` (#69); `apply_input_scale` docstrings clarified as export-only (#3).

### Test coverage
- New `tests/inference/test_run.py` — `run.predict` both-guards, build/predict kwarg forwarding, conditional kwargs, `from_export_dir` branch, `output_path` save, `device="auto"`.
- New `tests/inference/layers/backends/test_select_providers.py` — ONNX provider selection (cpu/auto/cuda/directml/dml-alias/fallback/unknown), runs without onnxruntime.
- `test_loaders.py` — legacy SLEAP ≤1.4 (`is_legacy=True`) load (gated on the checked-in fixture).
- `test_issue_584.py` — `Predictor.retrack` (+ `clean_empty_frames`), the correctness fixes above.
- `test_crops.py` — far/extreme OOB crops pinned to the current zero-fill (Option A; no shared-op change).

## Decision (reviewable)
- **Channel-coercion order (#8) intentionally kept as-is.** The finding wanted inference to match legacy *inference* (sizematcher-first), but the audit found current code matches the **training** pipeline (channel-coercion-first) while legacy inference disagreed with training. Since a model is trained on the training order, keeping inference consistent with training is the safer target. The reorder is sub-LSB and eff_scale-neutral; not changed. (The precedence fix #9 is orthogonal and was applied.)
- **Per-layer numeric parity vs legacy (#11/#15)** is covered by the `generate_centroids` mean-fallback test (added in #582) + the existing per-layer tests + the `test_parity_strong` CPU+CUDA end-to-end suite; no new heavy legacy-comparison test was added.

## Review notes (caught by the adversarial verification pass, fixed here)
- **#69**: the first cut used `warnings.catch_warnings(module="...predictors")`, which can't match the nested warning (it's issued with a stacklevel pointing at the caller). Switched to the module's own `legacy_predictor_internal_use()` threading-local guard, which reliably suppresses it.
- **#54**: the first cut forced `crop_size` from the confmap *unconditionally*, overriding an explicit user `--crop_size`. Now only forces from confmap when the caller didn't supply one (respects the user value, still beats a stray centroid `crop_size`).

## Test plan
- Full `tests/inference` suite: **504 passed / 14 skipped / 1 xfailed** (the 1 deselected is the local-only random-noise PAF spawn test that OOMs under memory pressure and is `_IN_CI`-skipped — not a regression). Parity goldens + strong-parity preserved. black + ruff clean. Run on a CUDA box.

Completes epic #508's post-#530 review follow-up stack (#582, #583, #584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
