### PR TITLE
Centroid-only models (3/3): authoring UX + export consistency + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,4 @@ Configurations are managed via Hydra and can be specified in YAML files (see `do
 - Inference: `sleap_nn/predict.py` - Run inference on trained models
 - CLI: `sleap_nn/cli.py` - Command-line interface (currently minimal)
 - Evaluation: `sleap_nn/evaluation.py` - Model evaluation utilities
+- Centroid-only models: first-class support — train a lone centroid head, `sleap-nn infer` auto-detects a single centroid directory (output collapses to a single-node `'centroid'` skeleton), distance-based eval (`--match_method centroid`), and standalone ONNX/TensorRT export. See `docs/guides/centroid-only-inference.md`.

--- a/docs/configuration/samples.md
+++ b/docs/configuration/samples.md
@@ -26,6 +26,19 @@ Two-stage: centroid detection + pose estimation.
 | [centered_instance_unet_medium](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_topdown_centered_instance_unet_medium_rf.yaml) | UNet | Stage 2, Medium |
 | [centered_instance_unet_large](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_topdown_centered_instance_unet_large_rf.yaml) | UNet | Stage 2, Large |
 
+### Centroid-Only (points)
+
+First-class single-stage "animals-as-points" model: one centroid per animal, no
+per-keypoint pose. This is a **standalone** centroid model — distinct from the
+top-down stage-1 centroid configs above, which are paired with a
+centered-instance model and trained on downscaled crops. Trains at full
+resolution; inference collapses to a single-node `'centroid'` skeleton. See the
+[Centroid-Only Inference guide](../guides/centroid-only-inference.md).
+
+| Config | Backbone | Notes |
+|--------|----------|-------|
+| [centroid_unet_standalone](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_centroid_unet_standalone.yaml) | UNet | Standalone, full-res, NOT top-down stage-1 |
+
 ### Bottom-Up
 
 Single-stage multi-instance.

--- a/docs/guides/centroid-only-inference.md
+++ b/docs/guides/centroid-only-inference.md
@@ -1,136 +1,220 @@
 # Centroid-only inference
 
 Run a trained centroid model standalone — without a paired centered-instance
-model — and save the predicted centroids to a `.slp` file. Useful when you
-only need instance localization (no pose), or as a quick sanity check on a
-centroid model in isolation.
+model — and save the predicted centroids to a `.slp` file. This is a
+first-class single-stage pipeline ("animals as points"): use it when you only
+need instance localization, tracking, or counting (no per-keypoint pose), or
+as a quick sanity check on a centroid model in isolation.
 
-## Quick start
+A standalone centroid model is trained exactly like any other head — see the
+[`config_centroid_unet_standalone.yaml`](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_centroid_unet_standalone.yaml)
+sample. Training is node-count-agnostic: a single-node skeleton works directly,
+and a multi-node skeleton works too (its centroids collapse to a single point
+at inference).
 
-### CLI
+## Output representation contract
 
-```bash
-# Auto-detected: single centroid model_path → centroid-only output.
-sleap-nn infer video.mp4 \
-    --model_paths models/centroid/ \
-    --output_path centroids.slp
+The predicted `.slp` uses a **single-node `'centroid'` skeleton**
+(`sio.get_centroid_skeleton()`) — *not* the full training skeleton NaN-padded
+at every non-anchor node. Each detection is one point.
 
-# Explicit override: both models configured, but only want centroids.
-sleap-nn infer video.mp4 \
-    --model_paths models/centroid/ \
-    --model_paths models/centered_instance/ \
-    --centroid-only \
-    --output_path centroids.slp
-```
-
-### Python
-
-```python
-from sleap_nn.inference import Predictor
-
-# Auto-detect.
-predictor = Predictor.from_model_paths(["models/centroid/"])
-labels = predictor.predict("video.mp4")
-labels.save("centroids.slp")
-
-# Explicit override on a two-model setup.
-predictor = Predictor.from_model_paths(
-    ["models/centroid/", "models/centered_instance/"],
-    centroid_only=True,
-)
-```
-
-## Output structure: anchor node + NaN padding
-
-The output `.slp` uses the **full skeleton** from training (every node
-position is present in every `PredictedInstance`), but only the anchor node
-slot is populated:
-
-- **Anchor node** (configured `anchor_part`, or node 0 if unset): receives
-  the predicted centroid coordinate. The per-keypoint score equals the
-  centroid confidence value.
-- **Every other node**: NaN for both coordinates and scores.
-- **Per-instance score** (`PredictedInstance.score`): centroid confidence.
-
-This packaging plugs into every standard `.slp` consumer (sleap-io readers,
-metrics, viewers) — NaN is the natural "not predicted" marker and downstream
-tools degrade gracefully.
+- When the model was trained on a **multi-node** skeleton, inference
+  automatically collapses the output to the 1-node `'centroid'` skeleton
+  (`Predictor._resolve_centroid_packaging` engages when the head is a
+  centroid layer and the training skeleton has more than one node).
+- By **default** each detection is a single-node `PredictedInstance` on the
+  `'centroid'` skeleton, with the centroid confidence as both the per-node and
+  per-instance score. This is loadable by the current SLEAP frontend with no
+  changes.
 
 ```python
 import sleap_io as sio
-import numpy as np
 
 labels = sio.load_slp("centroids.slp")
+assert [n.name for n in labels.skeletons[0].nodes] == ["centroid"]
 for frame in labels:
     for inst in frame.instances:
-        pts = inst.numpy()                  # (n_nodes, 2)
-        anchor_xy = pts[0]                  # anchor node — populated
-        rest = pts[1:]                      # all other nodes — NaN
-        assert np.all(np.isnan(rest))
+        (x, y) = inst.numpy()[0]   # the centroid point
 ```
 
-## Anchor-node convention
+### Opt-in `sio.PredictedCentroid` emission
 
-The anchor node is resolved in this priority order, falling back gracefully:
+If you prefer the dedicated centroid object over a single-node instance, opt in
+with `--centroid-output` (CLI) / `emit_centroid` (Python). The choices are:
 
-1. **`anchor_part`** in `training_config.yaml` (model head config).
-2. **Node 0** if `anchor_part` is unset (documented default).
+| Value | Output |
+|-------|--------|
+| `instance` (default) | Single-node `PredictedInstance` on the `'centroid'` skeleton. Frontend-compatible. |
+| `centroid` | `sio.PredictedCentroid` in `LabeledFrame.centroids` (carries an instance-level score and a `source` tag). |
+| `both` | Both representations. |
 
-Note that the *centroid value itself* — the (x, y) that the model is trained
-to predict and that comes out at inference — uses a separate fallback when
-`anchor_part` is unset: the **NaN-ignoring mean of all visible nodes** in
-each instance (see [`generate_centroids`](../reference/sleap_nn/data/instance_centroids.md)).
+The `source` tag on a `PredictedCentroid` mirrors the trained target's meaning
+(see the [anchor convention](#anchor-node-convention-586) below): an explicit
+anchor records `"anchor:<node>"`; no anchor records `"center_of_mass"`.
+
+## End-to-end workflow
+
+### 1. Train
+
+Train a standalone centroid head (full-resolution, no cropping). Start from the
+[standalone sample config](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_centroid_unet_standalone.yaml)
+or generate one (`sleap-nn config --pipeline centroid ...`):
+
+```bash
+sleap-nn train --config-name config_centroid_unet_standalone.yaml
+```
+
+### 2. Infer
+
+`sleap-nn infer` auto-detects a centroid-only model when `--model_paths` points
+to a single centroid directory. `--centroid_only` is only needed when you also
+pass a centered-instance model but want centroid-only output.
+
+```bash
+# Auto-detected: a lone centroid model directory → centroid-only output.
+sleap-nn infer \
+    -i video.mp4 \
+    -m models/centroid/ \
+    -o centroids.slp
+
+# Emit sio.PredictedCentroid objects instead of single-node instances.
+sleap-nn infer \
+    -i video.mp4 \
+    -m models/centroid/ \
+    -o centroids.slp \
+    --centroid-output centroid
+
+# Explicit override: both models configured, but only want centroids.
+sleap-nn infer \
+    -i video.mp4 \
+    -m models/centroid/ \
+    -m models/centered_instance/ \
+    --centroid_only \
+    -o centroids.slp
+```
+
+```python
+from sleap_nn.inference.run import predict
+
+# Auto-detect a lone centroid directory.
+labels = predict(
+    data_path="video.mp4",
+    model_paths=["models/centroid/"],
+    output_path="centroids.slp",
+)
+
+# Explicit override on a two-model setup, emitting PredictedCentroid objects.
+labels = predict(
+    data_path="video.mp4",
+    model_paths=["models/centroid/", "models/centered_instance/"],
+    centroid_only=True,
+    emit_centroid="centroid",
+)
+```
+
+### 3. Evaluate
+
+Use distance-based matching for centroids — OKS is degenerate for a single
+point (it needs the full keypoint set and per-node scales). `--match_method
+auto` already selects centroid matching when the prediction skeleton is
+single-node, but you can request it explicitly:
+
+```bash
+sleap-nn eval \
+    -g labels.gt.slp \
+    -p centroids.slp \
+    --match_method centroid
+```
+
+Ground-truth centroids are computed with `generate_centroids` — the configured
+`--anchor_part` if given, otherwise the NaN-ignoring mean of visible nodes
+(#586). This is the same definition used to build training targets, so GT and
+predictions agree.
+
+### 4. Export and run exported inference
+
+Standalone centroid export works end-to-end (ONNX and TensorRT). Export a
+single centroid directory, then run the exported model with the same output
+representation choices:
+
+```bash
+# Export a standalone centroid model.
+sleap-nn export models/centroid -o exports/centroid --format onnx
+
+# Run the exported model. --centroid-output mirrors the checkpoint flow.
+sleap-nn predict exports/centroid video.mp4 -o centroids.slp \
+    --centroid-output instance
+```
+
+```python
+from sleap_nn.inference.predictor import Predictor
+
+predictor = Predictor.from_export_dir(
+    "exports/centroid",
+    runtime="onnx",
+    device="cpu",
+    emit_centroid="centroid",
+)
+labels = predictor.predict("video.mp4")
+```
+
+The exported runtime reads the full training skeleton from
+`training_config.yaml` and applies the same collapse, so the output is
+bit-for-bit identical to the checkpoint path. See the
+[Export guide](export.md#standalone-centroid) for details.
+
+## Anchor-node convention (#586)
+
+The centroid's *meaning* is defined by
+[`generate_centroids`](../reference/sleap_nn/data/instance_centroids.md) — the
+same function used for training-target generation and GT-centroid evaluation:
+
+1. **`anchor_part`** in `training_config.yaml` (the centroid head config): the
+   centroid is that node when visible.
+2. **`anchor_part` unset** (recommended for a 1-node skeleton, where the sole
+   node *is* the centroid): the centroid is the **NaN-ignoring mean of all
+   visible nodes** in each instance.
+
 This is project-wide convention as of v0.3 — earlier versions used the
-**bounding-box midpoint**, which differs on asymmetric instances (long
-tails, sprawled limbs).
-
-If you trained a centroid model on the old bbox-midpoint convention, the GT
-centroid targets for partial instances shift slightly. Re-training is
-recommended if `anchor_part` was unset in your training config; otherwise
-behavior is unchanged.
+**bounding-box midpoint**, which differs on asymmetric instances (long tails,
+sprawled limbs). If you trained a centroid model on the old bbox-midpoint
+convention with `anchor_part` unset, the GT centroid targets for partial
+instances shift slightly; re-training is recommended.
 
 ## Interaction with filtering, tracking, and metrics
 
 ### Filtering
 
-All `FilterConfig` knobs apply to centroid-only outputs:
+`FilterConfig` knobs apply to centroid-only outputs:
 
 - **`min_instance_score`**: filters on the centroid confidence value.
-- **`min_visible_nodes` / `min_visible_node_fraction`**: use with caution —
-  centroid-only outputs always have `n_nodes - 1` NaN nodes per instance,
-  so a threshold > 1 will drop every instance.
-- **`overlapping` with `overlapping_method="iou"`**: works; bbox-IoU on
-  point centroids is effectively an exact-duplicate filter.
-- **`overlapping` with `overlapping_method="oks"`**: emits a
-  `UserWarning` and falls back to IoU. OKS needs keypoints, which are
-  NaN in centroid-only outputs.
+- **`min_visible_nodes` / `min_visible_node_fraction`**: a single-node
+  detection has exactly one visible node, so keep any threshold `<= 1`.
+- **`overlapping` with `overlapping_method="oks"`**: emits a `UserWarning` and
+  falls back to IoU. OKS needs the full keypoint set, which a centroid lacks.
 
 ### Tracking
 
-Use `features="centroids"` and a centroid-compatible scoring method
-(`scoring_method="euclidean_dist"` is the natural choice):
+Use `features="centroids"`. For a single-node skeleton the scoring method
+auto-resolves to `euclidean_dist` (pixel distance between centroids); OKS /
+keypoint scoring is degenerate on a single point
+(`sleap_nn/inference/tracking.py`).
 
 ```python
 from sleap_nn.inference.tracking import TrackerConfig
 
 tracker_config = TrackerConfig(
     features="centroids",
+    # scoring_method auto-resolves to "euclidean_dist" for single-node;
+    # set it explicitly if you want to be sure.
     scoring_method="euclidean_dist",
     window_size=5,
     track_matching_method="hungarian",
 )
-
-predictor = Predictor.from_model_paths(
-    ["models/centroid/"],
-    tracker_config=tracker_config,
-)
 ```
-
-`features="keypoints"` will technically run but only sees the anchor node;
-this is rarely what you want.
 
 ### Metrics
 
-Standard sleap-io metrics that expect full skeletons (OKS, PCK) will compute
-NaN for every non-anchor node. Centroid-centric metrics (instance count,
-centroid localization error) work as expected.
+Distance-based metrics (centroid localization error, instance count) work as
+expected. OKS/PCK expect the full keypoint set and are degenerate for points —
+use `--match_method centroid` (above) for evaluation.

--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -108,6 +108,35 @@ sleap-nn export models/multi_class_bottomup \
     -o exports/multiclass --format onnx
 ```
 
+### Standalone Centroid
+
+A standalone centroid model (a first-class single-stage "animals-as-points"
+pipeline, *not* a top-down stage-1) exports from a **single** directory. The
+exported runtime reads the full training skeleton from `training_config.yaml`
+and collapses the output to a single-node `'centroid'` skeleton, bit-for-bit
+identical to the checkpoint flow.
+
+```bash
+# Export one centroid directory (NOT a centroid + centered_instance pair).
+sleap-nn export models/centroid -o exports/centroid --format onnx
+
+# Run the exported model. Choose the output representation with --centroid-output:
+#   instance (default) -> single-node PredictedInstance (frontend-compatible)
+#   centroid           -> sio.PredictedCentroid
+#   both               -> both
+sleap-nn predict exports/centroid video.mp4 -o centroids.slp \
+    --centroid-output instance
+```
+
+!!! note "One directory only"
+    Passing two centroid directories raises an error — that pattern is almost
+    always a mistake (you likely meant a centroid + centered-instance top-down
+    bundle). Pass a single centroid directory for a standalone export.
+
+See the [Centroid-Only Inference guide](centroid-only-inference.md) for the
+full train → infer → eval → export workflow and the output representation
+contract.
+
 ---
 
 ## Inference Options
@@ -122,6 +151,12 @@ sleap-nn predict EXPORT_DIR VIDEO [options]
 | `-r`, `--runtime` | Inference runtime | `auto`, `onnx`, `tensorrt` | `auto` |
 | `-b`, `--batch-size` | Batch size | `INT` | `4` |
 | `-n`, `--n-frames` | Frames to process (0=all) | `INT` | `0` |
+| `--centroid-output` | Standalone-centroid output representation | `instance`, `centroid`, `both` | `instance` |
+
+!!! tip "Running unexported checkpoints"
+    To run inference on a trained checkpoint directory (not an exported
+    ONNX/TensorRT model), prefer the unified [`sleap-nn infer`](inference.md)
+    entry point. `sleap-nn predict` here runs an **exported** model directory.
 
 ### Examples
 
@@ -191,7 +226,7 @@ exports/my_model/
 - **TensorRT engines are GPU-specific** - Regenerate for different hardware
 - **Fixed image size** - Height/width set at export time
 - **Bottom-up grouping on CPU** - PAF matching can't be GPU-accelerated
-- **No standalone centroid/instance** - Use combined top-down or Python API
+- **No standalone centered-instance** - Export a combined top-down bundle (a standalone *centroid* model exports fine — see [Standalone Centroid](#standalone-centroid))
 
 ---
 

--- a/docs/sample_configs/config_centroid_unet_standalone.yaml
+++ b/docs/sample_configs/config_centroid_unet_standalone.yaml
@@ -1,0 +1,191 @@
+# Standalone centroid-only model (first-class single-stage pipeline).
+#
+# This is NOT a top-down stage-1 centroid model. A top-down centroid (see
+# config_centroid_unet.yaml) is paired with a centered-instance model and is
+# trained on downscaled, cropped data. THIS config trains a centroid head on
+# its own, at full resolution, to localize one point per animal — useful for
+# multi-instance "animals-as-points" detection, tracking, or counting where
+# per-keypoint pose is not needed.
+#
+# At inference (`sleap-nn infer` auto-detects a lone centroid model directory),
+# the output collapses to a single-node 'centroid' skeleton — see
+# docs/guides/centroid-only-inference.md for the output representation contract,
+# distance-based evaluation, and export.
+#
+# Skeleton: a single-node skeleton works directly, and a multi-node skeleton
+# also works — its centroids collapse to a single 'centroid' node at inference.
+# When `anchor_part` is null (recommended for a 1-node skeleton, where the sole
+# node IS the centroid), the centroid is the NaN-ignoring mean of visible nodes
+# (#586). See docs/reference/sleap_nn/data/instance_centroids.md.
+data_config:
+  train_labels_path: null
+  val_labels_path: null
+  validation_fraction: 0.1
+  use_same_data_for_val: false
+  test_file_path: null
+  provider: LabelsReader
+  user_instances_only: true
+  data_pipeline_fw: torch_dataset
+  cache_img_path: null
+  use_existing_imgs: false
+  delete_cache_imgs_after_training: true
+  preprocessing:
+    ensure_rgb: false
+    ensure_grayscale: false
+    max_height: null
+    max_width: null
+    # Full-resolution standalone centroid model (NOT a downscaled top-down
+    # stage-1). No cropping: crop_size stays null.
+    scale: 1.0
+    crop_size: null
+    min_crop_size: 100
+  use_augmentations_train: true
+  augmentation_config:
+    intensity:
+      uniform_noise_min: 0.0
+      uniform_noise_max: 0.04
+      uniform_noise_p: 0.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
+      gaussian_noise_p: 0.0
+      contrast_min: 0.9
+      contrast_max: 1.1
+      contrast_p: 0.0
+      brightness_min: 0.9
+      brightness_max: 1.1
+      brightness_p: 0.0
+    geometric:
+      rotation_min: -15.0
+      rotation_max: 15.0
+      scale_min: 0.9
+      scale_max: 1.1
+      translate_width: 0.0
+      translate_height: 0.0
+      affine_p: 1.0
+      erase_scale_min: 0.0001
+      erase_scale_max: 0.01
+      erase_ratio_min: 1.0
+      erase_ratio_max: 1.0
+      erase_p: 0.0
+      mixup_lambda_min: 0.01
+      mixup_lambda_max: 0.05
+      mixup_p: 0.0
+  # Optional single-node skeleton example. A standalone centroid model is the
+  # one case where a 1-node skeleton is natural: the sole node IS the centroid.
+  # A multi-node skeleton also works and collapses to a single 'centroid' node
+  # at inference, so you can train on your existing multi-node labels too.
+  #
+  # skeletons:
+  #   - name: Animal
+  #     nodes:
+  #       - name: centroid
+  #     edges: []
+  #     symmetries: []
+  skeletons:
+model_config:
+  init_weights: default
+  pretrained_backbone_weights: null
+  pretrained_head_weights: null
+  backbone_config:
+    unet:
+      in_channels: 1
+      kernel_size: 3
+      filters: 16
+      filters_rate: 2.0
+      max_stride: 16
+      stem_stride: null
+      middle_block: true
+      up_interpolate: true
+      stacks: 1
+      convs_per_block: 2
+      output_stride: 2
+    convnext: null
+    swint: null
+  head_configs:
+    single_instance: null
+    # The head stays the canonical "centroid" head, so get_model_type_from_cfg
+    # returns 'centroid' and the new infer flow auto-detects a centroid-only
+    # model. anchor_part stays null for a 1-node skeleton (the node is the
+    # centroid); for a multi-node skeleton set it to a node name to anchor on.
+    centroid:
+      confmaps:
+        anchor_part: null
+        sigma: 2.5
+        output_stride: 2
+    centered_instance: null
+    bottomup: null
+    multi_class_bottomup: null
+    multi_class_topdown: null
+  total_params: null
+trainer_config:
+  train_data_loader:
+    batch_size: 4
+    shuffle: true
+    num_workers: 0
+  val_data_loader:
+    batch_size: 4
+    shuffle: false
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: false
+  trainer_devices:
+  trainer_device_indices: null
+  trainer_accelerator: auto
+  profiler: null
+  trainer_strategy: auto
+  enable_progress_bar: true
+  min_train_steps_per_epoch: 200
+  train_steps_per_epoch: null
+  visualize_preds_during_training: true
+  keep_viz: false
+  max_epochs: 200
+  seed: null
+  use_wandb: false
+  save_ckpt: true
+  ckpt_dir: models
+  run_name: null
+  resume_ckpt_path: null
+  wandb:
+    entity: null
+    project: null
+    name: null
+    save_viz_imgs_wandb: false
+    api_key: null
+    wandb_mode: null
+    prv_runid: null
+    group: null
+    current_run_id: null
+  optimizer_name: Adam
+  optimizer:
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    step_lr: null
+    reduce_lr_on_plateau:
+      threshold: 1.0e-08
+      threshold_mode: abs
+      cooldown: 3
+      patience: 5
+      factor: 0.5
+      min_lr: 1.0e-08
+  early_stopping:
+    min_delta: 1.0e-08
+    patience: 20
+    stop_training_on_plateau: true
+  online_hard_keypoint_mining:
+    online_mining: false
+    hard_to_easy_ratio: 2.0
+    min_hard_keypoints: 2
+    max_hard_keypoints: null
+    loss_scale: 5.0
+  zmq:
+    controller_port: 9000
+    controller_polling_timeout: 10
+    publish_port: 9001
+  eval:
+    enabled: true
+    frequency: 1
+    match_threshold: 50.0  # Max distance (px) for centroid matching
+name: ''
+description: ''

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -2072,6 +2072,7 @@ def _register_export_commands():
     type=click.Choice(
         [
             "single_instance",
+            "centroid",
             "bottomup",
             "topdown",
             "multi_class_bottomup",
@@ -2079,7 +2080,11 @@ def _register_export_commands():
         ]
     ),
     default=None,
-    help="Override model pipeline type. 'topdown' generates paired centroid + centered_instance configs.",
+    help=(
+        "Override model pipeline type. 'centroid' generates a single STANDALONE "
+        "centroid config (one point per animal); 'topdown' generates paired "
+        "centroid + centered_instance configs."
+    ),
 )
 @click.option(
     "--show-yaml",
@@ -2124,9 +2129,16 @@ def config(
 
         # Apply overrides
         if pipeline:
-            # 'topdown' is a CLI alias for the centroid stage, which triggers
-            # paired centroid + centered_instance config generation.
-            gen.pipeline("centroid" if pipeline == "topdown" else pipeline)
+            # 'topdown' is a CLI alias for the centroid STAGE (is_topdown=True),
+            # which triggers paired centroid + centered_instance generation.
+            # 'centroid' is the STANDALONE single-config centroid model
+            # (is_topdown=False), emitted via the "centroid_only" pipeline.
+            if pipeline == "topdown":
+                gen.pipeline("centroid")
+            elif pipeline == "centroid":
+                gen.pipeline("centroid_only")
+            else:
+                gen.pipeline(pipeline)
 
         if show_yaml:
             click.echo(gen.to_yaml())

--- a/sleap_nn/config_generator/generator.py
+++ b/sleap_nn/config_generator/generator.py
@@ -370,6 +370,9 @@ class ConfigGenerator:
 
         - ``centroid``: centroid stage of top-down — main preprocessing,
           scale=0.5, sigma=5.0, output_stride=2.
+        - ``centroid_only``: STANDALONE centroid model (one config, no paired
+          centered_instance) — main preprocessing, scale=1.0, sigma=2.5,
+          output_stride=2. Emits the same ``centroid`` head as ``centroid``.
         - ``centered_instance``, ``multi_class_topdown``: CI stage of top-down —
           CI preprocessing (crop_size), scale=1.0, sigma=2.5, output_stride=2.
         - ``single_instance``, ``bottomup``, ``multi_class_bottomup``: main
@@ -386,6 +389,14 @@ class ConfigGenerator:
         if pipeline == "centroid":
             self._input_scale = 0.5
             self._sigma = 5.0
+            self._output_stride = 2
+            self._recalculate_max_stride()
+        elif pipeline == "centroid_only":
+            # Standalone centroid model: run at full resolution (no
+            # crop-and-refine second stage), tighter sigma than the top-down
+            # stage-1 centroid (0.5/5.0). One config, non-cropped preprocessing.
+            self._input_scale = 1.0
+            self._sigma = 2.5
             self._output_stride = 2
             self._recalculate_max_stride()
         elif pipeline in ("centered_instance", "multi_class_topdown"):
@@ -840,7 +851,13 @@ class ConfigGenerator:
                 }
             }
 
-        elif self._pipeline == "centroid":
+        elif self._pipeline in ("centroid", "centroid_only"):
+            # Both the top-down stage-1 ``centroid`` pipeline and the standalone
+            # ``centroid_only`` pipeline emit the SAME canonical ``centroid`` head
+            # (head key stays "centroid"), so ``get_model_type_from_cfg`` returns
+            # 'centroid' and the inference flow auto-detects either as a centroid
+            # model. They differ only in preprocessing/scale defaults (see
+            # ``pipeline()``).
             head_configs["centroid"] = {
                 "confmaps": {
                     "anchor_part": self._anchor_part,

--- a/sleap_nn/config_generator/recommender.py
+++ b/sleap_nn/config_generator/recommender.py
@@ -13,6 +13,7 @@ from sleap_nn.config_generator.analyzer import DatasetStats, ViewType
 PipelineType = Literal[
     "single_instance",
     "centroid",
+    "centroid_only",
     "centered_instance",
     "bottomup",
     "multi_class_bottomup",
@@ -120,6 +121,23 @@ def recommend_pipeline(stats: DatasetStats) -> PipelineRecommendation:
             requires_second_model=False,
         )
 
+    # Multi-instance with a single-node skeleton: there are no keypoints to
+    # crop-and-refine, so the only meaningful detection target is the centroid
+    # itself. Recommend a STANDALONE centroid model (one config, no second
+    # centered-instance stage) rather than the paired top-down bundle.
+    if stats.num_nodes == 1:
+        single_node_alternatives: List[PipelineType] = ["bottomup"]
+        if stats.has_identity:
+            single_node_alternatives.append("multi_class_bottomup")
+        return PipelineRecommendation(
+            recommended="centroid_only",
+            reason="Single-node skeleton - a standalone centroid model detects "
+            "the one point per animal directly (no second model needed)",
+            alternatives=single_node_alternatives,
+            warnings=[],
+            requires_second_model=False,
+        )
+
     # Multi-instance: small animals -> top-down
     if stats.animal_to_frame_ratio < 0.20:
         # Small animals - recommend top-down
@@ -196,7 +214,9 @@ def _recommend_sigma(stats: DatasetStats, pipeline: PipelineType) -> Tuple[float
     Returns:
         Tuple of (sigma, reason).
     """
-    if pipeline == "bottomup":
+    if pipeline == "centroid_only":
+        return (2.5, "Tighter sigma for precise standalone centroid localization")
+    elif pipeline == "bottomup":
         return (2.5, "Tighter sigma for multi-instance disambiguation")
     elif stats.max_bbox_size < 50:
         return (2.5, "Small animals need precise localization")

--- a/sleap_nn/config_generator/tui/screens/model_select_screen.py
+++ b/sleap_nn/config_generator/tui/screens/model_select_screen.py
@@ -256,6 +256,18 @@ class ModelSelectScreen(Widget):
             id="opt-topdown",
         )
 
+        # Centroid (standalone) - single point per animal, ONE config.
+        yield ModelTypeOption(
+            pipeline_type="centroid_only",
+            title="Centroid (single point per animal)",
+            description="Detect one point per animal directly (no keypoint refinement stage).",
+            details="Best for: Single-node skeletons / animal counting / tracking a single landmark.",
+            is_recommended=rec.pipeline.recommended == "centroid_only",
+            is_two_stage=False,
+            classes="model-option",
+            id="opt-centroid-only",
+        )
+
         # Bottom-Up
         bottomup_disabled = stats.num_edges == 0
         is_bottomup_rec = rec.pipeline.recommended in [
@@ -320,18 +332,19 @@ class ModelSelectScreen(Widget):
         if self._state:
             # Check if identity is enabled
             checkbox = self.query_one("#identity-checkbox", Checkbox)
-            if checkbox.value:
-                if pipeline_type == "centroid":
-                    self._state._pipeline = "multi_class_topdown"
-                elif pipeline_type == "bottomup":
-                    self._state._pipeline = "multi_class_bottomup"
-                else:
-                    self._state._pipeline = pipeline_type
+            # The standalone centroid model has no multi-class variant — the
+            # identity checkbox must NOT upgrade it. Only the paired top-down
+            # ``centroid`` and ``bottomup`` map to their multi_class variants.
+            if checkbox.value and pipeline_type == "centroid":
+                self._state._pipeline = "multi_class_topdown"
+            elif checkbox.value and pipeline_type == "bottomup":
+                self._state._pipeline = "multi_class_bottomup"
             else:
                 self._state._pipeline = pipeline_type
 
-            # Update input scale based on pipeline type (web app behavior)
-            # Top-down centroid uses lower scale (0.5), others use full scale (1.0)
+            # Update input scale based on pipeline type (web app behavior).
+            # Top-down stage-1 centroid uses lower scale (0.5); the standalone
+            # centroid_only and other single-stage models use full scale (1.0).
             is_topdown = self._state._pipeline in [
                 "centroid",
                 "centered_instance",
@@ -340,6 +353,11 @@ class ModelSelectScreen(Widget):
             if is_topdown:
                 self._state._input_scale = 0.5  # Lower scale for centroid
                 self._state._sigma = 5.0  # Larger sigma for centroid
+                self._state._output_stride = 2
+            elif self._state._pipeline == "centroid_only":
+                # Standalone centroid: full resolution, tighter sigma.
+                self._state._input_scale = 1.0
+                self._state._sigma = 2.5
                 self._state._output_stride = 2
             else:
                 self._state._input_scale = 1.0  # Full scale for other models
@@ -375,6 +393,13 @@ class ModelSelectScreen(Widget):
                 "  [yellow]1. Centroid Model[/yellow] - Detects animal centers in full images\n"
                 "  [yellow]2. Centered Instance Model[/yellow] - Detects keypoints in cropped regions\n"
                 "You'll configure both models and get [bold]2 YAML configs[/bold]."
+            )
+        elif pipeline_type == "centroid_only":
+            info_widget.update(
+                "[bold cyan]Centroid Pipeline (standalone)[/bold cyan]\n"
+                "Trains [bold]one model[/bold] that detects a single point per animal\n"
+                "(anchor node, or mean of visible nodes). No keypoint-refinement stage.\n"
+                "You'll get [bold]1 YAML config[/bold] file."
             )
         elif pipeline_type == "bottomup":
             info_widget.update(

--- a/sleap_nn/config_generator/tui/state.py
+++ b/sleap_nn/config_generator/tui/state.py
@@ -504,8 +504,23 @@ class ConfigState:
         self._ensure_rgb = bool(is_pretrained and self.stats.num_channels == 1)
         self._ensure_grayscale = False
 
+        # Standalone centroid model: full resolution, tighter sigma, single
+        # config (NO centered-instance/_ci_* second stage). Distinct from the
+        # top-down stage-1 centroid (0.5/5.0).
+        if self._pipeline == "centroid_only":
+            self._input_scale = 1.0
+            self._sigma = 2.5
+            self._output_stride = 2
+
+            # Floor max_stride by RF coverage at full scale (no rebucket).
+            scaled_max_animal_size = self.stats.max_bbox_size * self._input_scale
+            coverage_stride = self._compute_max_stride_for_animal_size(
+                scaled_max_animal_size
+            )
+            self._max_stride = max(self._max_stride, coverage_stride)
+
         # Set defaults for top-down models
-        if self.is_topdown:
+        elif self.is_topdown:
             # Centroid model defaults - lower scale is OK for detecting centers
             self._input_scale = 0.5
             self._sigma = 5.0

--- a/sleap_nn/export/cli.py
+++ b/sleap_nn/export/cli.py
@@ -140,6 +140,18 @@ def export(
     model_types = [resolve_model_type(cfg) for cfg in cfgs]
     backbone_types = [resolve_backbone_type(cfg) for cfg in cfgs]
 
+    # A standalone centroid model is exported from a SINGLE directory; passing two
+    # centroid dirs is almost always a mistake (the user likely meant centroid +
+    # centered_instance for a top-down bundle). Catch it with a clear message
+    # rather than letting it fall through to the generic combination error.
+    if len(model_paths) == 2 and all(mt == "centroid" for mt in model_types):
+        raise click.ClickException(
+            "Received two centroid model directories. A standalone centroid model "
+            "is exported from a single directory; a top-down bundle pairs a centroid "
+            "directory with a centered_instance (or multi_class_topdown) directory. "
+            "Pass one centroid directory for a standalone centroid export."
+        )
+
     if len(model_paths) == 1:
         model_path = model_paths[0]
         cfg = cfgs[0]
@@ -919,6 +931,17 @@ def export(
     "When > 0, inference and PAF grouping run in a producer-consumer pipeline. "
     "0 = sequential (legacy) mode.",
 )
+@click.option(
+    "--centroid-output",
+    "--centroid_output",
+    "centroid_output",
+    type=click.Choice(["instance", "centroid", "both"], case_sensitive=False),
+    default="instance",
+    show_default=True,
+    help="Output representation for a standalone centroid model: 'instance' "
+    "(single-node PredictedInstance, frontend-compatible), 'centroid' "
+    "(sio.PredictedCentroid), or 'both'. Ignored for non-centroid models.",
+)
 def predict(
     export_dir: Path,
     video_path: Path,
@@ -935,6 +958,7 @@ def predict(
     peak_conf_threshold: float,
     max_instances: Optional[int],
     cpu_workers: int,
+    centroid_output: str,
 ) -> None:
     """Run inference on exported models and save predictions to SLP.
 
@@ -1041,6 +1065,7 @@ def predict(
             min_instance_peaks=min_instance_peaks,
             min_line_scores=min_line_scores,
             paf_workers=cpu_workers,
+            emit_centroid=centroid_output.lower(),
         )
     except (FileNotFoundError, ValueError) as e:
         raise click.ClickException(str(e))

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -737,6 +737,7 @@ class Predictor:
         min_instance_peaks: float = 0,
         min_line_scores: float = 0.25,
         peak_conf_threshold: Optional[float] = None,
+        emit_centroid: str = "instance",
     ) -> "Predictor":
         """Build a :class:`Predictor` from an exported ONNX/TensorRT directory.
 
@@ -759,6 +760,12 @@ class Predictor:
                 threshold baked at export time (``metadata.peak_threshold``).
                 Note the wrapper already bakes a peak threshold during peak
                 finding, so this can only *tighten* beyond the baked value.
+            emit_centroid: Centroid-only output representation for an exported
+                standalone centroid model: ``"instance"`` (default; single-node
+                ``PredictedInstance``, frontend-compatible), ``"centroid"``
+                (``sio.PredictedCentroid``), or ``"both"``. Honored only for
+                ``ExportedCentroidLayer``; mirrors ``from_model_paths`` so the
+                exported runtime matches the checkpoint path.
         """
         from sleap_nn.export.metadata import ExportMetadata
 
@@ -801,6 +808,7 @@ class Predictor:
             "paf_workers": paf_workers,
             "model_paths": [str(export_dir)],
             "device": device,
+            "emit_centroid": emit_centroid,
         }
         if filter_config is not None:
             kwargs["filter_config"] = filter_config

--- a/tests/assets/generated_configs/centroid_only.yaml
+++ b/tests/assets/generated_configs/centroid_only.yaml
@@ -1,0 +1,105 @@
+data_config:
+  train_labels_path:
+  - /path/to/labels.slp
+  val_labels_path: null
+  validation_fraction: 0.1
+  test_file_path: null
+  provider: LabelsReader
+  user_instances_only: true
+  data_pipeline_fw: torch_dataset
+  cache_img_path: null
+  use_existing_imgs: false
+  delete_cache_imgs_after_training: true
+  parallel_caching: true
+  cache_workers: 0
+  preprocessing:
+    ensure_rgb: false
+    ensure_grayscale: false
+    max_height: 384
+    max_width: 384
+    scale: 1.0
+    crop_size: null
+  use_augmentations_train: true
+  augmentation_config:
+    geometric:
+      rotation_min: -15.0
+      rotation_max: 15.0
+      rotation_p: 1.0
+      scale_min: 0.9
+      scale_max: 1.1
+      scale_p: 1.0
+model_config:
+  init_weights: default
+  pretrained_backbone_weights: null
+  pretrained_head_weights: null
+  backbone_config:
+    unet:
+      in_channels: 1
+      kernel_size: 3
+      filters: 32
+      filters_rate: 1.5
+      max_stride: 16
+      output_stride: 2
+    convnext: null
+    swint: null
+  head_configs:
+    single_instance: null
+    centroid:
+      confmaps:
+        anchor_part: null
+        sigma: 2.5
+        output_stride: 2
+    centered_instance: null
+    bottomup: null
+    multi_class_bottomup: null
+    multi_class_topdown: null
+trainer_config:
+  train_data_loader:
+    batch_size: 8
+    shuffle: true
+    num_workers: 0
+  val_data_loader:
+    batch_size: 8
+    shuffle: false
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: true
+  trainer_devices: auto
+  trainer_accelerator: auto
+  enable_progress_bar: true
+  min_train_steps_per_epoch: 200
+  visualize_preds_during_training: true
+  keep_viz: false
+  max_epochs: 200
+  seed: null
+  use_wandb: false
+  save_ckpt: true
+  ckpt_dir: ./models
+  run_name: null
+  resume_ckpt_path: null
+  optimizer_name: Adam
+  optimizer:
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    step_lr: null
+    reduce_lr_on_plateau:
+      threshold: 1.0e-06
+      threshold_mode: abs
+      cooldown: 3
+      patience: 5
+      factor: 0.5
+      min_lr: 1.0e-08
+    cosine_annealing_warmup: null
+    linear_warmup_linear_decay: null
+  early_stopping:
+    stop_training_on_plateau: true
+    min_delta: 1.0e-06
+    patience: 5
+  online_hard_keypoint_mining:
+    online_mining: false
+    hard_to_easy_ratio: 2.0
+    min_hard_keypoints: 2
+    max_hard_keypoints: null
+    loss_scale: 5.0

--- a/tests/export/test_cli.py
+++ b/tests/export/test_cli.py
@@ -43,6 +43,16 @@ class TestPredictCommandHelp:
             "predict" in result.output.lower() or "inference" in result.output.lower()
         )
 
+    def test_predict_command_exposes_centroid_output(self):
+        """The predict command exposes --centroid-output for centroid models."""
+        from sleap_nn.export.cli import predict
+
+        runner = CliRunner()
+        result = runner.invoke(predict, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--centroid-output" in result.output
+
 
 @requires_onnx
 class TestExportCommand:
@@ -220,6 +230,80 @@ class TestExportCommand:
             or "error" in result.output.lower()
             or "not found" in result.output.lower()
         )
+
+
+class TestTwoCentroidGuard:
+    """Two centroid directories is an error (no onnx dependency required).
+
+    The guard fires before any model load, so it needs no export deps.
+    """
+
+    def test_two_centroid_dirs_raises(self, minimal_instance_centroid_ckpt, tmp_path):
+        """Passing the same centroid dir twice raises a clear ClickException."""
+        from sleap_nn.export.cli import export
+
+        runner = CliRunner()
+        result = runner.invoke(
+            export,
+            [
+                str(minimal_instance_centroid_ckpt),
+                str(minimal_instance_centroid_ckpt),
+                "-o",
+                str(tmp_path / "out"),
+                "--no-verify",
+            ],
+        )
+
+        assert result.exit_code != 0
+        # Clear, specific message — not the generic combination fallthrough.
+        assert "two centroid model directories" in result.output.lower()
+
+
+@requires_onnx
+class TestCentroidExportConsistency:
+    """Standalone centroid export → metadata consistency (requires onnx)."""
+
+    def test_standalone_centroid_metadata(
+        self, minimal_instance_centroid_ckpt, tmp_path
+    ):
+        """A single centroid dir exports metadata with model_type='centroid'.
+
+        Asserts node_names carries the full (multi-node) training skeleton and
+        anchor_part round-trips (None for this fixture, which has no anchor).
+        """
+        from omegaconf import OmegaConf
+
+        from sleap_nn.export.cli import export
+        from sleap_nn.export.metadata import ExportMetadata
+        from sleap_nn.export.utils import resolve_anchor_part, resolve_node_names
+
+        output_dir = tmp_path / "export_standalone_centroid"
+        runner = CliRunner()
+        result = runner.invoke(
+            export,
+            [
+                str(minimal_instance_centroid_ckpt),
+                "-o",
+                str(output_dir),
+                "--format",
+                "onnx",
+                "--no-verify",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        meta = ExportMetadata.load(output_dir / "export_metadata.json")
+        assert meta.model_type == "centroid"
+
+        cfg = OmegaConf.load(
+            (minimal_instance_centroid_ckpt / "training_config.yaml").as_posix()
+        )
+        assert meta.node_names == resolve_node_names(cfg, "centroid")
+        assert meta.anchor_part == resolve_anchor_part(cfg, "centroid")
+        # The full training skeleton must be preserved for the #586 source tag
+        # (the runtime collapses to a single 'centroid' node at packaging time,
+        # not in the metadata).
+        assert len(meta.node_names) > 1
 
 
 @requires_onnx

--- a/tests/inference/test_factory_export.py
+++ b/tests/inference/test_factory_export.py
@@ -493,6 +493,159 @@ def test_centroid_adapter_nan_pads_invalid_slots(centroid_export):
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Standalone-centroid export → single-node 'centroid' collapse (PR III)
+#
+# The export runtime must match the checkpoint path: a centroid model
+# trained on a MULTI-node skeleton collapses its predicted Labels to a
+# single-node 'centroid' skeleton (sio.get_centroid_skeleton()), with the
+# #586 source tag derived from the export's real node_names / anchor_part.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_centroid_export_skeleton_resolves_to_full_node_names(centroid_export):
+    """``from_export_dir`` carries the full (multi-node) training skeleton.
+
+    The collapse decision in ``_resolve_centroid_packaging`` keys off
+    ``len(skeleton.nodes) > 1`` AND the source tag needs the real node
+    names, so the predictor must NOT pre-collapse the skeleton at load.
+    """
+    from sleap_nn.inference.predictor import Predictor
+
+    predictor = Predictor.from_export_dir(centroid_export, device="cpu")
+    # centroid_export metadata declares a 2-node skeleton (n0, n1).
+    assert predictor.skeleton is not None
+    assert list(predictor.skeleton.node_names) == ["n0", "n1"]
+
+
+def test_centroid_export_collapses_to_single_node_centroid(centroid_export):
+    """Multi-node centroid export → predicted skeleton is single-node 'centroid'.
+
+    Mirrors the checkpoint path (``from_model_paths(centroid_only=True)``):
+    the standalone centroid model's output Labels collapse to a 1-node
+    'centroid' skeleton and a single-node ``PredictedInstance``.
+    """
+    import sleap_io as sio
+
+    from sleap_nn.inference.predictor import Predictor
+    from sleap_nn.inference.providers import NumpyProvider
+
+    predictor = Predictor.from_export_dir(centroid_export, device="cpu")
+
+    # The packaging decision should engage collapse (>1 training node) and
+    # default to the mean-of-visible / center_of_mass source (anchor_part
+    # is unset in this export).
+    pkg = predictor._resolve_centroid_packaging()
+    assert pkg.collapse_skeleton is not None
+    assert list(pkg.collapse_skeleton.node_names) == ["centroid"]
+    assert pkg.anchor_ind is None
+    assert pkg.source == "center_of_mass"
+    assert pkg.emit_centroid == "instance"
+
+    images = np.random.randint(0, 256, (1, 1, 16, 16), dtype=np.uint8)
+    provider = NumpyProvider(images=images, batch_size=1)
+    labels = predictor.predict(provider, make_labels=True)
+
+    assert len(labels.skeletons) == 1
+    assert list(labels.skeletons[0].node_names) == ["centroid"]
+    for lf in labels.labeled_frames:
+        for inst in lf.instances:
+            assert isinstance(inst, sio.PredictedInstance)
+            assert len(inst.points) == 1
+            assert list(inst.skeleton.node_names) == ["centroid"]
+
+
+def test_centroid_export_anchor_part_round_trip(tmp_path):
+    """``anchor_part`` in metadata resolves to anchor_ind + ``anchor:<name>`` source."""
+    from sleap_nn.inference.predictor import Predictor
+    from sleap_nn.inference.layers.exported import ExportedCentroidLayer
+
+    export_dir = tmp_path / "centroid_anchor_export"
+    export_dir.mkdir()
+    _export_tiny_centroid(export_dir, max_instances=4, n_nodes=2)
+    # Re-write metadata with a real anchor node name (node index 1).
+    meta_path = _write_metadata(export_dir, model_type="centroid", n_nodes=2)
+    meta = json.loads(meta_path.read_text())
+    meta["anchor_part"] = "n1"
+    meta_path.write_text(json.dumps(meta))
+
+    predictor = Predictor.from_export_dir(export_dir, device="cpu")
+    assert isinstance(predictor.layer, ExportedCentroidLayer)
+    # node_names ["n0", "n1"] → anchor "n1" → index 1.
+    assert predictor.layer.anchor_ind == 1
+
+    pkg = predictor._resolve_centroid_packaging()
+    assert pkg.anchor_ind == 1
+    assert pkg.source == "anchor:n1"
+    assert list(pkg.collapse_skeleton.node_names) == ["centroid"]
+
+
+def test_centroid_export_bad_anchor_part_raises(tmp_path):
+    """An ``anchor_part`` not in ``node_names`` raises a clear ``ValueError``."""
+    from sleap_nn.inference.predictor import Predictor
+
+    export_dir = tmp_path / "centroid_bad_anchor_export"
+    export_dir.mkdir()
+    _export_tiny_centroid(export_dir, max_instances=4, n_nodes=2)
+    meta_path = _write_metadata(export_dir, model_type="centroid", n_nodes=2)
+    meta = json.loads(meta_path.read_text())
+    meta["anchor_part"] = "does_not_exist"
+    meta_path.write_text(json.dumps(meta))
+
+    with pytest.raises(ValueError, match="not found in export node_names"):
+        Predictor.from_export_dir(export_dir, device="cpu")
+
+
+@pytest.mark.parametrize("emit", ["instance", "centroid", "both"])
+def test_centroid_export_emit_centroid_threads_through(centroid_export, emit):
+    """``from_export_dir(emit_centroid=...)`` controls the output representation.
+
+    Uses a deterministically-constructed ``Outputs`` (one valid centroid) so
+    the packaging path is exercised without depending on the synthetic ONNX
+    model's stochastic peak validity. The predictor's own
+    ``_resolve_centroid_packaging`` (collapse + source + emit) drives the
+    conversion via ``to_labels``.
+    """
+    import sleap_io as sio
+
+    from sleap_nn.inference.outputs import Outputs
+    from sleap_nn.inference.predictor import Predictor
+
+    predictor = Predictor.from_export_dir(
+        centroid_export, device="cpu", emit_centroid=emit
+    )
+    assert predictor.emit_centroid == emit
+    assert predictor._resolve_centroid_packaging().emit_centroid == emit
+
+    # One frame, one guaranteed-valid centroid at (5, 7).
+    outputs = Outputs(
+        pred_centroids=torch.tensor([[[5.0, 7.0]]]),
+        pred_centroid_values=torch.tensor([[0.9]]),
+        instance_valid=torch.tensor([[True]]),
+        frame_indices=torch.tensor([0]),
+        video_indices=torch.tensor([0]),
+    )
+    labels = predictor.to_labels([outputs], videos=[None])
+
+    # Collapse always engages for this multi-node export.
+    assert list(labels.skeletons[0].node_names) == ["centroid"]
+
+    has_instance = any(
+        isinstance(inst, sio.PredictedInstance)
+        for lf in labels.labeled_frames
+        for inst in lf.instances
+    )
+    has_centroid = any(getattr(lf, "centroids", None) for lf in labels.labeled_frames)
+    if emit == "instance":
+        assert has_instance
+        assert not has_centroid
+    elif emit == "centroid":
+        assert has_centroid
+        assert not has_instance
+    else:  # both
+        assert has_instance and has_centroid
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Bottom-up synthetic export (PR 20)
 # ──────────────────────────────────────────────────────────────────────
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -344,11 +344,19 @@ class TestConfigCommand:
         assert not (tmp_path / "cfg_centroid.yaml").exists()
         assert not (tmp_path / "cfg_centered_instance.yaml").exists()
 
-    @pytest.mark.parametrize("removed", ["centroid", "centered_instance"])
-    def test_internal_pipeline_names_not_exposed(
-        self, minimal_instance, tmp_path, removed
+    def test_pipeline_centroid_writes_single_standalone_config(
+        self, minimal_instance, tmp_path
     ):
-        """Internal stage names (centroid, centered_instance) are not valid CLI choices."""
+        """`--pipeline centroid` is the STANDALONE single-config centroid model.
+
+        Unlike `topdown` (paired), it writes exactly ONE config that resolves to
+        model_type 'centroid' (full-res, no crop_size).
+        """
+        from omegaconf import OmegaConf
+
+        from sleap_nn.config.utils import get_model_type_from_cfg
+
+        out = tmp_path / "cfg.yaml"
         runner = CliRunner()
         result = runner.invoke(
             cli,
@@ -357,7 +365,37 @@ class TestConfigCommand:
                 str(minimal_instance),
                 "--auto",
                 "--pipeline",
-                removed,
+                "centroid",
+                "-o",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        # No paired top-down split files.
+        assert not (tmp_path / "cfg_centroid.yaml").exists()
+        assert not (tmp_path / "cfg_centered_instance.yaml").exists()
+
+        cfg = OmegaConf.load(str(out))
+        assert get_model_type_from_cfg(cfg) == "centroid"
+        assert cfg.data_config.preprocessing.scale == 1.0
+        assert cfg.data_config.preprocessing.crop_size is None
+
+    def test_internal_pipeline_names_not_exposed(self, minimal_instance, tmp_path):
+        """Internal stage name ``centered_instance`` is not a valid CLI choice.
+
+        (``centroid`` IS exposed now — it's the standalone single-config model;
+        ``centered_instance`` remains an internal top-down stage only.)
+        """
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                str(minimal_instance),
+                "--auto",
+                "--pipeline",
+                "centered_instance",
                 "-o",
                 str(tmp_path / "cfg.yaml"),
             ],
@@ -376,6 +414,7 @@ class TestConfigCommand:
         assert result.exit_code == 0
         for choice in [
             "single_instance",
+            "centroid",
             "bottomup",
             "topdown",
             "multi_class_bottomup",

--- a/tests/test_config_generator_yaml.py
+++ b/tests/test_config_generator_yaml.py
@@ -32,6 +32,13 @@ GOLDEN_DIR = Path("tests/assets/generated_configs")
 PLACEHOLDER_PATH = "/path/to/labels.slp"
 
 
+# ``centroid_only`` is a single-stage STANDALONE centroid pipeline whose head
+# key remains the canonical ``centroid`` (so ``get_model_type_from_cfg`` returns
+# 'centroid'). It is golden-tested but is NOT part of ``PIPELINES`` for the
+# "head key == pipeline name" oneof test (its head key differs from its name).
+GOLDEN_PIPELINES = PIPELINES + ["centroid_only"]
+
+
 def _build_config(pipeline: str) -> dict:
     """Build a config for ``pipeline`` and normalize the labels path."""
     gen = ConfigGenerator.from_slp(FIXTURE_SLP).auto().pipeline(pipeline)
@@ -40,7 +47,7 @@ def _build_config(pipeline: str) -> dict:
     return yaml.safe_load(OmegaConf.to_yaml(cfg))
 
 
-@pytest.mark.parametrize("pipeline", PIPELINES)
+@pytest.mark.parametrize("pipeline", GOLDEN_PIPELINES)
 def test_yaml_matches_golden(pipeline):
     """Generated YAML for each pipeline matches the checked-in golden.
 
@@ -50,8 +57,9 @@ def test_yaml_matches_golden(pipeline):
         from sleap_nn.config_generator.generator import ConfigGenerator
         from omegaconf import OmegaConf
         from pathlib import Path
-        for p in ['single_instance', 'centroid', 'centered_instance',
-                  'bottomup', 'multi_class_bottomup', 'multi_class_topdown']:
+        for p in ['single_instance', 'centroid', 'centroid_only',
+                  'centered_instance', 'bottomup', 'multi_class_bottomup',
+                  'multi_class_topdown']:
             gen = ConfigGenerator.from_slp(
                 'tests/assets/datasets/minimal_instance.pkg.slp'
             ).auto().pipeline(p)
@@ -68,7 +76,7 @@ def test_yaml_matches_golden(pipeline):
     assert actual == expected
 
 
-@pytest.mark.parametrize("pipeline", PIPELINES)
+@pytest.mark.parametrize("pipeline", GOLDEN_PIPELINES)
 def test_exactly_one_backbone_active(pipeline):
     """Generated YAML has exactly one non-null backbone (oneof contract)."""
     cfg = _build_config(pipeline)
@@ -86,7 +94,7 @@ def test_exactly_one_head_active(pipeline):
     assert active == [pipeline]
 
 
-@pytest.mark.parametrize("pipeline", PIPELINES)
+@pytest.mark.parametrize("pipeline", GOLDEN_PIPELINES)
 def test_round_trips_through_model_trainer(pipeline):
     """Generated config is accepted by the canonical ModelTrainer.
 
@@ -202,3 +210,167 @@ def test_augmentation_uses_canonical_field_names():
                 "contrast_p",
             }
             assert "limit" not in k
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Standalone "centroid_only" pipeline (single-config centroid model)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_centroid_only_emits_single_centroid_head():
+    """centroid_only emits ONE config with only the canonical ``centroid`` head.
+
+    Head key is ``centroid`` (not ``centroid_only``) so ``get_model_type_from_cfg``
+    returns 'centroid' and the inference flow auto-detects a centroid model.
+    """
+    cfg = _build_config("centroid_only")
+    heads = cfg["model_config"]["head_configs"]
+    active = [k for k, v in heads.items() if v is not None]
+    assert active == ["centroid"]
+    confmaps = heads["centroid"]["confmaps"]
+    assert confmaps["sigma"] == 2.5
+    assert confmaps["output_stride"] == 2
+
+
+def test_centroid_only_full_res_no_crop():
+    """centroid_only is full resolution (scale 1.0) with no crop_size."""
+    cfg = _build_config("centroid_only")
+    preproc = cfg["data_config"]["preprocessing"]
+    assert preproc["scale"] == 1.0
+    assert preproc["crop_size"] is None
+    # Non-cropped preprocessing emits max_height/max_width (not a CI crop block).
+    assert "max_height" in preproc
+    assert "max_width" in preproc
+
+
+def test_centroid_only_resolves_to_centroid_model_type():
+    """The generated centroid_only config resolves to model_type 'centroid'."""
+    from omegaconf import OmegaConf
+
+    from sleap_nn.config.utils import get_model_type_from_cfg
+
+    gen = ConfigGenerator.from_slp(FIXTURE_SLP).auto().pipeline("centroid_only")
+    cfg = gen.build()
+    assert get_model_type_from_cfg(cfg) == "centroid"
+
+
+def test_centroid_only_is_not_topdown_but_centroid_is():
+    """is_topdown is False for centroid_only (single config) and True for centroid."""
+    standalone = ConfigGenerator.from_slp(FIXTURE_SLP).auto().pipeline("centroid_only")
+    assert standalone.is_topdown is False
+
+    paired = ConfigGenerator.from_slp(FIXTURE_SLP).auto().pipeline("centroid")
+    assert paired.is_topdown is True
+
+
+def test_centroid_only_save_emits_single_file(tmp_path):
+    """save() writes ONE file for centroid_only vs TWO for the paired centroid."""
+    out = tmp_path / "cfg.yaml"
+
+    gen = ConfigGenerator.from_slp(FIXTURE_SLP).auto().pipeline("centroid_only")
+    gen.save(str(out))
+    assert out.exists()
+    # No paired centroid/centered_instance split files.
+    assert not (tmp_path / "cfg_centroid.yaml").exists()
+    assert not (tmp_path / "cfg_centered_instance.yaml").exists()
+
+    # By contrast, the paired top-down ``centroid`` pipeline dual-emits.
+    out2 = tmp_path / "td.yaml"
+    paired = ConfigGenerator.from_slp(FIXTURE_SLP).auto().pipeline("centroid")
+    paired.save(str(out2))
+    assert (tmp_path / "td_centroid.yaml").exists()
+    assert (tmp_path / "td_centered_instance.yaml").exists()
+    assert not out2.exists()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Recommender: single-node multi-instance -> centroid_only
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _make_stats(num_nodes: int, num_edges: int = 0) -> "DatasetStats":
+    """Build a multi-instance DatasetStats with small animals (~10% of frame)."""
+    from sleap_nn.config_generator.analyzer import DatasetStats
+
+    node_names = [f"n{i}" for i in range(num_nodes)]
+    return DatasetStats(
+        slp_path="x.slp",
+        num_labeled_frames=10,
+        num_videos=1,
+        max_height=1000,
+        max_width=1000,
+        num_channels=1,
+        max_instances_per_frame=3,  # multi-instance
+        avg_instances_per_frame=3.0,
+        max_bbox_size=100.0,
+        avg_bbox_size=100.0,  # ~10% of 1000 -> small animals
+        avg_bbox_diagonal=140.0,
+        num_nodes=num_nodes,
+        num_edges=num_edges,
+        node_names=node_names,
+        edges=[],
+        has_tracks=False,
+        num_tracks=0,
+        estimated_total_bytes=0,
+    )
+
+
+def test_recommender_single_node_multi_instance_picks_centroid_only():
+    """A single-node multi-instance skeleton recommends 'centroid_only'."""
+    from sleap_nn.config_generator.recommender import recommend_pipeline
+
+    rec = recommend_pipeline(_make_stats(num_nodes=1))
+    assert rec.recommended == "centroid_only"
+    assert rec.requires_second_model is False
+    assert rec.reason  # non-empty explanation
+
+
+def test_recommender_multi_node_small_animals_still_centroid():
+    """A multi-node small-animal skeleton still recommends the paired 'centroid'."""
+    from sleap_nn.config_generator.recommender import recommend_pipeline
+
+    rec = recommend_pipeline(_make_stats(num_nodes=5))
+    assert rec.recommended == "centroid"
+    assert rec.requires_second_model is True
+
+
+def test_recommend_config_centroid_only_sigma_no_crop():
+    """recommend_config for a single-node dataset uses tight sigma, no crop_size."""
+    from sleap_nn.config_generator.recommender import recommend_config
+
+    rec = recommend_config(_make_stats(num_nodes=1))
+    assert rec.pipeline.recommended == "centroid_only"
+    assert rec.sigma == 2.5
+    assert rec.crop_size is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI: `config ... --pipeline centroid` -> single standalone config file
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_cli_config_pipeline_centroid_writes_single_file(tmp_path):
+    """`config --pipeline centroid` writes ONE config resolving to 'centroid'."""
+    from click.testing import CliRunner
+    from omegaconf import OmegaConf
+
+    from sleap_nn.cli import config as config_cmd
+    from sleap_nn.config.utils import get_model_type_from_cfg
+
+    out = tmp_path / "out.yaml"
+    runner = CliRunner()
+    result = runner.invoke(
+        config_cmd,
+        [FIXTURE_SLP, "--auto", "--pipeline", "centroid", "-o", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Single standalone file — no paired split files.
+    assert out.exists()
+    assert not (tmp_path / "out_centroid.yaml").exists()
+    assert not (tmp_path / "out_centered_instance.yaml").exists()
+
+    cfg = OmegaConf.load(str(out))
+    assert get_model_type_from_cfg(cfg) == "centroid"
+    assert cfg.data_config.preprocessing.scale == 1.0
+    assert cfg.data_config.preprocessing.crop_size is None


### PR DESCRIPTION
**Stacked PR 3 of 3** — base: `centroid-only/metrics-tracking` (#590). Merge #589 then #590 first.

### Changes
- **Authoring**: new single-stage `centroid_only` config-generator pipeline emits ONE centroid YAML (vs the paired top-down bundle); recommender picks it for multi-instance single-node skeletons; TUI standalone "Centroid (single point per animal)" card; CLI `config --pipeline centroid`. Emitted head stays the canonical `centroid` head so `get_model_type_from_cfg` returns `'centroid'` and `infer` auto-detects it.
- **Export**: exported-runtime output matches the checkpoint path (single-node 'centroid' collapse — verified empirically that PR1's `_resolve_centroid_packaging` already flows through the export path); clear guard against passing two centroid dirs; `export predict --centroid-output` parity.
- **Docs**: standalone sample config (`config_centroid_unet_standalone.yaml`) + rewritten `docs/guides/centroid-only-inference.md` (collapse contract, sio.Centroid opt-in, distance eval, end-to-end) + `export.md` fix + samples index + `CLAUDE.md` pointer.

### Tests
`tests/test_config_generator_yaml.py`, `tests/export/test_cli.py`, `tests/inference/test_factory_export.py`.

### Follow-ups (noted, not in this stack)
- `evaluation.get_instances` ignores `LabeledFrame.centroids` (only matters if evaluating a `sio.Centroid`-emitted `.slp`; default `emit_centroid='instance'` flow is unaffected).
- Frontend (talmolab/sleap#2724): switch the inference subprocess from `track` → `infer`, drop the `is_centroid_models_enabled` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
