### PR TITLE
Fix negative-frame metric double-count; add weighted/unweighted + per-head split metrics

### DIFF
--- a/docs/guides/negative-frames.md
+++ b/docs/guides/negative-frames.md
@@ -97,11 +97,13 @@ will be disabled.
 
 When `is_negative` is present in the batch:
 
-- Per-sample MSE is computed: `(y_pred - y_target)^2` averaged over spatial dims
+- Per-sample MSE is computed: `(y_pred - y_target)^2` averaged over all non-batch dims
 - Positive samples get weight `1.0`; negative samples get weight `negative_loss_weight`
-- The weighted per-sample losses are averaged to produce the final loss
+- The weighted per-sample losses are averaged to produce the final **training** loss
 
-When `negative_loss_weight=1.0` (default), this is numerically identical to `nn.MSELoss()`.
+When `negative_loss_weight=1.0` (default), this is numerically identical to `nn.MSELoss()`. On the **validation** split the loss is always unweighted, so `val/loss` matches plain `nn.MSELoss()` and stays a faithful model-selection metric.
+
+Metric logging is decoupled from loss computation: the positive/negative split metrics below are logged **once per step** (accurate even for two-head bottom-up models) and every logged loss value is **unweighted** with respect to `negative_loss_weight` on both train and val. `negative_loss_weight` only affects the backprop training loss, never a logged diagnostic.
 
 ### Feature Gating
 
@@ -115,22 +117,27 @@ When `use_negative_frames=False` (default), **no code paths change**:
 
 ## Monitoring
 
-When the feature is active, these additional metrics are logged to WandB/TensorBoard:
+When the feature is active, these additional metrics are logged to WandB/TensorBoard (and to `training_log.csv`). All split losses are **unweighted** w.r.t. `negative_loss_weight`.
 
 | Metric | Aggregation | What to Look For |
 |--------|-------------|------------------|
-| `train/loss` | epoch mean | Combined loss (always logged, unchanged) |
-| `train/loss_positive` | epoch mean | MSE on positive frames — should decrease as model learns poses |
-| `train/loss_negative` | epoch mean | MSE on negative frames — should approach 0 as model learns to suppress |
-| `train/n_positive` | epoch sum | Total positive samples seen in epoch |
+| `train/loss` | epoch mean | Combined optimized loss (always logged, unchanged) |
+| `train/n_positive` | epoch sum | Total positive samples seen in epoch (logged once per step — accurate for all model types) |
 | `train/n_negative` | epoch sum | Total negative samples seen in epoch |
-| `val/loss` | epoch mean | Combined val loss — **always unweighted** (never applies `negative_loss_weight`), so it stays identical to the old plain MSE and is used for checkpointing / early-stopping |
-| `val/loss_positive` | epoch mean | Unweighted MSE on positive val frames |
-| `val/loss_negative` | epoch mean | Unweighted MSE on negative val frames — should approach 0 if the model generalizes background suppression to held-out frames |
-| `val/n_positive` | epoch sum | Total positive samples in the val epoch |
-| `val/n_negative` | epoch sum | Total negative samples in the val epoch |
+| `train/loss_positive` | epoch mean | **Weighted** cross-head aggregate MSE on positive frames = `sum(loss_weight * head_split)`; mirrors the optimized-loss composition. Should decrease as poses are learned |
+| `train/loss_negative` | epoch mean | Weighted cross-head aggregate MSE on negative frames — should approach 0 as the model learns to suppress |
+| `train/loss_positive_unweighted` | epoch mean | Plain mean across heads of the per-head positive split — comparable across configs with different `loss_weight`s |
+| `train/loss_negative_unweighted` | epoch mean | Plain mean across heads of the per-head negative split |
+| `val/*` (same suffixes) | as above | Validation-split counterparts. `val/loss` stays **unweighted** and identical to plain MSE for checkpointing / early-stopping |
 
-Unlike the train split, the validation split metrics are **always unweighted** (`negative_loss_weight` is not applied), so `val/loss` remains comparable across runs and matches plain `nn.MSELoss()`.
+**Bottom-up models only** additionally emit per-head splits (so you can see which head drives the suppression signal), each with both `train/` and `val/` prefixes:
+
+| Model | Per-head keys |
+|-------|---------------|
+| Bottom-Up | `confmaps_loss_positive`, `confmaps_loss_negative`, `paf_loss_positive`, `paf_loss_negative` |
+| Bottom-Up Multi-Class | `confmaps_loss_positive`, `confmaps_loss_negative`, `classmap_loss_positive`, `classmap_loss_negative` |
+
+**All logged split losses are unweighted with respect to `negative_loss_weight`** — that train-only backprop trick never appears in any logged diagnostic, on either split. The word "weighted" in `loss_positive` / `loss_negative` refers only to the per-head `loss_weight` values used to combine heads; for single-head models (single-instance, centroid) the weighted and `_unweighted` aggregates are equal and no per-head keys are emitted. Counts (`n_positive` / `n_negative`) are per-epoch sums logged exactly once per step, so they are accurate even for the two-head bottom-up models. `val/loss` itself stays unweighted and identical to plain `nn.MSELoss()`, so it remains a faithful, comparable model-selection metric.
 
 !!! tip "Is It Working?"
     Watch `train/loss_negative` — it should decrease toward 0 over training. If it stays flat, the model isn't learning from negatives. Consider increasing `negative_loss_weight` or adding more diverse negative frames.
