### PR TITLE
Centroid-only models (2/3): distance eval + single-point tracking + train post-eval

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1166,13 +1166,28 @@ def _build_tracker_config(kwargs: dict) -> "object":
     if (pcsb or pre_cull) and target is None:
         target = max_instances
 
+    # --features / --scoring_method default to None (sentinel for "user left the
+    # default"). Record whether they were set so apply_tracking can substitute
+    # single-node / centroid defaults; fall back to the historical
+    # keypoints/oks defaults for the effective values when unset (#586).
+    features = kwargs.get("features")
+    scoring_method = kwargs.get("scoring_method")
+    features_explicit = features is not None
+    scoring_method_explicit = scoring_method is not None
+    if features is None:
+        features = "keypoints"
+    if scoring_method is None:
+        scoring_method = "oks"
+
     return TrackerConfig(
         window_size=kwargs.get("tracking_window_size", 5),
         min_new_track_points=kwargs.get("min_new_track_points", 0),
         candidates_method=candidates_method,
         min_match_points=kwargs.get("min_match_points", 0),
-        features=kwargs.get("features", "keypoints"),
-        scoring_method=kwargs.get("scoring_method", "oks"),
+        features=features,
+        scoring_method=scoring_method,
+        features_explicit=features_explicit,
+        scoring_method_explicit=scoring_method_explicit,
         scoring_reduction=kwargs.get("scoring_reduction", "mean"),
         robust_best_instance=kwargs.get("robust_best_instance", 1.0),
         track_matching_method=kwargs.get("track_matching_method", "hungarian"),
@@ -1841,8 +1856,19 @@ def _common_inference_options(f):
         # to local_queues when --max_tracks is set (#582).
         click.option("--candidates_method", type=str, default=None),
         click.option("--min_match_points", type=int, default=0),
-        click.option("--features", type=str, default="keypoints"),
-        click.option("--scoring_method", type=str, default="oks"),
+        # Default None (not "keypoints"/"oks") so _build_tracker_config can tell
+        # "user left the default" from an explicit choice, mirroring the
+        # --candidates_method default=None pattern. A single-node / centroid
+        # model then resolves these to centroids/euclidean_dist in
+        # apply_tracking (#586).
+        click.option("--features", type=str, default=None),
+        click.option(
+            "--scoring_method",
+            type=str,
+            default=None,
+            help="Track association scoring method. Single-node / centroid "
+            "models resolve to euclidean_dist when left unset.",
+        ),
         click.option("--scoring_reduction", type=str, default="mean"),
         click.option("--robust_best_instance", type=float, default=1.0),
         click.option("--track_matching_method", type=str, default="hungarian"),
@@ -1956,6 +1982,25 @@ def infer(**kwargs):
     "--user_labels_only/--no-user_labels_only",
     default=True,
     help="Only evaluate user-labeled frames (default: True)",
+)
+@click.option(
+    "--match_method",
+    type=click.Choice(["oks", "centroid", "auto"]),
+    default="auto",
+    help=(
+        "Matching method: 'oks' (full-skeleton), 'centroid' (single-point "
+        "pixel-distance), or 'auto' (centroid when the prediction skeleton is "
+        "single-node). Default: auto."
+    ),
+)
+@click.option(
+    "--anchor_part",
+    type=str,
+    default=None,
+    help=(
+        "GT skeleton node used to compute ground-truth centroids in centroid "
+        "mode. Defaults to the mean of visible nodes when absent (#586)."
+    ),
 )
 def eval(**kwargs):
     """Run evaluation workflow."""

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -9,6 +9,112 @@ import click
 from pathlib import Path
 
 
+def compute_gt_centroids(
+    instance_gt_points: np.ndarray, anchor_ind: Optional[int]
+) -> np.ndarray:
+    """Compute ground-truth centroids mirroring ``generate_centroids`` in numpy.
+
+    This is the numpy mirror of
+    :func:`sleap_nn.data.instance_centroids.generate_centroids`. The centroid's
+    MEANING is defined by that function (see also #586): when the configured
+    anchor node is present (non-NaN) it is that node; otherwise the centroid
+    falls back to the NaN-ignoring MEAN of visible nodes (NOT the bounding-box
+    midpoint). The fallback is computed via ``np.nanmean`` over the node axis,
+    and is NaN only when every node of an instance is NaN.
+
+    Args:
+        instance_gt_points: Ground-truth keypoints of shape ``(n_instances,
+            n_nodes, 2)`` or ``(n_nodes, 2)``. Missing/occluded nodes are NaN.
+        anchor_ind: Index of the node to use as the anchor. If ``None``, or if
+            the anchor node is NaN for a given instance, the centroid falls back
+            to the NaN-ignoring mean of visible nodes for that instance.
+
+    Returns:
+        Centroids of shape ``(n_instances, 2)`` (or ``(2,)`` for a single
+        instance input), reducing the node axis.
+    """
+    points = np.asarray(instance_gt_points, dtype=np.float64)
+
+    if anchor_ind is not None:
+        centroids = points[..., anchor_ind, :].copy()
+    else:
+        centroids = np.full(points.shape[:-2] + (2,), np.nan, dtype=points.dtype)
+
+    missing_anchors = np.isnan(centroids).any(axis=-1)
+    if np.any(missing_anchors):
+        # NaN-ignoring mean of visible nodes. np.nanmean over the node axis
+        # yields NaN only when all nodes for that instance are NaN (matching
+        # find_points_mean). Suppress the all-NaN-slice RuntimeWarning.
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            mean_fallback = np.nanmean(points, axis=-2)
+        centroids[missing_anchors] = mean_fallback[missing_anchors]
+
+    return centroids
+
+
+def match_centroids(
+    pred_centroids: "np.ndarray",
+    gt_centroids: "np.ndarray",
+    max_distance: float = 50.0,
+) -> tuple:
+    """Match predicted centroids to ground truth using Hungarian algorithm.
+
+    Args:
+        pred_centroids: Predicted centroid locations, shape (n_pred, 2).
+        gt_centroids: Ground truth centroid locations, shape (n_gt, 2).
+        max_distance: Maximum distance threshold for valid matches (in pixels).
+
+    Returns:
+        Tuple of:
+            - matched_pred_indices: Indices of matched predictions
+            - matched_gt_indices: Indices of matched ground truth
+            - unmatched_pred_indices: Indices of unmatched predictions (false positives)
+            - unmatched_gt_indices: Indices of unmatched ground truth (false negatives)
+    """
+    import numpy as np
+    from scipy.optimize import linear_sum_assignment
+    from scipy.spatial.distance import cdist
+
+    n_pred = len(pred_centroids)
+    n_gt = len(gt_centroids)
+
+    # Handle edge cases
+    if n_pred == 0 and n_gt == 0:
+        return np.array([]), np.array([]), np.array([]), np.array([])
+    if n_pred == 0:
+        return np.array([]), np.array([]), np.array([]), np.arange(n_gt)
+    if n_gt == 0:
+        return np.array([]), np.array([]), np.arange(n_pred), np.array([])
+
+    # Compute pairwise distances
+    cost_matrix = cdist(pred_centroids, gt_centroids)
+
+    # Run Hungarian algorithm for optimal matching
+    pred_indices, gt_indices = linear_sum_assignment(cost_matrix)
+
+    # Filter matches that exceed max_distance
+    matched_pred = []
+    matched_gt = []
+    for p_idx, g_idx in zip(pred_indices, gt_indices):
+        if cost_matrix[p_idx, g_idx] <= max_distance:
+            matched_pred.append(p_idx)
+            matched_gt.append(g_idx)
+
+    matched_pred = np.array(matched_pred)
+    matched_gt = np.array(matched_gt)
+
+    # Find unmatched indices
+    all_pred = set(range(n_pred))
+    all_gt = set(range(n_gt))
+    unmatched_pred = np.array(list(all_pred - set(matched_pred)))
+    unmatched_gt = np.array(list(all_gt - set(matched_gt)))
+
+    return matched_pred, matched_gt, unmatched_pred, unmatched_gt
+
+
 @attrs.define(auto_attribs=True, slots=True)
 class MatchInstance:
     """Class to have a new structure for sio.Instance object."""
