### PR TITLE
Fix #575: accept .ckpt / training_config paths in model_paths

### DIFF
--- a/docs/guides/inference-api.md
+++ b/docs/guides/inference-api.md
@@ -47,7 +47,7 @@ The most common:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `source` | Video path, `sio.Video`, `sio.Labels`, or a Provider | required |
-| `model_paths` | List of checkpoint dirs (1 for single/bottom-up, 2 for top-down) | `None` |
+| `model_paths` | List of model dirs — or a model's `best.ckpt` / `training_config.yaml` path, which resolves to its dir (1 for single/bottom-up, 2 for top-down) | `None` |
 | `export_dir` | Exported ONNX/TRT dir (alternative to `model_paths`) | `None` |
 | `device` | `"auto"`, `"cpu"`, `"cuda"`, `"cuda:0"`, `"mps"` | `"auto"` |
 | `batch_size` | Frames per batch | `4` |

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -89,7 +89,7 @@ labels.export("predictions.analysis.h5")
 | Parameter | Description | Values | Default |
 |-----------|-------------|--------|---------|
 | `--data_path` / `-i` | Video or labels file | `PATH` | Required |
-| `--model_paths` / `-m` | Model directory (repeat for top-down) | `PATH` | Required* |
+| `--model_paths` / `-m` | Model dir, or its `best.ckpt` / `training_config.yaml` (repeat for top-down) | `PATH` | Required* |
 | `--output_path` / `-o` | Output file path | `PATH` | `<input>.predictions.slp` |
 | `--device` / `-d` | Compute device | `auto`, `cuda`, `cuda:0`, `cpu`, `mps` | `auto` |
 | `--batch_size` / `-b` | Frames per batch | `INT` | `4` |
@@ -98,6 +98,8 @@ labels.export("predictions.analysis.h5")
 | `--peak_threshold` | Min confidence for peaks | `FLOAT` | `0.2` |
 
 *Not required for track-only mode.
+
+Each `--model_paths` entry may be a model **directory**, or a path to that model's `best.ckpt` or `training_config.yaml`/`.json` file — all three resolve to the model directory and load `best.ckpt`. (Pointing at a different checkpoint such as `last.ckpt` still loads `best.ckpt` and warns; use `--backbone_ckpt_path` / `--head_ckpt_path` to load a specific checkpoint.)
 
 !!! tip "Device selection"
     The `--device` parameter accepts:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -77,13 +77,15 @@ sleap-nn track --data_path INPUT --model_paths MODEL [OPTIONS]
 | Option | Short | Description | Values | Default |
 |--------|-------|-------------|--------|---------|
 | `--data_path` | `-i` | Video or labels file | `PATH` | Required |
-| `--model_paths` | `-m` | Model directory (multiple for top-down) | `PATH` | Required* |
+| `--model_paths` | `-m` | Model dir, or its `best.ckpt` / `training_config.yaml` (multiple for top-down) | `PATH` | Required* |
 | `--output_path` | `-o` | Output file path | `PATH` | `<input>.predictions.slp` |
 | `--device` | `-d` | Compute device | `auto`, `cuda`, `cuda:0`, `cuda:1`, `cpu`, `mps` | `auto` |
 | `--batch_size` | `-b` | Batch size | `INT` | `4` |
 | `--tracking` | `-t` | Enable tracking | Flag | `false` |
 
 *Not required for track-only mode.
