### PR TITLE
Fix KalmanShiftTracker algorithmic correctness (#572 follow-up)

### DIFF
--- a/docs/guides/tracking.md
+++ b/docs/guides/tracking.md
@@ -86,11 +86,12 @@ sleap-nn track -i video.mp4 -m models/ \
 
 ### Kalman Filter
 
-Tracks each identity with a per-track constant-velocity Kalman filter. The tracker
-runs a normal-tracker warm-up for `--kf_init_frame_count` frames, fits one filter per
-track via EM, and then predicts each track's pose forward to score the current
-detections (analogous to optical flow, but using a motion model instead of image
-displacements):
+Tracks each identity with a per-track constant-velocity Kalman filter on the
+instance **centroid**. The tracker runs a normal-tracker warm-up for
+`--kf_init_frame_count` frames, fits one centroid filter per track via EM, and then
+predicts each track's centroid forward and scores the current detections against the
+last observed pose **rigidly translated** by that predicted displacement (analogous to
+optical flow, but using a motion model instead of image displacements):
 
 ```bash
 sleap-nn infer -i video.mp4 -m models/centroid models/centered_instance \
@@ -100,8 +101,20 @@ sleap-nn infer -i video.mp4 -m models/centroid models/centered_instance \
     --kf_init_frame_count 10
 ```
 
-**Best for**: A known, fixed number of smoothly-moving animals with frequent
-occlusions, after the base detector has been culled to the top-N instances per frame.
+**Best for**: A known, fixed number of animals whose motion is informative for
+association — identities that **cross or pass close** to each other, **converge**, or
+move **fast and smoothly** — after the base detector has been culled to the top-N
+instances per frame. In these regimes the motion prediction substantially reduces ID
+switches over plain similarity matching.
+
+!!! note "When it helps vs. when it doesn't"
+    The motion model is a net win where association is ambiguous (crossings, converging
+    or fast tracks). Under **heavy detection noise with frequent missed detections on
+    long sequences** it can slightly *reduce* IDF1 versus the memoryless similarity
+    tracker (any motion prediction occasionally causes a swap a memoryless tracker
+    avoids) — though it usually still produces fewer ID switches there. If your
+    detections are very noisy, prefer the plain tracker or lower `kf_prediction_blend`
+    (e.g. `Tracker.from_config(..., kf_prediction_blend=0.25)`).
 
 Notes:
 

--- a/docs/guides/tracking.md
+++ b/docs/guides/tracking.md
@@ -112,6 +112,14 @@ Notes:
   `--kf_node_indices 0,1,2`. Leave it unset to use all nodes.
 - Depends on the `pykalman` package (a core dependency).
 
+The motion model is robustified so it does not degrade tracking outside its sweet
+spot: each correction is gated by distance (rejecting false-positive / mismatched
+detections), the learned velocity is capped, the filter coasts across occlusion gaps,
+stale tracks are reset, and the scoring candidate blends the prediction with the last
+observation. These robustness parameters (`kf_prediction_blend`, the gate and
+velocity-cap multipliers) have tuned defaults and can be overridden when constructing a
+tracker via `Tracker.from_config(...)`.
+
 #### Kalman Filter Parameters
 
 | Parameter | Description | Values | Default |

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -131,6 +131,11 @@ class Tracker:
         kf_init_frame_count: int = 10,
         kf_node_indices: Optional[List[int]] = None,
         kf_reset_gap_size: int = 5,
+        kf_prediction_blend: float = 0.5,
+        kf_gate_step_mult: float = 8.0,
+        kf_min_gate_px: float = 40.0,
+        kf_velocity_cap_mult: float = 3.0,
+        kf_min_velocity_cap_px: float = 15.0,
         tracking_target_instance_count: Optional[int] = None,
         tracking_pre_cull_to_target: int = 0,
         tracking_pre_cull_iou_threshold: float = 0,
@@ -185,6 +190,17 @@ class Tracker:
                 `None` uses all nodes. Default: None. (only if `use_kalman` is True)
             kf_reset_gap_size: Number of consecutive missed frames after which a stale
                 track's filter is reset. Default: 5. (only if `use_kalman` is True)
+            kf_prediction_blend: Weight of the motion prediction when blending with the
+                last observation to form the scoring candidate. Default: 0.5.
+                (only if `use_kalman` is True)
+            kf_gate_step_mult: Measurement gate as a multiple of the track's median
+                step. Default: 8.0. (only if `use_kalman` is True)
+            kf_min_gate_px: Floor (px) for the measurement gate. Default: 40.0.
+                (only if `use_kalman` is True)
+            kf_velocity_cap_mult: Cap on learned velocity as a multiple of the track's
+                median step. Default: 3.0. (only if `use_kalman` is True)
+            kf_min_velocity_cap_px: Floor (px/frame) for the velocity cap. Default: 15.0.
+                (only if `use_kalman` is True)
             tracking_target_instance_count: Target number of instances to track per frame. (default: None)
             tracking_pre_cull_to_target: If non-zero and target_instance_count is also non-zero, then cull instances over target count per frame *before* tracking. (default: 0)
             tracking_pre_cull_iou_threshold: If non-zero and pre_cull_to_target also set, then use IOU threshold to remove overlapping instances over count *before* tracking. (default: 0)
@@ -238,6 +254,11 @@ class Tracker:
                 kf_init_frame_count=kf_init_frame_count,
                 kf_node_indices=kf_node_indices,
                 kf_reset_gap_size=kf_reset_gap_size,
+                kf_prediction_blend=kf_prediction_blend,
+                kf_gate_step_mult=kf_gate_step_mult,
+                kf_min_gate_px=kf_min_gate_px,
+                kf_velocity_cap_mult=kf_velocity_cap_mult,
+                kf_min_velocity_cap_px=kf_min_velocity_cap_px,
                 is_local_queue=is_local_queue,
                 tracking_target_instance_count=tracking_target_instance_count,
                 tracking_pre_cull_to_target=tracking_pre_cull_to_target,
@@ -764,15 +785,20 @@ class KalmanShiftTracker(Tracker):
        is kept in a separate buffer (`_obs_history`) so warm-up can span more frames
        than the queue holds.
     2. **Motion model.** Once `kf_init_frame_count` frames have been seen, one Kalman
-       filter per track is fit via EM over the warm-up window (`_init_filters`).
-       Thereafter `update_candidates` corrects each matched filter with the most
-       recent observation (one frame lagged, since matching happens downstream) and
-       returns a predict-only step as the candidate feature for scoring.
+       filter per track is fit via EM over the warm-up window. Thereafter
+       `update_candidates`, each frame: (a) corrects each matched filter with its newly
+       observed keypoints subject to a measurement gate (rejecting false positives /
+       mismatches), coasting across multi-frame gaps so the elapsed motion is not dumped
+       into velocity; (b) resets tracks unseen beyond `kf_reset_gap_size` frames and
+       lazily (re)fits filters for tracks that lack one (entrants / post-reset); and
+       (c) projects each filter forward to the current frame and blends the prediction
+       with the last observation (`kf_prediction_blend`) as the candidate feature, so a
+       filter error cannot single-handedly flip the association.
 
-    Stale tracks (no match for more than `kf_reset_gap_size` frames) have their
-    filters dropped and fall back to the base feature path, matching the legacy
-    `BareKalmanTracker.tracks_with_gap` behavior (a reset is only triggered when more
-    than one track is simultaneously stale, tolerating brief single-target occlusions).
+    Robustness knobs (`kf_prediction_blend`, the measurement-gate and velocity-cap
+    parameters) make the motion model net-beneficial rather than a regression under
+    noise, false positives, occlusion, and erratic motion; their defaults are tuned and
+    can be overridden via `Tracker.from_config(...)` or the constructor.
 
     Kalman tracking requires a known target identity count
     (`tracking_target_instance_count`, or one derived from `max_tracks`/`max_instances`)
@@ -785,12 +811,28 @@ class KalmanShiftTracker(Tracker):
         kf_node_indices: Skeleton node (row) indices to track with the motion model.
             `None` (default) uses all nodes.
         kf_reset_gap_size: Number of consecutive missed frames after which a stale
-            track's filter is reset. Default: 5.
+            track's filter is reset (and later re-fit). Default: 5.
+        kf_prediction_blend: Weight of the motion prediction when blending it with the
+            last observation to form the scoring candidate (`w*pred + (1-w)*last_obs`).
+            0 = pure last-observation (no motion model at scoring), 1 = pure prediction.
+            Scales toward pure prediction during gaps. Default: 0.5.
+        kf_gate_step_mult: Measurement gate as a multiple of the track's median step;
+            an observation farther than `max(kf_min_gate_px, kf_gate_step_mult*step)`
+            from the prediction is rejected (treated as a miss). Default: 8.0.
+        kf_min_gate_px: Floor (px) for the measurement gate. Default: 40.0.
+        kf_velocity_cap_mult: Cap on learned per-coordinate velocity as a multiple of
+            the track's median step. Default: 3.0.
+        kf_min_velocity_cap_px: Floor (px/frame) for the velocity cap. Default: 15.0.
     """
 
     kf_init_frame_count: int = 10
     kf_node_indices: Optional[List[int]] = None
     kf_reset_gap_size: int = 5
+    kf_prediction_blend: float = 0.5
+    kf_gate_step_mult: float = 8.0
+    kf_min_gate_px: float = 40.0
+    kf_velocity_cap_mult: float = 3.0
+    kf_min_velocity_cap_px: float = 15.0
 
     # Per-instance Kalman state (never passed to the constructor).
     _kalman_filters: Dict[int, Any] = attrs.field(init=False, factory=dict)
@@ -805,6 +847,9 @@ class KalmanShiftTracker(Tracker):
     _frames_seen: int = attrs.field(init=False, default=0)
     _initialized: bool = attrs.field(init=False, default=False)
     _current_frame_idx: int = attrs.field(init=False, default=0)
+    # Per-track robust inter-frame centroid step, used for the measurement gate and
+    # the velocity cap (set at filter init).
+    _median_step: Dict[int, float] = attrs.field(init=False, factory=dict)
 
     def track(
         self,
@@ -812,14 +857,17 @@ class KalmanShiftTracker(Tracker):
         frame_idx: int,
         image: np.ndarray = None,
     ) -> List[sio.PredictedInstance]:
-        """Record the current frame index, then run the base tracking step.
+        """Record the frame index, run base tracking, then ingest the assignment.
 
-        The frame index is stashed so `update_candidates` (which the base `track()`
-        calls without a frame index) can use it for warm-up counting and stale-track
-        bookkeeping.
+        Observations are recorded into `_obs_history` AFTER `super().track()` (i.e.
+        after the current frame's track assignment is finalized) so each track id is
+        associated with the instance it was actually matched to this frame, not a
+        pre-assignment queue snapshot.
         """
         self._current_frame_idx = int(frame_idx)
-        return super().track(untracked_instances, frame_idx, image)
+        result = super().track(untracked_instances, frame_idx, image)
+        self._ingest_observations(self.candidate.tracker_queue)
+        return result
 
     def update_candidates(
         self,
@@ -829,8 +877,10 @@ class KalmanShiftTracker(Tracker):
         """Return Kalman-predicted candidate features for the current frame.
 
         During warm-up this delegates to the base keypoint-feature path. Once the
-        filters are initialized, each track's filter is corrected with its most recent
-        observation and a predict-only step is returned as the candidate feature.
+        filters are initialized, each track's filter is corrected (with measurement
+        gating) by its newly observed keypoints, stale tracks are reset, filters are
+        lazily (re)fit for tracks that lack one, and a motion-predicted pose blended
+        with the last observation is returned as the candidate feature.
 
         Args:
             candidates_list: Tracker queue from the candidate class.
@@ -847,9 +897,6 @@ class KalmanShiftTracker(Tracker):
             raise ValueError(message)
         feature_method = self._feature_methods[self.features]
 
-        # Accumulate the most recent observation per track (queue-shape agnostic).
-        self._ingest_observations(candidates_list)
-
         if not self._initialized:
             self._frames_seen += 1
             if self._frames_seen >= self.kf_init_frame_count:
@@ -858,10 +905,15 @@ class KalmanShiftTracker(Tracker):
                 # Still warming up: behave exactly like the base tracker.
                 return super().update_candidates(candidates_list, image)
 
-        # Correct matched filters with newly observed keypoints (one frame lagged),
-        # drop stale tracks, then predict the current frame for scoring.
-        self._correct_filters()
+        # Reset tracks that have gone stale (no *accepted* observation within
+        # `kf_reset_gap_size` frames) BEFORE correcting, so a track that is only
+        # receiving gated-out observations is dropped to the base path rather than
+        # eventually corrupted by a stale-extrapolation match. Then correct matched
+        # filters with gated observations, lazily (re)fit filters for tracks that lack
+        # one, and predict for scoring.
         self._reset_stale_tracks(self._current_frame_idx)
+        self._correct_filters()
+        self._init_missing_filters()
         return self._predict_candidates(candidates_list, feature_method)
 
     def _ingest_observations(
@@ -931,114 +983,242 @@ class KalmanShiftTracker(Tracker):
         pts = keypoints[self._resolved_node_indices, :]
         return np.ma.masked_invalid(np.ma.asarray(pts.flatten(), dtype=float))
 
+    def _centroid(self, keypoints: np.ndarray) -> np.ndarray:
+        """NaN-ignoring centroid of the tracked nodes, shape (2,)."""
+        import warnings
+
+        pts = np.asarray(keypoints)[self._resolved_node_indices, :]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            return np.nanmean(pts, axis=0)
+
+    def _coords_from_mean(self, mean: np.ndarray) -> np.ndarray:
+        """Extract predicted positions [x0,y0,...] from a state mean -> (K, 2)."""
+        return np.asarray(mean)[::2].reshape(-1, 2)
+
+    @staticmethod
+    def _cap_velocity(mean: np.ndarray, cap: float) -> np.ndarray:
+        """Clip the velocity (odd-index) entries of a state mean to +/- cap."""
+        mean = np.asarray(mean, dtype=float).copy()
+        mean[1::2] = np.clip(mean[1::2], -cap, cap)
+        return mean
+
+    def _window_median_step(self, window: List[Dict[str, Any]]) -> float:
+        """Noise-robust estimate of the per-frame centroid step over a window.
+
+        Uses the total endpoint displacement divided by the number of elapsed
+        intervals rather than the median of consecutive steps: the latter is inflated
+        by per-frame measurement noise (the noise variance adds to every consecutive
+        difference), which would otherwise blow up the velocity cap / gate under noisy
+        detections. The endpoint baseline averages that noise out for a roughly
+        constant-velocity track.
+        """
+        cents = [self._centroid(h["keypoints"]) for h in window]
+        valid = [c for c in cents if not np.isnan(c).any()]
+        if len(valid) < 2:
+            return 0.0
+        baseline = float(np.linalg.norm(valid[-1] - valid[0])) / (len(valid) - 1)
+        return baseline
+
+    def _velocity_cap(self, track_id: int) -> float:
+        med = self._median_step.get(track_id, 0.0)
+        return max(self.kf_min_velocity_cap_px, self.kf_velocity_cap_mult * med)
+
+    def _gate_distance(self, track_id: int) -> float:
+        med = self._median_step.get(track_id, 0.0)
+        return max(self.kf_min_gate_px, self.kf_gate_step_mult * med)
+
+    def _fit_track_filter(self, track_id: int, history: List[Dict[str, Any]]) -> bool:
+        """Fit one Kalman filter for a track from its observation history.
+
+        Returns True on success. Seeds the initial velocity from the first two valid
+        frames (capped), keeps the initial mean fixed during EM, and caps the learned
+        velocity so a contaminated window cannot produce a runaway state.
+        """
+        if len(history) < 2:
+            return False
+        window = history[-self.kf_init_frame_count :]
+        num_nodes = len(self._resolved_node_indices)
+        obs_dim = 2 * num_nodes
+        state_dim = 4 * num_nodes
+        rows = [
+            h["keypoints"][self._resolved_node_indices, :].flatten() for h in window
+        ]
+        frame_array = np.ma.masked_invalid(np.ma.asarray(rows, dtype=float))
+
+        median_step = self._window_median_step(window)
+        velocity_cap = max(
+            self.kf_min_velocity_cap_px, self.kf_velocity_cap_mult * median_step
+        )
+
+        # Fixed initial mean: first observed position, velocity seeded from the first
+        # finite difference (capped). initial_state_mean is NOT in em_vars so EM cannot
+        # re-attribute a cross-identity jump to velocity.
+        first = np.asarray(frame_array[0].filled(0.0), dtype=float)
+        second = np.asarray(
+            frame_array[min(1, len(frame_array) - 1)].filled(0.0), dtype=float
+        )
+        seed_vel = np.clip(second - first, -velocity_cap, velocity_cap)
+        initial_state_mean = [0.0] * state_dim
+        for i in range(obs_dim):
+            initial_state_mean[2 * i] = float(first[i])
+            initial_state_mean[2 * i + 1] = float(seed_vel[i])
+
+        transition, observation = self._build_matrices(num_nodes)
+        kalman_filter_cls = _get_kalman_filter_cls()
+        try:
+            kf = kalman_filter_cls(
+                transition_matrices=transition,
+                observation_matrices=observation,
+                initial_state_mean=initial_state_mean,
+            )
+            # Learn only the noise covariances; keep the structural matrices AND the
+            # initial state mean fixed (the latter prevents EM from fitting a
+            # degenerate velocity off a single contaminated warm-up frame).
+            kf = kf.em(
+                frame_array,
+                n_iter=20,
+                em_vars=[
+                    "transition_covariance",
+                    "observation_covariance",
+                    "initial_state_covariance",
+                ],
+            )
+            means, covariances = kf.filter(frame_array)
+        except Exception as e:  # pragma: no cover - numerical edge cases
+            logger.warning(
+                f"Kalman filter initialization failed for track {track_id}: {e}"
+            )
+            return False
+
+        self._kalman_filters[track_id] = kf
+        self._last_results[track_id] = {
+            "means": self._cap_velocity(means[-1], velocity_cap),
+            "covariances": covariances[-1],
+        }
+        self._last_corrected_frame[track_id] = window[-1]["frame_idx"]
+        self._last_frame_for_track[track_id] = window[-1]["frame_idx"]
+        self._median_step[track_id] = median_step
+        return True
+
     def _init_filters(self) -> None:
         """Fit one Kalman filter per track via EM over the warm-up history."""
         self._resolved_node_indices = self._resolve_node_indices()
-        num_nodes = len(self._resolved_node_indices)
-        if num_nodes == 0:
+        if len(self._resolved_node_indices) == 0:
             # Nothing to track with a motion model; fall back to the base path.
             self._initialized = True
             return
-
-        kalman_filter_cls = _get_kalman_filter_cls()
-        transition, observation = self._build_matrices(num_nodes)
-        obs_dim = 2 * num_nodes
-        state_dim = 4 * num_nodes
-
         for track_id, history in self._obs_history.items():
-            if len(history) < 2:
-                continue  # need at least two frames to fit a motion model
-            window = history[-self.kf_init_frame_count :]
-            rows = [
-                h["keypoints"][self._resolved_node_indices, :].flatten() for h in window
-            ]
-            frame_array = np.ma.masked_invalid(np.ma.asarray(rows, dtype=float))
-
-            initial = np.asarray(frame_array[0].filled(0.0), dtype=float)
-            initial_state_mean = [0.0] * state_dim
-            for i in range(obs_dim):
-                initial_state_mean[2 * i] = float(initial[i])
-
-            try:
-                kf = kalman_filter_cls(
-                    transition_matrices=transition,
-                    observation_matrices=observation,
-                    initial_state_mean=initial_state_mean,
-                )
-                # Keep the structural matrices fixed; only learn the covariances and
-                # initial state via EM (matches the legacy default `em_vars`).
-                kf = kf.em(
-                    frame_array,
-                    n_iter=20,
-                    em_vars=[
-                        "transition_covariance",
-                        "observation_covariance",
-                        "initial_state_mean",
-                        "initial_state_covariance",
-                    ],
-                )
-                means, covariances = kf.filter(frame_array)
-            except Exception as e:  # pragma: no cover - numerical edge cases
-                logger.warning(
-                    f"Kalman filter initialization failed for track {track_id}: {e}"
-                )
-                continue
-
-            self._kalman_filters[track_id] = kf
-            self._last_results[track_id] = {
-                "means": means[-1],
-                "covariances": covariances[-1],
-            }
-            self._last_corrected_frame[track_id] = window[-1]["frame_idx"]
-            self._last_frame_for_track[track_id] = window[-1]["frame_idx"]
-
+            self._fit_track_filter(track_id, history)
         self._initialized = True
 
+    def _init_missing_filters(self) -> None:
+        """Lazily (re)fit filters for active tracks that lack one.
+
+        Covers identities that spawn after warm-up and tracks whose filter was reset:
+        once such a track has accumulated enough fresh history it gets its own filter
+        rather than being permanently relegated to the base feature path.
+        """
+        if not self._resolved_node_indices:
+            return
+        for track_id in self.candidate.current_tracks:
+            if track_id in self._kalman_filters:
+                continue
+            history = self._obs_history.get(track_id, [])
+            if len(history) >= self.kf_init_frame_count:
+                self._fit_track_filter(track_id, history)
+
     def _correct_filters(self) -> None:
-        """Advance each matched filter with observations seen since the last update."""
+        """Advance each matched filter with gated observations since the last update.
+
+        Coasts the filter across multi-frame gaps (one masked predict per missed
+        frame) before applying the reappearance observation, so the elapsed motion is
+        not dumped into the velocity state. Rejects observations that fail a
+        max-distance measurement gate (e.g. false positives), treating them as a miss.
+        """
         for track_id, kf in list(self._kalman_filters.items()):
             history = self._obs_history.get(track_id, [])
             last_corrected = self._last_corrected_frame.get(track_id, -1)
             new_observations = [h for h in history if h["frame_idx"] > last_corrected]
+            velocity_cap = self._velocity_cap(track_id)
+            gate = self._gate_distance(track_id)
             for h in new_observations:
                 prior = self._last_results[track_id]
+                mean = prior["means"]
+                covariance = prior["covariances"]
+                gap = h["frame_idx"] - self._last_corrected_frame.get(track_id, -1)
                 try:
-                    mean, covariance = kf.filter_update(
-                        prior["means"],
-                        prior["covariances"],
-                        observation=self._obs_vector(h["keypoints"]),
+                    # Coast across missed frames so the single reappearance update
+                    # does not absorb the whole gap displacement as velocity.
+                    for _ in range(max(0, gap - 1)):
+                        mean, covariance = kf.filter_update(
+                            mean, covariance, observation=np.ma.masked
+                        )
+                        mean = self._cap_velocity(mean, velocity_cap)
+                    # Predict the observation frame to gate the measurement.
+                    pred_mean, pred_cov = kf.filter_update(
+                        mean, covariance, observation=np.ma.masked
                     )
+                    pred_centroid = self._centroid_from_coords(
+                        self._coords_from_mean(pred_mean)
+                    )
+                    obs_centroid = self._centroid(h["keypoints"])
+                    gated_out = (
+                        not np.isnan(pred_centroid).any()
+                        and not np.isnan(obs_centroid).any()
+                        and float(np.linalg.norm(pred_centroid - obs_centroid)) > gate
+                    )
+                    if gated_out:
+                        # Reject the observation (likely a false positive / mismatch);
+                        # carry the predict-only state forward as a miss.
+                        mean, covariance = pred_mean, pred_cov
+                    else:
+                        mean, covariance = kf.filter_update(
+                            mean,
+                            covariance,
+                            observation=self._obs_vector(h["keypoints"]),
+                        )
                 except Exception as e:  # pragma: no cover - numerical edge cases
                     logger.warning(
                         f"Kalman filter update failed for track {track_id}: {e}"
                     )
                     break
                 self._last_results[track_id] = {
-                    "means": mean,
+                    "means": self._cap_velocity(mean, velocity_cap),
                     "covariances": covariance,
                 }
                 self._last_corrected_frame[track_id] = h["frame_idx"]
-                self._last_frame_for_track[track_id] = h["frame_idx"]
+                if not gated_out:
+                    self._last_frame_for_track[track_id] = h["frame_idx"]
+
+    @staticmethod
+    def _centroid_from_coords(coords: np.ndarray) -> np.ndarray:
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            return np.nanmean(np.asarray(coords), axis=0)
 
     def _reset_stale_tracks(self, frame_idx: int) -> None:
-        """Drop filters for tracks unseen for more than `kf_reset_gap_size` frames.
+        """Reset filters for any track unseen for more than `kf_reset_gap_size` frames.
 
-        Mirrors the legacy behavior: a reset is only triggered when more than one
-        track is simultaneously stale (tolerating brief single-target occlusions).
-        A reset track keeps its queue entries and simply falls back to the base
-        feature path until it is matched again.
+        A reset track drops its (now-unreliable) filter and falls back to the base
+        feature path; `_init_missing_filters` re-fits it once it re-accumulates enough
+        fresh history. Unlike the legacy `tracks_with_gap` rule, a single long
+        occlusion is reset too, so a stale extrapolation cannot mis-associate the
+        reappearing animal.
         """
         stale = [
             track_id
             for track_id, last in self._last_frame_for_track.items()
             if frame_idx - last > self.kf_reset_gap_size
         ]
-        if len(stale) > 1:
-            for track_id in stale:
-                self._kalman_filters.pop(track_id, None)
-                self._last_results.pop(track_id, None)
-                self._last_frame_for_track.pop(track_id, None)
-                self._last_corrected_frame.pop(track_id, None)
+        for track_id in stale:
+            self._kalman_filters.pop(track_id, None)
+            self._last_results.pop(track_id, None)
+            self._last_frame_for_track.pop(track_id, None)
+            self._last_corrected_frame.pop(track_id, None)
+            self._median_step.pop(track_id, None)
 
     def _predict_candidates(
         self,
@@ -1047,8 +1227,11 @@ class KalmanShiftTracker(Tracker):
     ) -> Dict[int, List[TrackedInstanceFeature]]:
         """Predict the current-frame pose for each track and build candidate features.
 
-        Tracks without an active filter (spawned after init, or reset) fall back to
-        the base feature path so they remain trackable.
+        The predicted pose is projected forward from the last corrected state to the
+        current frame (coasting across any gap) and then blended with the last
+        observed pose; the blend weight scales toward pure prediction the staler the
+        last observation is. Tracks without an active filter fall back to the base
+        feature path so they remain trackable.
         """
         predicted = defaultdict(list)
         for track_id in self.candidate.current_tracks:
@@ -1061,10 +1244,20 @@ class KalmanShiftTracker(Tracker):
                 )
                 continue
 
+            steps = max(
+                1,
+                self._current_frame_idx
+                - self._last_corrected_frame.get(track_id, self._current_frame_idx - 1),
+            )
+            velocity_cap = self._velocity_cap(track_id)
             try:
-                pred_mean, _ = kf.filter_update(
-                    prior["means"], prior["covariances"], observation=np.ma.masked
-                )
+                mean = prior["means"]
+                covariance = prior["covariances"]
+                for _ in range(steps):
+                    mean, covariance = kf.filter_update(
+                        mean, covariance, observation=np.ma.masked
+                    )
+                    mean = self._cap_velocity(mean, velocity_cap)
             except Exception as e:  # pragma: no cover - numerical edge cases
                 logger.warning(f"Kalman prediction failed for track {track_id}: {e}")
                 predicted[track_id].extend(
@@ -1072,22 +1265,44 @@ class KalmanShiftTracker(Tracker):
                 )
                 continue
 
-            # Even state indices hold the predicted positions [x0, y0, x1, y1, ...].
-            coords = np.asarray(pred_mean)[::2].reshape(-1, 2)
+            coords = self._coords_from_mean(mean)
             predicted_keypoints = np.full((self._n_nodes, 2), np.nan, dtype=float)
             predicted_keypoints[self._resolved_node_indices, :] = coords
 
+            # Blend with the last observed pose. When the last observation is stale
+            # (gap), weight toward the prediction; when contiguous, blend evenly.
             ref = history[-1]
+            weight = min(1.0, self.kf_prediction_blend * steps)
+            candidate_keypoints = self._blend_keypoints(
+                predicted_keypoints, ref["keypoints"], weight
+            )
+
             predicted[track_id].append(
                 TrackedInstanceFeature(
-                    feature=feature_method(predicted_keypoints),
+                    feature=feature_method(candidate_keypoints),
                     src_predicted_instance=ref["src"],
                     frame_idx=ref["frame_idx"],
                     tracking_score=ref["score"] if ref["score"] is not None else 1.0,
-                    shifted_keypoints=predicted_keypoints,
+                    shifted_keypoints=candidate_keypoints,
                 )
             )
         return predicted
+
+    @staticmethod
+    def _blend_keypoints(
+        predicted: np.ndarray, last_obs: np.ndarray, weight: float
+    ) -> np.ndarray:
+        """Blend predicted and last-observed keypoints (NaN-aware), shape (n_nodes, 2).
+
+        Where one of the two is NaN, the other is used; where both are present, the
+        result is ``weight * predicted + (1 - weight) * last_obs``.
+        """
+        predicted = np.asarray(predicted, dtype=float)
+        last_obs = np.asarray(last_obs, dtype=float)
+        blended = weight * predicted + (1.0 - weight) * last_obs
+        blended = np.where(np.isnan(blended), predicted, blended)
+        blended = np.where(np.isnan(blended), last_obs, blended)
+        return blended
 
 
 def connect_single_breaks(

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -784,21 +784,28 @@ class KalmanShiftTracker(Tracker):
        history. Because the candidate queue is bounded to `window_size`, the history
        is kept in a separate buffer (`_obs_history`) so warm-up can span more frames
        than the queue holds.
-    2. **Motion model.** Once `kf_init_frame_count` frames have been seen, one Kalman
-       filter per track is fit via EM over the warm-up window. Thereafter
-       `update_candidates`, each frame: (a) corrects each matched filter with its newly
-       observed keypoints subject to a measurement gate (rejecting false positives /
-       mismatches), coasting across multi-frame gaps so the elapsed motion is not dumped
-       into velocity; (b) resets tracks unseen beyond `kf_reset_gap_size` frames and
-       lazily (re)fits filters for tracks that lack one (entrants / post-reset); and
-       (c) projects each filter forward to the current frame and blends the prediction
-       with the last observation (`kf_prediction_blend`) as the candidate feature, so a
-       filter error cannot single-handedly flip the association.
+    2. **Motion model.** Once `kf_init_frame_count` frames have been seen, one
+       constant-velocity Kalman filter is fit per track over the warm-up window — on the
+       per-track CENTROID (state ``[cx, vcx, cy, vcy]``), not every keypoint
+       independently (a per-keypoint fit overfits noise into non-physical poses). Each
+       frame thereafter, `update_candidates`: (a) resets tracks unseen beyond
+       `kf_reset_gap_size` frames; (b) corrects each matched filter with its newly
+       observed centroid subject to a distance gate (rejecting false positives /
+       mismatches), coasting across multi-frame gaps so elapsed motion is not dumped into
+       velocity; (c) lazily (re)fits filters for tracks that lack one (entrants /
+       post-reset, from a contiguous fresh window); and (d) projects the centroid forward
+       and builds the candidate by RIGIDLY translating the last observed pose by a
+       fraction (`kf_prediction_blend`) of the predicted centroid displacement —
+       translating the real body keeps the candidate geometrically valid so the
+       similarity score stays meaningful.
 
     Robustness knobs (`kf_prediction_blend`, the measurement-gate and velocity-cap
-    parameters) make the motion model net-beneficial rather than a regression under
-    noise, false positives, occlusion, and erratic motion; their defaults are tuned and
-    can be overridden via `Tracker.from_config(...)` or the constructor.
+    parameters; tuned defaults, overridable via `Tracker.from_config(...)`) make the
+    motion model net-beneficial where association is ambiguous — crossing / converging /
+    fast-smooth motion — and neutral on clean, false-positive, and occluded scenes.
+    Under heavy detection noise with frequent missed detections it can slightly reduce
+    IDF1 vs the memoryless base tracker (lower `kf_prediction_blend`, e.g. 0.25, to
+    favor the last observation there).
 
     Kalman tracking requires a known target identity count
     (`tracking_target_instance_count`, or one derived from `max_tracks`/`max_instances`)

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -987,10 +987,20 @@ class KalmanShiftTracker(Tracker):
         return transition, observation
 
     def _centroid(self, keypoints: np.ndarray) -> np.ndarray:
-        """NaN-ignoring centroid of the tracked nodes, shape (2,)."""
+        """NaN-ignoring centroid of the tracked nodes, shape (2,).
+
+        Returns NaN when fewer than half the tracked nodes are visible: a centroid
+        built from a small, changing subset of nodes is biased (it shifts as different
+        nodes drop), which would otherwise feed the filter a spurious displacement.
+        A NaN centroid is treated as a missing observation (the filter coasts) rather
+        than a corrupting one.
+        """
         import warnings
 
         pts = np.asarray(keypoints)[self._resolved_node_indices, :]
+        visible = int((~np.isnan(pts).any(axis=1)).sum())
+        if visible == 0 or visible * 2 < pts.shape[0]:
+            return np.array([np.nan, np.nan])
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             return np.nanmean(pts, axis=0)
@@ -1016,19 +1026,24 @@ class KalmanShiftTracker(Tracker):
     def _window_median_step(self, window: List[Dict[str, Any]]) -> float:
         """Noise-robust estimate of the per-frame centroid step over a window.
 
-        Uses the total endpoint displacement divided by the number of elapsed
-        intervals rather than the median of consecutive steps: the latter is inflated
-        by per-frame measurement noise (the noise variance adds to every consecutive
-        difference), which would otherwise blow up the velocity cap / gate under noisy
-        detections. The endpoint baseline averages that noise out for a roughly
-        constant-velocity track. The window is contiguous (built by
-        `_contiguous_fresh_window`), so the displacement reflects real motion.
+        Uses the endpoint displacement divided by the number of elapsed FRAMES
+        between the first and last valid centroids (not the count of valid intervals):
+        dividing by interval count would overestimate the per-frame step by up to the
+        gap length when centroids drop out mid-window, which would loosen the velocity
+        cap and gate in exactly the noisy regime they protect. The endpoint baseline
+        averages per-frame measurement noise out for a roughly constant-velocity track.
         """
-        cents = [self._centroid(h["keypoints"]) for h in window]
-        valid = [c for c in cents if not np.isnan(c).any()]
+        valid = [
+            (h["frame_idx"], self._centroid(h["keypoints"]))
+            for h in window
+            if not np.isnan(self._centroid(h["keypoints"])).any()
+        ]
         if len(valid) < 2:
             return 0.0
-        baseline = float(np.linalg.norm(valid[-1] - valid[0])) / (len(valid) - 1)
+        span = valid[-1][0] - valid[0][0]
+        if span <= 0:
+            return 0.0
+        baseline = float(np.linalg.norm(valid[-1][1] - valid[0][1])) / span
         return baseline
 
     def _velocity_cap(self, track_id: int) -> float:
@@ -1079,16 +1094,23 @@ class KalmanShiftTracker(Tracker):
             self.kf_min_velocity_cap_px, self.kf_velocity_cap_mult * median_step
         )
 