@@ -171,4 +178,4 @@ print(lf.is_negative)  # True or False
 
 - **Use `negative_loss_weight` to tune.** If negatives are rare relative to positives and `train/loss_negative` isn't decreasing, try `negative_loss_weight: 2.0` or higher to amplify the gradient signal.
 
-- **Check val metrics too.** Negative frames in the validation set (via the train/val split) contribute to `val/loss`, and are also broken out as `val/loss_positive` / `val/loss_negative` / `val/n_positive` / `val/n_negative`. Note that `val/loss` stays **unweighted** even when `negative_loss_weight > 1`, so it remains a faithful, comparable model-selection metric. Watch `val/loss_negative`: if it stays high while `train/loss_negative` falls, the model is memorizing training backgrounds rather than generalizing the "no animal → no detection" behavior, and will still hallucinate on unseen empty backgrounds.
+- **Check val metrics too.** Negative frames in the validation set (via the train/val split) contribute to `val/loss`, and are also broken out as `val/loss_positive` / `val/loss_negative` (plus the `_unweighted` variants, and per-head `val/confmaps_loss_*` / `val/paf_loss_*` / `val/classmap_loss_*` for bottom-up models) and the counts `val/n_positive` / `val/n_negative`. All of these split losses are **unweighted** w.r.t. `negative_loss_weight`, and `val/loss` stays unweighted even when `negative_loss_weight > 1`, so it remains a faithful, comparable model-selection metric. Watch `val/loss_negative`: if it stays high while `train/loss_negative` falls, the model is memorizing training backgrounds rather than generalizing the "no animal → no detection" behavior, and will still hallucinate on unseen empty backgrounds.

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -1,6 +1,6 @@
 """This module has the LightningModule classes for all model types."""
 
-from typing import Optional, Union, Dict, Any, List
+from typing import Optional, Union, Dict, Any, List, Tuple
 import time
 from torch import nn
 import numpy as np