@@ -442,10 +548,19 @@ class Evaluator:
             keypoint similarity; see `compute_oks` function for details.
         oks_scale: The scale to use for calculating object
             keypoint similarity; see `compute_oks` function for details.
-        match_threshold: The threshold to use on oks scores when determining
-            which instances match between ground truth and predicted frames.
+        match_threshold: The threshold to use when determining which instances
+            match between ground truth and predicted frames. For
+            ``match_method="oks"`` this is an OKS threshold; for
+            ``match_method="centroid"`` this is a PIXEL distance threshold.
         user_labels_only: If False, predicted instances in the ground truth frame may be
             considered for matching.
+        match_method: Either ``"oks"`` (default, full-skeleton OKS matching) or
+            ``"centroid"`` (single-point distance matching for centroid-only /
+            single-node predictions).
+        anchor_ind: For ``match_method="centroid"``, the index of the GT
+            skeleton node used to compute each ground-truth centroid (see
+            :func:`compute_gt_centroids` and #586). ``None`` falls back to the
+            NaN-ignoring mean of visible nodes.
 
     """
 
@@ -457,6 +572,8 @@ class Evaluator:
         oks_scale: Optional[float] = None,
         match_threshold: float = 0,
         user_labels_only: bool = True,
+        match_method: str = "oks",
+        anchor_ind: Optional[int] = None,
     ):
         """Initialize the Evaluator class with ground-truth and predicted labels."""
         self.ground_truth_instances = ground_truth_instances
@@ -465,6 +582,10 @@ class Evaluator:
         self.oks_stddev = oks_stddev
         self.oks_scale = oks_scale
         self.user_labels_only = user_labels_only
+        self.match_method = match_method
+        self.anchor_ind = anchor_ind
+        # Populated only in centroid mode.
+        self.false_positives = []
 
         self._process_frames()
 
@@ -477,6 +598,10 @@ class Evaluator:
             logger.error(message)
             raise Exception(message)
 
+        if self.match_method == "centroid":
+            self._process_frames_centroid()
+            return
+
         self.positive_pairs, self.false_negatives = match_frame_pairs(
             self.frame_pairs,
             stddev=self.oks_stddev,
@@ -485,6 +610,107 @@ class Evaluator:
         )
 
         self.dists_dict = compute_dists(self.positive_pairs)
+
+    def _process_frames_centroid(self):
+        """Match predicted vs GT centroids by pixel distance (per frame).
+
+        Each predicted instance is collapsed to its single centroid point (its
+        sole visible point / node-0 for a 1-node prediction). Ground-truth
+        centroids are computed via :func:`compute_gt_centroids` to exactly
+        mirror the centroid target used during training (#586). Matching uses
+        :func:`match_centroids` with ``self.match_threshold`` as a PIXEL
+        distance. Populates ``positive_pairs`` as ``(gt_inst, pr_inst, dist)``
+        3-tuples, ``false_negatives`` (unmatched GT), and ``false_positives``
+        (unmatched predictions).
+        """
+        self.positive_pairs = []
+        self.false_negatives = []
+        self.false_positives = []
+
+        for frame_gt, frame_pr in self.frame_pairs:
+            gt_match_instances = get_instances(frame_gt)
+            pr_match_instances = get_instances(frame_pr)
+
+            # Collapse each predicted instance to its single centroid point.
+            pred_centroids = np.array(
+                [
+                    self._collapse_pred_centroid(m.instance.numpy())
+                    for m in pr_match_instances
+                ]
+            ).reshape(-1, 2)
+
+            # GT centroids mirror generate_centroids exactly (#586).
+            gt_centroids = np.array(
+                [
+                    compute_gt_centroids(m.instance.numpy(), self.anchor_ind)
+                    for m in gt_match_instances
+                ]
+            ).reshape(-1, 2)
+
+            # Drop NaN centroids before Hungarian matching: scipy's cdist /
+            # linear_sum_assignment reject NaN, and a fully-occluded (all-NaN)
+            # GT instance is common in real labels. Index maps translate the
+            # filtered match indices back to the original instance lists so
+            # FN/FP/positive-pair attribution stays correct. (A NaN-row GT is
+            # counted as an automatic false negative — matching the legacy
+            # CentroidEvaluationCallback; a NaN-row prediction is not a real
+            # detection and is simply excluded.)
+            gt_valid = ~np.isnan(gt_centroids).any(axis=1)
+            pred_valid = ~np.isnan(pred_centroids).any(axis=1)
+            gt_map = np.flatnonzero(gt_valid)
+            pred_map = np.flatnonzero(pred_valid)
+
+            matched_pred, matched_gt, unmatched_pred, unmatched_gt = match_centroids(
+                pred_centroids[pred_valid],
+                gt_centroids[gt_valid],
+                max_distance=self.match_threshold,
+            )
+
+            for p_local, g_local in zip(matched_pred, matched_gt):
+                p_idx = int(pred_map[int(p_local)])
+                g_idx = int(gt_map[int(g_local)])
+                dist = float(
+                    np.linalg.norm(pred_centroids[p_idx] - gt_centroids[g_idx])
+                )
+                self.positive_pairs.append(
+                    (gt_match_instances[g_idx], pr_match_instances[p_idx], dist)
+                )
+
+            for g_local in unmatched_gt:
+                self.false_negatives.append(
+                    gt_match_instances[int(gt_map[int(g_local)])]
+                )
+            # Fully-occluded (all-NaN) GT instances -> automatic false negatives.
+            for g_idx in np.flatnonzero(~gt_valid):
+                self.false_negatives.append(gt_match_instances[int(g_idx)])
+
+            for p_local in unmatched_pred:
+                self.false_positives.append(
+                    pr_match_instances[int(pred_map[int(p_local)])]
+                )
+
+        # Build the dists dict directly from matched-pair centroid distances so
+        # distance_metrics() works uniformly across match methods.
+        dists = np.array([dist for _, _, dist in self.positive_pairs])
+        self.dists_dict = {
+            "dists": dists,
+            "frame_idxs": [gt.frame_idx for gt, _, _ in self.positive_pairs],
+            "video_paths": [gt.video_path for gt, _, _ in self.positive_pairs],
+        }
+
+    @staticmethod
+    def _collapse_pred_centroid(points: np.ndarray) -> np.ndarray:
+        """Collapse a predicted instance to its single centroid point.
+
+        For a 1-node ('centroid') prediction this is node-0. For predictions
+        with multiple nodes (e.g. a single-instance model used as a detector)
+        we take the single visible point, falling back to node-0.
+        """
+        points = np.asarray(points, dtype=np.float64).reshape(-1, 2)
+        visible = ~np.isnan(points).any(axis=-1)
+        if visible.any():
+            return points[np.argmax(visible)]
+        return points[0]
 
     def voc_metrics(
         self,
@@ -607,7 +833,13 @@ class Evaluator:
             "frame_idxs": self.dists_dict["frame_idxs"],
             "video_paths": self.dists_dict["video_paths"],
             "dists": dists,
-            "avg": np.nanmean(dists),
+            # Guard the empty / all-NaN matched set (zero true positives in a
+            # split) so np.nanmean doesn't emit a "Mean of empty slice" warning.
+            "avg": (
+                float(np.nanmean(dists))
+                if np.asarray(dists).size and not np.all(np.isnan(dists))
+                else np.nan
+            ),
             "p50": np.nan,
             "p75": np.nan,
             "p90": np.nan,
@@ -620,6 +852,57 @@ class Evaluator:
             non_nans = dists[is_non_nan]
             for ptile in (50, 75, 90, 95, 99):
                 results[f"p{ptile}"] = np.percentile(non_nans, ptile)
+
+        return results
+
+    def detection_metrics(self) -> dict:
+        """Compute detection metrics for centroid-only / single-point matching.
+
+        Reuses the same aggregation as
+        ``CentroidEvaluationCallback._compute_metrics``: precision/recall/F1
+        over TP/FP/FN counts, plus localization-error percentiles over the
+        Euclidean distances of the matched centroid pairs. Intended for
+        ``match_method="centroid"``.
+
+        Returns:
+            A dict with ``precision``, ``recall``, ``f1``, ``n_tp``, ``n_fp``,
+            ``n_fn`` and localization-error percentiles ``avg``/``p50``/``p75``/
+            ``p90``/``p95``/``p99`` (NaN when there are no matched pairs).
+        """
+        n_tp = len(self.positive_pairs)
+        n_fp = len(self.false_positives)
+        n_fn = len(self.false_negatives)
+
+        precision = n_tp / (n_tp + n_fp) if (n_tp + n_fp) > 0 else 0.0
+        recall = n_tp / (n_tp + n_fn) if (n_tp + n_fn) > 0 else 0.0
+        f1 = (
+            2 * precision * recall / (precision + recall)
+            if (precision + recall) > 0
+            else 0.0
+        )
+
+        dists = self.dists_dict["dists"]
+        results = {
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "n_tp": n_tp,
+            "n_fp": n_fp,
+            "n_fn": n_fn,
+            "avg": np.nan,
+            "p50": np.nan,
+            "p75": np.nan,
+            "p90": np.nan,
+            "p95": np.nan,
+            "p99": np.nan,
+        }
+
+        is_non_nan = ~np.isnan(dists) if len(dists) else np.array([], dtype=bool)
+        if np.any(is_non_nan):
+            non_nans = dists[is_non_nan]
+            results["avg"] = float(np.mean(non_nans))
+            for ptile in (50, 75, 90, 95, 99):
+                results[f"p{ptile}"] = float(np.percentile(non_nans, ptile))
 
         return results
 
@@ -685,6 +968,17 @@ class Evaluator:
 
     def evaluate(self):
         """Return the evaluation metrics."""
+        if self.match_method == "centroid":
+            # Single-node / centroid-only: OKS/PCK/mOKS/visibility are
+            # degenerate for one node, so we only report detection +
+            # distance metrics. We intentionally do NOT compute OKS for a
+            # single node (no magic OKS-scale constant) — the OKS path stays
+            # only for match_method="oks".
+            return {
+                "detection_metrics": self.detection_metrics(),
+                "distance_metrics": self.distance_metrics(),
+            }
+
         metrics = {}
         metrics["voc_metrics"] = self.voc_metrics(match_score_by="oks")
         metrics["voc_metrics"].update(self.voc_metrics(match_score_by="pck"))
@@ -801,6 +1095,40 @@ def load_metrics(
     return _load_npz_metrics(metrics_path)
 
 
+def _resolve_anchor_ind(
+    skeleton: "sio.Skeleton", anchor_part: Optional[str]
+) -> Optional[int]:
+    """Resolve an anchor node name to its index in the GT skeleton.
+
+    Mirrors the anchor resolution in
+    ``sleap_nn.inference.predictor`` (#582): returns the node index when
+    ``anchor_part`` is present in the skeleton node names, else ``None`` (which
+    drives the mean-of-visible-nodes fallback in :func:`compute_gt_centroids`).
+    """
+    if anchor_part is None or skeleton is None:
+        return None
+    node_names = list(getattr(skeleton, "node_names", []) or [])
+    if anchor_part in node_names:
+        return node_names.index(anchor_part)
+    logger.warning(
+        f"Anchor part {anchor_part!r} not found in GT skeleton node_names: "
+        f"{node_names}. Falling back to mean-of-visible-nodes centroid."
+    )
+    return None
+
+
+def _is_single_node_skeleton(skeleton: "sio.Skeleton") -> bool:
+    """Return True if the skeleton is a single-node (centroid-like) skeleton.
+
+    Detects ``sio.get_centroid_skeleton()`` (node_names == ['centroid']) as well
+    as any other single-node skeleton.
+    """
+    if skeleton is None:
+        return False
+    node_names = list(getattr(skeleton, "node_names", []) or [])
+    return len(node_names) == 1
+
+
 def run_evaluation(
     ground_truth_path: str,
     predicted_path: str,
@@ -809,8 +1137,29 @@ def run_evaluation(
     match_threshold: float = 0,
     user_labels_only: bool = True,
     save_metrics: Optional[str] = None,
+    match_method: str = "oks",
+    anchor_part: Optional[str] = None,
 ):
-    """Evaluate SLEAP-NN model predictions against ground truth labels."""
+    """Evaluate SLEAP-NN model predictions against ground truth labels.
+
+    Args:
+        ground_truth_path: Path to the ground-truth ``.slp`` file.
+        predicted_path: Path to the predicted ``.slp`` file.
+        oks_stddev: OKS standard deviation (OKS mode only).
+        oks_scale: OKS scale override (OKS mode only).
+        match_threshold: Matching threshold. OKS threshold for OKS mode; PIXEL
+            distance for centroid mode. In centroid mode, if the caller leaves
+            the OKS default of ``0.0`` it is bumped to ``50.0`` px.
+        user_labels_only: If False, predicted instances in the GT frame may be
+            matched.
+        save_metrics: Optional ``.npz`` path to save metrics to.
+        match_method: ``"oks"``, ``"centroid"``, or ``"auto"``. ``"auto"``
+            switches to centroid mode when the PREDICTION skeleton is a
+            single-node skeleton (e.g. ``sio.get_centroid_skeleton()``).
+        anchor_part: Name of the GT skeleton node used to compute GT centroids
+            (centroid mode). Resolved against the GT skeleton; ``None`` (or an
+            absent name) falls back to the mean of visible nodes (#586).
+    """
     logger.info("Loading ground truth labels...")
     ground_truth_instances = sio.load_slp(ground_truth_path)
     logger.info(
@@ -824,6 +1173,32 @@ def run_evaluation(
         f"  Predictions: {len(predicted_instances.videos)} videos, "
         f"{len(predicted_instances.labeled_frames)} frames"
     )
+
+    # Auto-detect centroid mode from the PREDICTION skeleton.
+    pred_skeleton = (
+        predicted_instances.skeletons[0] if predicted_instances.skeletons else None
+    )
+    if match_method == "auto":
+        if _is_single_node_skeleton(pred_skeleton):
+            match_method = "centroid"
+            logger.info(
+                "Auto-detected centroid mode (single-node prediction skeleton)."
+            )
+        else:
+            match_method = "oks"
+
+    # Resolve the anchor node against the GT skeleton (mirror predictor.py).
+    gt_skeleton = (
+        ground_truth_instances.skeletons[0]
+        if ground_truth_instances.skeletons
+        else None
+    )
+    anchor_ind = _resolve_anchor_ind(gt_skeleton, anchor_part)
+
+    # In centroid mode, default the (pixel) match threshold to 50.0 if the
+    # caller left the OKS default of 0.0.
+    if match_method == "centroid" and match_threshold == 0:
+        match_threshold = 50.0
 
     logger.info("Matching videos and frames...")
     # Get match stats before creating evaluator
@@ -840,6 +1215,8 @@ def run_evaluation(
         oks_scale=oks_scale,
         match_threshold=match_threshold,
         user_labels_only=user_labels_only,
+        match_method=match_method,
+        anchor_ind=anchor_ind,
     )
     logger.info(
         f"  Frame pairs: {len(evaluator.frame_pairs)}, "
@@ -849,6 +1226,31 @@ def run_evaluation(
 
     logger.info("Computing evaluation metrics...")
     metrics = evaluator.evaluate()
+
+    if match_method == "centroid":
+        # Centroid mode: report detection + distance metrics only (no
+        # oks_voc.*/mOKS/PCK/visibility keys exist).
+        det = metrics["detection_metrics"]
+        dist = metrics["distance_metrics"]
+        logger.info("Evaluation Results (centroid mode):")
+        logger.info(f"  Precision: {det['precision']:.4f}")
+        logger.info(f"  Recall: {det['recall']:.4f}")
+        logger.info(f"  F1: {det['f1']:.4f}")
+        logger.info(f"  Counts: TP={det['n_tp']}, FP={det['n_fp']}, FN={det['n_fn']}")
+        logger.info(f"  Average Distance: {dist['avg']:.2f} px")
+        logger.info(f"  dist.p50: {dist['p50']:.2f} px")
+        logger.info(f"  dist.p90: {dist['p90']:.2f} px")
+        logger.info(f"  dist.p95: {dist['p95']:.2f} px")
+        logger.info(f"  dist.p99: {dist['p99']:.2f} px")
+
+        if save_metrics:
+            logger.info(f"Saving metrics to {save_metrics}...")
+            save_path = Path(save_metrics)
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            np.savez_compressed(save_path, **{"metrics": metrics})
+            logger.info(f"Metrics saved successfully to {save_path}")
+
+        return metrics
 
     # Compute PCK at specific thresholds (5 and 10 pixels)
     dists = metrics["distance_metrics"]["dists"]

--- a/sleap_nn/inference/filters.py
+++ b/sleap_nn/inference/filters.py
@@ -127,6 +127,24 @@ class FilterPipeline:
                     stacklevel=2,
                 )
             else:
+                # OKS on a single-node keypoint tensor is degenerate (the
+                # per-keypoint scale is derived from the instance's own bbox
+                # area, which is 0 for one point — _oks's internal <2-visible
+                # guard would make every score 0). Fall back to IoU so the
+                # NMS still does something meaningful (#586).
+                if (
+                    method == "oks"
+                    and outputs.pred_keypoints is not None
+                    and outputs.pred_keypoints.shape[-2] < 2
+                ):
+                    import warnings
+
+                    warnings.warn(
+                        "OKS overlap NMS is degenerate for single-node "
+                        "(centroid) keypoints; falling back to IoU.",
+                        stacklevel=2,
+                    )
+                    method = "iou"
                 outputs = self._filter_overlapping(
                     outputs,
                     threshold=cfg.overlapping_threshold,

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -75,6 +75,15 @@ class TrackerConfig:
     tracking_clean_iou_threshold: float = 0.0
     post_connect_single_breaks: bool = False
 
+    # Single-node (centroid) default resolution ─────────────────────────
+    # True (the default) means the user explicitly chose ``scoring_method`` /
+    # ``features`` — direct constructors keep current behavior. The CLI sets
+    # these False when the corresponding flag was left at its sentinel, which
+    # lets ``apply_tracking`` substitute single-node-appropriate defaults
+    # (``euclidean_dist`` / ``centroids``) for a 1-node skeleton.
+    scoring_method_explicit: bool = True
+    features_explicit: bool = True
+
 
 def apply_tracking(
     labels: sio.Labels,
@@ -132,13 +141,36 @@ def apply_tracking(
             config.max_tracks,
         )
 
+    # Single-node (centroid) default resolution. A centroid model collapses to
+    # a 1-node Skeleton(['centroid']) (#586); OKS/keypoints are degenerate on a
+    # single point, so unless the caller explicitly chose otherwise, substitute
+    # euclidean-distance scoring on centroid features. Compute on locals — the
+    # frozen config is never mutated. Multi-node / multi-skeleton: unchanged.
+    effective_scoring_method = config.scoring_method
+    effective_features = config.features
+    if len(labels.skeletons) == 1 and len(labels.skeletons[0].nodes) == 1:
+        if not config.scoring_method_explicit:
+            effective_scoring_method = "euclidean_dist"
+        if not config.features_explicit:
+            effective_features = "centroids"
+        if (
+            effective_scoring_method != config.scoring_method
+            or effective_features != config.features
+        ):
+            logger.info(
+                "Single-node skeleton detected; applying centroid tracking "
+                "defaults: scoring_method=%r, features=%r.",
+                effective_scoring_method,
+                effective_features,
+            )
+
     tracker = Tracker.from_config(
         window_size=config.window_size,
         min_new_track_points=config.min_new_track_points,
         candidates_method=config.candidates_method,
         min_match_points=config.min_match_points,
-        features=config.features,
-        scoring_method=config.scoring_method,
+        features=effective_features,
+        scoring_method=effective_scoring_method,
         scoring_reduction=config.scoring_reduction,
         robust_best_instance=config.robust_best_instance,
         track_matching_method=config.track_matching_method,

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -16,7 +16,96 @@ from sleap_nn.config.get_config import (
     get_model_config,
     get_data_config,
 )
+from sleap_nn.config.utils import get_model_type_from_cfg
 from sleap_nn.system_info import get_startup_info_string
+
+
+def _run_centroid_split_eval(
+    config: DictConfig,
+    d_name: str,
+    path: str,
+    run_path: Path,
+    pred_path: Path,
+    metrics_path: Path,
+    device: str,
+):
+    """Run post-training eval for a single split of a centroid-only model.
+
+    Centroid-only models use the NEW inference flow
+    (``sleap_nn.inference.run.predict``), which collapses a multi-node skeleton
+    to a single ``centroid`` node, and centroid-mode evaluation
+    (``run_evaluation(match_method="centroid", ...)``). The centroid metrics
+    dict only has ``detection_metrics`` + ``distance_metrics`` (no
+    ``voc_metrics``/``mOKS``/``pck``/``visibility`` keys), so every access here
+    is guarded and the OKS mAP line is intentionally NOT logged.
+
+    Args:
+        config: Training configuration.
+        d_name: Split name, e.g. ``"train.0"``/``"val.0"``/``"test.0"``.
+        path: Path to the ground-truth ``.slp`` for this split.
+        run_path: The ``<ckpt_dir>/<run_name>`` directory (the centroid model).
+        pred_path: Output path for the predicted ``.slp``.
+        metrics_path: Output path for the saved metrics ``.npz``.
+        device: Torch device string to run inference on.
+
+    Returns:
+        The metrics dict returned by ``run_evaluation`` (centroid mode), or
+        ``None`` if there were no predicted frames (eval skipped).
+    """
+    # Lazy import of the NEW inference flow (centroid-only standalone path).
+    from sleap_nn.inference.run import predict as predict_new
+
+    # NOTE: the new predict has NO `make_labels` param (it hardcodes
+    # make_labels=True) and takes `source` positionally (not data_path=).
+    pred_labels = predict_new(
+        path,
+        model_paths=[run_path],
+        centroid_only=True,
+        peak_threshold=0.2,
+        device=device,
+        output_path=pred_path,
+    )
+
+    if not len(pred_labels):
+        logger.info(
+            f"Skipping eval on `{d_name}` dataset as there are no labeled frames..."
+        )
+        return None
+
+    # Anchor part defining the centroid's meaning (#586). Guard the access in
+    # case the head config is missing/partial.
+    anchor_part = OmegaConf.select(
+        config, "model_config.head_configs.centroid.confmaps.anchor_part", default=None
+    )
+    # Pixel match threshold from the eval config if present, else 50.0.
+    match_threshold = OmegaConf.select(
+        config, "trainer_config.eval.match_threshold", default=None
+    )
+    if match_threshold is None:
+        match_threshold = 50.0
+
+    metrics = run_evaluation(
+        ground_truth_path=path,
+        predicted_path=pred_path.as_posix(),
+        match_method="centroid",
+        anchor_part=anchor_part,
+        match_threshold=match_threshold,
+        save_metrics=metrics_path.as_posix(),
+    )
+
+    # Centroid metrics: detection_metrics + distance_metrics only. Guard every
+    # key access (no oks_voc.* / mOKS / pck / visibility keys exist here).
+    det = metrics.get("detection_metrics", {}) if metrics is not None else {}
+    dist = metrics.get("distance_metrics", {}) if metrics is not None else {}
+    logger.info(f"---------Evaluation on `{d_name}` dataset (centroid)---------")
+    logger.info(f"Detection precision: {det.get('precision')}")
+    logger.info(f"Detection recall: {det.get('recall')}")
+    logger.info(f"Detection f1: {det.get('f1')}")
+    logger.info(f"Average distance: {dist.get('avg')}")
+    logger.info(f"p90 dist: {dist.get('p90')}")
+    logger.info(f"p50 dist: {dist.get('p50')}")
+
+    return metrics
 
 
 def run_training(
@@ -83,10 +172,27 @@ def run_training(
                 for idx, test_path in enumerate(test_paths):
                     data_paths[f"test.{idx}"] = test_path
 
+            # Determine the model type once before the per-split eval loop so
+            # centroid-only models can route to the NEW inference + centroid
+            # evaluation flow (the legacy predictors path is not used for them).
+            model_type = get_model_type_from_cfg(trainer.config)
+
             for d_name, path in data_paths.items():
                 # d_name is now in format: "train.0", "val.0", "test.0", etc.
                 pred_path = run_path / f"labels_pr.{d_name}.slp"
                 metrics_path = run_path / f"metrics.{d_name}.npz"
+
+                if model_type == "centroid":
+                    _run_centroid_split_eval(
+                        config=trainer.config,
+                        d_name=d_name,
+                        path=path,
+                        run_path=run_path,
+                        pred_path=pred_path,
+                        metrics_path=metrics_path,
+                        device=str(trainer.trainer.strategy.root_device),
+                    )
+                    continue
 
                 pred_labels = predict(
                     data_path=path,

--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -1299,64 +1299,10 @@ class EpochEndEvaluationCallback(Callback):
                 wandb_logger.experiment.summary[summary_key] = value
 
 
-def match_centroids(
-    pred_centroids: "np.ndarray",
-    gt_centroids: "np.ndarray",
-    max_distance: float = 50.0,
-) -> tuple:
-    """Match predicted centroids to ground truth using Hungarian algorithm.
-
-    Args:
-        pred_centroids: Predicted centroid locations, shape (n_pred, 2).
-        gt_centroids: Ground truth centroid locations, shape (n_gt, 2).
-        max_distance: Maximum distance threshold for valid matches (in pixels).
-
-    Returns:
-        Tuple of:
-            - matched_pred_indices: Indices of matched predictions
-            - matched_gt_indices: Indices of matched ground truth
-            - unmatched_pred_indices: Indices of unmatched predictions (false positives)
-            - unmatched_gt_indices: Indices of unmatched ground truth (false negatives)
-    """
-    import numpy as np
-    from scipy.optimize import linear_sum_assignment
-    from scipy.spatial.distance import cdist
-
-    n_pred = len(pred_centroids)
-    n_gt = len(gt_centroids)
-
-    # Handle edge cases
-    if n_pred == 0 and n_gt == 0:
-        return np.array([]), np.array([]), np.array([]), np.array([])
-    if n_pred == 0:
-        return np.array([]), np.array([]), np.array([]), np.arange(n_gt)
-    if n_gt == 0:
-        return np.array([]), np.array([]), np.arange(n_pred), np.array([])
-
-    # Compute pairwise distances
-    cost_matrix = cdist(pred_centroids, gt_centroids)
-
-    # Run Hungarian algorithm for optimal matching
-    pred_indices, gt_indices = linear_sum_assignment(cost_matrix)
-
-    # Filter matches that exceed max_distance
-    matched_pred = []
-    matched_gt = []
-    for p_idx, g_idx in zip(pred_indices, gt_indices):
-        if cost_matrix[p_idx, g_idx] <= max_distance:
-            matched_pred.append(p_idx)
-            matched_gt.append(g_idx)
-
-    matched_pred = np.array(matched_pred)
-    matched_gt = np.array(matched_gt)
-
-    # Find unmatched indices
-    all_pred = set(range(n_pred))
-    all_gt = set(range(n_gt))
-    unmatched_pred = np.array(list(all_pred - set(matched_pred)))
-    unmatched_gt = np.array(list(all_gt - set(matched_gt)))
-
-    return matched_pred, matched_gt, unmatched_pred, unmatched_gt
+# `match_centroids` now lives in `sleap_nn.evaluation` (centroid-only distance
+# evaluation subsystem). Re-exported here so existing callback imports/tests
+# keep working.
+from sleap_nn.evaluation import match_centroids  # noqa: E402
 
 
 class CentroidEvaluationCallback(Callback):

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -269,3 +269,125 @@ def test_predictor_with_tracker_picklable_round_trip():
     restored_cfg = pickle.loads(pickle.dumps(pred.tracker_config))
     assert restored_cfg.window_size == 11
     assert restored_cfg.max_tracks == 4
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Single-node (centroid) tracking default resolution (#586)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _capture_from_config_kwargs(monkeypatch):
+    """Patch ``Tracker.from_config`` to record the kwargs it receives.
+
+    Returns a dict that ``apply_tracking`` fills in with the resolved
+    ``features`` / ``scoring_method`` (and friends). The stub returns a
+    Tracker whose ``track`` is a no-op so ``apply_tracking`` runs end-to-end
+    without exercising real association logic.
+    """
+    import sleap_nn.tracking.tracker as tracker_mod
+
+    captured: dict = {}
+
+    class _NoopTracker:
+        def track(self, untracked_instances, frame_idx, image=None):
+            return list(untracked_instances)
+
+    def _fake_from_config(cls, **kwargs):
+        captured.update(kwargs)
+        return _NoopTracker()
+
+    monkeypatch.setattr(
+        tracker_mod.Tracker,
+        "from_config",
+        classmethod(_fake_from_config),
+    )
+    return captured
+
+
+def test_apply_tracking_single_node_resolves_centroid_defaults(video, monkeypatch):
+    """1-node Skeleton(['centroid']) + non-explicit config → euclidean/centroids."""
+    centroid_skel = sio.Skeleton(nodes=["centroid"])
+    pts = np.array([[5.0, 5.0]], dtype=np.float32)
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[
+            sio.PredictedInstance.from_numpy(
+                points_data=pts, skeleton=centroid_skel, score=0.9
+            )
+        ],
+    )
+    labels = sio.Labels(videos=[video], skeletons=[centroid_skel], labeled_frames=[lf])
+    captured = _capture_from_config_kwargs(monkeypatch)
+
+    apply_tracking(
+        labels,
+        TrackerConfig(scoring_method_explicit=False, features_explicit=False),
+    )
+
+    assert captured["scoring_method"] == "euclidean_dist"
+    assert captured["features"] == "centroids"
+
+
+def test_apply_tracking_multi_node_keeps_defaults(skeleton, video, monkeypatch):
+    """Multi-node skeleton + non-explicit config → keep oks/keypoints."""
+    labels = _make_labels(skeleton, video, frames=1, instances_per_frame=1)
+    captured = _capture_from_config_kwargs(monkeypatch)
+
+    apply_tracking(
+        labels,
+        TrackerConfig(scoring_method_explicit=False, features_explicit=False),
+    )
+
+    assert captured["scoring_method"] == "oks"
+    assert captured["features"] == "keypoints"
+
+
+def test_apply_tracking_single_node_explicit_not_overridden(video, monkeypatch):
+    """1-node skeleton + explicit scoring_method='oks' → NOT overridden."""
+    centroid_skel = sio.Skeleton(nodes=["centroid"])
+    pts = np.array([[5.0, 5.0]], dtype=np.float32)
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[
+            sio.PredictedInstance.from_numpy(
+                points_data=pts, skeleton=centroid_skel, score=0.9
+            )
+        ],
+    )
+    labels = sio.Labels(videos=[video], skeletons=[centroid_skel], labeled_frames=[lf])
+    captured = _capture_from_config_kwargs(monkeypatch)
+
+    # scoring_method explicit (default True) → keep 'oks'; features left
+    # non-explicit → still resolve to 'centroids'.
+    apply_tracking(
+        labels,
+        TrackerConfig(
+            scoring_method="oks",
+            scoring_method_explicit=True,
+            features_explicit=False,
+        ),
+    )
+
+    assert captured["scoring_method"] == "oks"
+    assert captured["features"] == "centroids"
+
+
+def test_build_tracker_config_explicit_sentinels():
+    """_build_tracker_config records *_explicit from kwargs presence (#586)."""
+    from sleap_nn.cli import _build_tracker_config
+
+    # Both unset (CLI sentinel None) → not explicit, fall back to oks/keypoints.
+    cfg = _build_tracker_config({"features": None, "scoring_method": None})
+    assert cfg.features_explicit is False
+    assert cfg.scoring_method_explicit is False
+    assert cfg.features == "keypoints"
+    assert cfg.scoring_method == "oks"
+
+    # Both set explicitly → explicit, values forwarded verbatim.
+    cfg2 = _build_tracker_config({"features": "bboxes", "scoring_method": "iou"})
+    assert cfg2.features_explicit is True
+    assert cfg2.scoring_method_explicit is True
+    assert cfg2.features == "bboxes"
+    assert cfg2.scoring_method == "iou"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -659,3 +659,361 @@ def test_load_metrics(single_instance_with_metrics_ckpt, tmp_path):
     loaded_old = load_metrics(old_format_dir, split="val")
     assert loaded_old["mOKS"]["mOKS"] == 0.75
     assert loaded_old["voc_metrics"]["oks_voc.mAP"] == 0.6
+
+
+# ---------------------------------------------------------------------------
+# Centroid-only / single-node distance evaluation
+# ---------------------------------------------------------------------------
+
+from sleap_nn.evaluation import compute_gt_centroids, run_evaluation, match_centroids
+from sleap_nn.data.instance_centroids import generate_centroids
+
+
+@pytest.mark.parametrize("anchor_ind", [None, 0, 1])
+def test_compute_gt_centroids_parity_with_generate_centroids(anchor_ind):
+    """compute_gt_centroids must EXACTLY mirror generate_centroids (#586)."""
+    # Multi-node poses: anchor-visible, anchor-NaN->mean, all-NaN.
+    poses = np.array(
+        [
+            # Anchor visible (all nodes visible).
+            [[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]],
+            # Anchor (node 0 and node 1) NaN -> mean of visible nodes.
+            [[np.nan, np.nan], [np.nan, np.nan], [5.0, 7.0]],
+            # All nodes NaN -> NaN centroid.
+            [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
+            # Partially visible, anchor present for ind 0/1.
+            [[1.0, 2.0], [3.0, 4.0], [np.nan, np.nan]],
+        ],
+        dtype=np.float32,
+    )
+
+    expected = generate_centroids(
+        torch.from_numpy(poses), anchor_ind=anchor_ind
+    ).numpy()
+    got = compute_gt_centroids(poses, anchor_ind=anchor_ind)
+
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-5, equal_nan=True)
+
+
+@pytest.mark.parametrize("anchor_ind", [None, 0])
+def test_compute_gt_centroids_single_node(anchor_ind):
+    """Parity on 1-node poses (the collapsed centroid skeleton case)."""
+    poses = np.array(
+        [
+            [[12.0, 34.0]],
+            [[np.nan, np.nan]],
+        ],
+        dtype=np.float32,
+    )
+    expected = generate_centroids(
+        torch.from_numpy(poses), anchor_ind=anchor_ind
+    ).numpy()
+    got = compute_gt_centroids(poses, anchor_ind=anchor_ind)
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-5, equal_nan=True)
+
+
+def test_compute_gt_centroids_anchor_nan_falls_back_to_mean():
+    """When the anchor node is NaN, fall back to mean-of-visible (not bbox)."""
+    # Single instance, anchor (node 0) is NaN.
+    pose = np.array([[np.nan, np.nan], [0.0, 0.0], [10.0, 20.0]], dtype=np.float32)
+    got = compute_gt_centroids(pose, anchor_ind=0)
+    # Mean of the two visible nodes = (5, 10). Bbox midpoint would also be
+    # (5, 10) here, so use an asymmetric extra node to disambiguate.
+    pose2 = np.array(
+        [[np.nan, np.nan], [0.0, 0.0], [0.0, 0.0], [9.0, 30.0]], dtype=np.float32
+    )
+    got2 = compute_gt_centroids(pose2, anchor_ind=0)
+    # Mean of visible = (3, 10); bbox midpoint would be (4.5, 15).
+    np.testing.assert_allclose(got, [5.0, 10.0])
+    np.testing.assert_allclose(got2, [3.0, 10.0])
+
+
+def _make_centroid_labels(minimal_instance):
+    """Build (gt_multi_node, pred_single_node) labels for centroid eval.
+
+    GT is a 3-node skeleton; predictions use a single-node ('centroid')
+    skeleton. Two GT instances should match two predicted centroids; one GT is
+    a false negative (no nearby prediction); one prediction is a false positive
+    (just beyond the match threshold).
+    """
+    gt_skeleton = sio.Skeleton(
+        nodes=["head", "thorax", "abdomen"],
+        edges=[("head", "thorax"), ("thorax", "abdomen")],
+    )
+    centroid_skeleton = sio.get_centroid_skeleton()
+
+    min_labels = sio.load_slp(minimal_instance)
+    video = min_labels.videos[0]
+
+    # GT instance A: mean of visible nodes = (10, 10).
+    gt_a = sio.Instance.from_numpy(
+        points_data=np.array([[0.0, 0.0], [10.0, 10.0], [20.0, 20.0]]),
+        skeleton=gt_skeleton,
+    )
+    # GT instance B: mean of visible nodes = (100, 100).
+    gt_b = sio.Instance.from_numpy(
+        points_data=np.array([[90.0, 90.0], [100.0, 100.0], [110.0, 110.0]]),
+        skeleton=gt_skeleton,
+    )
+    # GT instance C: mean = (500, 500) -> false negative (no nearby pred).
+    gt_c = sio.Instance.from_numpy(
+        points_data=np.array([[490.0, 490.0], [500.0, 500.0], [510.0, 510.0]]),
+        skeleton=gt_skeleton,
+    )
+
+    gt_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[gt_a, gt_b, gt_c])
+    gt_labels = sio.Labels(
+        videos=[video], skeletons=[gt_skeleton], labeled_frames=[gt_lf]
+    )
+
+    # Pred near A (dist ~3 px) and near B (dist ~4 px) -> true positives.
+    pred_a = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[13.0, 10.0]]),
+        skeleton=centroid_skeleton,
+        point_scores=np.array([0.9]),
+        score=0.9,
+    )
+    pred_b = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[100.0, 96.0]]),
+        skeleton=centroid_skeleton,
+        point_scores=np.array([0.8]),
+        score=0.8,
+    )
+    # Pred just beyond threshold from C: C is at (500, 500); place pred at
+    # (560, 500) -> dist 60 > threshold 50 -> false positive (+ C is FN).
+    pred_fp = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[560.0, 500.0]]),
+        skeleton=centroid_skeleton,
+        point_scores=np.array([0.7]),
+        score=0.7,
+    )
+
+    pred_lf = sio.LabeledFrame(
+        video=video, frame_idx=0, instances=[pred_a, pred_b, pred_fp]
+    )
+    pred_labels = sio.Labels(
+        videos=[video], skeletons=[centroid_skeleton], labeled_frames=[pred_lf]
+    )
+
+    return gt_labels, pred_labels
+
+
+def test_evaluator_centroid_match(minimal_instance):
+    """Evaluator(match_method='centroid') TP/FP/FN + detection + distance."""
+    gt_labels, pred_labels = _make_centroid_labels(minimal_instance)
+
+    evaluator = Evaluator(
+        gt_labels,
+        pred_labels,
+        match_threshold=50.0,
+        match_method="centroid",
+        anchor_ind=None,  # mean-of-visible-nodes centroid
+    )
+
+    # 2 true positives, 1 false positive (pred_fp), 1 false negative (gt_c).
+    assert len(evaluator.positive_pairs) == 2
+    assert len(evaluator.false_positives) == 1
+    assert len(evaluator.false_negatives) == 1
+
+    det = evaluator.detection_metrics()
+    assert det["n_tp"] == 2
+    assert det["n_fp"] == 1
+    assert det["n_fn"] == 1
+    # precision = 2/3, recall = 2/3, f1 = 2/3.
+    np.testing.assert_allclose(det["precision"], 2 / 3)
+    np.testing.assert_allclose(det["recall"], 2 / 3)
+    np.testing.assert_allclose(det["f1"], 2 / 3)
+
+    # Localization distances: A=3 px, B=4 px.
+    np.testing.assert_allclose(sorted(evaluator.dists_dict["dists"]), [3.0, 4.0])
+    np.testing.assert_allclose(det["avg"], 3.5)
+    for key in ("p50", "p75", "p90", "p95", "p99"):
+        assert not np.isnan(det[key])
+
+    # evaluate() returns only detection + distance metrics (no OKS/PCK/etc.).
+    metrics = evaluator.evaluate()
+    assert set(metrics.keys()) == {"detection_metrics", "distance_metrics"}
+    assert "voc_metrics" not in metrics
+    assert "mOKS" not in metrics
+
+
+def test_evaluator_centroid_handles_fully_occluded_gt(minimal_instance):
+    """Regression: a fully-occluded (all-NaN) GT instance must NOT crash
+    centroid matching (scipy cdist/linear_sum_assignment reject NaN). It is
+    counted as a false negative."""
+    gt_skeleton = sio.Skeleton(
+        nodes=["head", "thorax", "abdomen"],
+        edges=[("head", "thorax"), ("thorax", "abdomen")],
+    )
+    centroid_skeleton = sio.get_centroid_skeleton()
+    video = sio.load_slp(minimal_instance).videos[0]
+
+    gt_match = sio.Instance.from_numpy(
+        points_data=np.array([[0.0, 0.0], [10.0, 10.0], [20.0, 20.0]]),  # mean (10,10)
+        skeleton=gt_skeleton,
+    )
+    gt_occluded = sio.Instance.from_numpy(
+        points_data=np.full((3, 2), np.nan),  # fully occluded -> centroid NaN
+        skeleton=gt_skeleton,
+    )
+    gt_lf = sio.LabeledFrame(
+        video=video, frame_idx=0, instances=[gt_match, gt_occluded]
+    )
+    gt_labels = sio.Labels(
+        videos=[video], skeletons=[gt_skeleton], labeled_frames=[gt_lf]
+    )
+    pred = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[11.0, 10.0]]),  # ~1px from gt_match
+        skeleton=centroid_skeleton,
+        point_scores=np.array([0.9]),
+        score=0.9,
+    )
+    pred_labels = sio.Labels(
+        videos=[video],
+        skeletons=[centroid_skeleton],
+        labeled_frames=[sio.LabeledFrame(video=video, frame_idx=0, instances=[pred])],
+    )
+
+    # Must not raise.
+    evaluator = Evaluator(
+        gt_labels,
+        pred_labels,
+        match_threshold=50.0,
+        match_method="centroid",
+        anchor_ind=None,
+    )
+    det = evaluator.detection_metrics()
+    assert (det["n_tp"], det["n_fp"], det["n_fn"]) == (1, 0, 1)
+
+
+def test_evaluator_centroid_middle_occluded_fn_attribution(minimal_instance):
+    """An occluded GT between two matched GTs: the NaN-filter index map must
+    keep TP/FN attribution and matched distances correct."""
+    gt_skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    centroid_skeleton = sio.get_centroid_skeleton()
+    video = sio.load_slp(minimal_instance).videos[0]
+
+    gt_a = sio.Instance.from_numpy(
+        points_data=np.array([[10.0, 10.0], [10.0, 10.0]]), skeleton=gt_skeleton
+    )
+    gt_mid = sio.Instance.from_numpy(
+        points_data=np.full((2, 2), np.nan), skeleton=gt_skeleton
+    )
+    gt_c = sio.Instance.from_numpy(
+        points_data=np.array([[200.0, 200.0], [200.0, 200.0]]), skeleton=gt_skeleton
+    )
+    gt_labels = sio.Labels(
+        videos=[video],
+        skeletons=[gt_skeleton],
+        labeled_frames=[
+            sio.LabeledFrame(video=video, frame_idx=0, instances=[gt_a, gt_mid, gt_c])
+        ],
+    )
+    pred_a = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[12.0, 10.0]]),  # ~2px from gt_a
+        skeleton=centroid_skeleton,
+        point_scores=np.array([0.9]),
+        score=0.9,
+    )
+    pred_c = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[200.0, 205.0]]),  # 5px from gt_c
+        skeleton=centroid_skeleton,
+        point_scores=np.array([0.8]),
+        score=0.8,
+    )
+    pred_labels = sio.Labels(
+        videos=[video],
+        skeletons=[centroid_skeleton],
+        labeled_frames=[
+            sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_a, pred_c])
+        ],
+    )
+
+    evaluator = Evaluator(
+        gt_labels,
+        pred_labels,
+        match_threshold=50.0,
+        match_method="centroid",
+        anchor_ind=None,
+    )
+    det = evaluator.detection_metrics()
+    assert (det["n_tp"], det["n_fp"], det["n_fn"]) == (2, 0, 1)
+    np.testing.assert_allclose(sorted(evaluator.dists_dict["dists"]), [2.0, 5.0])
+
+
+def test_evaluator_centroid_pred_just_beyond_threshold(minimal_instance):
+    """A prediction just beyond threshold becomes FP + its GT becomes FN."""
+    gt_skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    centroid_skeleton = sio.get_centroid_skeleton()
+    min_labels = sio.load_slp(minimal_instance)
+    video = min_labels.videos[0]
+
+    # GT centroid (mean of visible) at (50, 50).
+    gt = sio.Instance.from_numpy(
+        points_data=np.array([[40.0, 50.0], [60.0, 50.0]]),
+        skeleton=gt_skeleton,
+    )
+    gt_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[gt])
+    gt_labels = sio.Labels(
+        videos=[video], skeletons=[gt_skeleton], labeled_frames=[gt_lf]
+    )
+
+    # Pred at (61, 50) -> dist 11 from GT centroid.
+    pred = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[61.0, 50.0]]),
+        skeleton=centroid_skeleton,
+        point_scores=np.array([0.9]),
+        score=0.9,
+    )
+    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred])
+    pred_labels = sio.Labels(
+        videos=[video], skeletons=[centroid_skeleton], labeled_frames=[pred_lf]
+    )
+
+    # threshold 10 < dist 11 -> FP + FN, no match.
+    evaluator = Evaluator(
+        gt_labels, pred_labels, match_threshold=10.0, match_method="centroid"
+    )
+    assert len(evaluator.positive_pairs) == 0
+    assert len(evaluator.false_positives) == 1
+    assert len(evaluator.false_negatives) == 1
+    det = evaluator.detection_metrics()
+    assert det["precision"] == 0.0
+    assert det["recall"] == 0.0
+    assert det["f1"] == 0.0
+    assert np.isnan(det["avg"])
+
+    # threshold 12 > dist 11 -> matched.
+    evaluator2 = Evaluator(
+        gt_labels, pred_labels, match_threshold=12.0, match_method="centroid"
+    )
+    assert len(evaluator2.positive_pairs) == 1
+    assert len(evaluator2.false_positives) == 0
+    assert len(evaluator2.false_negatives) == 0
+    np.testing.assert_allclose(evaluator2.detection_metrics()["avg"], 11.0)
+
+
+def test_run_evaluation_auto_detects_centroid(minimal_instance, tmp_path):
+    """run_evaluation auto-detects centroid mode for a single-node prediction."""
+    gt_labels, pred_labels = _make_centroid_labels(minimal_instance)
+
+    gt_path = tmp_path / "gt.slp"
+    pred_path = tmp_path / "pred.slp"
+    sio.save_slp(gt_labels, gt_path.as_posix())
+    sio.save_slp(pred_labels, pred_path.as_posix())
+
+    metrics = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pred_path.as_posix(),
+        match_method="auto",
+        user_labels_only=False,
+    )
+
+    # Centroid mode -> detection + distance metrics, no OKS VOC keys.
+    assert set(metrics.keys()) == {"detection_metrics", "distance_metrics"}
+    assert "voc_metrics" not in metrics
+    assert "mOKS" not in metrics
+    det = metrics["detection_metrics"]
+    assert det["n_tp"] == 2
+    assert det["n_fp"] == 1
+    assert det["n_fn"] == 1

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -9,6 +9,179 @@ from sleap_nn.train import train, run_training as main
 import sleap_io as sio
 
 