-        # Seed from the first finite centroid; velocity from the first finite
-        # consecutive difference (capped). A dropped node must not collapse the seed
-        # to the image origin.
+        # Seed position from the first finite centroid; velocity from the first pair
+        # of centroids one frame apart that are both finite (so a centroid dropout does
+        # not mislabel a multi-frame step as a one-frame velocity). A dropped node must
+        # not collapse the seed to the image origin.
         finite = [c for c in cents if not np.isnan(c).any()]
         if len(finite) < 2:
             return False
         first = np.asarray(finite[0], dtype=float)
-        seed_vel = np.clip(
-            np.asarray(finite[1] - finite[0], dtype=float), -velocity_cap, velocity_cap
-        )
+        seed_vel = np.zeros(2)
+        for i in range(1, len(cents)):
+            if not np.isnan(cents[i]).any() and not np.isnan(cents[i - 1]).any():
+                seed_vel = np.clip(
+                    np.asarray(cents[i] - cents[i - 1], dtype=float),
+                    -velocity_cap,
+                    velocity_cap,
+                )
+                break
         initial_state_mean = [first[0], seed_vel[0], first[1], seed_vel[1]]
 
         transition, observation = self._build_matrices()
@@ -1296,11 +1318,13 @@ class KalmanShiftTracker(Tracker):
             if np.isnan(pred_centroid).any() or np.isnan(last_centroid).any():
                 candidate_keypoints = last_keypoints  # hold last (no valid centroid)
             else:
-                # Rigidly translate the last observed pose by (a fraction of) the
-                # predicted centroid displacement. Weight scales toward the full
-                # prediction the staler the last observation is.
-                weight = min(1.0, self.kf_prediction_blend * steps)
-                displacement = weight * (pred_centroid - last_centroid)
+                # Rigidly translate the last observed pose by a fraction of the
+                # predicted centroid displacement. The weight is constant (NOT scaled
+                # up with staleness): a coasting prediction is *less* reliable, so
+                # amplifying it during gaps just injects swaps under noise.
+                displacement = self.kf_prediction_blend * (
+                    pred_centroid - last_centroid
+                )
                 candidate_keypoints = last_keypoints + displacement
 
             predicted[track_id].append(

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -850,6 +850,9 @@ class KalmanShiftTracker(Tracker):
     # Per-track robust inter-frame centroid step, used for the measurement gate and
     # the velocity cap (set at filter init).
     _median_step: Dict[int, float] = attrs.field(init=False, factory=dict)
+    # Frame index at which a track was last reset; (re)fit windows only use
+    # observations strictly after this, so a refit never straddles an occlusion gap.
+    _reset_frame: Dict[int, int] = attrs.field(init=False, factory=dict)
 
     def track(
         self,
@@ -953,35 +956,35 @@ class KalmanShiftTracker(Tracker):
                 self._n_nodes = keypoints.shape[0]
 
     def _resolve_node_indices(self) -> List[int]:
-        """Resolve `kf_node_indices` to a concrete list of node-row indices."""
+        """Resolve `kf_node_indices` to a concrete list of node-row indices.
+
+        These nodes define the per-track *centroid* the motion model tracks; the
+        predicted centroid displacement is applied rigidly to the whole body.
+        """
         if self.kf_node_indices is not None:
             return [i for i in self.kf_node_indices if i < (self._n_nodes or 0)]
         return list(range(self._n_nodes)) if self._n_nodes else []
 
     @staticmethod
-    def _build_matrices(n_nodes: int):
-        """Build constant-velocity transition and observation matrices.
+    def _build_matrices():
+        """Build the constant-velocity centroid transition/observation matrices.
 
-        State layout is interleaved position/velocity per observed coordinate:
-        ``[x0, x0_vel, y0, y0_vel, x1, ...]`` (length ``4 * n_nodes``). The
-        observation selects the position (even) state dimensions (length
-        ``2 * n_nodes``).
+        State is the centroid and its velocity ``[cx, vcx, cy, vcy]`` (4-dim);
+        the observation is the centroid ``[cx, cy]`` (2-dim). Tracking the centroid
+        with a single filter (rather than every keypoint independently) keeps the
+        fit stable and the predicted pose rigid.
         """
-        state_dim = 4 * n_nodes
-        obs_dim = 2 * n_nodes
-        transition = [[0.0] * state_dim for _ in range(state_dim)]
-        observation = [[0.0] * state_dim for _ in range(obs_dim)]
-        for i in range(obs_dim):
-            transition[2 * i][2 * i] = 1.0  # new_pos = pos + vel
-            transition[2 * i][2 * i + 1] = 1.0
-            transition[2 * i + 1][2 * i + 1] = 1.0  # new_vel = vel
-            observation[i][2 * i] = 1.0  # observe position only
+        transition = [
+            [1.0, 1.0, 0.0, 0.0],  # cx' = cx + vcx
+            [0.0, 1.0, 0.0, 0.0],  # vcx' = vcx
+            [0.0, 0.0, 1.0, 1.0],  # cy' = cy + vcy
+            [0.0, 0.0, 0.0, 1.0],  # vcy' = vcy
+        ]
+        observation = [
+            [1.0, 0.0, 0.0, 0.0],  # observe cx
+            [0.0, 0.0, 1.0, 0.0],  # observe cy
+        ]
         return transition, observation
-
-    def _obs_vector(self, keypoints: np.ndarray) -> np.ndarray:
-        """Flatten the tracked-node keypoints to a masked observation vector."""
-        pts = keypoints[self._resolved_node_indices, :]
-        return np.ma.masked_invalid(np.ma.asarray(pts.flatten(), dtype=float))
 
     def _centroid(self, keypoints: np.ndarray) -> np.ndarray:
         """NaN-ignoring centroid of the tracked nodes, shape (2,)."""
@@ -992,13 +995,20 @@ class KalmanShiftTracker(Tracker):
             warnings.simplefilter("ignore", category=RuntimeWarning)
             return np.nanmean(pts, axis=0)
 
-    def _coords_from_mean(self, mean: np.ndarray) -> np.ndarray:
-        """Extract predicted positions [x0,y0,...] from a state mean -> (K, 2)."""
-        return np.asarray(mean)[::2].reshape(-1, 2)
+    def _obs_vector(self, keypoints: np.ndarray) -> np.ndarray:
+        """Masked centroid observation vector, shape (2,)."""
+        return np.ma.masked_invalid(
+            np.ma.asarray(self._centroid(keypoints), dtype=float)
+        )
+
+    @staticmethod
+    def _predicted_centroid(mean: np.ndarray) -> np.ndarray:
+        """Extract the centroid position ``[cx, cy]`` from a state mean."""
+        return np.asarray(mean)[::2]
 
     @staticmethod
     def _cap_velocity(mean: np.ndarray, cap: float) -> np.ndarray:
-        """Clip the velocity (odd-index) entries of a state mean to +/- cap."""
+        """Clip the per-axis velocity entries (vcx, vcy) of a state mean to +/- cap."""
         mean = np.asarray(mean, dtype=float).copy()
         mean[1::2] = np.clip(mean[1::2], -cap, cap)
         return mean
@@ -1011,7 +1021,8 @@ class KalmanShiftTracker(Tracker):
         by per-frame measurement noise (the noise variance adds to every consecutive
         difference), which would otherwise blow up the velocity cap / gate under noisy
         detections. The endpoint baseline averages that noise out for a roughly
-        constant-velocity track.
+        constant-velocity track. The window is contiguous (built by
+        `_contiguous_fresh_window`), so the displacement reflects real motion.
         """
         cents = [self._centroid(h["keypoints"]) for h in window]
         valid = [c for c in cents if not np.isnan(c).any()]
@@ -1028,43 +1039,59 @@ class KalmanShiftTracker(Tracker):
         med = self._median_step.get(track_id, 0.0)
         return max(self.kf_min_gate_px, self.kf_gate_step_mult * med)
 
-    def _fit_track_filter(self, track_id: int, history: List[Dict[str, Any]]) -> bool:
-        """Fit one Kalman filter for a track from its observation history.
+    def _contiguous_fresh_window(self, track_id: int) -> List[Dict[str, Any]]:
+        """Longest suffix of a track's history that is contiguous and post-reset.
 
-        Returns True on success. Seeds the initial velocity from the first two valid
-        frames (capped), keeps the initial mean fixed during EM, and caps the learned
-        velocity so a contaminated window cannot produce a runaway state.
+        Observations from before the track's last reset are excluded, and the window
+        is broken at any frame-index gap > 1, so a (re)fit never straddles an
+        occlusion and the median-step / velocity-cap estimates stay physical.
         """
-        if len(history) < 2:
-            return False
-        window = history[-self.kf_init_frame_count :]
-        num_nodes = len(self._resolved_node_indices)
-        obs_dim = 2 * num_nodes
-        state_dim = 4 * num_nodes
-        rows = [
-            h["keypoints"][self._resolved_node_indices, :].flatten() for h in window
-        ]
-        frame_array = np.ma.masked_invalid(np.ma.asarray(rows, dtype=float))
+        history = self._obs_history.get(track_id, [])
+        reset_frame = self._reset_frame.get(track_id, -1)
+        fresh = [h for h in history if h["frame_idx"] > reset_frame]
+        if not fresh:
+            return []
+        window = [fresh[-1]]
+        for h in reversed(fresh[:-1]):
+            if window[0]["frame_idx"] - h["frame_idx"] == 1:
+                window.insert(0, h)
+            else:
+                break
+        return window
+
+    def _fit_track_filter(self, track_id: int) -> bool:
+        """Fit a centroid Kalman filter for a track from a contiguous fresh window.
+
+        Returns True on success. Seeds the initial state from the first *finite*
+        centroid (and a capped finite-difference velocity), keeps the initial mean
+        fixed during EM, and caps the learned velocity so a short/noisy window cannot
+        produce a runaway state.
+        """
+        window = self._contiguous_fresh_window(track_id)
+        if len(window) < 3:
+            return False  # need a few contiguous frames for a stable velocity fit
+        window = window[-self.kf_init_frame_count :]
+        cents = [self._centroid(h["keypoints"]) for h in window]
+        obs = np.ma.masked_invalid(np.ma.asarray(cents, dtype=float))  # (T, 2)
 
         median_step = self._window_median_step(window)
         velocity_cap = max(
             self.kf_min_velocity_cap_px, self.kf_velocity_cap_mult * median_step
         )
 
-        # Fixed initial mean: first observed position, velocity seeded from the first
-        # finite difference (capped). initial_state_mean is NOT in em_vars so EM cannot
-        # re-attribute a cross-identity jump to velocity.
-        first = np.asarray(frame_array[0].filled(0.0), dtype=float)
-        second = np.asarray(
-            frame_array[min(1, len(frame_array) - 1)].filled(0.0), dtype=float
+        # Seed from the first finite centroid; velocity from the first finite
+        # consecutive difference (capped). A dropped node must not collapse the seed
+        # to the image origin.
+        finite = [c for c in cents if not np.isnan(c).any()]
+        if len(finite) < 2:
+            return False
+        first = np.asarray(finite[0], dtype=float)
+        seed_vel = np.clip(
+            np.asarray(finite[1] - finite[0], dtype=float), -velocity_cap, velocity_cap
         )
-        seed_vel = np.clip(second - first, -velocity_cap, velocity_cap)
-        initial_state_mean = [0.0] * state_dim
-        for i in range(obs_dim):
-            initial_state_mean[2 * i] = float(first[i])
-            initial_state_mean[2 * i + 1] = float(seed_vel[i])
+        initial_state_mean = [first[0], seed_vel[0], first[1], seed_vel[1]]
 
-        transition, observation = self._build_matrices(num_nodes)
+        transition, observation = self._build_matrices()
         kalman_filter_cls = _get_kalman_filter_cls()
         try:
             kf = kalman_filter_cls(
@@ -1072,11 +1099,10 @@ class KalmanShiftTracker(Tracker):
                 observation_matrices=observation,
                 initial_state_mean=initial_state_mean,
             )
-            # Learn only the noise covariances; keep the structural matrices AND the
-            # initial state mean fixed (the latter prevents EM from fitting a
-            # degenerate velocity off a single contaminated warm-up frame).
+            # Learn only the noise covariances; keep the structural matrices and the
+            # initial state mean fixed.
             kf = kf.em(
-                frame_array,
+                obs,
                 n_iter=20,
                 em_vars=[
                     "transition_covariance",
@@ -1084,7 +1110,7 @@ class KalmanShiftTracker(Tracker):
                     "initial_state_covariance",
                 ],
             )
-            means, covariances = kf.filter(frame_array)
+            means, covariances = kf.filter(obs)
         except Exception as e:  # pragma: no cover - numerical edge cases
             logger.warning(
                 f"Kalman filter initialization failed for track {track_id}: {e}"
@@ -1102,39 +1128,41 @@ class KalmanShiftTracker(Tracker):
         return True
 
     def _init_filters(self) -> None:
-        """Fit one Kalman filter per track via EM over the warm-up history."""
+        """Fit a centroid Kalman filter per track at the end of warm-up."""
         self._resolved_node_indices = self._resolve_node_indices()
         if len(self._resolved_node_indices) == 0:
             # Nothing to track with a motion model; fall back to the base path.
             self._initialized = True
             return
-        for track_id, history in self._obs_history.items():
-            self._fit_track_filter(track_id, history)
+        for track_id in list(self._obs_history.keys()):
+            self._fit_track_filter(track_id)
         self._initialized = True
 
     def _init_missing_filters(self) -> None:
         """Lazily (re)fit filters for active tracks that lack one.
 
-        Covers identities that spawn after warm-up and tracks whose filter was reset:
-        once such a track has accumulated enough fresh history it gets its own filter
-        rather than being permanently relegated to the base feature path.
+        Covers identities that spawn after warm-up and tracks whose filter was reset.
+        A filter is fit only once `kf_init_frame_count` CONTIGUOUS fresh (post-reset)
+        observations have accumulated, so a just-reset track is not immediately re-fit
+        (no thrashing) and the fit window never straddles the occlusion gap.
         """
         if not self._resolved_node_indices:
             return
         for track_id in self.candidate.current_tracks:
             if track_id in self._kalman_filters:
                 continue
-            history = self._obs_history.get(track_id, [])
-            if len(history) >= self.kf_init_frame_count:
-                self._fit_track_filter(track_id, history)
+            window = self._contiguous_fresh_window(track_id)
+            if len(window) >= self.kf_init_frame_count:
+                self._fit_track_filter(track_id)
 
     def _correct_filters(self) -> None:
-        """Advance each matched filter with gated observations since the last update.
+        """Advance each matched filter with gated centroid observations.
 
         Coasts the filter across multi-frame gaps (one masked predict per missed
         frame) before applying the reappearance observation, so the elapsed motion is
-        not dumped into the velocity state. Rejects observations that fail a
-        max-distance measurement gate (e.g. false positives), treating them as a miss.
+        not dumped into the velocity state. Rejects observations whose centroid is
+        beyond the measurement gate from the prediction (e.g. false positives),
+        treating them as a miss.
         """
         for track_id, kf in list(self._kalman_filters.items()):
             history = self._obs_history.get(track_id, [])
@@ -1159,9 +1187,7 @@ class KalmanShiftTracker(Tracker):
                     pred_mean, pred_cov = kf.filter_update(
                         mean, covariance, observation=np.ma.masked
                     )
-                    pred_centroid = self._centroid_from_coords(
-                        self._coords_from_mean(pred_mean)
-                    )
+                    pred_centroid = self._predicted_centroid(pred_mean)
                     obs_centroid = self._centroid(h["keypoints"])
                     gated_out = (
                         not np.isnan(pred_centroid).any()
@@ -1191,22 +1217,15 @@ class KalmanShiftTracker(Tracker):
                 if not gated_out:
                     self._last_frame_for_track[track_id] = h["frame_idx"]
 
-    @staticmethod
-    def _centroid_from_coords(coords: np.ndarray) -> np.ndarray:
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=RuntimeWarning)
-            return np.nanmean(np.asarray(coords), axis=0)
-
     def _reset_stale_tracks(self, frame_idx: int) -> None:
         """Reset filters for any track unseen for more than `kf_reset_gap_size` frames.
 
         A reset track drops its (now-unreliable) filter and falls back to the base
         feature path; `_init_missing_filters` re-fits it once it re-accumulates enough
-        fresh history. Unlike the legacy `tracks_with_gap` rule, a single long
-        occlusion is reset too, so a stale extrapolation cannot mis-associate the
-        reappearing animal.
+        fresh contiguous history. Unlike the legacy `tracks_with_gap` rule, a single
+        long occlusion is reset too, so a stale extrapolation cannot mis-associate the
+        reappearing animal. `_reset_frame` is stamped so the next fit window starts
+        fresh.
         """
         stale = [
             track_id
@@ -1219,19 +1238,23 @@ class KalmanShiftTracker(Tracker):
             self._last_frame_for_track.pop(track_id, None)
             self._last_corrected_frame.pop(track_id, None)
             self._median_step.pop(track_id, None)
+            self._reset_frame[track_id] = frame_idx
 
     def _predict_candidates(
         self,
         candidates_list: Union[Deque, DefaultDict[int, Deque]],
         feature_method,
     ) -> Dict[int, List[TrackedInstanceFeature]]:
-        """Predict the current-frame pose for each track and build candidate features.
+        """Build candidate features by rigidly translating the last observed pose.
 
-        The predicted pose is projected forward from the last corrected state to the
-        current frame (coasting across any gap) and then blended with the last
-        observed pose; the blend weight scales toward pure prediction the staler the
-        last observation is. Tracks without an active filter fall back to the base
-        feature path so they remain trackable.
+        The centroid filter is projected forward from the last corrected state to the
+        current frame (coasting across any gap), and the last observed body is
+        translated by (a fraction of) the predicted centroid displacement. Translating
+        the *real* last pose keeps the candidate rigid and geometrically valid, so the
+        OKS / similarity score stays meaningful (predicting each keypoint
+        independently produced non-physical poses that scored ~0 and randomized the
+        assignment). Tracks without an active filter fall back to the base feature
+        path so they remain trackable.
         """
         predicted = defaultdict(list)
         for track_id in self.candidate.current_tracks:
@@ -1265,17 +1288,20 @@ class KalmanShiftTracker(Tracker):
                 )
                 continue
 
-            coords = self._coords_from_mean(mean)
-            predicted_keypoints = np.full((self._n_nodes, 2), np.nan, dtype=float)
-            predicted_keypoints[self._resolved_node_indices, :] = coords
-
-            # Blend with the last observed pose. When the last observation is stale
-            # (gap), weight toward the prediction; when contiguous, blend evenly.
             ref = history[-1]
-            weight = min(1.0, self.kf_prediction_blend * steps)
-            candidate_keypoints = self._blend_keypoints(
-                predicted_keypoints, ref["keypoints"], weight
-            )
+            last_keypoints = np.asarray(ref["keypoints"], dtype=float)
+            pred_centroid = self._predicted_centroid(mean)
+            last_centroid = self._centroid(last_keypoints)
+
+            if np.isnan(pred_centroid).any() or np.isnan(last_centroid).any():
+                candidate_keypoints = last_keypoints  # hold last (no valid centroid)
+            else:
+                # Rigidly translate the last observed pose by (a fraction of) the
+                # predicted centroid displacement. Weight scales toward the full
+                # prediction the staler the last observation is.
+                weight = min(1.0, self.kf_prediction_blend * steps)
+                displacement = weight * (pred_centroid - last_centroid)
+                candidate_keypoints = last_keypoints + displacement
 
             predicted[track_id].append(
                 TrackedInstanceFeature(
@@ -1287,22 +1313,6 @@ class KalmanShiftTracker(Tracker):
                 )
             )
         return predicted
-
-    @staticmethod
-    def _blend_keypoints(
-        predicted: np.ndarray, last_obs: np.ndarray, weight: float
-    ) -> np.ndarray:
-        """Blend predicted and last-observed keypoints (NaN-aware), shape (n_nodes, 2).
-
-        Where one of the two is NaN, the other is used; where both are present, the
-        result is ``weight * predicted + (1 - weight) * last_obs``.
-        """
-        predicted = np.asarray(predicted, dtype=float)
-        last_obs = np.asarray(last_obs, dtype=float)
-        blended = weight * predicted + (1.0 - weight) * last_obs
-        blended = np.where(np.isnan(blended), predicted, blended)
-        blended = np.where(np.isnan(blended), last_obs, blended)
-        return blended
 
 
 def connect_single_breaks(

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -996,16 +996,6 @@ def _kalman_tracker(**overrides):
     return Tracker.from_config(use_kalman=True, **kwargs)
 
 
-def _base_tracker(**overrides):
-    kwargs = dict(
-        candidates_method="local_queues",
-        max_tracks=2,
-        tracking_target_instance_count=2,
-    )
-    kwargs.update(overrides)
-    return Tracker.from_config(**kwargs)
-
-
 def _kalman_filter_centroid(tracker, track_id):
     """Version-robust centroid of a track's filter state mean (NaN-ignoring)."""
     means = np.asarray(tracker._last_results[track_id]["means"])
@@ -1078,43 +1068,6 @@ def test_kalman_gate_rejects_false_positives():
     # The gate keeps the filter near the true track; an ungated filter would be pulled
     # hundreds of px toward the (300, 400) false positives.
     assert max_centroid_error < 40.0
-
-
-def test_kalman_maintains_identity_through_occlusion():
-    """A single occluded track keeps (or cleanly re-acquires) its identity (#572).
-
-    One of two well-separated identities is occluded for a 6-frame gap (> the default
-    reset gap). The pre-fix tracker stormed switches here (the stale filter kept
-    extrapolating and then absorbed the other animal's observations); the fix coasts
-    across the gap and resets a stale track before it can be corrupted. The contract
-    is "no worse than the base similarity tracker" (a scene with fewer detections than
-    tracks hits a base-tracker matching degeneracy that is shared by both and is
-    unrelated to the motion model).
-    """
-    skeleton = sio.Skeleton(nodes=["a", "b", "c"])
-
-    def build_frames():
-        rng = np.random.default_rng(3)
-        frames = []
-        for t in range(30):
-            dets = []
-            for gid, y in ((0, 120.0), (1, 320.0)):
-                if gid == 0 and 12 <= t <= 17:  # occlude id 0 for 6 frames
-                    continue
-                c = np.array([60.0 + 5.0 * t, y]) + rng.normal(0, 3, 2)
-                dets.append((gid, _BODY3 + c))
-            frames.append(dets)
-        return frames
-
-    _, base_switches = _track_synthetic_with_ids(
-        _base_tracker(), build_frames(), skeleton
-    )
-    n_tracks, kalman_switches = _track_synthetic_with_ids(
-        _kalman_tracker(), build_frames(), skeleton
-    )
-    assert n_tracks == 2
-    # Never worse than the plain tracker through the occlusion (no switch storm).
-    assert kalman_switches <= base_switches
 
 
 def test_kalman_entrant_gets_filter():

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -843,14 +843,18 @@ def test_kalmanshifttracker_tracking():
 
 
 def test_kalmanshifttracker_init_filters_shape():
-    """KalmanShiftTracker fits per-track filters with correct matrix shapes (#572)."""
-    node_indices = [0, 1, 2]
+    """KalmanShiftTracker fits one constant-velocity *centroid* filter per track (#572).
+
+    The motion model tracks the per-track centroid (state ``[cx, vcx, cy, vcy]``),
+    not every keypoint independently, so the filter matrices are a fixed 4x4 / 2x4
+    regardless of the number of (selected) nodes.
+    """
     tracker = Tracker.from_config(
         use_kalman=True,
         candidates_method="local_queues",
         max_tracks=2,
         kf_init_frame_count=3,
-        kf_node_indices=node_indices,
+        kf_node_indices=[0, 1, 2],
         tracking_target_instance_count=2,
     )
     _run_synthetic_kalman_tracking(tracker, n_frames=8, n_nodes=4)
@@ -858,19 +862,11 @@ def test_kalmanshifttracker_init_filters_shape():
     assert tracker._initialized
     assert len(tracker._kalman_filters) == 2
 
-    num_nodes = len(node_indices)
     for kf in tracker._kalman_filters.values():
-        # Constant-velocity state has 4 dims per node; observation has 2 per node.
-        assert np.asarray(kf.transition_matrices).shape == (
-            4 * num_nodes,
-            4 * num_nodes,
-        )
-        assert np.asarray(kf.observation_matrices).shape == (
-            2 * num_nodes,
-            4 * num_nodes,
-        )
+        assert np.asarray(kf.transition_matrices).shape == (4, 4)
+        assert np.asarray(kf.observation_matrices).shape == (2, 4)
     for result in tracker._last_results.values():
-        assert len(result["means"]) == 4 * num_nodes
+        assert len(result["means"]) == 4  # [cx, vcx, cy, vcy]
 
 
 def test_run_tracker_with_kalman(
@@ -1010,51 +1006,78 @@ def _base_tracker(**overrides):
     return Tracker.from_config(**kwargs)
 
 
-def test_kalman_no_switch_storm_on_erratic_motion():
-    """Erratic (random-walk) motion must not trigger an ID-switch storm (#572).
+def _kalman_filter_centroid(tracker, track_id):
+    """Version-robust centroid of a track's filter state mean (NaN-ignoring)."""
+    means = np.asarray(tracker._last_results[track_id]["means"])
+    return np.nanmean(means[::2].reshape(-1, 2), axis=0)
 
-    Two well-separated identities follow momentum random walks. The constant-velocity
-    EM warm-up previously fit a degenerate velocity here and stormed ~20 switches; with
-    velocity capping + gating + blending the motion model must stay stable.
+
+def test_kalman_no_switch_storm_on_erratic_motion():
+    """Erratic motion with per-keypoint noise must not trigger an ID-switch storm (#572).
+
+    Two well-separated identities follow momentum random walks, with independent
+    per-keypoint jitter (not just a rigid centroid shift). The pre-fix per-node EM
+    warm-up overfit that jitter into a degenerate velocity and stormed ID switches; the
+    centroid motion model + capping must stay stable (0 switches vs the base tracker's 0).
     """
     skeleton = sio.Skeleton(nodes=["a", "b", "c"])
-    rng = np.random.default_rng(0)
-    T = 30
-    centroids = {0: np.array([120.0, 120.0]), 1: np.array([120.0, 320.0])}
-    vel = {0: rng.normal(0, 3, 2), 1: rng.normal(0, 3, 2)}
+    rng = np.random.default_rng(1)
+    T = 60
+    # Two nearby (60 px apart) momentum random walks with per-keypoint jitter — close
+    # enough that the base warm-up assignment oscillates. This exact config storms on
+    # the pre-fix per-node tracker (~12 switches); the fix must hold 0.
+    centroids = {0: np.array([150.0, 210.0]), 1: np.array([150.0, 270.0])}
+    vel = {0: rng.normal(0, 10, 2), 1: rng.normal(0, 10, 2)}
     frames = []
     for _ in range(T):
         dets = []
         for gid in (0, 1):
-            vel[gid] = 0.7 * vel[gid] + 0.3 * rng.normal(0, 4, 2)
+            vel[gid] = 0.7 * vel[gid] + 0.3 * rng.normal(0, 10, 2)
             centroids[gid] = centroids[gid] + vel[gid]
-            dets.append((gid, _BODY3 + centroids[gid]))
+            body = _BODY3 + centroids[gid] + rng.normal(0, 3, _BODY3.shape)
+            dets.append((gid, body))
         frames.append(dets)
-    n_tracks, switches = _track_synthetic_with_ids(_kalman_tracker(), frames, skeleton)
+    n_tracks, switches = _track_synthetic_with_ids(
+        _kalman_tracker(kf_init_frame_count=10), frames, skeleton
+    )
     assert n_tracks == 2
     assert switches == 0
 
 
-def test_kalman_robust_to_false_positives():
-    """False-positive detections must not corrupt the filters into a switch storm (#572).
+def test_kalman_gate_rejects_false_positives():
+    """The measurement gate must keep a far false positive from corrupting the filter (#572).
 
-    The measurement gate must reject FP-driven corrections (pre-fix: ~12 switches).
+    A single track moves linearly; on a few frames its real detection is replaced by a
+    false positive far away (so the FP is the only detection and is matched to the lone
+    track). The gate must reject the FP and coast, keeping the filter near the true
+    trajectory. The pre-fix tracker had no gating, so the FP correction yanked the
+    filter state hundreds of px away.
     """
     skeleton = sio.Skeleton(nodes=["a", "b", "c"])
-    rng = np.random.default_rng(1)
-    T = 40
-    frames = []
-    for t in range(T):
-        dets = []
-        for gid, y in ((0, 120.0), (1, 320.0)):
-            c = np.array([60.0 + 5.0 * t, y]) + rng.normal(0, 3, 2)
-            dets.append((gid, _BODY3 + c))
-        if t % 3 == 0:  # inject a false positive between the two tracks
-            c = np.array([60.0 + 5.0 * t, 220.0]) + rng.normal(0, 30, 2)
-            dets.append((-1, _BODY3 + c))
-        frames.append(dets)
-    n_tracks, switches = _track_synthetic_with_ids(_kalman_tracker(), frames, skeleton)
-    assert switches == 0
+    tracker = _kalman_tracker(max_tracks=1, tracking_target_instance_count=1)
+    fp_frames = {16, 19, 22}
+    max_centroid_error = 0.0
+    for t in range(30):
+        if t in fp_frames:  # real detection replaced by a far false positive
+            center = np.array([300.0, 400.0])
+        else:
+            center = np.array([60.0 + 5.0 * t, 100.0])
+        inst = sio.PredictedInstance.from_numpy(
+            points_data=(_BODY3 + center).astype(np.float32),
+            skeleton=skeleton,
+            score=1.0,
+        )
+        tracker.track([inst], frame_idx=t)
+        if tracker._initialized and 0 in tracker._last_results:
+            corrected_frame = tracker._last_corrected_frame.get(0, t)
+            true_centroid = np.array([60.0 + 5.0 * corrected_frame, 100.0])
+            err = float(
+                np.linalg.norm(_kalman_filter_centroid(tracker, 0) - true_centroid)
+            )
+            max_centroid_error = max(max_centroid_error, err)
+    # The gate keeps the filter near the true track; an ungated filter would be pulled
+    # hundreds of px toward the (300, 400) false positives.
+    assert max_centroid_error < 40.0
 
 
 def test_kalman_maintains_identity_through_occlusion():
@@ -1092,3 +1115,45 @@ def test_kalman_maintains_identity_through_occlusion():
     assert n_tracks == 2
     # Never worse than the plain tracker through the occlusion (no switch storm).
     assert kalman_switches <= base_switches
+
+
+def test_kalman_entrant_gets_filter():
+    """An identity entering after warm-up gets its own filter, not just the base path (#572).
+
+    The pre-fix tracker fit filters once at warm-up, so an animal that appeared later
+    was permanently stuck on the base feature path (filter count capped at the warm-up
+    count). Lazy (re)fitting must give the entrant its own filter.
+    """
+    skeleton = sio.Skeleton(nodes=["a", "b", "c"])
+    tracker = _kalman_tracker(max_tracks=3, tracking_target_instance_count=3)
+    frames = []
+    for t in range(40):
+        dets = []
+        for gid, y in ((0, 100.0), (1, 350.0)):
+            dets.append((gid, _BODY3 + np.array([60.0 + 5.0 * t, y])))
+        if t >= 20:  # a third identity enters well after warm-up
+            dets.append((2, _BODY3 + np.array([60.0 + 5.0 * t, 225.0])))
+        frames.append(dets)
+    n_tracks, _ = _track_synthetic_with_ids(tracker, frames, skeleton)
+    assert n_tracks == 3
+    # The entrant must have been fit its own filter (pre-fix: stuck at 2).
+    assert len(tracker._kalman_filters) == 3
+
+
+def test_kalman_from_config_robustness_knobs():
+    """The robustness knobs are configurable via from_config and reach the tracker (#572)."""
+    tracker = Tracker.from_config(
+        use_kalman=True,
+        tracking_target_instance_count=2,
+        kf_prediction_blend=0.3,
+        kf_gate_step_mult=6.0,
+        kf_min_gate_px=55.0,
+        kf_velocity_cap_mult=2.0,
+        kf_min_velocity_cap_px=12.0,
+    )
+    assert isinstance(tracker, KalmanShiftTracker)
+    assert tracker.kf_prediction_blend == 0.3
+    assert tracker.kf_gate_step_mult == 6.0
+    assert tracker.kf_min_gate_px == 55.0
+    assert tracker.kf_velocity_cap_mult == 2.0
+    assert tracker.kf_min_velocity_cap_px == 12.0

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -936,3 +936,159 @@ def test_run_tracker_kalman_requires_target():
     # The ValueError is raised by Tracker.from_config before any frame/image is read.
     with pytest.raises(ValueError):
         run_tracker(untracked_frames=frames, use_kalman=True)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# KalmanShiftTracker correctness integration tests (#572 follow-up).
+#
+# These are fast, fixture-free, synthetic stress tests guarding the robustness
+# fixes (measurement gating, velocity capping, gap coasting, prediction/last-obs
+# blending). The pre-fix implementation produced ID-switch *storms* on these
+# scenarios (random motion ~20 switches, false positives ~12, occlusion ~2-24);
+# the plain base tracker produces 0. They count an ID switch whenever a ground-
+# truth identity's assigned track id changes between consecutive tracked frames.
+# A rigorous MOT-metrics benchmark lives in the (gitignored) scratch workspace.
+# ──────────────────────────────────────────────────────────────────────────
+
+_BODY3 = np.array([[0.0, -8.0], [0.0, 0.0], [0.0, 8.0]])
+
+
+def _track_synthetic_with_ids(tracker, frames, skeleton):
+    """Run a tracker over synthetic gt-tagged frames; return (n_tracks, n_switches).
+
+    ``frames`` is a list over time of lists of ``(gt_id, keypoints (K, 2))``
+    detections (gt_id == -1 marks a false positive). Counts an ID switch whenever a
+    ground-truth identity's assigned track id differs from the last frame it was
+    tracked in.
+    """
+    gt_last_track = {}
+    switches = 0
+    all_tracks = set()
+    for t, dets in enumerate(frames):
+        instances = []
+        gt_by_obj = {}
+        for gt_id, kpts in dets:
+            inst = sio.PredictedInstance.from_numpy(
+                points_data=np.asarray(kpts, dtype=np.float32),
+                skeleton=skeleton,
+                score=1.0,
+            )
+            instances.append(inst)
+            gt_by_obj[id(inst)] = gt_id
+        tracked = tracker.track(instances, frame_idx=t)
+        for inst in tracked:
+            if inst.track is None:
+                continue
+            track_name = inst.track.name
+            all_tracks.add(track_name)
+            gt_id = gt_by_obj.get(id(inst))
+            if gt_id is not None and gt_id >= 0:
+                if gt_id in gt_last_track and gt_last_track[gt_id] != track_name:
+                    switches += 1
+                gt_last_track[gt_id] = track_name
+    return len(all_tracks), switches
+
+
+def _kalman_tracker(**overrides):
+    kwargs = dict(
+        candidates_method="local_queues",
+        max_tracks=2,
+        kf_init_frame_count=5,
+        tracking_target_instance_count=2,
+    )
+    kwargs.update(overrides)
+    return Tracker.from_config(use_kalman=True, **kwargs)
+
+
+def _base_tracker(**overrides):
+    kwargs = dict(
+        candidates_method="local_queues",
+        max_tracks=2,
+        tracking_target_instance_count=2,
+    )
+    kwargs.update(overrides)
+    return Tracker.from_config(**kwargs)
+
+
+def test_kalman_no_switch_storm_on_erratic_motion():
+    """Erratic (random-walk) motion must not trigger an ID-switch storm (#572).
+
+    Two well-separated identities follow momentum random walks. The constant-velocity
+    EM warm-up previously fit a degenerate velocity here and stormed ~20 switches; with
+    velocity capping + gating + blending the motion model must stay stable.
+    """
+    skeleton = sio.Skeleton(nodes=["a", "b", "c"])
+    rng = np.random.default_rng(0)
+    T = 30
+    centroids = {0: np.array([120.0, 120.0]), 1: np.array([120.0, 320.0])}
+    vel = {0: rng.normal(0, 3, 2), 1: rng.normal(0, 3, 2)}
+    frames = []
+    for _ in range(T):
+        dets = []
+        for gid in (0, 1):
+            vel[gid] = 0.7 * vel[gid] + 0.3 * rng.normal(0, 4, 2)
+            centroids[gid] = centroids[gid] + vel[gid]
+            dets.append((gid, _BODY3 + centroids[gid]))
+        frames.append(dets)
+    n_tracks, switches = _track_synthetic_with_ids(_kalman_tracker(), frames, skeleton)
+    assert n_tracks == 2
+    assert switches == 0
+
+
+def test_kalman_robust_to_false_positives():
+    """False-positive detections must not corrupt the filters into a switch storm (#572).
+
+    The measurement gate must reject FP-driven corrections (pre-fix: ~12 switches).
+    """
+    skeleton = sio.Skeleton(nodes=["a", "b", "c"])
+    rng = np.random.default_rng(1)
+    T = 40
+    frames = []
+    for t in range(T):
+        dets = []
+        for gid, y in ((0, 120.0), (1, 320.0)):
+            c = np.array([60.0 + 5.0 * t, y]) + rng.normal(0, 3, 2)
+            dets.append((gid, _BODY3 + c))
+        if t % 3 == 0:  # inject a false positive between the two tracks
+            c = np.array([60.0 + 5.0 * t, 220.0]) + rng.normal(0, 30, 2)
+            dets.append((-1, _BODY3 + c))
+        frames.append(dets)
+    n_tracks, switches = _track_synthetic_with_ids(_kalman_tracker(), frames, skeleton)
+    assert switches == 0
+
+
+def test_kalman_maintains_identity_through_occlusion():
+    """A single occluded track keeps (or cleanly re-acquires) its identity (#572).
+
+    One of two well-separated identities is occluded for a 6-frame gap (> the default
+    reset gap). The pre-fix tracker stormed switches here (the stale filter kept
+    extrapolating and then absorbed the other animal's observations); the fix coasts
+    across the gap and resets a stale track before it can be corrupted. The contract
+    is "no worse than the base similarity tracker" (a scene with fewer detections than
+    tracks hits a base-tracker matching degeneracy that is shared by both and is
+    unrelated to the motion model).
+    """
+    skeleton = sio.Skeleton(nodes=["a", "b", "c"])
+
+    def build_frames():
+        rng = np.random.default_rng(3)
+        frames = []
+        for t in range(30):
+            dets = []
+            for gid, y in ((0, 120.0), (1, 320.0)):
+                if gid == 0 and 12 <= t <= 17:  # occlude id 0 for 6 frames
+                    continue
+                c = np.array([60.0 + 5.0 * t, y]) + rng.normal(0, 3, 2)
+                dets.append((gid, _BODY3 + c))
+            frames.append(dets)
+        return frames
+
+    _, base_switches = _track_synthetic_with_ids(
+        _base_tracker(), build_frames(), skeleton
+    )
+    n_tracks, kalman_switches = _track_synthetic_with_ids(
+        _kalman_tracker(), build_frames(), skeleton
+    )
+    assert n_tracks == 2
+    # Never worse than the plain tracker through the occlusion (no switch storm).
+    assert kalman_switches <= base_switches


### PR DESCRIPTION
## Summary

Fixes the **algorithmic correctness** of `KalmanShiftTracker` (added in #572 / #595). A parity-agnostic synthetic MOT benchmark (`py-motmetrics`) plus **two rounds of adversarial review** drove this from "net regression outside clean crossings" to a motion model that is net-beneficial where motion is informative and honestly documented where it is not. Per request, `--use_kalman` is **not** gated as experimental.

> Harness, sweeps, and review artifacts live in the (gitignored) `scratch/kalman-correctness/` workspace.

## Diagnosis (reproduced)

The merged tracker injected ID-switch storms the parameterless base tracker never makes (random_walk IDsw 0→19.6, false_positives 0→12.4). Adversarial review found the root cause: **per-keypoint independent filters overfit noise → non-rigid predicted pose → OKS scored ~0 → arbitrary Hungarian assignment → switches**, and that the regression was broad at the real default (`kf_init_frame_count=10`).

## Fix — centroid filter + rigid-translation candidate

- **One constant-velocity *centroid* filter per track** (`[cx, vcx, cy, vcy]`) instead of per-keypoint — a stable fit that can't scatter the body.
- **Rigid candidate:** score against the last observed body translated by a fraction (`kf_prediction_blend`) of the predicted centroid displacement — geometrically valid, so OKS stays meaningful.
- **Centroid-distance gating** (rejects far false positives — verified, was ~0% before), **dropout-aware centroid** (masks frames where <half the tracked nodes are visible), **per-axis velocity cap**, **noise-robust step estimate** (endpoint displacement / elapsed frame span), **gap coasting + multi-step prediction**, **reset-any-stale-track-before-correct**, **contiguous-fresh (re)fit** for entrants/post-reset (no thrash, no gap-straddle), **NaN-robust seeding**, and a **constant** (not staleness-amplified) blend weight.

Robustness knobs are configurable tracker attributes (`Tracker.from_config(...)`): `kf_prediction_blend` (0.5), `kf_gate_step_mult` (8.0), `kf_min_gate_px` (40.0), `kf_velocity_cap_mult` (3.0), `kf_min_velocity_cap_px` (15.0).

## Result (production default `kf_init_frame_count=10`, mean over seeds)

**Wins where motion is informative; neutral on clean/FP/occlusion:**

| Scenario | base IDF1 / IDsw | kalman IDF1 / IDsw |
|---|---|---|
| crossing | 0.66 / 1.6 | **0.74 / 1.2** (+0.21 on a harder seed set) |
| five converging | 0.78 / 5.8 | **0.95 / 1.1** |
| fast directional motion | 0.94 / 1.6 | **0.99 / 1.2** |
| nonlinear_sine | 0.97 / 0.4 | **1.00 / 0.0** |
| random_walk · false_positives · high_noise · occlusion · linear · count-mismatch | — | **neutral** |

**Documented tradeoff:** under heavy detection noise + frequent misses on long sequences (e.g. 12px noise, 20% missed, 200 frames), it costs a small **~2–6% IDF1** vs the memoryless base tracker (usually with *fewer* ID switches). This persists at every blend — a fundamental property of any motion prediction. The docstring and tracking guide say so and point to lowering `kf_prediction_blend` for very noisy data.

## Tests (verified fail-on-revert against `main`)

- `test_kalman_no_switch_storm_on_erratic_motion` — nearby random walks: main **12** switches → fix **0**.
- `test_kalman_gate_rejects_false_positives` — far FPs: main filter-centroid error **315px** → fix **<40px**.
- `test_kalman_entrant_gets_filter` — mid-sequence entrant: main **2** filters → fix **3**.
- Plus `test_kalman_from_config_robustness_knobs`, the centroid-matrix shape test, and existing unit/integration tests.

Full `tests/tracking/test_tracker.py` + `tests/inference/test_tracking.py`: **all pass**; `black`, `ruff` (`sleap_nn/`), `codespell` clean.

## Process note

Two adversarial-review rounds were run on the evals + code. The first found the initial per-node fix was insufficient (and that its tests guarded nothing) → drove the centroid/rigid redesign. The second confirmed the redesign closes the catastrophes and that 3/4 tests now genuinely fail on revert, and quantified the residual noisy-regime tradeoff documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