@@ -413,27 +413,31 @@ class LightningModel(L.LightningModule):
     ) -> torch.Tensor:
         """Compute MSE loss with optional negative sample weighting.
 
-        When ``is_negative`` is absent from the batch this returns plain
-        ``nn.MSELoss()``.  Otherwise, per-sample MSE is computed and split
-        metrics (positive/negative loss and counts) are logged under the
-        ``{stage}/`` prefix.
+        This is a **pure loss function**: it computes the (optionally weighted)
+        loss for backprop and logs **nothing**. Diagnostic split metrics
+        (positive/negative loss and counts) are logged separately by
+        :meth:`_log_negative_split_metrics`, which is called exactly once per
+        step (so counts are not double-logged for multi-head models, which call
+        this loss helper once per head).
 
-        Weighting behavior depends on ``stage``:
+        When ``is_negative`` is absent from the batch this returns plain
+        ``nn.MSELoss()``. Otherwise per-sample MSE is computed and weighting
+        depends on ``stage``:
 
         * ``stage == "train"``: negative samples are weighted by
           ``negative_loss_weight`` (only when it is not 1.0).
         * ``stage != "train"`` (e.g. ``"val"``): the loss is **always
-          unweighted** (``per_sample.mean()``).  This keeps ``val/loss``
-          numerically identical to the old plain ``nn.MSELoss()`` so that
+          unweighted** (``per_sample.mean()``). This keeps ``val/loss``
+          numerically identical to plain ``nn.MSELoss()`` so that
           ``ModelCheckpoint(monitor="val/loss")`` and ``EarlyStopping``
-          behavior is unchanged; only the positive/negative breakdown is added.
+          behavior is unchanged.
 
         Args:
             y_preds: Predicted tensor.
             y: Ground truth tensor.
             batch: Batch dictionary, may contain ``is_negative`` key.
-            stage: Logging-key prefix and weighting gate. ``"train"`` applies
-                negative weighting; any other value returns the unweighted mean.
+            stage: Weighting gate. ``"train"`` applies negative weighting; any
+                other value returns the unweighted mean.
 
         Returns:
             The (optionally weighted) loss tensor.
@@ -442,37 +446,72 @@ class LightningModel(L.LightningModule):
         if is_negative is None:
             return nn.MSELoss()(y_preds, y)
 
-        # Per-sample loss for split tracking and weighting
+        # Per-sample loss for weighting. Mean over all non-batch dims makes this
+        # agnostic to head shape (confmaps vs PAF vs classmaps).
         per_sample = (
             (y_preds - y).pow(2).mean(dim=list(range(1, y_preds.ndim)))
         )  # (batch,)
 
+        # Negative weighting is train-only; val/eval stages stay unweighted so
+        # val/loss remains numerically identical to plain nn.MSELoss().
+        if stage != "train" or self.negative_loss_weight == 1.0:
+            return per_sample.mean()
+
         is_neg = is_negative.to(y_preds.device)
+        weights = torch.where(
+            is_neg,
+            torch.tensor(self.negative_loss_weight, device=y_preds.device),
+            torch.tensor(1.0, device=y_preds.device),
+        )
+        return (per_sample * weights).mean()
+
+    def _log_negative_split_metrics(
+        self,
+        heads: List[Tuple[str, torch.Tensor, torch.Tensor, float]],
+        batch: Dict,
+        stage: str = "train",
+    ) -> None:
+        """Log positive/negative split diagnostics, exactly once per step.
+
+        Decoupled from :meth:`_compute_negative_weighted_loss` so the counts
+        are not double-logged for multi-head models (which call the loss helper
+        once per head). **All logged loss values are unweighted with respect to
+        ``negative_loss_weight``** (a train-only backprop trick) on both train
+        and val. The word "weighted" below refers only to the per-head
+        ``loss_weights``.
+
+        Logged keys (only when ``is_negative`` is present in ``batch``):
+
+        * ``{stage}/n_positive`` / ``{stage}/n_negative`` (``reduce_fx="sum"``)
+          -- logged once per step.
+        * ``{stage}/loss_positive`` / ``{stage}/loss_negative`` -- PRIMARY
+          WEIGHTED cross-head aggregate ``sum(weight * head_split)``; mirrors
+          the composition of the real optimized loss.
+        * ``{stage}/loss_positive_unweighted`` /
+          ``{stage}/loss_negative_unweighted`` -- SECONDARY plain MEAN across
+          heads of the per-head splits.
+        * ``{stage}/{name}_loss_positive`` / ``{stage}/{name}_loss_negative``
+          -- per-head split, only emitted when there is more than one head.
+
+        For single-head models the weighted and unweighted aggregates are equal
+        (one head, weight 1.0) and no per-head keys are emitted.
+
+        Args:
+            heads: List of ``(name, y_pred, y, weight)`` tuples. ``weight`` is
+                the per-head ``loss_weight`` (1.0 for single-head models).
+            batch: Batch dict; logs nothing if ``is_negative`` is absent.
+            stage: Key prefix, e.g. ``"train"`` or ``"val"``.
+        """
+        is_negative = batch.get("is_negative", None)
+        if is_negative is None:
+            return
+
+        is_neg = is_negative.to(heads[0][1].device)
         is_pos = ~is_neg
         n_neg = int(is_neg.sum().item())
         n_pos = int(is_pos.sum().item())
 
-        # Log split losses and counts
-        if n_pos > 0:
-            loss_pos = per_sample[is_pos].mean()
-            self.log(
-                f"{stage}/loss_positive",
-                loss_pos,
-                prog_bar=False,
-                on_step=False,
-                on_epoch=True,
-                sync_dist=True,
-            )
-        if n_neg > 0:
-            loss_neg = per_sample[is_neg].mean()
-            self.log(
-                f"{stage}/loss_negative",
-                loss_neg,
-                prog_bar=False,
-                on_step=False,
-                on_epoch=True,
-                sync_dist=True,
-            )
+        # Counts: logged once per step regardless of head count.
         self.log(
             f"{stage}/n_positive",
             float(n_pos),
@@ -492,17 +531,76 @@ class LightningModel(L.LightningModule):
             reduce_fx="sum",
         )
 
-        # Negative weighting is train-only; val/eval stages stay unweighted so
-        # val/loss remains numerically identical to plain nn.MSELoss().
-        if stage != "train" or self.negative_loss_weight == 1.0:
-            return per_sample.mean()
+        multi_head = len(heads) > 1
+        weighted_pos = 0.0
+        weighted_neg = 0.0
+        unweighted_pos = []
+        unweighted_neg = []
 
-        weights = torch.where(
-            is_neg,
-            torch.tensor(self.negative_loss_weight, device=y_preds.device),
-            torch.tensor(1.0, device=y_preds.device),
-        )
-        return (per_sample * weights).mean()
+        for name, y_pred, y, weight in heads:
+            per_sample = (y_pred - y).pow(2).mean(dim=list(range(1, y_pred.ndim)))
+
+            if n_pos > 0:
+                head_pos = per_sample[is_pos].mean()
+                weighted_pos = weighted_pos + weight * head_pos
+                unweighted_pos.append(head_pos)
+                if multi_head:
+                    self.log(
+                        f"{stage}/{name}_loss_positive",
+                        head_pos,
+                        prog_bar=False,
+                        on_step=False,
+                        on_epoch=True,
+                        sync_dist=True,
+                    )
+            if n_neg > 0:
+                head_neg = per_sample[is_neg].mean()
+                weighted_neg = weighted_neg + weight * head_neg
+                unweighted_neg.append(head_neg)
+                if multi_head:
+                    self.log(
+                        f"{stage}/{name}_loss_negative",
+                        head_neg,
+                        prog_bar=False,
+                        on_step=False,
+                        on_epoch=True,
+                        sync_dist=True,
+                    )
+
+        if n_pos > 0:
+            self.log(
+                f"{stage}/loss_positive",
+                weighted_pos,
+                prog_bar=False,
+                on_step=False,
+                on_epoch=True,
+                sync_dist=True,
+            )
+            self.log(
+                f"{stage}/loss_positive_unweighted",
+                torch.stack(unweighted_pos).mean(),
+                prog_bar=False,
+                on_step=False,
+                on_epoch=True,
+                sync_dist=True,
+            )
+        if n_neg > 0:
+            self.log(
+                f"{stage}/loss_negative",
+                weighted_neg,
+                prog_bar=False,
+                on_step=False,
+                on_epoch=True,
+                sync_dist=True,
+            )
+            self.log(
+                f"{stage}/loss_negative_unweighted",
+                torch.stack(unweighted_neg).mean(),
+                prog_bar=False,
+                on_step=False,
+                on_epoch=True,
+                sync_dist=True,
+            )
 
     def training_step(self, batch, batch_idx):
         """Training step."""
@@ -776,6 +874,9 @@ class SingleInstanceLightningModule(LightningModel):
         y_preds = self.model(X)["SingleInstanceConfmapsHead"]
 
         loss = self._compute_negative_weighted_loss(y_preds, y, batch)
+        self._log_negative_split_metrics(
+            [("confmaps", y_preds, y, 1.0)], batch, stage="train"
+        )
 
         if self.online_mining is not None and self.online_mining:
             ohkm_loss = compute_ohkm_loss(
@@ -826,6 +927,9 @@ class SingleInstanceLightningModule(LightningModel):
 
         y_preds = self.model(X)["SingleInstanceConfmapsHead"]
         val_loss = self._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
+        self._log_negative_split_metrics(
+            [("confmaps", y_preds, y, 1.0)], batch, stage="val"
+        )
         if self.online_mining is not None and self.online_mining:
             ohkm_loss = compute_ohkm_loss(
                 y_gt=y,
@@ -1318,6 +1422,9 @@ class CentroidLightningModule(LightningModel):
 
         y_preds = self.model(X)["CentroidConfmapsHead"]
         loss = self._compute_negative_weighted_loss(y_preds, y, batch)
+        self._log_negative_split_metrics(
+            [("confmaps", y_preds, y, 1.0)], batch, stage="train"
+        )
         # Log step-level loss (every batch, uses global_step x-axis)
         self.log(
             "loss",
@@ -1342,6 +1449,9 @@ class CentroidLightningModule(LightningModel):
 
         y_preds = self.model(X)["CentroidConfmapsHead"]
         val_loss = self._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
+        self._log_negative_split_metrics(
+            [("confmaps", y_preds, y, 1.0)], batch, stage="val"
+        )
         self.log(
             "val/loss",
             val_loss,
@@ -1598,6 +1708,14 @@ class BottomUpLightningModule(LightningModel):
 
         confmap_loss = self._compute_negative_weighted_loss(confmaps, y_confmap, batch)
         pafs_loss = self._compute_negative_weighted_loss(pafs, y_paf, batch)
+        self._log_negative_split_metrics(
+            [
+                ("confmaps", confmaps, y_confmap, self.loss_weights[0]),
+                ("paf", pafs, y_paf, self.loss_weights[1]),
+            ],
+            batch,
+            stage="train",
+        )
 
         if self.online_mining is not None and self.online_mining:
             confmap_ohkm_loss = compute_ohkm_loss(
@@ -1668,6 +1786,14 @@ class BottomUpLightningModule(LightningModel):
         )
         pafs_loss = self._compute_negative_weighted_loss(
             pafs, y_paf, batch, stage="val"
+        )
+        self._log_negative_split_metrics(
+            [
+                ("confmaps", confmaps, y_confmap, self.loss_weights[0]),
+                ("paf", pafs, y_paf, self.loss_weights[1]),
+            ],
+            batch,
+            stage="val",
         )
 
         if self.online_mining is not None and self.online_mining:
@@ -1955,6 +2081,14 @@ class BottomUpMultiClassLightningModule(LightningModel):
         classmaps_loss = self._compute_negative_weighted_loss(
             classmaps, y_classmap, batch
         )
+        self._log_negative_split_metrics(
+            [
+                ("confmaps", confmaps, y_confmap, self.loss_weights[0]),
+                ("classmap", classmaps, y_classmap, self.loss_weights[1]),
+            ],
+            batch,
+            stage="train",
+        )
 
         if self.online_mining is not None and self.online_mining:
             confmap_ohkm_loss = compute_ohkm_loss(
@@ -2069,6 +2203,14 @@ class BottomUpMultiClassLightningModule(LightningModel):
         )
         classmaps_loss = self._compute_negative_weighted_loss(
             classmaps, y_classmap, batch, stage="val"
+        )
+        self._log_negative_split_metrics(
+            [
+                ("confmaps", confmaps, y_confmap, self.loss_weights[0]),
+                ("classmap", classmaps, y_classmap, self.loss_weights[1]),
+            ],
+            batch,
+            stage="val",
         )
 
         if self.online_mining is not None and self.online_mining:

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -912,18 +912,50 @@ class ModelTrainer:
                 "bottomup",
                 "multi_class_bottomup",
             ]:
+                # Aggregate split metrics (all four supported model types).
                 csv_log_keys.extend(
                     [
-                        "train/loss_positive",
-                        "train/loss_negative",
                         "train/n_positive",
                         "train/n_negative",
-                        "val/loss_positive",
-                        "val/loss_negative",
+                        "train/loss_positive",
+                        "train/loss_negative",
+                        "train/loss_positive_unweighted",
+                        "train/loss_negative_unweighted",
                         "val/n_positive",
                         "val/n_negative",
+                        "val/loss_positive",
+                        "val/loss_negative",
+                        "val/loss_positive_unweighted",
+                        "val/loss_negative_unweighted",
                     ]
                 )
+                # Per-head split metrics (two-head models only).
+                if self.model_type == "bottomup":
+                    csv_log_keys.extend(
+                        [
+                            "train/confmaps_loss_positive",
+                            "train/confmaps_loss_negative",
+                            "train/paf_loss_positive",
+                            "train/paf_loss_negative",
+                            "val/confmaps_loss_positive",
+                            "val/confmaps_loss_negative",
+                            "val/paf_loss_positive",
+                            "val/paf_loss_negative",
+                        ]
+                    )
+                elif self.model_type == "multi_class_bottomup":
+                    csv_log_keys.extend(
+                        [
+                            "train/confmaps_loss_positive",
+                            "train/confmaps_loss_negative",
+                            "train/classmap_loss_positive",
+                            "train/classmap_loss_negative",
+                            "val/confmaps_loss_positive",
+                            "val/confmaps_loss_negative",
+                            "val/classmap_loss_positive",
+                            "val/classmap_loss_negative",
+                        ]
+                    )
             # Add model-specific keys for wandb parity
             if self.model_type in [
                 "single_instance",

--- a/tests/data/test_negative_frames.py
+++ b/tests/data/test_negative_frames.py
@@ -522,7 +522,7 @@ class TestNegativeSampleFraction:
 
 
 class TestNegativeLossWeighting:
-    """Tests for _compute_negative_weighted_loss in lightning modules."""
+    """Tests for _compute_negative_weighted_loss and _log_negative_split_metrics."""
 
     def _make_model(self, weight=1.0):
         """Create a minimal mock for testing _compute_negative_weighted_loss."""
@@ -596,8 +596,8 @@ class TestNegativeLossWeighting:
         loss = model._compute_negative_weighted_loss(y_preds, y, batch)
         assert loss.item() == 0.0
 
-    def test_split_metrics_logged(self):
-        """Verify split loss and count metrics are logged."""
+    def test_helper_does_not_log(self):
+        """The pure loss helper no longer logs anything (train or val)."""
         model = self._make_model(weight=2.0)
 
         y_preds = torch.randn(4, 2, 8, 8)
@@ -605,54 +605,8 @@ class TestNegativeLossWeighting:
         batch = {"is_negative": torch.tensor([False, False, True, False])}
 
         model._compute_negative_weighted_loss(y_preds, y, batch)
-
-        logged_keys = {call.args[0] for call in model.log.call_args_list}
-        assert "train/loss_positive" in logged_keys
-        assert "train/loss_negative" in logged_keys
-        assert "train/n_positive" in logged_keys
-        assert "train/n_negative" in logged_keys
-
-        # Check counts
-        for call in model.log.call_args_list:
-            if call.args[0] == "train/n_positive":
-                assert call.args[1] == 3.0
-            if call.args[0] == "train/n_negative":
-                assert call.args[1] == 1.0
-
-    def test_no_metrics_when_is_negative_absent(self):
-        """No split metrics logged when is_negative is not in batch."""
-        model = self._make_model(weight=2.0)
-
-        y_preds = torch.randn(4, 2, 8, 8)
-        y = torch.randn(4, 2, 8, 8)
-        batch = {}
-
-        model._compute_negative_weighted_loss(y_preds, y, batch)
-        model.log.assert_not_called()
-
-    def test_val_stage_logs_val_prefixed_keys(self):
-        """stage='val' logs val/* split keys, not train/*."""
-        model = self._make_model(weight=2.0)
-
-        y_preds = torch.randn(4, 2, 8, 8)
-        y = torch.randn(4, 2, 8, 8)
-        batch = {"is_negative": torch.tensor([False, False, True, False])}
-
         model._compute_negative_weighted_loss(y_preds, y, batch, stage="val")
-
-        logged_keys = {call.args[0] for call in model.log.call_args_list}
-        assert "val/loss_positive" in logged_keys
-        assert "val/loss_negative" in logged_keys
-        assert "val/n_positive" in logged_keys
-        assert "val/n_negative" in logged_keys
-        # Must NOT leak train/* keys on the val path.
-        assert not any(k.startswith("train/") for k in logged_keys)
-
-        for call in model.log.call_args_list:
-            if call.args[0] == "val/n_positive":
-                assert call.args[1] == 3.0
-            if call.args[0] == "val/n_negative":
-                assert call.args[1] == 1.0
+        model.log.assert_not_called()
 
     def test_val_stage_never_weighted(self):
         """stage='val' returns UNWEIGHTED MSE even when weight != 1.0."""
@@ -708,9 +662,170 @@ class TestNegativeLossWeighting:
         expected = (per_sample * weights).mean()
         assert torch.allclose(loss, expected, atol=1e-6)
 
-        logged_keys = {call.args[0] for call in model.log.call_args_list}
-        assert "train/loss_positive" in logged_keys
-        assert not any(k.startswith("val/") for k in logged_keys)
+    # ---- _log_negative_split_metrics ----
+
+    @staticmethod
+    def _logged(model):
+        """Map of logged key -> value from the mock (last write per key)."""
+        out = {}
+        for call in model.log.call_args_list:
+            out[call.args[0]] = call.args[1]
+        return out
+
+    def test_log_counts_once_for_two_heads(self):
+        """Counts are logged exactly once per call (not 2x) for two heads."""
+        model = self._make_model(weight=3.0)
+
+        b = torch.tensor([False, True, True, False])  # n_pos=2, n_neg=2
+        cm_p, cm_y = torch.randn(4, 2, 8, 8), torch.randn(4, 2, 8, 8)
+        paf_p, paf_y = torch.randn(4, 6, 8, 8), torch.randn(4, 6, 8, 8)
+        heads = [("confmaps", cm_p, cm_y, 1.0), ("paf", paf_p, paf_y, 1.0)]
+
+        model._log_negative_split_metrics(heads, {"is_negative": b}, stage="train")
+
+        n_pos_calls = [
+            c for c in model.log.call_args_list if c.args[0] == "train/n_positive"
+        ]
+        n_neg_calls = [
+            c for c in model.log.call_args_list if c.args[0] == "train/n_negative"
+        ]
+        assert len(n_pos_calls) == 1
+        assert len(n_neg_calls) == 1
+        assert n_pos_calls[0].args[1] == 2.0  # true count, NOT 4.0 (2x)
+        assert n_neg_calls[0].args[1] == 2.0
+        # reduce_fx="sum" preserved on the count keys.
+        assert n_pos_calls[0].kwargs.get("reduce_fx") == "sum"
+        assert n_neg_calls[0].kwargs.get("reduce_fx") == "sum"
+
+    def test_log_per_head_keys_present_for_two_heads(self):
+        """Per-head split keys emitted only when there is >1 head."""
+        model = self._make_model(weight=2.0)
+
+        b = torch.tensor([False, True, True, False])
+        cm = (torch.randn(4, 2, 8, 8), torch.randn(4, 2, 8, 8))
+        paf = (torch.randn(4, 6, 8, 8), torch.randn(4, 6, 8, 8))
+        heads = [("confmaps", *cm, 1.0), ("paf", *paf, 2.0)]
+
+        model._log_negative_split_metrics(heads, {"is_negative": b}, stage="train")
+        keys = set(self._logged(model))
+        assert "train/confmaps_loss_positive" in keys
+        assert "train/confmaps_loss_negative" in keys
+        assert "train/paf_loss_positive" in keys
+        assert "train/paf_loss_negative" in keys
+
+    def test_log_no_per_head_keys_for_single_head(self):
+        """Single head => no per-head keys; aggregate == the head value."""
+        model = self._make_model(weight=2.0)
+
+        b = torch.tensor([False, True, True, False])
+        y_p, y = torch.randn(4, 2, 8, 8), torch.randn(4, 2, 8, 8)
+        heads = [("confmaps", y_p, y, 1.0)]
+
+        model._log_negative_split_metrics(heads, {"is_negative": b}, stage="train")
+        logged = self._logged(model)
+        assert "train/confmaps_loss_positive" not in logged
+        assert "train/confmaps_loss_negative" not in logged
+
+        per_sample = (y_p - y).pow(2).mean(dim=[1, 2, 3])
+        exp_pos = per_sample[~b].mean()
+        exp_neg = per_sample[b].mean()
+        # Single head, weight 1.0: weighted == unweighted == the head value.
+        assert torch.allclose(logged["train/loss_positive"], exp_pos, atol=1e-6)
+        assert torch.allclose(logged["train/loss_negative"], exp_neg, atol=1e-6)
+        assert torch.allclose(
+            logged["train/loss_positive_unweighted"], exp_pos, atol=1e-6
+        )
+        assert torch.allclose(
+            logged["train/loss_negative_unweighted"], exp_neg, atol=1e-6
+        )
+
+    def test_log_weighted_and_unweighted_aggregates(self):
+        """Weighted == sum(weight*head); unweighted == mean(heads); weight=99 ignored."""
+        model = self._make_model(weight=99.0)  # must NOT affect logged values
+
+        b = torch.tensor([False, True])  # n_pos=1 (idx0), n_neg=1 (idx1)
+        cm_p = torch.tensor([[[[1.0]]], [[[3.0]]]])  # (2,1,1,1); per_sample=[1, 9]
+        cm_y = torch.zeros(2, 1, 1, 1)
+        paf_p = torch.tensor([[[[2.0]]], [[[4.0]]]])  # per_sample=[4, 16]
+        paf_y = torch.zeros(2, 1, 1, 1)
+        heads = [("confmaps", cm_p, cm_y, 2.0), ("paf", paf_p, paf_y, 3.0)]
+
+        model._log_negative_split_metrics(heads, {"is_negative": b}, stage="train")
+        logged = self._logged(model)
+
+        # positive (idx 0): cm_pos=1, paf_pos=4
+        assert torch.allclose(
+            logged["train/loss_positive"], torch.tensor(2.0 * 1.0 + 3.0 * 4.0)
+        )  # 14.0
+        assert torch.allclose(
+            logged["train/loss_positive_unweighted"], torch.tensor((1.0 + 4.0) / 2)
+        )  # 2.5
+        # negative (idx 1): cm_neg=9, paf_neg=16
+        assert torch.allclose(
+            logged["train/loss_negative"], torch.tensor(2.0 * 9.0 + 3.0 * 16.0)
+        )  # 66.0
+        assert torch.allclose(
+            logged["train/loss_negative_unweighted"], torch.tensor((9.0 + 16.0) / 2)
+        )  # 12.5
+        # Per-head values.
+        assert torch.allclose(logged["train/confmaps_loss_positive"], torch.tensor(1.0))
+        assert torch.allclose(logged["train/paf_loss_negative"], torch.tensor(16.0))
+
+    def test_log_val_prefix_no_cross_leak(self):
+        """stage='val' logs only val/* keys, never train/*."""
+        model = self._make_model(weight=2.0)
+
+        b = torch.tensor([False, True, True, False])
+        y_p, y = torch.randn(4, 2, 8, 8), torch.randn(4, 2, 8, 8)
+        heads = [("confmaps", y_p, y, 1.0)]
+
+        model._log_negative_split_metrics(heads, {"is_negative": b}, stage="val")
+        keys = set(self._logged(model))
+        assert "val/n_positive" in keys
+        assert "val/loss_positive" in keys
+        assert not any(k.startswith("train/") for k in keys)
+
+    def test_log_nothing_when_is_negative_absent(self):
+        """No is_negative key => logs nothing at all."""
+        model = self._make_model(weight=2.0)
+
+        y_p, y = torch.randn(4, 2, 8, 8), torch.randn(4, 2, 8, 8)
+        heads = [("confmaps", y_p, y, 1.0)]
+
+        model._log_negative_split_metrics(heads, {}, stage="train")
+        model.log.assert_not_called()
+
+    def test_log_all_positive_omits_negative_keys(self):
+        """When n_neg==0, negative loss keys are not logged (guard preserved)."""
+        model = self._make_model(weight=2.0)
+
+        b = torch.tensor([False, False])  # all positive
+        y_p, y = torch.randn(2, 2, 4, 4), torch.randn(2, 2, 4, 4)
+        heads = [("confmaps", y_p, y, 1.0)]
+
+        model._log_negative_split_metrics(heads, {"is_negative": b}, stage="train")
+        logged = self._logged(model)
+        assert "train/loss_negative" not in logged
+        assert "train/loss_negative_unweighted" not in logged
+        assert "train/loss_positive" in logged
+        # Counts always logged (n_negative == 0.0).
+        assert logged["train/n_negative"] == 0.0
+
+    def test_log_all_negative_omits_positive_keys(self):
+        """When n_pos==0, positive loss keys are not logged (guard preserved)."""
+        model = self._make_model(weight=2.0)
+
+        b = torch.tensor([True, True])  # all negative
+        y_p, y = torch.randn(2, 2, 4, 4), torch.randn(2, 2, 4, 4)
+        heads = [("confmaps", y_p, y, 1.0)]
+
+        model._log_negative_split_metrics(heads, {"is_negative": b}, stage="train")
+        logged = self._logged(model)
+        assert "train/loss_positive" not in logged
+        assert "train/loss_positive_unweighted" not in logged
+        assert "train/loss_negative" in logged
+        # Counts always logged (n_positive == 0.0).
+        assert logged["train/n_positive"] == 0.0
 
 
 class TestDataConfigNegativeFrames:


### PR DESCRIPTION
@
## Summary

Follow-up to #594. For the two-head models (**bottom-up**, **multi-class bottom-up**) the negative-frame split metrics were logged **once per head — twice per step**, because `_compute_negative_weighted_loss` both computed the loss *and* logged the split, and those models call it once per head. Consequences:

- `n_positive` / `n_negative` (`reduce_fx="sum"`) were reported at **2× the true count**.
- `loss_positive` / `loss_negative` (mean-reduced) collapsed into an undocumented **cross-head blend**.

This was a **diagnostic-only** inaccuracy — the optimized loss, `val/loss`, `ModelCheckpoint(monitor="val/loss")`, and `EarlyStopping` are computed separately and were always correct. It pre-dated #594 (train side, from #484) and was mirrored to val in #594. Reconfirmed empirically with an isolated Lightning run: a `reduce_fx="sum"` key logged twice/step yields **6.0 where the true value is 3.0**.

## Fix — decouple logging from loss computation

- **`_compute_negative_weighted_loss` is now a pure loss function** (logs nothing). Its return values are unchanged (weighted on train, unweighted on val), so the **backprop and `val/loss` paths are byte-identical**.
- **New `_log_negative_split_metrics(heads, batch, stage)`** logs the diagnostics **exactly once per step**:
  - `{stage}/n_positive` · `{stage}/n_negative` — once per step, so **counts are now accurate** for every model type.
  - `{stage}/loss_positive` · `{stage}/loss_negative` — **primary, weighted** cross-head aggregate `Σ (loss_weight · head_split)`, mirroring the composition of the optimized loss.
  - `{stage}/loss_positive_unweighted` · `{stage}/loss_negative_unweighted` — secondary plain mean across heads, comparable across configs.
  - `{stage}/{head}_loss_positive` · `_negative` — **per-head** splits, emitted only for the two-head models (`confmaps` + `paf`/`classmap`).
- **All logged split losses are unweighted w.r.t. `negative_loss_weight`** (a train-only backprop trick) on both train and val. "Weighted" refers only to the per-head `loss_weights`. Single-head models (single-instance, centroid) use weight `1.0`, never touch `self.loss_weights` (undefined for them), and emit no per-head keys.
- Wired the logger into all **8 step methods**; head weights aligned to the existing `zip(self.loss_weights, losses)` ordering (`[0]`→confmaps, `[1]`→paf/classmap).
- Expanded `csv_log_keys` per model type (12 aggregate keys; +8 per-head for two-head models), still gated on `use_negative_frames`.
- Rewrote the docs metrics section (weighted/unweighted/per-head distinction; once-per-step counts).
- Migrated the #594 tests that asserted the loss helper logs (it no longer does) onto the new logger, and added coverage: counts-once, per-head presence/absence by head count, weighted-vs-unweighted aggregate math, train/val prefix isolation, no-op when `is_negative` absent, and all-positive/all-negative guard symmetry.

## Behavior preserved

- **Feature off** (`use_negative_frames` false / no `is_negative` key): nothing new is logged; behavior is byte-identical.
- **Backprop loss** and **`val/loss`**: unchanged (only logging moved out of the loss helper).

## Empirical verification

Three independent isolated Lightning micro-tests (CPU, 1 epoch) during review confirmed: two-head counts come out **2.0, not 4.0/6.0**, and the weighted/unweighted aggregates match hand-computed values exactly (e.g. weighted `= 2·2.0 + 3·15.0 = 49.0`, unweighted `= mean(2.0,15.0) = 8.5`). A counter-factual sentinel reproduced the old 2× behavior, proving the new tests are sensitive to the very bug fixed.

## Testing

```
uv run pytest tests/data/test_negative_frames.py -q   # 42 passed
uv run black --check sleap_nn tests                    # clean
uv run ruff check sleap_nn/                            # clean
```

## Process

Verified → planned → implemented → adversarially reviewed (5 lenses incl. live Lightning micro-tests for counts/aggregate correctness, loss-weight alignment, invariants, CSV/docs, and test coverage) via a multi-agent workflow; one nit (a missing all-negative symmetry test) was confirmed and fixed, and the diff was independently re-verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@