### PR TITLE
Centroid-only models (1/3): core inference — collapse + sio.Centroid emission

### DIFF
--- a/CENTROID_ONLY_PLAN.md
+++ b/CENTROID_ONLY_PLAN.md
@@ -1,0 +1,279 @@
+# Centroid-only models — cross-repo architecture plan
+
+> First-class **centroid-only** training + inference in `sleap-nn`: train a model that
+> predicts just the centroid (anchor point) of each instance, and run inference with
+> **only** that model — no second-stage centered-instance model. Primary use case:
+> **multi-instance single-node skeletons** (animals tracked as single points), where a
+> top-down centered-instance second stage is pure redundancy.
+>
+> Status: **plan** (study + design complete; implementation not started).
+> Produced from a cross-repo study of `sleap-nn`, `sleap-io`, and `sleap` (frontend PR #2724).
+
+---
+
+## 0. Binding decisions (from the maintainer)
+
+| # | Decision |
+|---|----------|
+| Scope | `sleap-nn` for train/infer/eval/track/export/authoring/docs. `sleap-io` **only** for centroid file-format support. **Do NOT touch the `sleap` frontend this session** — add the entrypoint in `infer`; circle back to the frontend later. |
+| Entry point | Centroid-only inference goes through the **new** flow (`sleap-nn infer` → `inference/run.py::predict` → `inference/predictor.py::Predictor.from_model_paths` → `CentroidLayer`). The **legacy** path (`track`, `sleap_nn.predict.run_inference`, `inference/predictors.py`) gets **no** new centroid features and **hard-errors** for a lone centroid model. |
+| Depth | **Full first-class** (authoring UX, eval, tracking defaults, export, docs). |
+| Output rep | Multi-node-trained centroid model → **collapse** to a single-node `Skeleton(['centroid'])`. **Also emit `sio.Centroid`** as an **opt-in** alongside the default single-node `PredictedInstance`. Default output stays a single-node `PredictedInstance` (loadable by today's Centroid-unaware frontend). |
+| #586 | The centroid's *meaning* (anchor vs mean-of-visible fallback) is a **shared train+infer contract** via `data/instance_centroids.py::generate_centroids` (currently mean-of-visible, locked by tests). Collapse semantics, `sio.Centroid.source/method`, and eval GT-centroid computation must mirror it and must not diverge training from inference. |
+
+---
+
+## 1. Current state (verified)
+
+### Training — already works ✅
+A standalone centroid head trains end-to-end today. `get_model_type_from_cfg` (`config/utils.py:7-14`)
+returns `"centroid"` purely from the head-config key; `CentroidConfmapsHead` emits 1 channel;
+`CentroidLightningModule` hard-codes `node_names=["centroid"]`. The whole data/model/loss path is
+**node-count-agnostic** (a 1-node skeleton just works; `tests/assets/generated_configs/centroid.yaml`
+is a working standalone config).
+
+**Gaps:** authoring (`config_generator`/TUI only emit centroid as a *paired* top-down bundle), and
+post-training auto-eval (`train.py:12` imports the **legacy** `run_inference`, which is GT-dependent
+for centroid).
+
+### Inference — new flow works, legacy is broken 🟡
+- **New** path (`sleap-nn infer`): centroid-only **works** — `_select_layer` builds a standalone
+  `CentroidLayer`; `outputs.to_instances` produces real `PredictedInstance`s (verified empirically).
+- **Legacy** path (`sleap-nn track` → deprecated `predict.py::run_inference` → `predictors.py`):
+  routes a lone centroid to `FindInstancePeaksGroundTruth` (**requires GT**, useless on video) and
+  **pops `--centroid_only`** (`cli.py:968`). **This is the PR #2724 blocker** — the frontend's
+  `runners.py:541` hardcodes its inference subprocess to call `track`, not `infer`.
+
+**Three correctness bugs in the new path** (harmless for pure single-node, wrong for multi-node anchors):
+1. **Anchor dropped** — `loaders._build_topdown:500-513` builds the real `CentroidCrop` without
+   `anchor_ind` (passed only in the GT branch `:493`). *Impact (corrected by review): this affects only
+   `CentroidLayer.anchor_ind` → the packaging slot + `source` tag, **not** the predicted coordinate
+   (the real-model forward derives centroids from `find_local_peaks` and ignores `anchor_ind`).*
+2. **Writer ignores anchor/mode** — `writer.py:103` calls `to_labels` without the packaging params,
+   so streaming/`predict_to_file` diverge from in-memory `predict()`.
+3. **Filters no-op** — every filter early-returns when `pred_keypoints is None`
+   (`filters.py:146,162,182,212`), so centroid-only output is unfiltered.
+
+### Scoring degenerate for single points 🔴
+Default OKS uses bbox area = 0 for a single node → a 1.0/0.0 step function. Breaks the tracker default
+`scoring_method='oks'` (`tracker.py:81`) and `run_evaluation`'s OKS metrics. `euclidean_dist`/`iou` work
+but aren't the defaults.
+
+### `sio.Centroid` 🟢 (available) / frontend unaware 🔴
+sleap-io 0.7.0 (already pinned `>=0.7.0,<0.8.0`) ships `Centroid`/`PredictedCentroid` +
+`get_centroid_skeleton()` (`Skeleton(['centroid'])`), a separate `LabeledFrame.centroids` container, a
+`/centroids` HDF5 group, and **lossless** `to_instance()`/`from_instance()`. **But**: the frontend is
+Centroid-unaware (would drop `/centroids` on resave) and sleap-io doesn't bump `format_id` for centroids.
+→ single-node `PredictedInstance` is the zero-friction default; `sio.Centroid` is opt-in now.
+
+---
+
+## 2. The keystone: Output Representation Contract
+
+*(Consolidates the two overlapping design specs the reviewer flagged. One owner, one PR.)*
+
+A single decision point on the `Predictor` resolves how centroid output is packaged, and the **same
+struct** is threaded into in-memory `predict()`, streaming, and the writer so all three are identical.
+
+```
+Predictor._resolve_centroid_packaging() -> CentroidPackaging(
+    collapse_skeleton,   # sio.get_centroid_skeleton() when centroid-only AND model skeleton has >1 node; else None
+    anchor_ind,          # CentroidLayer.anchor_ind (for source tagging; packaging slot is node 0 on collapsed skel)
+    emit_centroid,       # 'instance' (default) | 'centroid' | 'both'
+    source_method,       # 'anchor:<node>' if anchor configured, else 'center_of_mass' (== generate_centroids mean-of-visible, #586)
+)
+```
+
+**Rules**
+- **Collapse** engages only when `isinstance(layer, (CentroidLayer, ExportedCentroidLayer))` **and** the
+  model skeleton has `>1` node → output is a genuine 1-node `Skeleton(['centroid'])` instance (centroid
+  at node 0). A **genuinely 1-node** model is emitted verbatim (structurally identical). The old
+  multi-node-NaN-pad path is **not** used in the new flow.
+- **Raw `Outputs.to_instances` stays backward-compatible** (keeps NaN-pad when no `collapse_skeleton` is
+  passed) — collapse engages *only* via `Predictor`. This preserves the existing
+  `tests/inference/test_centroid_only.py` packaging tests.
+- **`emit_centroid`** (the opt-in): `'instance'` (default; single-node `PredictedInstance`, frontend-safe),
+  `'centroid'` (`sio.PredictedCentroid` into `LabeledFrame.centroids`), `'both'`. A new module
+  `sleap_nn/inference/centroid_convert.py` owns the sio mapping (built on lossless
+  `Centroid.to_instance()/from_instance()`), incl. `source_method` derivation consistent with #586.
+- **Scores**: single-node `PredictedInstance` carries both per-point (centroid value at node 0) and
+  per-instance score; `PredictedCentroid` carries instance-level `.score`/`.tracking_score` only.
+
+**Unified API names** (resolving the reviewer's collision): `emit_centroid: {instance,centroid,both}`
+everywhere (CLI `--centroid-output`, `run.predict`, `Predictor.from_model_paths`, writer, export);
+`source_method` for the #586 tag; adopt `centroid_convert.py` for the conversion helpers.
+
+---
+
+## 3. Staged implementation plan (PRs)
+
+Ordering minimizes risk and lands a working slice early. PR 2 is the keystone everything else consumes.
+
+### PR 1 — Foundation (low risk, independent)
+- Thread `anchor_ind` into the real-model `CentroidCrop` in `_build_topdown` (`loaders.py:500-513`) and
+  `_build_topdown_multiclass` (`:650-663`). *(Affects the packaging slot/source tag, not coordinates.)*
+- **Legacy closure**: `predict.py::run_inference` raises `ValueError` for a lone-centroid `model_paths`
+  (detect via `get_model_type_from_cfg`, config-parse only) pointing to `sleap-nn infer`; `cli.py track`
+  stops silently popping `--centroid_only` and raises `click.UsageError`; update the deprecation docstring.
+- **Regression guard**: a 2-model top-down run still emits the **full** multi-node skeleton (assert
+  `_resolve_centroid_packaging` returns `collapse_skeleton=None` for a `TopDownLayer` even with
+  `anchor_ind` now populated on the underlying `CentroidCrop`).
+
+### PR 2 — Keystone: output representation (medium risk)
+- `outputs.py`: collapse logic + `to_centroids()`; `to_labels` empty-frame guard
+  `if not instances and not centroids: continue`; `Labels.skeletons=[collapse_skeleton]` when collapsing.
+- `predictor.py`: `_resolve_centroid_packaging()`, `Predictor.emit_centroid` field,
+  `from_model_paths(emit_centroid=...)`, `to_labels` + `predict_to_file` wiring.
+- `centroid_convert.py` (new): `centroid_source_for_anchor`, `build_predicted_centroid`,
+  `predicted_instance_to_centroid`, `centroid_to_instance`.
+- `writer.py`: thread `anchor_ind`/`collapse_skeleton`/`emit_centroid`/`source_method` so streaming ==
+  in-memory; `_finalize` uses the collapse skeleton.
+- `filters.py`: centroid-aware branches — `_nan_out_where` clears `pred_centroids`/`pred_centroid_values`;
+  `_filter_confidence` gates `min_instance_score` on centroid values; skip node-count/mean-node-score.
+  **Overlap-NMS decision (see §4): add a small `FilterConfig` centroid-distance/radius knob** so
+  overlap-NMS is a *real* dedup (point-bbox IoU is 0 for distinct points → otherwise a no-op).
+- Update `tests/inference/test_centroid_only.py` to assert collapse semantics where the `Predictor`
+  drives it; keep raw-`Outputs` NaN-pad tests for the un-collapsed API.
+
+### PR 3 — CLI/run wiring (low risk; depends on PR 2)
+- `run.predict(..., emit_centroid='instance')`; CLI `infer` gains `--centroid-output {instance,centroid,both}`;
+  thread through `_run_in_memory_new_flow` + `_run_stream_to_file`. Fix the stale `--centroid_only` help text.
+- Tests via `CliRunner` + mocked `run.predict` (avoid subprocess/torch-venv corruption — see §5).
+
+### PR 4 — Tracking defaults (medium risk; depends on PR 2; parallel with PR 5)
+- `TrackerConfig` gains `scoring_method_explicit`/`features_explicit` sentinels (default True for direct
+  callers). `apply_tracking`: when `len(labels.skeletons)==1 and len(nodes)==1` *(guard promoted from the
+  reviewer's note)* and the user didn't pin one, default `scoring_method='euclidean_dist'`,
+  `features='centroids'`; log it. CLI `--scoring_method`/`--features` default `None`.
+- `filters` OKS-NMS fallback-to-IoU guard widened to `<2` nodes (collapsed output has 1 *populated* node).
+- Document the `> min_new_track_points` / `> min_match_points` off-by-one for single points (keep default 0).
+
+### PR 5 — Evaluation (high risk; depends on PR 2; parallel with PR 4)
+- `compute_gt_centroids(points, anchor_ind)` — numpy mirror of `generate_centroids` (mean-of-visible,
+  **#586 parity test** against `find_points_mean`).
+- Move `match_centroids` from `training/callbacks.py` into `evaluation.py` **byte-identical** and
+  re-export from `callbacks.py` (keep callback tests green).
+- `Evaluator(match_method='oks'|'centroid', anchor_ind=...)`; `detection_metrics()`
+  (precision/recall/F1 + localization-error percentiles); `run_evaluation(match_method, anchor_part)`
+  auto-detects centroid mode (pred skeleton == `get_centroid_skeleton()` or single visible node);
+  default `match_threshold=50.0` in centroid mode; consume `trainer_config.eval.match_threshold`.
+- **OKS-for-1-node decision (see §4): omit OKS as primary** for 1-node (report distance/detection);
+  do not ship the arbitrary fixed-scale constant unless explicitly wanted.
+
+### PR 6 — Authoring (medium risk; mostly independent)
+- `recommender.py`: new `PipelineType` member `"centroid_only"`; `num_nodes==1` multi-instance branch
+  (ordered **before** the animal-to-frame split) → recommend standalone centroid, `requires_second_model=False`.
+- `generator.py`: `centroid_only` builds **one** centroid YAML (`is_topdown` stays False → no dual-emit);
+  `_build_head_config` emits a canonical `centroid` head; full-res defaults (`scale=1.0`, `sigma=2.5`).
+- TUI: standalone "Centroid (single point per animal)" card + state/selection wiring.
+- CLI `config --pipeline`: `centroid` = standalone (1 config); `topdown` = paired (2 configs).
+- New golden `tests/assets/generated_configs/centroid_only.yaml`.
+- *(train.py post-eval is **deferred to PR 7** to avoid the two-spec collision.)*
+
+### PR 7 — `train.py` post-eval (high risk; single merged edit; depends on PR 2 + PR 5)
+- One owner for the ~30-line block: branch on `model_type=='centroid'` → call the **new**
+  `sleap_nn.inference.run.predict` with `source=path` (positional), `centroid_only=True`,
+  `output_path=...` — **drop `make_labels`** (the new `predict` has no such param; hardcodes True) and
+  rename `data_path`→`source`. Route eval to `run_evaluation(match_method='centroid', anchor_part=...)`;
+  log detection + distance metrics, **guard every metric-key access** (no `oks_voc.mAP` for centroid).
+  Non-centroid models stay on the existing path. *(Verify the predicted `frame_idx` set matches the GT
+  labeled-frame set for `labels_gt.*.slp`.)*
+
+### PR 8 — Export + docs (low/medium risk; depends on PR 2)
+- `from_export_dir`: resolve `skeleton = sio.get_centroid_skeleton()` when `metadata.model_type=='centroid'`
+  (so the export Predictor self-describes collapse); `export predict` CLI stops force-passing the full
+  training skeleton for centroid models; `--centroid-output` flag matching PR 3.
+- Clearer guard when two centroid dirs are passed to `export` (point to single-dir standalone).
+- Docs: rewrite `docs/guides/centroid-only-inference.md` to the collapse contract + end-to-end
+  (train → `infer` → distance `eval` → export → exported infer); fix `docs/guides/export.md`
+  ("No standalone centroid" is now false); add `config_centroid_unet_standalone.yaml` + single-node
+  skeleton example; update `docs/configuration/samples.md` and a one-line `CLAUDE.md` pointer.
+
+---
+
+## 4. Open decisions resolved (recommendations — adjust if you disagree)
+
+| Decision | Recommendation | Why |
+|---|---|---|
+| Centroid overlap-NMS | **Add a small `FilterConfig` centroid-distance (px-radius) knob** and do distance-NMS | Multi-instance single-point tracking specifically needs duplicate-centroid suppression; point-bbox IoU is structurally 0 → no-op. The only spot that adds a `FilterConfig` field. |
+| OKS for 1-node | **Omit OKS as primary**; report detection (P/R/F1) + localization error. No magic OKS-scale constant. | bbox-area OKS is ill-defined for points; distance is the standard for point detection. Avoids shipping an arbitrary constant + an untested forced-OKS path. |
+| `emit_centroid='centroid'` + tracking | **Auto-upgrade to `'both'` (or warn)** when a tracker is configured | Tracker/eval read `predicted_instances`; a centroids-only frame would silently track nothing. |
+| Default `emit_centroid` | **`'instance'`** | Frontend-compatible today; `sio.Centroid` is opt-in per your decision. |
+| 1-node bottom-up | **Do not offer** bottom-up for `num_nodes==1` (PAF grouping needs edges) | A single-node skeleton has 0 edges; guard/doc it in the recommender. |
+
+---
+
+## 5. Risks & test strategy
+
+- **Top-down stage-1 reuse**: the centroid head/`CentroidCrop` is shared. Verified `anchor_ind` is inert
+  in the real-model forward, so PR 1 doesn't change top-down crop centering — but add a regression test
+  that a 2-model top-down run still emits the full skeleton (collapse gated on layer type).
+- **#530/#582/#583/#584 parity**: the `to_labels` empty-frame guard loosening (PR 2) must not change
+  non-centroid behavior; run the full `tests/inference` suite. The #582 strict video-index handling stays.
+- **CI is CPU-only and CLI tests can corrupt the venv torch** (per project memory): prefer in-process
+  `CliRunner` + mocked `run.predict` over subprocess; guard ONNX/export tests behind availability skips;
+  assert flag propagation via monkeypatch, not real inference.
+- **`match_centroids` move** (PR 5): keep byte-identical + re-export from `callbacks.py`; callback
+  `match_threshold` tests are the regression gate.
+- **Back-compat**: default `emit_centroid='instance'` → no `/centroids`, no `format_id` bump. Add a test
+  that a centroid-free `Labels` keeps `format_id <= 2.2` and the default `.slp` has zero `/centroids` datasets.
+
+---
+
+## 6. `sio.Centroid` porting (Phase 2, in this initiative)
+
+Per your "also emit `sio.Centroid` now" decision — folded into PR 2/PR 8 as an **opt-in**, plus minimal
+sleap-io format support:
+
+- **sleap-nn**: `centroid_convert.py` (lossless conversion via `Centroid.to_instance/from_instance`),
+  `emit_centroid` opt-in, `source/method` tagging consistent with #586. Round-trip test
+  (save → load preserves `x/y/score/source`).
+- **sleap-io** (format only, allowed): bump `format_id` to `2.3` when `labels.centroids` is non-empty
+  (`write_metadata`, `slp.py:1613-1648`) + history docstring; add `Centroid.numpy()` and
+  `Labels.numpy_centroids()` array accessors for eval/tracking. Backward-compatible (reader has no
+  max-version guard; older `.slp` without `/centroids` → empty list).
+- **Version coordination**: the bump is backward-compatible and can ship in a `0.7.x` patch under the
+  existing pin; only raise the floor if sleap-nn must *guarantee* a version that stamps `2.3`.
+
+**Inter-conversion summary** (`Centroid` ↔ single-node `Instance`):
+- `Centroid.to_instance()` → 1-node `Skeleton(['centroid'])` instance (drops z/category/name/source).
+- `Centroid.from_instance(method=...)` ← maps to #586 fallback: `center_of_mass` ≈ mean-of-visible,
+  `bbox_center` ≈ bbox-midpoint, `anchor` ≈ explicit node. Older `.slp` (pre-Centroid) need no migration.
+
+---
+
+## 7. Frontend contract (for the later `sleap` session — NOT this session)
+
+When we circle back to PR #2724, the frontend should:
+- Switch its inference subprocess from `sleap track` to **`sleap-nn infer`** (`runners.py:541`,
+  `make_predict_cli_call`). For a lone centroid model dir, **`--centroid_only` is not needed**
+  (auto-detected); it's only needed to force centroid output when a centered-instance model is also passed.
+- Invocation: `sleap-nn infer --data_path <video|slp> --model_paths <centroid_dir> [--device ...]
+  [--max_instances N] [--peak_threshold T] [--centroid-output instance]`.
+- Default output is a single-node `Skeleton(['centroid'])` `PredictedInstance` — already mergeable via
+  `Labels.merge` against the frontend's committed `sleap/skeletons/centroid.json`. The frontend can stay
+  Centroid-unaware until it opts into `--centroid-output centroid`/`both`.
+- Remove the `is_centroid_models_enabled` feature flag and add the inference-side pipeline option +
+  `get_most_recent_pipeline_trained` extension to `mode=='inference'`.
+
+---
+
+## 8. Subsystem → file map (quick reference)
+
+| Subsystem | Key files |
+|---|---|
+| Output rep (keystone) | `inference/outputs.py`, `inference/predictor.py`, `inference/loaders.py`, `inference/writer.py`, `inference/filters.py`, `inference/centroid_convert.py` (new), `inference/layers/centroid.py` |
+| Entry points | `cli.py` (`infer`/`track`), `inference/run.py`, `predict.py` (legacy hard-error), `inference/predictors.py` |
+| Authoring + train eval | `config_generator/{generator,recommender,analyzer}.py`, `config_generator/tui/*`, `cli.py config`, `train.py`, `training/model_trainer.py` (callback) |
+| Evaluation | `evaluation.py`, `data/instance_centroids.py` (#586), `cli.py eval`, `training/callbacks.py` |
+| Tracking | `tracking/tracker.py`, `tracking/utils.py`, `tracking/candidates/*`, `inference/tracking.py`, `inference/filters.py` |
+| sio.Centroid | `inference/centroid_convert.py`, `inference/outputs.py`; sleap-io `model/centroid.py`, `model/labels.py`, `io/slp.py` |
+| Export + docs | `export/cli.py`, `export/metadata.py`, `export/wrappers/centroid.py`, `docs/guides/*`, `docs/sample_configs/*` |
+
+---
+
+## 9. Suggested first slice
+
+PR 1 (foundation/legacy-closure) + PR 2 (keystone) together produce a correct, frontend-loadable
+centroid-only `infer` flow on a single-node skeleton — the minimum that unblocks the eventual PR #2724
+frontend switch. PRs 3–8 layer on the full first-class experience.

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -965,8 +965,13 @@ def track(**kwargs):
     kwargs.pop("cpu_workers", None)
     kwargs.pop("stream_to_file", None)
     kwargs.pop("write_interval", None)
+    # New-flow-only flags, inert here. `track` cannot do centroid-only
+    # inference; a lone centroid model is rejected downstream by run_inference
+    # with a message pointing to `sleap-nn infer`.
     kwargs.pop("centroid_only", None)
     kwargs.pop("centroid_peak_threshold", None)
+    kwargs.pop("centroid_output", None)
+    kwargs.pop("filter_min_centroid_distance", None)
 
     return run_inference(**kwargs)
 
@@ -1097,12 +1102,14 @@ def _build_filter_config(kwargs: dict) -> "object":
     )
     min_mean_node_score = float(kwargs.get("filter_min_mean_node_score") or 0.0)
     min_instance_score = float(kwargs.get("filter_min_instance_score") or 0.0)
+    min_centroid_distance = float(kwargs.get("filter_min_centroid_distance") or 0.0)
     if not (
         overlapping
         or min_visible_nodes
         or min_visible_node_fraction
         or min_mean_node_score
         or min_instance_score
+        or min_centroid_distance
     ):
         return None
     return FilterConfig(
@@ -1115,6 +1122,7 @@ def _build_filter_config(kwargs: dict) -> "object":
         min_visible_node_fraction=min_visible_node_fraction,
         min_mean_node_score=min_mean_node_score,
         min_instance_score=min_instance_score,
+        min_centroid_distance=min_centroid_distance,
     )
 
 
@@ -1345,6 +1353,8 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         predict_kwargs["tracker_config"] = _build_tracker_config(kwargs)
     if kwargs.get("centroid_only"):
         predict_kwargs["centroid_only"] = True
+    if kwargs.get("centroid_output") and kwargs["centroid_output"] != "instance":
+        predict_kwargs["emit_centroid"] = kwargs["centroid_output"]
     filter_config = _build_filter_config(kwargs)
     if filter_config is not None:
         predict_kwargs["filter_config"] = filter_config
@@ -1571,6 +1581,8 @@ def _run_stream_to_file(
         factory_kwargs["head_ckpt_path"] = kwargs["head_ckpt_path"]
     if kwargs.get("centroid_only"):
         factory_kwargs["centroid_only"] = True
+    if kwargs.get("centroid_output") and kwargs["centroid_output"] != "instance":
+        factory_kwargs["emit_centroid"] = kwargs["centroid_output"]
     filter_config = _build_filter_config(kwargs)
     if filter_config is not None:
         factory_kwargs["filter_config"] = filter_config
@@ -1694,9 +1706,24 @@ def _common_inference_options(f):
                 "Force centroid-only output. Required only when both a "
                 "centroid and a centered-instance model are configured but "
                 "you want centroid-only predictions; if model_paths contains "
-                "a single centroid model, this mode is auto-detected. "
-                "Output skeleton is NaN-padded; centroid lands on the "
-                "configured anchor node (or node 0 if unset)."
+                "a single centroid model, this mode is auto-detected. For a "
+                "model trained on a multi-node skeleton, output collapses to a "
+                "single-node 'centroid' skeleton; use --centroid-output to "
+                "choose the representation."
+            ),
+        ),
+        click.option(
+            "--centroid-output",
+            "--centroid_output",
+            "centroid_output",
+            type=click.Choice(["instance", "centroid", "both"]),
+            default="instance",
+            show_default=True,
+            help=(
+                "Centroid-only output representation: 'instance' (single-node "
+                "PredictedInstance, loadable by the current frontend), "
+                "'centroid' (sio.PredictedCentroid in LabeledFrame.centroids), "
+                "or 'both'. Only meaningful for centroid-only models."
             ),
         ),
         click.option(
@@ -1794,6 +1821,18 @@ def _common_inference_options(f):
         click.option("--filter_min_visible_node_fraction", type=float, default=0.0),
         click.option("--filter_min_mean_node_score", type=float, default=0.0),
         click.option("--filter_min_instance_score", type=float, default=0.0),
+        click.option(
+            "--filter_min_centroid_distance",
+            type=float,
+            default=0.0,
+            help=(
+                "Centroid-only de-duplication radius in pixels: greedy NMS drops "
+                "any predicted centroid within this distance of a higher-scored "
+                "kept centroid. 0 disables. Use this (not --filter_overlapping) "
+                "for centroid-only output, since bbox-IoU/OKS are degenerate for "
+                "single points."
+            ),
+        ),
         click.option("--integral_refinement", type=str, default="integral"),
         click.option("--tracking_window_size", type=int, default=5),
         click.option("--min_new_track_points", type=int, default=0),

--- a/sleap_nn/inference/centroid_convert.py
+++ b/sleap_nn/inference/centroid_convert.py
@@ -1,0 +1,106 @@
+"""Conversion helpers for centroid-only output representation.
+
+Single place that owns the mapping between sleap-nn's centroid predictions
+and ``sleap_io`` objects, so the representation (single-node ``PredictedInstance``
+vs ``sio.PredictedCentroid``) and the ``source`` tag stay consistent across
+``outputs.py`` / ``predictor.py`` / ``writer.py``.
+
+**#586 consistency.** The centroid's *meaning* is defined by
+``sleap_nn/data/instance_centroids.py::generate_centroids`` (shared by training
+target generation AND GT-centroid inference). Its fallback when the configured
+anchor is missing/occluded is the NaN-ignoring mean of visible nodes
+(``find_points_mean``). The ``source`` tag we record mirrors that and the
+``sio.Centroid.from_instance(method=...)`` vocabulary:
+
+* an explicit, configured anchor node  -> ``"anchor:<node>"``
+* no anchor configured (mean-of-visible) -> ``"center_of_mass"``
+* (reserved) bbox-midpoint fallback      -> ``"bbox_center"``
+
+so the recorded metadata never contradicts the trained target. If #586 later
+makes the fallback config-selectable, extend ``centroid_source_for_anchor`` in
+lockstep with ``generate_centroids``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    import sleap_io as sio
+
+# Default ``source`` when no explicit anchor node is configured: the centroid is
+# the mean of visible nodes (``generate_centroids`` fallback == sio
+# ``center_of_mass``).
+CENTER_OF_MASS = "center_of_mass"
+
+
+def centroid_source_for_anchor(
+    anchor_ind: Optional[int],
+    node_names: Optional[List[str]] = None,
+) -> str:
+    """Return the ``sio.Centroid.source`` tag for a centroid model.
+
+    Args:
+        anchor_ind: The configured anchor-node index (``None`` when the model
+            was trained with no explicit anchor, i.e. the mean-of-visible
+            fallback governs the target — see :data:`CENTER_OF_MASS`).
+        node_names: The training skeleton's node names, used to resolve a
+            human-readable ``"anchor:<name>"`` tag. When unavailable, the
+            index is used (``"anchor:<ind>"``).
+
+    Returns:
+        ``"center_of_mass"`` when ``anchor_ind is None``; otherwise
+        ``"anchor:<node-name-or-index>"``.
+
+    Note:
+        This is a MODEL-level descriptor, not per-instance: a trained centroid
+        model with an anchor will have learned to predict that anchor when
+        visible and (per #586) the mean-of-visible otherwise, but we cannot
+        recover per-instance visibility from a bare centroid peak. ``anchor:*``
+        is the closest faithful model-level tag.
+    """
+    if anchor_ind is None:
+        return CENTER_OF_MASS
+    if node_names is not None and 0 <= anchor_ind < len(node_names):
+        return f"anchor:{node_names[anchor_ind]}"
+    return f"anchor:{anchor_ind}"
+
+
+def build_predicted_centroid(
+    x: float,
+    y: float,
+    score: float,
+    *,
+    track: Optional["sio.Track"] = None,
+    tracking_score: Optional[float] = None,
+    source: str = CENTER_OF_MASS,
+) -> "sio.PredictedCentroid":
+    """Construct a ``sio.PredictedCentroid`` from a predicted centroid peak.
+
+    Args:
+        x: Centroid x-coordinate in original-image pixels.
+        y: Centroid y-coordinate in original-image pixels.
+        score: Per-instance confidence (the centroid peak value).
+        track: Optional ``sio.Track`` assignment.
+        tracking_score: Optional per-instance tracking score.
+        source: The ``source`` method tag (see :func:`centroid_source_for_anchor`).
+
+    Returns:
+        A ``sio.PredictedCentroid``. ``PredictedCentroid`` carries only an
+        instance-level ``score`` (no per-node slot), per the representation
+        contract.
+    """
+    import sleap_io as sio
+
+    kwargs = {}
+    if track is not None:
+        kwargs["track"] = track
+    if tracking_score is not None:
+        kwargs["tracking_score"] = tracking_score
+    return sio.PredictedCentroid(
+        x=float(x),
+        y=float(y),
+        score=float(score),
+        source=source,
+        **kwargs,
+    )

--- a/sleap_nn/inference/filters.py
+++ b/sleap_nn/inference/filters.py
@@ -62,6 +62,11 @@ class FilterConfig:
             lower-scoring overlap is dropped.
         overlapping_method: ``"iou"`` (bbox IoU) or ``"oks"`` (keypoint
             OKS) for the overlap similarity metric.
+        min_centroid_distance: Centroid-only de-duplication radius in pixels.
+            Greedy NMS drops any predicted centroid within this distance of a
+            higher-scored kept centroid. ``0.0`` disables. Use this (not
+            ``overlapping``) for centroid-only output, since bbox-IoU / OKS are
+            degenerate for single points.
     """
 
     min_peak_value: float = 0.0
@@ -72,6 +77,7 @@ class FilterConfig:
     overlapping: bool = False
     overlapping_threshold: float = 0.8
     overlapping_method: Literal["iou", "oks"] = "iou"
+    min_centroid_distance: float = 0.0
 
 
 @attrs.define
@@ -110,25 +116,24 @@ class FilterPipeline:
             )
         if cfg.overlapping:
             method = cfg.overlapping_method
-            if (
-                method == "oks"
-                and outputs.pred_keypoints is None
-                and outputs.pred_centroids is not None
-            ):
+            if outputs.pred_keypoints is None and outputs.pred_centroids is not None:
                 import warnings
 
                 warnings.warn(
-                    "OKS NMS is not meaningful for centroid-only outputs "
-                    "(no keypoints to compute keypoint similarity); falling "
-                    "back to IoU.",
+                    "overlapping NMS (iou/oks) is not meaningful for "
+                    "centroid-only outputs (single points have degenerate "
+                    "bbox-IoU / OKS); use FilterConfig.min_centroid_distance "
+                    "for centroid de-duplication. Skipping overlap NMS.",
                     stacklevel=2,
                 )
-                method = "iou"
-            outputs = self._filter_overlapping(
-                outputs,
-                threshold=cfg.overlapping_threshold,
-                method=method,
-            )
+            else:
+                outputs = self._filter_overlapping(
+                    outputs,
+                    threshold=cfg.overlapping_threshold,
+                    method=method,
+                )
+        if cfg.min_centroid_distance > 0.0:
+            outputs = self._filter_centroid_distance(outputs, cfg.min_centroid_distance)
         return outputs
 
     @classmethod
@@ -180,7 +185,24 @@ class FilterPipeline:
     ) -> Outputs:
         """Drop instances by score (instance-level + mean-node-score)."""
         if outputs.pred_keypoints is None:
-            return outputs
+            # Centroid-only: gate on the per-instance centroid value (or
+            # ``instance_scores`` when present). Mean-node-score is undefined
+            # for a single point and is skipped.
+            if outputs.pred_centroids is None or min_instance_score <= 0.0:
+                return outputs
+            scores = (
+                outputs.instance_scores
+                if outputs.instance_scores is not None
+                else outputs.pred_centroid_values
+            )
+            if scores is None:
+                return outputs
+            # NaN scores (empty slots) compare False, so they are not dropped
+            # here; they are already NaN centroids and ignored at packaging.
+            # NaN scores are not a valid pass of a positive gate; drop them too
+            # (a valid centroid always carries a finite value upstream).
+            drop = (scores < min_instance_score) | torch.isnan(scores)  # (B, I)
+            return FilterPipeline._nan_out_where(drop, outputs)
         keep = torch.ones(
             outputs.pred_keypoints.shape[:2],
             dtype=torch.bool,
@@ -313,4 +335,60 @@ class FilterPipeline:
             scores = outputs.instance_scores.clone()
             scores[drop_mask] = float("nan")
             kwargs["instance_scores"] = scores
+        # Centroid-only fields: dropped slots must vanish here too, or they
+        # reappear at packaging (to_instances/to_centroids skip only NaN slots).
+        if outputs.pred_centroids is not None:
+            cen = outputs.pred_centroids.clone()
+            cen[drop_mask] = float("nan")
+            kwargs["pred_centroids"] = cen
+        if outputs.pred_centroid_values is not None:
+            cvals = outputs.pred_centroid_values.clone()
+            cvals[drop_mask] = float("nan")
+            kwargs["pred_centroid_values"] = cvals
         return attrs.evolve(outputs, **kwargs)
+
+    @staticmethod
+    def _filter_centroid_distance(outputs: Outputs, min_distance: float) -> Outputs:
+        """Greedy NMS on predicted centroids by Euclidean distance.
+
+        For each frame, sort centroids by score (``pred_centroid_values``, else
+        ``instance_scores``) descending and drop any centroid within
+        ``min_distance`` pixels of an already-kept (higher-scored) centroid.
+        No-op when there are no centroids.
+        """
+        if outputs.pred_centroids is None:
+            return outputs
+        B, I, _ = outputs.pred_centroids.shape
+        dev = outputs.pred_centroids.device
+        if outputs.pred_centroid_values is not None:
+            scores = outputs.pred_centroid_values
+        elif outputs.instance_scores is not None:
+            scores = outputs.instance_scores
+        else:
+            scores = torch.zeros(B, I, device=dev)
+        thresh_sq = float(min_distance) ** 2
+        drop_mask = torch.zeros(B, I, dtype=torch.bool, device=dev)
+        for b in range(B):
+            cen_b = outputs.pred_centroids[b]  # (I, 2)
+            valid_b = ~torch.isnan(cen_b).any(dim=-1)  # (I,)
+            if valid_b.sum() <= 1:
+                continue
+            # Sort by score desc; NaN scores sort last (treated as -inf).
+            sb = scores[b].clone()
+            sb = torch.where(torch.isnan(sb), torch.full_like(sb, float("-inf")), sb)
+            order = sb.argsort(descending=True)
+            kept: list[int] = []
+            for idx in order.tolist():
+                if not valid_b[idx]:
+                    continue
+                p = cen_b[idx]
+                too_close = False
+                for k in kept:
+                    if ((p - cen_b[k]) ** 2).sum().item() < thresh_sq:
+                        too_close = True
+                        break
+                if too_close:
+                    drop_mask[b, idx] = True
+                else:
+                    kept.append(idx)
+        return FilterPipeline._nan_out_where(drop_mask, outputs)

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -510,6 +510,7 @@ def _build_topdown(
             input_scale=centroid_config.data_config.preprocessing.scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
+            anchor_ind=anchor_ind,
         )
 
     # Build FindInstancePeaks
@@ -660,6 +661,7 @@ def _build_topdown_multiclass(
             input_scale=centroid_config.data_config.preprocessing.scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
+            anchor_ind=anchor_ind,
         )
 
     max_stride_inst = confmap_config.model_config.backbone_config[

--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -267,6 +267,8 @@ class Outputs:
         batch_index: int = 0,
         anchor_ind: Optional[int] = None,
         tracks: Optional[list["sio.Track"]] = None,
+        *,
+        collapse_skeleton: Optional["sio.Skeleton"] = None,
     ) -> list["sio.PredictedInstance"]:
         """Convert one batch slot into a list of ``sio.PredictedInstance``.
 
@@ -288,6 +290,11 @@ class Outputs:
                 ``instance_tracking_scores``. Matches legacy
                 ``TopDownMultiClass`` / ``BottomUpMultiClass`` packaging.
                 ``None`` for non-multiclass paths.
+            collapse_skeleton: Centroid-only collapse — when supplied (a 1-node
+                'centroid' skeleton), standalone-centroid output is packaged on
+                it with the centroid at node 0, instead of NaN-padding the
+                multi-node ``skeleton``. ``None`` keeps the legacy NaN-pad
+                behavior on ``skeleton``.
 
         Returns:
             One ``sio.PredictedInstance`` per non-NaN instance slot.
@@ -307,8 +314,17 @@ class Outputs:
         """
         import sleap_io as sio
 
-        # Centroid-only branch: synthesize NaN-padded keypoints from centroids.
+        # Centroid-only branch: synthesize keypoints from centroids. When a
+        # ``collapse_skeleton`` (a 1-node 'centroid' skeleton) is supplied, the
+        # standalone-centroid output collapses to that single node (anchor 0)
+        # rather than NaN-padding the original multi-node skeleton.
         if self.pred_keypoints is None and self.pred_centroids is not None:
+            if collapse_skeleton is not None:
+                return self._to_instances_centroid_only(
+                    skeleton=collapse_skeleton,
+                    batch_index=batch_index,
+                    anchor_ind=0,
+                )
             return self._to_instances_centroid_only(
                 skeleton=skeleton,
                 batch_index=batch_index,
@@ -423,7 +439,7 @@ class Outputs:
 
         instances: List[sio.PredictedInstance] = []
         for i in range(centroids.shape[0]):
-            if np.all(np.isnan(centroids[i])):
+            if np.isnan(centroids[i]).any():
                 continue
             kpts = np.full((n_nodes, 2), np.nan, dtype=np.float32)
             kpts[anchor_ind] = centroids[i]
@@ -440,12 +456,75 @@ class Outputs:
             )
         return instances
 
+    def to_centroids(
+        self,
+        batch_index: int = 0,
+        *,
+        source: str = "center_of_mass",
+        tracks: Optional[list["sio.Track"]] = None,
+    ) -> list["sio.PredictedCentroid"]:
+        """Convert one batch slot's centroids into ``sio.PredictedCentroid``s.
+
+        Centroid-only packaging alternative to :meth:`to_instances`: each
+        non-NaN centroid becomes a ``sio.PredictedCentroid`` (stored in
+        ``LabeledFrame.centroids``) carrying the centroid value as its
+        instance-level ``score`` and a ``source`` method tag (#586-consistent).
+        Returns ``[]`` when there are no centroids.
+
+        Args:
+            batch_index: Which sample in the batch to convert.
+            source: ``sio.Centroid.source`` method tag (see
+                :func:`sleap_nn.inference.centroid_convert.centroid_source_for_anchor`).
+            tracks: Optional per-slot ``sio.Track`` registry (tracking).
+        """
+        if self.pred_centroids is None:
+            return []
+        from sleap_nn.inference.centroid_convert import build_predicted_centroid
+
+        centroids = self.pred_centroids[batch_index].detach().cpu().numpy()  # (I, 2)
+        cvals = (
+            self.pred_centroid_values[batch_index].detach().cpu().numpy()
+            if self.pred_centroid_values is not None
+            else np.full((centroids.shape[0],), np.nan, dtype=np.float32)
+        )
+        tracking_scores = (
+            self.instance_tracking_scores[batch_index].detach().cpu().numpy()
+            if self.instance_tracking_scores is not None
+            else None
+        )
+        out: List["sio.PredictedCentroid"] = []
+        for i in range(centroids.shape[0]):
+            if np.isnan(centroids[i]).any():
+                continue
+            score = float(cvals[i]) if not np.isnan(cvals[i]) else 0.0
+            track = tracks[i] if (tracks is not None and i < len(tracks)) else None
+            tscore = (
+                float(tracking_scores[i])
+                if tracking_scores is not None and not np.isnan(tracking_scores[i])
+                else None
+            )
+            out.append(
+                build_predicted_centroid(
+                    centroids[i, 0],
+                    centroids[i, 1],
+                    score,
+                    track=track,
+                    tracking_score=tscore,
+                    source=source,
+                )
+            )
+        return out
+
     def to_labels(
         self,
         skeleton: "sio.Skeleton",
         videos: Optional[list["sio.Video"]] = None,
         anchor_ind: Optional[int] = None,
         tracks: Optional[list["sio.Track"]] = None,
+        *,
+        collapse_skeleton: Optional["sio.Skeleton"] = None,
+        emit_centroid: str = "instance",
+        source: str = "center_of_mass",
     ) -> "sio.Labels":
         """Convert this ``Outputs`` to a ``sleap_io.Labels``.
 
@@ -459,6 +538,15 @@ class Outputs:
                 class. Forwarded to :meth:`to_instances`; the tracks that get
                 used are registered on the returned ``sio.Labels.tracks``.
                 ``None`` for non-multiclass paths.
+            collapse_skeleton: When set (a 1-node 'centroid' skeleton), a
+                standalone centroid model's output is packaged on it instead of
+                the original multi-node ``skeleton`` and ``Labels.skeletons`` is
+                set to it. ``None`` keeps the original skeleton.
+            emit_centroid: Output representation for centroid-only packaging:
+                ``"instance"`` (default; single-node ``PredictedInstance``),
+                ``"centroid"`` (``sio.PredictedCentroid`` into
+                ``LabeledFrame.centroids``), or ``"both"``.
+            source: ``sio.Centroid.source`` method tag for emitted centroids.
 
         Returns:
             A ``sleap_io.Labels`` containing one ``LabeledFrame`` per
@@ -472,17 +560,41 @@ class Outputs:
         import sleap_io as sio
 
         videos = list(videos) if videos else [None]
+        # Skeleton attached to emitted PredictedInstances and to Labels.skeletons.
+        # ``collapse_skeleton`` (a 1-node 'centroid' skeleton) wins when a
+        # standalone centroid model trained on a multi-node skeleton collapses.
+        pkg_skeleton = collapse_skeleton if collapse_skeleton is not None else skeleton
+        want_instances = emit_centroid in ("instance", "both")
+        want_centroids = emit_centroid in ("centroid", "both")
         labeled_frames: List[sio.LabeledFrame] = []
         used_tracks: List["sio.Track"] = []
         seen_track_ids: set[int] = set()
         for b in range(self.batch_size):
-            instances = self.to_instances(
-                skeleton=skeleton, batch_index=b, anchor_ind=anchor_ind, tracks=tracks
+            instances = (
+                self.to_instances(
+                    skeleton=skeleton,
+                    batch_index=b,
+                    anchor_ind=anchor_ind,
+                    tracks=tracks,
+                    collapse_skeleton=collapse_skeleton,
+                )
+                if want_instances
+                else []
             )
-            if not instances:
+            centroids = (
+                self.to_centroids(batch_index=b, source=source, tracks=tracks)
+                if want_centroids
+                else []
+            )
+            if not instances and not centroids:
                 continue
             for inst in instances:
                 trk = getattr(inst, "track", None)
+                if trk is not None and id(trk) not in seen_track_ids:
+                    seen_track_ids.add(id(trk))
+                    used_tracks.append(trk)
+            for cen in centroids:
+                trk = getattr(cen, "track", None)
                 if trk is not None and id(trk) not in seen_track_ids:
                     seen_track_ids.add(id(trk))
                     used_tracks.append(trk)
@@ -516,13 +628,14 @@ class Outputs:
                     video=video,
                     frame_idx=frame_idx,
                     instances=instances,
+                    centroids=centroids,
                 )
             )
         valid_videos = [v for v in videos if v is not None]
         labels = sio.Labels(
             labeled_frames=labeled_frames,
             videos=valid_videos,
-            skeletons=[skeleton],
+            skeletons=[pkg_skeleton],
         )
         if used_tracks:
             labels.tracks = used_tracks

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -23,7 +23,16 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Union,
+)
 
 import attrs
 import numpy as np
@@ -45,6 +54,21 @@ from sleap_nn.inference.layers.topdown_multiclass import (
 from sleap_nn.inference.outputs import Outputs
 from sleap_nn.inference.providers import Provider
 from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+
+class _CentroidPackaging(NamedTuple):
+    """Single-source centroid output-packaging decision.
+
+    Resolved once per :class:`Predictor` (see ``_resolve_centroid_packaging``)
+    and threaded identically into in-memory ``to_labels`` and the streaming
+    writer so all output paths agree.
+    """
+
+    collapse_skeleton: Optional[Any]  # 1-node sio.Skeleton, or None (no collapse)
+    anchor_ind: Optional[int]
+    emit_centroid: str  # "instance" | "centroid" | "both"
+    source: str  # sio.Centroid.source method tag
+
 
 if TYPE_CHECKING:
     import sleap_io as sio
@@ -571,6 +595,9 @@ class Predictor:
     # #530 gap: the new flow previously wrote no provenance).
     model_paths: Optional[List[str]] = None
     device: Optional[str] = None
+    # Centroid-only output representation: "instance" (default; single-node
+    # PredictedInstance), "centroid" (sio.PredictedCentroid), or "both".
+    emit_centroid: str = "instance"
 
     @property
     def filter_pipeline(self) -> FilterPipeline:
@@ -601,6 +628,7 @@ class Predictor:
         paf_workers: int = 0,
         tracker_config: Optional["TrackerConfig"] = None,
         centroid_only: bool = False,
+        emit_centroid: str = "instance",
         max_edge_length_ratio: float = 0.25,
         dist_penalty_weight: float = 1.0,
         n_points: int = 10,
@@ -631,6 +659,10 @@ class Predictor:
             tracker_config: :class:`TrackerConfig` for tracking.
             centroid_only: Force centroid-only output even when a
                 centered-instance model is among ``model_paths``.
+            emit_centroid: Centroid-only output representation: ``"instance"``
+                (default; single-node ``PredictedInstance``), ``"centroid"``
+                (``sio.PredictedCentroid``), or ``"both"``. Honored only for
+                centroid-only layers.
             max_edge_length_ratio: Bottom-up PAF max edge length ratio.
             dist_penalty_weight: Bottom-up PAF distance penalty weight.
             n_points: Bottom-up PAF line integration sample count.
@@ -681,6 +713,7 @@ class Predictor:
             "paf_workers": paf_workers,
             "model_paths": [str(p) for p in model_paths],
             "device": device,
+            "emit_centroid": emit_centroid,
         }
         if filter_config is not None:
             kwargs["filter_config"] = filter_config
@@ -1041,6 +1074,20 @@ class Predictor:
         """
         from datetime import datetime
 
+        # Tracking operates on sio.PredictedInstance objects; centroid emission
+        # (emit_centroid != 'instance') puts predictions in LabeledFrame.centroids
+        # as sio.PredictedCentroid, which the tracker would silently drop. Fail
+        # fast rather than lose data.
+        if self.tracker_config is not None and self.emit_centroid != "instance":
+            raise ValueError(
+                "Tracking is incompatible with emit_centroid="
+                f"{self.emit_centroid!r}: the tracker operates on "
+                "sio.PredictedInstance objects, but this mode emits "
+                "sio.PredictedCentroid objects (in LabeledFrame.centroids) that "
+                "would be dropped. Use emit_centroid='instance' (the default) "
+                "for tracking."
+            )
+
         provider, auto_videos = self._make_provider(source, frames=frames)
         if videos is None:
             videos = auto_videos
@@ -1235,11 +1282,16 @@ class Predictor:
         # `videos` (possibly None) is used (#582).
         if videos is None:
             videos = derived
+        pkg = self._resolve_centroid_packaging()
         writer = IncrementalLabelsWriter(
             path=path,
             skeleton=self.skeleton,
             videos=videos,
             write_interval=write_interval,
+            anchor_ind=pkg.anchor_ind,
+            collapse_skeleton=pkg.collapse_skeleton,
+            emit_centroid=pkg.emit_centroid,
+            source=pkg.source,
         )
         _prov_start = datetime.now()
         with writer:
@@ -1384,9 +1436,15 @@ class Predictor:
         import sleap_io as sio
 
         skeleton = self.skeleton
-        anchor_ind = self._packaging_anchor_ind()
+        pkg = self._resolve_centroid_packaging()
         tracks = self._multiclass_tracks()
         videos = list(videos) if videos else [None]
+        # When a standalone centroid model collapses to a 1-node 'centroid'
+        # skeleton, that is the skeleton attached to emitted instances and to
+        # Labels.skeletons; otherwise the original training skeleton is kept.
+        out_skeleton = (
+            pkg.collapse_skeleton if pkg.collapse_skeleton is not None else skeleton
+        )
         all_lf: list = []
         used_tracks: list = []
         seen_track_ids: set = set()
@@ -1394,8 +1452,11 @@ class Predictor:
             sub = outputs.to_labels(
                 skeleton=skeleton,
                 videos=videos,
-                anchor_ind=anchor_ind,
+                anchor_ind=pkg.anchor_ind,
                 tracks=tracks,
+                collapse_skeleton=pkg.collapse_skeleton,
+                emit_centroid=pkg.emit_centroid,
+                source=pkg.source,
             )
             all_lf.extend(sub.labeled_frames)
             for trk in sub.tracks:
@@ -1406,7 +1467,7 @@ class Predictor:
         labels = sio.Labels(
             labeled_frames=all_lf,
             videos=valid_videos,
-            skeletons=[skeleton],
+            skeletons=[out_skeleton],
         )
         if used_tracks:
             labels.tracks = used_tracks
@@ -1430,12 +1491,53 @@ class Predictor:
 
     def _packaging_anchor_ind(self) -> Optional[int]:
         """Anchor-node slot for centroid-only output packaging."""
-        from sleap_nn.inference.layers.centroid import CentroidLayer
         from sleap_nn.inference.layers.exported import ExportedCentroidLayer
 
         if isinstance(self.layer, (CentroidLayer, ExportedCentroidLayer)):
             return self.layer.anchor_ind
         return None
+
+    def _is_centroid_only_layer(self) -> bool:
+        """``True`` iff ``layer`` is a standalone centroid layer."""
+        from sleap_nn.inference.layers.exported import ExportedCentroidLayer
+
+        return isinstance(self.layer, (CentroidLayer, ExportedCentroidLayer))
+
+    def _resolve_centroid_packaging(self) -> _CentroidPackaging:
+        """Resolve the single-source centroid output-packaging decision.
+
+        For a centroid-only layer trained on a MULTI-node skeleton, the output
+        collapses to a 1-node 'centroid' skeleton (``sio.get_centroid_skeleton()``);
+        a genuinely 1-node model is left as-is (``collapse_skeleton=None``). The
+        ``source`` tag mirrors the #586 anchor-fallback semantics. For
+        non-centroid layers, emission is forced to ``"instance"`` and no
+        collapse occurs.
+        """
+        from sleap_nn.inference.centroid_convert import centroid_source_for_anchor
+
+        if not self._is_centroid_only_layer():
+            return _CentroidPackaging(
+                collapse_skeleton=None,
+                anchor_ind=None,
+                emit_centroid="instance",
+                source=centroid_source_for_anchor(None),
+            )
+        anchor_ind = self._packaging_anchor_ind()
+        node_names = (
+            list(self.skeleton.node_names) if self.skeleton is not None else None
+        )
+        source = centroid_source_for_anchor(anchor_ind, node_names)
+        collapse_skeleton = None
+        if self.skeleton is not None and len(self.skeleton.nodes) > 1:
+            import sleap_io as sio
+
+            collapse_skeleton = sio.get_centroid_skeleton()
+        return _CentroidPackaging(
+            collapse_skeleton=collapse_skeleton,
+            anchor_ind=anchor_ind,
+            emit_centroid=self.emit_centroid,
+            source=source,
+        )
 
     # ──────────────────────────────────────────────────────────────────
     # Prediction-time postprocess overrides

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -51,6 +51,7 @@ def predict(
     anchor_part: Optional[str] = None,
     paf_workers: int = 0,
     centroid_only: bool = False,
+    emit_centroid: str = "instance",
     # Bottom-up PAF grouping knobs (construction-time; plain bottom-up only)
     max_edge_length_ratio: float = 0.25,
     dist_penalty_weight: float = 1.0,
@@ -99,6 +100,9 @@ def predict(
         paf_workers: CPU worker processes for bottom-up PAF grouping.
         centroid_only: Force centroid-only output even when a
             centered-instance model is among ``model_paths``.
+        emit_centroid: Centroid-only output representation: ``"instance"``
+            (default; single-node ``PredictedInstance``, frontend-compatible),
+            ``"centroid"`` (``sio.PredictedCentroid``), or ``"both"``.
         max_edge_length_ratio: Bottom-up PAF max edge length ratio.
         dist_penalty_weight: Bottom-up PAF distance penalty weight.
         n_points: Bottom-up PAF line integration sample count.
@@ -147,6 +151,14 @@ def predict(
             else "mps" if torch.backends.mps.is_available() else "cpu"
         )
 
+    if tracker_config is not None and emit_centroid != "instance":
+        raise ValueError(
+            "Tracking is incompatible with emit_centroid="
+            f"{emit_centroid!r}: tracking operates on sio.PredictedInstance "
+            "objects, but this mode emits sio.PredictedCentroid objects. Use "
+            "emit_centroid='instance' (the default) for tracking."
+        )
+
     # Build predictor
     build_kwargs: dict = {
         "device": device,
@@ -169,6 +181,8 @@ def predict(
             build_kwargs["anchor_part"] = anchor_part
         if centroid_only:
             build_kwargs["centroid_only"] = True
+        if emit_centroid != "instance":
+            build_kwargs["emit_centroid"] = emit_centroid
         # Bottom-up PAF knobs configure the scorer at load time (#583); inert
         # for non-bottom-up models (load_model_assets forwards them only there).
         build_kwargs["max_edge_length_ratio"] = max_edge_length_ratio

--- a/sleap_nn/inference/writer.py
+++ b/sleap_nn/inference/writer.py
@@ -61,6 +61,13 @@ class IncrementalLabelsWriter:
     # Provenance dict attached to the finalized Labels. May be set after
     # construction (e.g. once end-of-run timestamps are known). #583.
     provenance: Optional[dict] = None
+    # Centroid-only packaging — threaded from
+    # ``Predictor._resolve_centroid_packaging`` so the streamed ``.slp`` matches
+    # the in-memory ``predict()`` output (collapse + sio.Centroid emission).
+    anchor_ind: Optional[int] = None
+    collapse_skeleton: Optional[Any] = None
+    emit_centroid: str = "instance"
+    source: str = "center_of_mass"
 
     _buffer: List[Any] = attrs.field(factory=list, init=False, repr=False)
     _all_frames: List[Any] = attrs.field(factory=list, init=False, repr=False)
@@ -100,7 +107,14 @@ class IncrementalLabelsWriter:
 
         slim = outputs.slim()
         videos = self._resolve_videos()
-        sub = slim.to_labels(skeleton=self.skeleton, videos=videos)
+        sub = slim.to_labels(
+            skeleton=self.skeleton,
+            videos=videos,
+            anchor_ind=self.anchor_ind,
+            collapse_skeleton=self.collapse_skeleton,
+            emit_centroid=self.emit_centroid,
+            source=self.source,
+        )
         self._buffer.extend(sub.labeled_frames)
 
         if len(self._buffer) >= self.write_interval:
@@ -177,7 +191,7 @@ class IncrementalLabelsWriter:
         labels = sio.Labels(
             labeled_frames=self._all_frames,
             videos=videos,
-            skeletons=[self.skeleton],
+            skeletons=[self.collapse_skeleton or self.skeleton],
             provenance=self.provenance or {},
         )
         tmp = self.tmp_path

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -550,6 +550,36 @@ def run_inference(
             )
 
     else:
+        # Centroid-only models are unsupported on this legacy pipeline: a lone
+        # centroid model builds a GT-dependent FindInstancePeaksGroundTruth stage
+        # (predictors.py), silently substituting ground-truth centroids and only
+        # "predicting" labeled frames. Redirect to the new `infer` flow instead of
+        # producing misleading GT-copied output.
+        if model_paths:
+            from sleap_nn.config.utils import get_model_type_from_cfg
+            from sleap_nn.inference.loaders import _load_training_config
+
+            _types = []
+            for _mp in model_paths:
+                try:
+                    _cfg, _ = _load_training_config(_mp)
+                    _types.append(get_model_type_from_cfg(config=_cfg))
+                except (
+                    Exception
+                ):  # noqa: BLE001 - fail open; only block the exact lone-centroid case
+                    _types.append(None)
+            if _types == ["centroid"]:
+                raise ValueError(
+                    "Centroid-only inference is not supported by the legacy "
+                    "`track` / `run_inference` pipeline (it would silently "
+                    "substitute ground-truth centroids and require labeled "
+                    "frames). Use the new flow instead:\n"
+                    "  sleap-nn infer --data_path <video|.slp> --model_paths <centroid_dir>\n"
+                    "or, from Python:\n"
+                    "  from sleap_nn.inference.run import predict\n"
+                    "  predict(src, model_paths=[centroid_dir], centroid_only=True)"
+                )
+
         start_inf_time = time()
         start_datetime = datetime.now()
         start_timestamp = str(start_datetime)

--- a/tests/inference/test_centroid_only.py
+++ b/tests/inference/test_centroid_only.py
@@ -140,14 +140,13 @@ def test_centroid_only_labels_round_trip(tmp_path):
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# 4. FilterPipeline: OKS NMS on centroid-only warns + falls back to IoU
+# 4. FilterPipeline: overlap NMS is degenerate for points → warns + skips;
+#    min_centroid_distance is the meaningful centroid de-dup knob.
 # ─────────────────────────────────────────────────────────────────────────
 
 
-def test_filter_oks_on_centroid_only_warns_and_falls_back():
-    """``overlapping_method='oks'`` with no ``pred_keypoints`` →
-    warning + IoU fallback (which is a no-op on point centroids).
-    """
+def test_filter_overlapping_oks_on_centroid_only_warns_and_skips():
+    """``overlapping`` on centroid-only output warns + leaves it unchanged."""
     outputs = _stub_centroid_outputs()
     pipeline = FilterPipeline(
         FilterConfig(
@@ -160,28 +159,27 @@ def test_filter_oks_on_centroid_only_warns_and_falls_back():
         warnings.simplefilter("always")
         result = pipeline(outputs)
     msg = [str(w.message) for w in caught]
-    assert any("OKS NMS is not meaningful for centroid-only" in m for m in msg)
-    # Output should be unchanged (IoU on point centroids is a no-op).
-    assert result is outputs or torch.equal(
-        result.pred_centroids, outputs.pred_centroids
+    assert any("centroid-only" in m and "min_centroid_distance" in m for m in msg)
+    torch.testing.assert_close(
+        result.pred_centroids, outputs.pred_centroids, equal_nan=True
     )
 
 
-def test_filter_iou_on_centroid_only_does_not_warn():
-    """No warning when method is already 'iou'."""
+def test_filter_overlapping_iou_on_centroid_only_also_warns():
+    """IoU overlap is equally degenerate for single points → also warns + skips."""
     outputs = _stub_centroid_outputs()
     pipeline = FilterPipeline(
         FilterConfig(
-            overlapping=True,
-            overlapping_method="iou",
-            overlapping_threshold=0.5,
+            overlapping=True, overlapping_method="iou", overlapping_threshold=0.5
         )
     )
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        pipeline(outputs)
-    msg = [str(w.message) for w in caught]
-    assert not any("OKS NMS is not meaningful" in m for m in msg)
+        result = pipeline(outputs)
+    assert any("min_centroid_distance" in str(w.message) for w in caught)
+    torch.testing.assert_close(
+        result.pred_centroids, outputs.pred_centroids, equal_nan=True
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -226,3 +224,304 @@ def test_tracking_features_centroids_on_centroid_only_labels():
     # No crash + one tracked instance per frame.
     assert len(tracked.labeled_frames) == 2
     assert all(len(lf.predicted_instances) == 1 for lf in tracked.labeled_frames)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 7. PR I keystone: single-node collapse + sio.Centroid emission
+# ─────────────────────────────────────────────────────────────────────────
+
+from sleap_nn.inference.centroid_convert import centroid_source_for_anchor
+
+SLP_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "assets"
+    / "datasets"
+    / "minimal_instance.pkg.slp"
+)
+
+
+def test_centroid_source_for_anchor_mapping():
+    assert centroid_source_for_anchor(None) == "center_of_mass"
+    assert centroid_source_for_anchor(2, ["a", "b", "c"]) == "anchor:c"
+    assert centroid_source_for_anchor(1) == "anchor:1"
+    assert centroid_source_for_anchor(2, None) == "anchor:2"
+
+
+def test_outputs_to_labels_collapse_to_single_node():
+    """collapse_skeleton → genuine 1-node 'centroid' instances (no NaN padding)."""
+    outputs = _stub_centroid_outputs()
+    labels = outputs.to_labels(
+        skeleton=_make_skeleton(3), collapse_skeleton=sio.get_centroid_skeleton()
+    )
+    assert labels.skeletons[0].node_names == ["centroid"]
+    lf = labels.labeled_frames[0]
+    assert len(lf.instances) == 2
+    for inst in lf.instances:
+        pts = inst.numpy()
+        assert pts.shape == (1, 2)
+        assert not np.any(np.isnan(pts))
+    np.testing.assert_allclose(lf.instances[0].numpy()[0], [10.0, 20.0])
+
+
+def test_genuine_single_node_model_unaffected():
+    """A genuinely 1-node skeleton (collapse_skeleton=None) is emitted verbatim."""
+    outputs = _stub_centroid_outputs()
+    skel1 = _make_skeleton(1)
+    insts = outputs.to_instances(skeleton=skel1)
+    assert len(insts) == 2
+    assert insts[0].numpy().shape == (1, 2)
+    np.testing.assert_allclose(insts[0].numpy()[0], [10.0, 20.0])
+
+
+def test_outputs_to_labels_emit_centroid_mode():
+    outputs = _stub_centroid_outputs()
+    labels = outputs.to_labels(
+        skeleton=_make_skeleton(3),
+        collapse_skeleton=sio.get_centroid_skeleton(),
+        emit_centroid="centroid",
+        source="anchor:B",
+    )
+    lf = labels.labeled_frames[0]
+    assert len(lf.instances) == 0
+    assert len(lf.centroids) == 2
+    c0 = lf.centroids[0]
+    assert (c0.x, c0.y) == pytest.approx((10.0, 20.0))
+    assert c0.score == pytest.approx(0.9)
+    assert c0.source == "anchor:B"
+
+
+def test_outputs_to_labels_emit_both():
+    outputs = _stub_centroid_outputs()
+    labels = outputs.to_labels(
+        skeleton=_make_skeleton(3),
+        collapse_skeleton=sio.get_centroid_skeleton(),
+        emit_centroid="both",
+    )
+    lf = labels.labeled_frames[0]
+    assert len(lf.instances) == 2
+    assert len(lf.centroids) == 2
+    np.testing.assert_allclose(
+        lf.instances[0].numpy()[0], [lf.centroids[0].x, lf.centroids[0].y]
+    )
+
+
+def test_to_centroids_skips_nan_and_tags_source():
+    outputs = _stub_centroid_outputs()
+    cents = outputs.to_centroids(source="center_of_mass")
+    assert len(cents) == 2  # NaN slot dropped
+    assert all(c.source == "center_of_mass" for c in cents)
+    assert cents[0].score == pytest.approx(0.9)
+
+
+def test_predicted_centroid_round_trip(tmp_path):
+    """save + reload preserves PredictedCentroid x/y/score/source."""
+    outputs = _stub_centroid_outputs()
+    video = sio.Video.from_filename(
+        str(
+            Path(__file__).resolve().parents[1]
+            / "assets"
+            / "datasets"
+            / "small_robot.mp4"
+        )
+    )
+    labels = outputs.to_labels(
+        skeleton=_make_skeleton(3),
+        videos=[video],
+        collapse_skeleton=sio.get_centroid_skeleton(),
+        emit_centroid="centroid",
+        source="anchor:B",
+    )
+    out_path = tmp_path / "centroids.slp"
+    labels.save(str(out_path), embed=False)
+    reloaded = sio.load_slp(str(out_path))
+    cents = reloaded.labeled_frames[0].centroids
+    assert len(cents) == 2
+    assert cents[0].source == "anchor:B"
+    assert cents[0].score == pytest.approx(0.9)
+    np.testing.assert_allclose([cents[0].x, cents[0].y], [10.0, 20.0])
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 8. Centroid-aware filters
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_filter_min_instance_score_centroid_only():
+    outputs = _stub_centroid_outputs()  # values 0.9, 0.7, nan
+    result = FilterPipeline(FilterConfig(min_instance_score=0.8))(outputs)
+    cv = result.pred_centroid_values[0]
+    assert not torch.isnan(cv[0])  # 0.9 kept
+    assert torch.isnan(cv[1])  # 0.7 dropped
+    assert torch.isnan(result.pred_centroids[0, 1]).all()
+
+
+def test_filter_min_centroid_distance_nms():
+    centroids = torch.tensor([[[10.0, 20.0], [11.0, 20.0], [100.0, 100.0]]])
+    values = torch.tensor([[0.9, 0.6, 0.8]])
+    outputs = Outputs(pred_centroids=centroids, pred_centroid_values=values)
+    result = FilterPipeline(FilterConfig(min_centroid_distance=5.0))(outputs)
+    cv = result.pred_centroid_values[0]
+    assert not torch.isnan(cv[0])  # higher-scored of the close pair kept
+    assert torch.isnan(cv[1])  # within 5px of a kept centroid → dropped
+    assert not torch.isnan(cv[2])  # far centroid kept
+
+
+def test_nan_out_where_clears_centroid_tensors():
+    outputs = _stub_centroid_outputs()
+    drop = torch.tensor([[True, False, False]])
+    result = FilterPipeline._nan_out_where(drop, outputs)
+    assert torch.isnan(result.pred_centroids[0, 0]).all()
+    assert torch.isnan(result.pred_centroid_values[0, 0])
+    assert not torch.isnan(result.pred_centroids[0, 1]).any()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 9. End-to-end (real checkpoint): collapse, emit, top-down-not-collapsed
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and SLP_FIXTURE.exists()),
+    reason="centroid ckpt / slp fixture absent",
+)
+def test_centroid_only_predict_collapses_to_single_node():
+    pred = Predictor.from_model_paths([str(CENTROID_CKPT)], device="cpu")
+    labels = pred.predict(str(SLP_FIXTURE), make_labels=True)
+    assert labels.skeletons[0].node_names == ["centroid"]
+    insts = [i for lf in labels.labeled_frames for i in lf.instances]
+    assert insts, "expected at least one predicted centroid instance"
+    for inst in insts:
+        assert inst.numpy().shape == (1, 2)
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and SLP_FIXTURE.exists()),
+    reason="centroid ckpt / slp fixture absent",
+)
+def test_centroid_only_predict_emit_both():
+    pred = Predictor.from_model_paths(
+        [str(CENTROID_CKPT)], device="cpu", emit_centroid="both"
+    )
+    labels = pred.predict(str(SLP_FIXTURE), make_labels=True)
+    lf = next((f for f in labels.labeled_frames if f.instances or f.centroids), None)
+    assert lf is not None
+    assert len(lf.instances) >= 1
+    assert len(lf.centroids) >= 1
+    src = lf.centroids[0].source
+    assert src == "center_of_mass" or src.startswith("anchor:")
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and CENTERED_CKPT.exists() and SLP_FIXTURE.exists()),
+    reason="centroid+centered ckpts / slp fixture absent",
+)
+def test_topdown_not_collapsed():
+    """Two-model top-down still emits the full multi-node skeleton (no collapse)."""
+    pred = Predictor.from_model_paths(
+        [str(CENTROID_CKPT), str(CENTERED_CKPT)], device="cpu"
+    )
+    pkg = pred._resolve_centroid_packaging()
+    assert pkg.collapse_skeleton is None
+    assert pkg.emit_centroid == "instance"
+    labels = pred.predict(str(SLP_FIXTURE), make_labels=True)
+    assert labels.skeletons[0].node_names == ["A", "B"]
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and SLP_FIXTURE.exists()),
+    reason="centroid ckpt / slp fixture absent",
+)
+def test_centroid_only_predict_to_file_collapses(tmp_path):
+    """Streamed .slp matches in-memory: collapsed single-node 'centroid' skeleton."""
+    pred = Predictor.from_model_paths([str(CENTROID_CKPT)], device="cpu")
+    out = tmp_path / "stream.slp"
+    pred.predict_to_file(str(SLP_FIXTURE), str(out))
+    reloaded = sio.load_slp(str(out))
+    assert reloaded.skeletons[0].node_names == ["centroid"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 10. Legacy path is closed for centroid-only
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and SLP_FIXTURE.exists()),
+    reason="centroid ckpt / slp fixture absent",
+)
+def test_legacy_run_inference_lone_centroid_raises():
+    from sleap_nn.predict import run_inference
+
+    with pytest.raises(ValueError, match="infer"):
+        run_inference(
+            data_path=str(SLP_FIXTURE),
+            model_paths=[str(CENTROID_CKPT)],
+            make_labels=True,
+        )
+
+
+def test_cli_infer_has_centroid_output_option():
+    """The new --centroid-output option is wired onto `infer`, and the stale
+    'NaN-padded' wording is gone from --centroid_only help."""
+    from click.testing import CliRunner
+
+    from sleap_nn.cli import cli
+
+    result = CliRunner().invoke(cli, ["infer", "--help"])
+    assert result.exit_code == 0
+    assert "--centroid-output" in result.output
+    assert "NaN-padded" not in result.output
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and SLP_FIXTURE.exists()),
+    reason="centroid ckpt / slp fixture absent",
+)
+def test_cli_track_lone_centroid_errors():
+    """Legacy `track` with a lone centroid model errors, pointing to `infer`."""
+    from click.testing import CliRunner
+
+    from sleap_nn.cli import cli
+
+    result = CliRunner().invoke(
+        cli,
+        ["track", "--data_path", str(SLP_FIXTURE), "--model_paths", str(CENTROID_CKPT)],
+    )
+    assert result.exit_code != 0
+    assert result.exception is not None
+    assert "infer" in str(result.exception)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 11. Guard: centroid emission is incompatible with tracking
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_cli_filter_min_centroid_distance_wired():
+    """`--filter_min_centroid_distance` reaches FilterConfig and is registered
+    on the `infer` command."""
+    from sleap_nn.cli import _build_filter_config, infer
+
+    cfg = _build_filter_config({"filter_min_centroid_distance": 8.0})
+    assert cfg is not None
+    assert cfg.min_centroid_distance == 8.0
+    # Zero / absent -> no-op config (None) when nothing else is set.
+    assert _build_filter_config({"filter_min_centroid_distance": 0.0}) is None
+
+    assert "filter_min_centroid_distance" in {p.name for p in infer.params}
+
+
+def test_emit_centroid_with_tracking_raises():
+    """emit_centroid != 'instance' + tracking must hard-error (tracker drops
+    sio.PredictedCentroid). The guard fires before any inference work."""
+    pred = Predictor(
+        layer=object(), emit_centroid="centroid", tracker_config=TrackerConfig()
+    )
+    with pytest.raises(ValueError, match="Tracking"):
+        pred.predict("anything")
+
+    pred_both = Predictor(
+        layer=object(), emit_centroid="both", tracker_config=TrackerConfig()
+    )
+    with pytest.raises(ValueError, match="Tracking"):
+        pred_both.predict("anything")


### PR DESCRIPTION
**Stacked PR 1 of 3** (base: `main`). First-class centroid-only model support — unblocks frontend PR talmolab/sleap#2724. See `CENTROID_ONLY_PLAN.md`.

Makes `sleap-nn infer` produce correct standalone centroid-only output and closes the legacy `track` path for lone centroid models.

### Changes
- **Collapse**: a centroid model trained on a multi-node skeleton collapses its standalone output to a 1-node `sio.Skeleton(['centroid'])` via `Predictor._resolve_centroid_packaging()`. Genuine 1-node models are unaffected; top-down (shared centroid head) never collapses. Raw `Outputs.to_instances` stays NaN-pad backward-compatible.
- **`sio.Centroid` emission (opt-in)**: `--centroid-output {instance,centroid,both}` / `emit_centroid`. Default `instance` (single-node `PredictedInstance`, loadable by the current frontend). `centroid`/`both` emit `sio.PredictedCentroid` into `LabeledFrame.centroids`. New `centroid_convert.py` owns the conversion + a #586-consistent `source` tag.
- **Bug fixes**: thread `anchor_ind` into the real-model `CentroidCrop` (loaders); streaming writer threads the packaging so `predict_to_file` == `predict()`; centroid-aware filters (`min_instance_score`, new `--filter_min_centroid_distance` NMS, `_nan_out_where` clears centroid tensors).
- **Legacy closure**: a lone centroid model on `track` / `run_inference` hard-errors, pointing to `infer`.
- **Guard**: `emit_centroid != 'instance'` + tracking hard-errors (the tracker operates on `PredictedInstance`, not `PredictedCentroid`).

### Tests
`tests/inference/test_centroid_only.py` (28): collapse, emit modes, streaming parity, top-down-not-collapsed, legacy hard-error, tracking guard, `--filter_min_centroid_distance` wiring. No regressions across the inference parity suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