+
+Each `--model_paths` entry may be a model **directory**, or a path to that model's `best.ckpt` or `training_config.yaml`/`.json` file — all three resolve to the model directory and load `best.ckpt`. (A different checkpoint such as `last.ckpt` still loads `best.ckpt` and warns; use `--backbone_ckpt_path` / `--head_ckpt_path` for a specific checkpoint.)
 
 ### Output Options
 

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -546,7 +546,7 @@ def train(
     "--model_paths",
     "-m",
     multiple=True,
-    help="Path to trained model directory (with training_config.json). Multiple models can be specified, each preceded by --model_paths.",
+    help="Path to a trained model directory, or to its best.ckpt or training_config.yaml/.json file (all resolve to the model directory). Multiple models can be specified, each preceded by --model_paths.",
 )
 @click.option(
     "--output_path",
@@ -1681,7 +1681,7 @@ def _common_inference_options(f):
             "--model_paths",
             "-m",
             multiple=True,
-            help="Path to trained model directory. Multiple models may be passed (each preceded by --model_paths).",
+            help="Path to a trained model directory, or to its best.ckpt or training_config.yaml/.json file (all resolve to the model directory). Multiple models may be passed (each preceded by --model_paths).",
         ),
         click.option(
             "--output_path",

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -50,7 +50,7 @@ def resolve_model_dir(model_path: Union[str, Path]) -> str:
         if suffix in (".yaml", ".yml", ".json"):
             return p.parent.as_posix()
         if suffix == ".ckpt":
-            if p.name != "best.ckpt":
+            if p.name.lower() != "best.ckpt":
                 logger.warning(
                     f"Model path '{model_path}' points at a specific checkpoint, "
                     f"but inference always loads 'best.ckpt' from the model "

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -1,7 +1,73 @@
 """Utilities for config building and validation."""
 
+from pathlib import Path
+from typing import Union
+
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
+
+
+def resolve_model_dir(model_path: Union[str, Path]) -> str:
+    """Resolve a user-supplied model path to its model *directory*.
+
+    A trained model lives in a directory holding ``training_config.{yaml,json}``
+    and a ``best.ckpt`` checkpoint. Callers historically had to pass that
+    directory. This helper additionally accepts a path to a file *inside* it —
+    either the ``training_config.{yaml,json}`` config or a ``.ckpt`` checkpoint —
+    and returns the containing directory, so users can point at ``best.ckpt`` or
+    ``training_config.yaml`` wherever a model directory is expected (issue #575).
+
+    The directory's *contents* are intentionally NOT validated here: the caller's
+    loader (e.g. :func:`sleap_nn.inference.loaders._load_training_config`) remains
+    the single source of truth for whether the resolved directory holds a usable
+    config and checkpoint, so its error messages stay attributable.
+
+    A directory is always loaded via its ``best.ckpt``. If the path points at a
+    *different* checkpoint (e.g. ``last.ckpt``), a warning is emitted and
+    ``best.ckpt`` is loaded anyway — use ``backbone_ckpt_path`` / ``head_ckpt_path``
+    to load a specific checkpoint.
+
+    Args:
+        model_path: A model directory, or a path to a ``.ckpt`` checkpoint or a
+            ``training_config.{yaml,json,yml}`` file within one.
+
+    Returns:
+        The resolved model directory as a POSIX-style string. Relative paths are
+        preserved (only the path separators are normalized); the path is not
+        resolved against the filesystem root.
+
+    Raises:
+        FileNotFoundError: If ``model_path`` does not exist, or is a file that is
+            neither a config file nor a ``.ckpt`` checkpoint.
+    """
+    p = Path(model_path)
+    if p.is_dir():
+        # Backward-compatible fast path. Existence/contents of the config are
+        # validated downstream so the original directory behavior is unchanged.
+        return p.as_posix()
+    if p.is_file():
+        suffix = p.suffix.lower()
+        if suffix in (".yaml", ".yml", ".json"):
+            return p.parent.as_posix()
+        if suffix == ".ckpt":
+            if p.name != "best.ckpt":
+                logger.warning(
+                    f"Model path '{model_path}' points at a specific checkpoint, "
+                    f"but inference always loads 'best.ckpt' from the model "
+                    f"directory; '{p.name}' will be ignored. To load a different "
+                    f"checkpoint, use 'backbone_ckpt_path' / 'head_ckpt_path'."
+                )
+            return p.parent.as_posix()
+        raise FileNotFoundError(
+            f"Model path '{model_path}' is not a recognized model file. Pass a "
+            f"model directory, or a path to its 'best.ckpt' or "
+            f"'training_config.yaml'/'training_config.json' file."
+        )
+    raise FileNotFoundError(
+        f"Model path does not exist: {model_path}. Pass a model directory, or a "
+        f"path to its 'best.ckpt' or 'training_config.yaml'/'training_config.json' "
+        f"file."
+    )
 
 
 def get_model_type_from_cfg(config: DictConfig):

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     import sleap_io as sio
 
 from sleap_nn.config.training_job_config import TrainingJobConfig
-from sleap_nn.config.utils import get_model_type_from_cfg
+from sleap_nn.config.utils import get_model_type_from_cfg, resolve_model_dir
 from sleap_nn.inference.bottomup import (
     BottomUpInferenceModel,
     BottomUpMultiClassInferenceModel,
@@ -717,6 +717,10 @@ def load_model_assets(
 ) -> tuple[LoadedAssets, List[str]]:
     """Load checkpoints and build inference models.
 
+    Each entry in ``model_paths`` may be a model directory, or a path to its
+    ``best.ckpt`` checkpoint or ``training_config.{yaml,json}`` config file; every
+    form is resolved to the model directory (#575).
+
     The five bottom-up PAF grouping knobs (``max_edge_length_ratio``,
     ``dist_penalty_weight``, ``n_points``, ``min_instance_peaks``,
     ``min_line_scores``) are forwarded ONLY to the plain bottom-up builder
@@ -738,6 +742,12 @@ def load_model_assets(
                 "scale": None,
             }
         )
+
+    # Accept a model directory, a best.ckpt path, or a training_config.{yaml,json}
+    # path for each entry; resolve every form to its model directory before
+    # detection/dispatch (the builders below index back into model_paths and join
+    # `best.ckpt` onto it). #575.
+    model_paths = [resolve_model_dir(mp) for mp in model_paths]
 
     model_types: List[str] = []
     configs: List[Any] = []

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -638,9 +638,12 @@ class Predictor:
         """Build a :class:`Predictor` from one or more checkpoint paths.
 
         Args:
-            model_paths: Directories containing ``training_config.{yaml,json}``
-                + ``best.ckpt``. For top-down, pass two paths (centroid +
-                centered-instance) in either order.
+            model_paths: Trained model directories containing
+                ``training_config.{yaml,json}`` + ``best.ckpt``. Each entry may
+                alternatively be a path to that ``best.ckpt`` or
+                ``training_config.{yaml,json}`` file; all forms resolve to the
+                model directory and load ``best.ckpt`` (#575). For top-down, pass
+                two paths (centroid + centered-instance) in either order.
             device: ``"cpu"``, ``"cuda"``, ``"mps"``, or ``"cuda:N"``.
             batch_size: Default batch size for auto-constructed providers.
             backbone_ckpt_path: Override backbone weights with this ``.ckpt``.

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -87,8 +87,10 @@ def predict(
 
     Args:
         source: Video path, ``sio.Video``, ``sio.Labels``, or a Provider.
-        model_paths: Checkpoint directories (one for single-instance /
-            bottom-up, two for top-down).
+        model_paths: Trained model directories — or a path to a model's
+            ``best.ckpt`` or ``training_config.{yaml,json}`` file, which resolves
+            to its directory (#575). One for single-instance / bottom-up, two for
+            top-down.
         export_dir: Path to an exported ONNX/TRT directory (alternative
             to ``model_paths``).
         device: ``"auto"``, ``"cpu"``, ``"cuda"``, ``"mps"``, etc.

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -556,8 +556,18 @@ def run_inference(
         # "predicting" labeled frames. Redirect to the new `infer` flow instead of
         # producing misleading GT-copied output.
         if model_paths:
-            from sleap_nn.config.utils import get_model_type_from_cfg
+            from sleap_nn.config.utils import (
+                get_model_type_from_cfg,
+                resolve_model_dir,
+            )
             from sleap_nn.inference.loaders import _load_training_config
+
+            # Accept a model directory, a best.ckpt path, or a
+            # training_config.{yaml,json} path for each entry, resolving every
+            # form to its model directory. Covers both the lone-centroid guard
+            # below and the legacy `Predictor.from_model_paths` call further down
+            # (its loader does `path.iterdir()`, which breaks on a file). #575.
+            model_paths = [resolve_model_dir(_mp) for _mp in model_paths]
 
             _types = []
             for _mp in model_paths:

--- a/tests/inference/test_issue_575.py
+++ b/tests/inference/test_issue_575.py
@@ -128,6 +128,32 @@ def test_resolve_best_ckpt_does_not_warn(tmp_path):
     assert not any("best.ckpt" in m for m in msgs)
 
 
+def test_resolve_yml_suffix(tmp_path):
+    """A `.yml` (not just `.yaml`) config file resolves to its directory."""
+    d = tmp_path / "model"
+    d.mkdir()
+    (d / "training_config.yml").write_text("model_config: {}\n")
+    assert resolve_model_dir(d / "training_config.yml") == d.as_posix()
+
+
+def test_resolve_ckpt_name_case_insensitive(tmp_path):
+    """A case-variant `Best.ckpt` resolves to the dir without a spurious warning
+    (the checkpoint name check is case-insensitive)."""
+    d = tmp_path / "model"
+    d.mkdir()
+    shutil.copy(SINGLE_DIR / "best.ckpt", d / "Best.ckpt")
+
+    msgs: list[str] = []
+    sink = logger.add(lambda m: msgs.append(str(m)), level="WARNING")
+    try:
+        out = resolve_model_dir(d / "Best.ckpt")
+    finally:
+        logger.remove(sink)
+
+    assert out == d.as_posix()
+    assert not msgs
+
+
 def test_resolve_nonexistent_raises():
     """A path that does not exist raises FileNotFoundError with guidance."""
     with pytest.raises(FileNotFoundError, match="does not exist"):

--- a/tests/inference/test_issue_575.py
+++ b/tests/inference/test_issue_575.py
@@ -1,0 +1,206 @@
+"""Regression tests for issue #575 — accept .ckpt / training_config paths.
+
+``model_paths`` historically had to be a model *directory* (holding
+``training_config.{yaml,json}`` + ``best.ckpt``). The inference / tracking entry
+points (``Predictor.from_model_paths``, the new ``sleap-nn infer`` flow, and the
+legacy ``sleap-nn track`` / ``run_inference`` pipeline) now also accept a path to
+a model's ``best.ckpt`` or ``training_config.{yaml,json}`` file; every form
+resolves to the model directory, which is loaded via ``best.ckpt``.
+
+These tests cover the pure-path normalizer (:func:`resolve_model_dir`) plus
+parity between the directory form and the file forms through the public
+``Predictor.from_model_paths`` API and the legacy ``run_inference`` guard.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+from loguru import logger
+from omegaconf import OmegaConf
+
+from sleap_nn.config.utils import resolve_model_dir
+from sleap_nn.inference.predictor import Predictor
+
+CKPT_ROOT = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
+LEGACY_ROOT = Path(__file__).resolve().parents[1] / "assets" / "legacy_models"
+
+SINGLE_DIR = CKPT_ROOT / "minimal_instance_single_instance"
+CENTROID_DIR = CKPT_ROOT / "minimal_instance_centroid"
+CENTERED_DIR = CKPT_ROOT / "minimal_instance_centered_instance"
+LEGACY_SINGLE_DIR = LEGACY_ROOT / "minimal_robot.UNet.single_instance"
+
+_PREPROCESS = {
+    "ensure_rgb": None,
+    "ensure_grayscale": None,
+    "crop_size": None,
+    "max_width": None,
+    "max_height": None,
+    "scale": None,
+}
+
+
+def _build(paths):
+    """Build a Predictor from one or more model paths (dir or file form)."""
+    if not isinstance(paths, (list, tuple)):
+        paths = [paths]
+    return Predictor.from_model_paths(
+        [str(p) for p in paths],
+        peak_threshold=0.3,
+        preprocess_config=OmegaConf.create(_PREPROCESS),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# resolve_model_dir — pure path normalization
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_resolve_dir_unchanged():
+    """A model directory resolves to itself (POSIX-normalized)."""
+    assert resolve_model_dir(SINGLE_DIR) == SINGLE_DIR.as_posix()
+
+
+def test_resolve_dir_trailing_slash():
+    """A trailing slash is normalized away, not treated as a missing path."""
+    assert resolve_model_dir(SINGLE_DIR.as_posix() + "/") == SINGLE_DIR.as_posix()
+
+
+def test_resolve_best_ckpt():
+    """A best.ckpt path resolves to its containing directory."""
+    assert resolve_model_dir(SINGLE_DIR / "best.ckpt") == SINGLE_DIR.as_posix()
+
+
+def test_resolve_training_config_yaml():
+    """A training_config.yaml path resolves to its containing directory."""
+    assert (
+        resolve_model_dir(SINGLE_DIR / "training_config.yaml") == SINGLE_DIR.as_posix()
+    )
+
+
+def test_resolve_training_config_json():
+    """A legacy training_config.json path resolves to its directory (kept a dir
+    so the legacy ``load_legacy_model(model_dir=...)`` branch still gets a dir)."""
+    assert (
+        resolve_model_dir(LEGACY_SINGLE_DIR / "training_config.json")
+        == LEGACY_SINGLE_DIR.as_posix()
+    )
+
+
+def test_resolve_other_config_file_resolves_to_parent():
+    """Any config-like file inside a model dir resolves to that dir; the dir's
+    contents are validated downstream, not by the resolver."""
+    assert (
+        resolve_model_dir(SINGLE_DIR / "initial_config.yaml") == SINGLE_DIR.as_posix()
+    )
+
+
+def test_resolve_nonbest_ckpt_warns(tmp_path):
+    """Pointing at a non-best .ckpt still resolves to the dir but warns that
+    best.ckpt will be loaded instead."""
+    d = tmp_path / "model"
+    d.mkdir()
+    shutil.copy(SINGLE_DIR / "training_config.yaml", d / "training_config.yaml")
+    shutil.copy(SINGLE_DIR / "best.ckpt", d / "last.ckpt")
+
+    msgs: list[str] = []
+    sink = logger.add(lambda m: msgs.append(str(m)), level="WARNING")
+    try:
+        out = resolve_model_dir(d / "last.ckpt")
+    finally:
+        logger.remove(sink)
+
+    assert out == d.as_posix()
+    assert any("best.ckpt" in m and "last.ckpt" in m for m in msgs)
+
+
+def test_resolve_best_ckpt_does_not_warn(tmp_path):
+    """A plain best.ckpt path resolves silently (no spurious warning)."""
+    msgs: list[str] = []
+    sink = logger.add(lambda m: msgs.append(str(m)), level="WARNING")
+    try:
+        resolve_model_dir(SINGLE_DIR / "best.ckpt")
+    finally:
+        logger.remove(sink)
+    assert not any("best.ckpt" in m for m in msgs)
+
+
+def test_resolve_nonexistent_raises():
+    """A path that does not exist raises FileNotFoundError with guidance."""
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        resolve_model_dir(CKPT_ROOT / "no_such_model_dir")
+
+
+def test_resolve_unrecognized_file_raises():
+    """A real file that is neither a config nor a .ckpt raises FileNotFoundError."""
+    slp = SINGLE_DIR / "labels_val_gt_0.slp"
+    assert slp.exists()
+    with pytest.raises(FileNotFoundError, match="not a recognized model file"):
+        resolve_model_dir(slp)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Predictor.from_model_paths — parity across path forms
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("form", ["best.ckpt", "training_config.yaml"])
+def test_single_instance_file_form_parity(form):
+    """Building from best.ckpt / training_config.yaml matches the dir form."""
+    ref = _build(SINGLE_DIR)
+    alt = _build(SINGLE_DIR / form)
+    assert type(alt.layer).__name__ == type(ref.layer).__name__
+    assert alt.skeleton.node_names == ref.skeleton.node_names
+
+
+def test_topdown_mixed_forms_parity():
+    """A top-down pair with *mixed* forms (one .ckpt, one config) builds the same
+    predictor as passing both directories."""
+    ref = _build([CENTROID_DIR, CENTERED_DIR])
+    alt = _build([CENTROID_DIR / "best.ckpt", CENTERED_DIR / "training_config.yaml"])
+    assert type(alt.layer).__name__ == type(ref.layer).__name__
+    assert alt.skeleton.node_names == ref.skeleton.node_names
+
+
+def test_single_instance_prediction_parity(small_robot_minimal_video):
+    """End-to-end: predictions from the best.ckpt form are identical to the dir
+    form (same checkpoint, same resolved directory)."""
+    frames = list(range(4))
+
+    def run(model_path):
+        predictor = _build(model_path)
+        return predictor.predict(
+            small_robot_minimal_video.as_posix(), frames=frames, make_labels=True
+        )
+
+    ref = run(SINGLE_DIR)
+    alt = run(SINGLE_DIR / "best.ckpt")
+
+    assert len(alt) == len(ref) == len(frames)
+    for lf_ref, lf_alt in zip(ref, alt):
+        assert len(lf_alt.instances) == len(lf_ref.instances)
+        for inst_ref, inst_alt in zip(lf_ref.instances, lf_alt.instances):
+            np.testing.assert_array_equal(inst_alt.numpy(), inst_ref.numpy())
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Legacy run_inference centroid guard — must see through a .ckpt path
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_run_inference_centroid_guard_accepts_ckpt_path():
+    """The lone-centroid guard in ``run_inference`` resolves a centroid best.ckpt
+    path to its dir and still detects the centroid-only case (raising the
+    redirect error rather than silently failing open)."""
+    from sleap_nn.predict import run_inference
+
+    with pytest.raises(ValueError, match="Centroid-only inference is not supported"):
+        run_inference(
+            data_path="nonexistent_video.mp4",
+            model_paths=[str(CENTROID_DIR / "best.ckpt")],
+            tracking=False,
+            make_labels=True,
+        )


### PR DESCRIPTION
## Summary

Closes #575.

`model_paths` previously had to be a model **directory** (containing `training_config.{yaml,json}` + `best.ckpt`). Users naturally pass the path to `best.ckpt` or `training_config.yaml` instead (as raised in [talmolab/sleap#1480](https://github.com/talmolab/sleap/discussions/1480)), which errored. This PR makes all three forms work.

## Approach

New helper `resolve_model_dir()` in the lightweight, shared `sleap_nn/config/utils.py` resolves any of:

| Input form | Resolves to |
|---|---|
| model directory | itself (unchanged — backward compatible) |
| `…/best.ckpt` (or any `*.ckpt`) | parent directory |
| `…/training_config.{yaml,json,yml}` | parent directory |

The directory is always loaded via `best.ckpt`. Pointing at a **non-best** checkpoint (e.g. `last.ckpt`) resolves to the directory and emits a `logger.warning`, directing users to `backbone_ckpt_path` / `head_ckpt_path` for a specific checkpoint — the codebase's existing escape hatch for that. A nonexistent path, or a file that is neither a config nor a `.ckpt`, raises a `FileNotFoundError` that lists the accepted forms. The resolver only validates the *input path*; whether the resolved directory holds a usable config/checkpoint stays the responsibility of the downstream loader, so error messages remain attributable.

### Design decision: always `best.ckpt` (not "honor the pointed-at .ckpt")
A `.ckpt` path is treated purely as a pointer to its containing model directory. Honoring an arbitrary checkpoint filename would duplicate the existing `backbone_ckpt_path` / `head_ckpt_path` mechanism, would require threading a per-path filename through all six builders, and can't be honored uniformly anyway (the legacy-JSON branch loads `best_model.h5` via `load_legacy_model(model_dir=…)` and has no notion of a chosen `.ckpt`).

## Wiring (every track/inference entry point that flows through the loaders)
- **`loaders.load_model_assets`** — covers the new pipeline: `sleap-nn infer`, `Predictor.from_model_paths`, `run.predict`, and stream-to-file.
- **`predict.run_inference`** (legacy `sleap-nn track`) — normalizes the list for *both* the lone-centroid guard and the legacy `predictors.from_model_paths` call (whose loader does `path.iterdir()`, which raises on a file path).

Also updated: `--model_paths` CLI help (`track` + `infer`) and the `from_model_paths` / `predict` / `load_model_assets` docstrings.

`self.model_paths` (provenance only) intentionally still records the user's original input — no change, no separator/provenance regression.

## Out of scope (noted for follow-up)
- **`sleap-nn export`** — its `model_paths` argument is `click.Path(file_okay=False)` (rejects files at the CLI layer) and uses a separate loader (`export/utils.load_training_config`). Supporting files there is a distinct change to an unrelated command.
- **`evaluation.py`** — does not load models from `model_paths`.

## Tests
`tests/inference/test_issue_575.py`:
- **Resolver unit tests** — directory, `best.ckpt`, `training_config.yaml`, legacy `training_config.json`, other config file, trailing slash, non-best-`.ckpt` warning (+ no spurious warning for `best.ckpt`), nonexistent path, unrecognized file.
- **Parity via `Predictor.from_model_paths`** — single-instance dir vs `best.ckpt` vs `training_config.yaml` (layer type + skeleton), a **mixed-form** top-down pair (`best.ckpt` + `training_config.yaml`), and an **end-to-end prediction parity** check (identical predicted points).
- **Legacy guard** — `run_inference`'s lone-centroid guard sees through a centroid `best.ckpt` path.

### Test runs (local, CPU)
- `tests/inference/test_issue_575.py` — **15 passed**
- `test_predictors.py`, `test_run.py`, `test_factory.py`, `test_centroid_only.py`, `test_issue_582/583/584.py` — **106 passed, 2 skipped**
- `tests/cli/{test_infer_command,test_flag_validation,test_aliases,test_centroid_only_cli}.py`, `test_compat_shims.py` — **48 passed**
- `tests/test_predict.py` — 14 passed; **1 pre-existing failure** (`test_topdown_predictor`) unrelated to this PR: it fails identically on `main` because the recent centroid-only work (#589–591) added a lone-centroid guard to `run_inference` while that test still has a lone-centroid sub-test expecting the old legacy behavior. Left untouched here (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)