### PR TITLE
Fix #577: validation-side negative-frame split metrics (val/loss_negative, val/n_negative)

### DIFF
--- a/docs/guides/negative-frames.md
+++ b/docs/guides/negative-frames.md
@@ -124,6 +124,13 @@ When the feature is active, these additional metrics are logged to WandB/TensorB
 | `train/loss_negative` | epoch mean | MSE on negative frames — should approach 0 as model learns to suppress |
 | `train/n_positive` | epoch sum | Total positive samples seen in epoch |
 | `train/n_negative` | epoch sum | Total negative samples seen in epoch |
+| `val/loss` | epoch mean | Combined val loss — **always unweighted** (never applies `negative_loss_weight`), so it stays identical to the old plain MSE and is used for checkpointing / early-stopping |
+| `val/loss_positive` | epoch mean | Unweighted MSE on positive val frames |
+| `val/loss_negative` | epoch mean | Unweighted MSE on negative val frames — should approach 0 if the model generalizes background suppression to held-out frames |
+| `val/n_positive` | epoch sum | Total positive samples in the val epoch |
+| `val/n_negative` | epoch sum | Total negative samples in the val epoch |
+
+Unlike the train split, the validation split metrics are **always unweighted** (`negative_loss_weight` is not applied), so `val/loss` remains comparable across runs and matches plain `nn.MSELoss()`.
 
 !!! tip "Is It Working?"
     Watch `train/loss_negative` — it should decrease toward 0 over training. If it stays flat, the model isn't learning from negatives. Consider increasing `negative_loss_weight` or adding more diverse negative frames.
@@ -164,4 +171,4 @@ print(lf.is_negative)  # True or False
 
 - **Use `negative_loss_weight` to tune.** If negatives are rare relative to positives and `train/loss_negative` isn't decreasing, try `negative_loss_weight: 2.0` or higher to amplify the gradient signal.
 