+def test_run_centroid_split_eval_routing(monkeypatch, tmp_path):
+    """Centroid post-training eval uses the NEW flow + centroid match method.
+
+    Exercises ONLY the per-split centroid routing in
+    ``sleap_nn.train._run_centroid_split_eval`` (no real training/inference):
+    asserts it calls the NEW ``predict`` with ``centroid_only=True`` (and no
+    ``make_labels`` kwarg, since the new predict hardcodes it), calls
+    ``run_evaluation`` with ``match_method="centroid"`` + the configured
+    ``anchor_part``/``match_threshold``, and does NOT KeyError on the missing
+    OKS keys (centroid metrics only has detection/distance metrics).
+    """
+    import sleap_nn.train as train_mod
+    import sleap_nn.inference.run as run_mod
+
+    captured = {}
+
+    class _FakeLabels:
+        def __len__(self):
+            return 1  # non-empty -> eval proceeds
+
+    def fake_predict(*args, **kwargs):
+        captured["predict_args"] = args
+        captured["predict_kwargs"] = kwargs
+        return _FakeLabels()
+
+    def fake_run_evaluation(*args, **kwargs):
+        captured["eval_kwargs"] = kwargs
+        # Centroid-mode metrics: detection_metrics + distance_metrics ONLY.
+        # Intentionally NO voc_metrics/mOKS/pck/visibility keys -- the helper
+        # must not touch them.
+        return {
+            "detection_metrics": {
+                "precision": 0.9,
+                "recall": 0.8,
+                "f1": 0.85,
+                "n_tp": 9,
+                "n_fp": 1,
+                "n_fn": 2,
+            },
+            "distance_metrics": {"avg": 3.0, "p50": 2.0, "p90": 5.0},
+        }
+
+    # The helper lazily imports `predict` from sleap_nn.inference.run inside the
+    # branch, so patch it on that module; run_evaluation is imported into
+    # sleap_nn.train at module load, so patch it there.
+    monkeypatch.setattr(run_mod, "predict", fake_predict)
+    monkeypatch.setattr(train_mod, "run_evaluation", fake_run_evaluation)
+
+    config = OmegaConf.create(
+        {
+            "model_config": {
+                "head_configs": {
+                    "single_instance": None,
+                    "centered_instance": None,
+                    "bottomup": None,
+                    "centroid": {
+                        "confmaps": {
+                            "anchor_part": "B",
+                            "sigma": 1.5,
+                            "output_stride": 2,
+                        }
+                    },
+                }
+            },
+            "trainer_config": {"eval": {"match_threshold": 25.0}},
+        }
+    )
+
+    run_path = Path(tmp_path) / "run"
+    pred_path = run_path / "labels_pr.val.0.slp"
+    metrics_path = run_path / "metrics.val.0.npz"
+
+    metrics = train_mod._run_centroid_split_eval(
+        config=config,
+        d_name="val.0",
+        path="gt.slp",
+        run_path=run_path,
+        pred_path=pred_path,
+        metrics_path=metrics_path,
+        device="cpu",
+    )
+
+    # NEW predict flow: source positional, centroid_only=True, no make_labels.
+    assert captured["predict_args"] == ("gt.slp",)
+    pk = captured["predict_kwargs"]
+    assert pk["centroid_only"] is True
+    assert pk["model_paths"] == [run_path]
+    assert pk["peak_threshold"] == 0.2
+    assert pk["device"] == "cpu"
+    assert pk["output_path"] == pred_path
+    assert "make_labels" not in pk
+
+    # Centroid evaluation routing: match_method + anchor_part + threshold.
+    ek = captured["eval_kwargs"]
+    assert ek["match_method"] == "centroid"
+    assert ek["anchor_part"] == "B"
+    assert ek["match_threshold"] == 25.0
+    assert ek["ground_truth_path"] == "gt.slp"
+    assert ek["predicted_path"] == pred_path.as_posix()
+    assert ek["save_metrics"] == metrics_path.as_posix()
+
+    # Returned centroid metrics dict has no OKS keys; helper must not have
+    # raised a KeyError accessing them.
+    assert "voc_metrics" not in metrics
+    assert "detection_metrics" in metrics
+
+
+def test_run_centroid_split_eval_defaults_and_empty(monkeypatch, tmp_path):
+    """Defaults: match_threshold falls back to 50.0; empty preds skip eval."""
+    import sleap_nn.train as train_mod
+    import sleap_nn.inference.run as run_mod
+
+    captured = {}
+
+    class _EmptyLabels:
+        def __len__(self):
+            return 0  # empty -> eval is skipped
+
+    # ----- empty predictions: run_evaluation must NOT be called -----
+    monkeypatch.setattr(run_mod, "predict", lambda *a, **k: _EmptyLabels())
+
+    def fail_eval(*a, **k):  # pragma: no cover - should not be called
+        raise AssertionError("run_evaluation should not run for empty preds")
+
+    monkeypatch.setattr(train_mod, "run_evaluation", fail_eval)
+
+    config_empty = OmegaConf.create(
+        {
+            "model_config": {
+                "head_configs": {
+                    "centroid": {"confmaps": {"anchor_part": None}},
+                }
+            },
+            "trainer_config": {},
+        }
+    )
+    out = train_mod._run_centroid_split_eval(
+        config=config_empty,
+        d_name="train.0",
+        path="gt.slp",
+        run_path=Path(tmp_path) / "run",
+        pred_path=Path(tmp_path) / "p.slp",
+        metrics_path=Path(tmp_path) / "m.npz",
+        device="cpu",
+    )
+    assert out is None
+
+    # ----- no eval config: match_threshold defaults to 50.0; anchor None -----
+    class _Labels:
+        def __len__(self):
+            return 1
+
+    monkeypatch.setattr(run_mod, "predict", lambda *a, **k: _Labels())
+
+    def ok_eval(*a, **k):
+        captured["eval_kwargs"] = k
+        return {"detection_metrics": {}, "distance_metrics": {}}
+
+    monkeypatch.setattr(train_mod, "run_evaluation", ok_eval)
+
+    train_mod._run_centroid_split_eval(
+        config=config_empty,
+        d_name="train.0",
+        path="gt.slp",
+        run_path=Path(tmp_path) / "run",
+        pred_path=Path(tmp_path) / "p.slp",
+        metrics_path=Path(tmp_path) / "m.npz",
+        device="cpu",
+    )
+    assert captured["eval_kwargs"]["match_threshold"] == 50.0
+    assert captured["eval_kwargs"]["anchor_part"] is None
+
+
 @pytest.fixture
 def sample_cfg(minimal_instance, tmp_path):
     config = DictConfig(


### PR DESCRIPTION
**Stacked PR 2 of 3** — base: `centroid-only/core-inference` (#589). Merge #589 first.

### Changes
- **Evaluation**: `compute_gt_centroids` (numpy mirror of `generate_centroids` / #586); `match_centroids` moved into `evaluation.py` (re-exported from `training/callbacks.py`); `Evaluator(match_method='centroid')` + `detection_metrics` (precision/recall/F1 + localization-error percentiles); `run_evaluation` auto-detects single-node 'centroid' predictions and reports detection+distance metrics (OKS omitted for 1 node). **Fully-occluded (all-NaN) GT centroids are filtered before Hungarian matching** — scipy rejects NaN; occluded GT counted as a false negative (regression fix vs the legacy callback).
- **Tracking**: `TrackerConfig` `scoring_method_explicit`/`features_explicit` sentinels; `apply_tracking` auto-selects `scoring_method='euclidean_dist'` + `features='centroids'` for single-node skeletons; CLI `--scoring_method`/`--features` default to `None` sentinels; filters OKS-NMS falls back to IoU for <2-node keypoints.
- **train.py**: centroid-only post-training eval routes through the new infer flow + centroid distance metrics instead of the legacy GT-OKS path.

### Tests
`tests/test_evaluation.py` (incl. all-NaN and middle-occluded GT regressions), `tests/inference/test_tracking.py`, `tests/test_train.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