-- **Check val metrics too.** Negative frames in the validation set (via the train/val split) contribute to `val/loss`. A model that hallucinates on empty backgrounds will have higher val loss.
+- **Check val metrics too.** Negative frames in the validation set (via the train/val split) contribute to `val/loss`, and are also broken out as `val/loss_positive` / `val/loss_negative` / `val/n_positive` / `val/n_negative`. Note that `val/loss` stays **unweighted** even when `negative_loss_weight > 1`, so it remains a faithful, comparable model-selection metric. Watch `val/loss_negative`: if it stays high while `train/loss_negative` falls, the model is memorizing training backgrounds rather than generalizing the "no animal → no detection" behavior, and will still hallucinate on unseen empty backgrounds.

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -409,21 +409,31 @@ class LightningModel(L.LightningModule):
         )
 
     def _compute_negative_weighted_loss(
-        self, y_preds: torch.Tensor, y: torch.Tensor, batch: Dict
+        self, y_preds: torch.Tensor, y: torch.Tensor, batch: Dict, stage: str = "train"
     ) -> torch.Tensor:
         """Compute MSE loss with optional negative sample weighting.
 
-        When ``is_negative`` is absent from the batch or ``negative_loss_weight``
-        is 1.0, this returns plain ``nn.MSELoss()``.  Otherwise, per-sample MSE
-        is computed and negative samples are weighted by ``negative_loss_weight``.
+        When ``is_negative`` is absent from the batch this returns plain
+        ``nn.MSELoss()``.  Otherwise, per-sample MSE is computed and split
+        metrics (positive/negative loss and counts) are logged under the
+        ``{stage}/`` prefix.
 
-        Also logs split metrics (positive/negative loss and counts) when
-        negatives are present.
+        Weighting behavior depends on ``stage``:
+
+        * ``stage == "train"``: negative samples are weighted by
+          ``negative_loss_weight`` (only when it is not 1.0).
+        * ``stage != "train"`` (e.g. ``"val"``): the loss is **always
+          unweighted** (``per_sample.mean()``).  This keeps ``val/loss``
+          numerically identical to the old plain ``nn.MSELoss()`` so that
+          ``ModelCheckpoint(monitor="val/loss")`` and ``EarlyStopping``
+          behavior is unchanged; only the positive/negative breakdown is added.
 
         Args:
             y_preds: Predicted tensor.
             y: Ground truth tensor.
             batch: Batch dictionary, may contain ``is_negative`` key.
+            stage: Logging-key prefix and weighting gate. ``"train"`` applies
+                negative weighting; any other value returns the unweighted mean.
 
         Returns:
             The (optionally weighted) loss tensor.
@@ -446,7 +456,7 @@ class LightningModel(L.LightningModule):
         if n_pos > 0:
             loss_pos = per_sample[is_pos].mean()
             self.log(
-                "train/loss_positive",
+                f"{stage}/loss_positive",
                 loss_pos,
                 prog_bar=False,
                 on_step=False,
@@ -456,7 +466,7 @@ class LightningModel(L.LightningModule):
         if n_neg > 0:
             loss_neg = per_sample[is_neg].mean()
             self.log(
-                "train/loss_negative",
+                f"{stage}/loss_negative",
                 loss_neg,
                 prog_bar=False,
                 on_step=False,
@@ -464,7 +474,7 @@ class LightningModel(L.LightningModule):
                 sync_dist=True,
             )
         self.log(
-            "train/n_positive",
+            f"{stage}/n_positive",
             float(n_pos),
             prog_bar=False,
             on_step=False,
@@ -473,7 +483,7 @@ class LightningModel(L.LightningModule):
             reduce_fx="sum",
         )
         self.log(
-            "train/n_negative",
+            f"{stage}/n_negative",
             float(n_neg),
             prog_bar=False,
             on_step=False,
@@ -482,8 +492,9 @@ class LightningModel(L.LightningModule):
             reduce_fx="sum",
         )
 
-        # Apply weighting
-        if self.negative_loss_weight == 1.0:
+        # Negative weighting is train-only; val/eval stages stay unweighted so
+        # val/loss remains numerically identical to plain nn.MSELoss().
+        if stage != "train" or self.negative_loss_weight == 1.0:
             return per_sample.mean()
 
         weights = torch.where(
@@ -814,7 +825,7 @@ class SingleInstanceLightningModule(LightningModel):
         X = normalize_on_gpu(X)
 
         y_preds = self.model(X)["SingleInstanceConfmapsHead"]
-        val_loss = nn.MSELoss()(y_preds, y)
+        val_loss = self._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
         if self.online_mining is not None and self.online_mining:
             ohkm_loss = compute_ohkm_loss(
                 y_gt=y,
@@ -1330,7 +1341,7 @@ class CentroidLightningModule(LightningModel):
         X = normalize_on_gpu(X)
 
         y_preds = self.model(X)["CentroidConfmapsHead"]
-        val_loss = nn.MSELoss()(y_preds, y)
+        val_loss = self._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
         self.log(
             "val/loss",
             val_loss,
@@ -1652,8 +1663,12 @@ class BottomUpLightningModule(LightningModel):
         pafs = preds["PartAffinityFieldsHead"]
         confmaps = preds["MultiInstanceConfmapsHead"]
 
-        confmap_loss = nn.MSELoss()(confmaps, y_confmap)
-        pafs_loss = nn.MSELoss()(pafs, y_paf)
+        confmap_loss = self._compute_negative_weighted_loss(
+            confmaps, y_confmap, batch, stage="val"
+        )
+        pafs_loss = self._compute_negative_weighted_loss(
+            pafs, y_paf, batch, stage="val"
+        )
 
         if self.online_mining is not None and self.online_mining:
             confmap_ohkm_loss = compute_ohkm_loss(
@@ -2049,8 +2064,12 @@ class BottomUpMultiClassLightningModule(LightningModel):
         classmaps = preds["ClassMapsHead"]
         confmaps = preds["MultiInstanceConfmapsHead"]
 
-        confmap_loss = nn.MSELoss()(confmaps, y_confmap)
-        classmaps_loss = nn.MSELoss()(classmaps, y_classmap)
+        confmap_loss = self._compute_negative_weighted_loss(
+            confmaps, y_confmap, batch, stage="val"
+        )
+        classmaps_loss = self._compute_negative_weighted_loss(
+            classmaps, y_classmap, batch, stage="val"
+        )
 
         if self.online_mining is not None and self.online_mining:
             confmap_ohkm_loss = compute_ohkm_loss(

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -900,6 +900,30 @@ class ModelTrainer:
                 "train/time",
                 "val/time",
             ]
+            # Negative-frame split metrics (train + val), only for model types
+            # that support frame-level negatives and only when the feature is
+            # enabled. Gating avoids empty columns in the common no-negatives case.
+            use_negative_frames = OmegaConf.select(
+                self.config, "data_config.use_negative_frames", default=False
+            )
+            if use_negative_frames and self.model_type in [
+                "single_instance",
+                "centroid",
+                "bottomup",
+                "multi_class_bottomup",
+            ]:
+                csv_log_keys.extend(
+                    [
+                        "train/loss_positive",
+                        "train/loss_negative",
+                        "train/n_positive",
+                        "train/n_negative",
+                        "val/loss_positive",
+                        "val/loss_negative",
+                        "val/n_positive",
+                        "val/n_negative",
+                    ]
+                )
             # Add model-specific keys for wandb parity
             if self.model_type in [
                 "single_instance",

--- a/tests/data/test_negative_frames.py
+++ b/tests/data/test_negative_frames.py
@@ -630,6 +630,88 @@ class TestNegativeLossWeighting:
         model._compute_negative_weighted_loss(y_preds, y, batch)
         model.log.assert_not_called()
 
+    def test_val_stage_logs_val_prefixed_keys(self):
+        """stage='val' logs val/* split keys, not train/*."""
+        model = self._make_model(weight=2.0)
+
+        y_preds = torch.randn(4, 2, 8, 8)
+        y = torch.randn(4, 2, 8, 8)
+        batch = {"is_negative": torch.tensor([False, False, True, False])}
+
+        model._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
+
+        logged_keys = {call.args[0] for call in model.log.call_args_list}
+        assert "val/loss_positive" in logged_keys
+        assert "val/loss_negative" in logged_keys
+        assert "val/n_positive" in logged_keys
+        assert "val/n_negative" in logged_keys
+        # Must NOT leak train/* keys on the val path.
+        assert not any(k.startswith("train/") for k in logged_keys)
+
+        for call in model.log.call_args_list:
+            if call.args[0] == "val/n_positive":
+                assert call.args[1] == 3.0
+            if call.args[0] == "val/n_negative":
+                assert call.args[1] == 1.0
+
+    def test_val_stage_never_weighted(self):
+        """stage='val' returns UNWEIGHTED MSE even when weight != 1.0."""
+        model = self._make_model(weight=5.0)
+
+        y_preds = torch.randn(4, 2, 8, 8)
+        y = torch.randn(4, 2, 8, 8)
+        batch = {"is_negative": torch.tensor([False, False, True, False])}
+
+        loss = model._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
+        # Equals plain MSELoss == per_sample.mean(); weight=5.0 is ignored.
+        expected = torch.nn.MSELoss()(y_preds, y)
+        assert torch.allclose(loss, expected, atol=1e-6)
+
+    def test_val_stage_no_is_negative_key(self):
+        """stage='val' with is_negative absent => plain MSELoss, nothing logged."""
+        model = self._make_model(weight=5.0)
+
+        y_preds = torch.randn(4, 2, 8, 8)
+        y = torch.randn(4, 2, 8, 8)
+        batch = {}
+
+        loss = model._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
+        expected = torch.nn.MSELoss()(y_preds, y)
+        assert torch.allclose(loss, expected, atol=1e-6)
+        model.log.assert_not_called()
+
+    def test_val_stage_ndim_agnostic_paf_like(self):
+        """Per-sample mean over dims 1..ndim works for PAF-like 4D tensors."""
+        model = self._make_model(weight=3.0)
+
+        # PAF-like: more channels than confmaps; still 4D (B, 2*n_edges, H, W).
+        y_preds = torch.randn(3, 6, 5, 5)
+        y = torch.randn(3, 6, 5, 5)
+        batch = {"is_negative": torch.tensor([False, True, False])}
+
+        loss = model._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
+        expected = torch.nn.MSELoss()(y_preds, y)  # unweighted invariant
+        assert torch.allclose(loss, expected, atol=1e-6)
+
+    def test_default_stage_is_train(self):
+        """Omitting stage keeps train behavior: weighting applied, train/* keys."""
+        model = self._make_model(weight=5.0)
+
+        y_preds = torch.randn(4, 2, 8, 8)
+        y = torch.randn(4, 2, 8, 8)
+        batch = {"is_negative": torch.tensor([False, False, True, False])}
+
+        loss = model._compute_negative_weighted_loss(y_preds, y, batch)
+
+        per_sample = (y_preds - y).pow(2).mean(dim=[1, 2, 3])
+        weights = torch.tensor([1.0, 1.0, 5.0, 1.0])
+        expected = (per_sample * weights).mean()
+        assert torch.allclose(loss, expected, atol=1e-6)
+
+        logged_keys = {call.args[0] for call in model.log.call_args_list}
+        assert "train/loss_positive" in logged_keys
+        assert not any(k.startswith("val/") for k in logged_keys)
+
 
 class TestDataConfigNegativeFrames:
     """Test that the DataConfig accepts use_negative_frames."""


### PR DESCRIPTION
@
## Summary

Closes #577. Negative-frame training (PR #484) logged **train-side** split metrics but no **validation-side** ones, so users had no `val/loss_negative` / `val/n_negative` to check whether the model actually suppresses false positives on held-out background frames — the exact signal the feature exists to improve. This also closes the secondary gap that the train-side split metrics never reached `training_log.csv`.

## What changed

**1. Validation-side split metrics** — `_compute_negative_weighted_loss` gains a `stage="train"` parameter:
- Log keys are now `{stage}/loss_positive`, `{stage}/loss_negative`, `{stage}/n_positive`, `{stage}/n_negative`.
- For `stage != "train"` the loss is **always unweighted** — `negative_loss_weight` is never applied on the val path. This keeps `val/loss` numerically identical to the old `nn.MSELoss()`, so `ModelCheckpoint(monitor="val/loss")` and `EarlyStopping` select the exact same checkpoints/epochs as before.
- The default `stage="train"` keeps the train path byte-for-byte unchanged (all 7 pre-existing `TestNegativeLossWeighting` tests pass untouched).

The four `validation_step`s that support frame-level negatives now emit the val split: **SingleInstance**, **Centroid**, **BottomUp** (confmaps + pafs), **BottomUpMultiClass** (confmaps + classmaps). The crop-level **TopDown** centered models are intentionally left untouched — their `training_step` never negative-weights either.

**2. CSV logger** — the `train/` and `val/` split keys are added to `csv_log_keys`, gated on `data_config.use_negative_frames` and the four supporting model types. Gating avoids empty columns in the common no-negatives case; `CSVLoggerCallback` already writes empty cells for any key absent from `callback_metrics` on a given epoch, so this is safe.

**3. Docs** — `docs/guides/negative-frames.md` gains the `val/*` rows in the Monitoring table and an explicit note that the validation split is always unweighted (replacing the old "negatives just contribute to `val/loss`" wording).

**4. Tests** — 5 new unit tests in `TestNegativeLossWeighting`: val-prefixed keys are logged (and `train/` keys are not), the never-weighted invariant holds even with `negative_loss_weight=5.0` (incl. a PAF-like 4D shape), the no-`is_negative` path is a no-op, and omitting `stage` keeps train weighting.

## Invariant: `val/loss` is unchanged

For a sample of `M` elements, `per_sample.mean() = (1/B) Σ_b [(1/M) Σ_e (·)²] = (1/(B·M)) Σ_{b,e}(·)²`, which is exactly `nn.MSELoss()`. This is asserted empirically (`atol=1e-6`) for the weighted, unweighted, no-key, and PAF-like cases. For bottomup the combined `val/loss = Σ s_t · loss_t` over the unchanged `self.loss_weights`, so it is likewise unchanged.

## Known, intentional behavior

For bottomup / multi_class_bottomup the helper is called **twice per step** (once per loss term), mirroring the existing train side, so `val/n_*` inflate by the same factor as `train/n_*`. Symmetry is preserved by design (the issue asks for val to mirror train); fixing the pre-existing train-side double-count is out of scope here.

## Testing

```
uv run pytest tests/data/test_negative_frames.py -q   # 36 passed
uv run black --check sleap_nn tests                    # clean
uv run ruff check sleap_nn/                            # clean
```

## Process

Planned, implemented, and adversarially reviewed (5 lenses: numerical invariants, train/val parity, CSV safety, coverage/correctness, tests/docs) via a multi-agent workflow; review surfaced no confirmed issues, and the diff + tests were independently re-verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@