### PR TITLE
Add keypoints (per-node pose) tracking mode for KalmanShiftTracker (#572)

### DIFF
--- a/docs/guides/tracking.md
+++ b/docs/guides/tracking.md
@@ -125,6 +125,19 @@ Notes:
   `--kf_node_indices 0,1,2`. Leave it unset to use all nodes.
 - Depends on the `pykalman` package (a core dependency).
 
+!!! note "Centroid vs keypoints (`--kf_track_features`)"
+    By default (`--kf_track_features centroid`) the motion model tracks each instance's
+    **centroid** and rigidly translates the last pose — stable and the recommended
+    choice. `--kf_track_features keypoints` instead runs one filter **per node** and uses
+    the predicted pose directly: it can help when subjects are small and move
+    distinctively (e.g. it cut ID switches markedly on a 2-fly clip), but the per-node
+    prediction is noisier, so it needs a tolerant similarity score. Pair it with the
+    auto-default `--oks_stddev 0.1` (set automatically for keypoints mode; **do not** use
+    the strict 0.025), or with `--features bboxes --scoring_method iou` for noisy but
+    well-separated, non-rotating subjects. On clean or occlusion-heavy data the centroid
+    mode (or the plain tracker) is at least as good, so keypoints mode is an opt-in
+    alternative, not a replacement.
+
 The motion model is robustified so it does not degrade tracking outside its sweet
 spot: each correction is gated by distance (rejecting false-positive / mismatched
 detections), the learned velocity is capped, the filter coasts across occlusion gaps,
@@ -137,6 +150,8 @@ tracker via `Tracker.from_config(...)`.
 
 | Parameter | Description | Values | Default |
 |-----------|-------------|--------|---------|
+| `--kf_track_features` | What the motion model tracks | `centroid`, `keypoints` | `centroid` |
+| `--oks_stddev` | OKS keypoint-spread tolerance (larger = more forgiving) | `FLOAT` | `0.025`; `0.1` for `keypoints` |
 | `--kf_init_frame_count` | Warm-up frames before EM init | `INT` | `10` |
 | `--kf_node_indices` | Node indices to filter (comma-sep; empty = all) | e.g. `0,1,2` | `None` |
 | `--kf_reset_gap_size` | Missed frames before a stale track resets | `INT` | `5` |

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -2044,7 +2044,7 @@ def infer(**kwargs):
 @click.option(
     "--oks_stddev",
     type=float,
-    default=None,
+    default=0.025,
     help="Standard deviation for OKS calculation",
 )
 @click.option("--oks_scale", type=float, help="Scale factor for OKS calculation")

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -914,6 +914,18 @@ def train(
     help="If True, `KalmanShiftTracker` is used: poses are predicted with a per-track constant-velocity Kalman filter. Requires --tracking_target_instance_count (or --max_tracks/--max_instances) and is mutually exclusive with --use_flow.",
 )
 @click.option(
+    "--kf_track_features",
+    type=click.Choice(["centroid", "keypoints"]),
+    default="centroid",
+    help="What the Kalman motion model tracks: 'centroid' (default; rigid, stable) or 'keypoints' (per-node poses; noisier — pair with --oks_stddev or --features bboxes --scoring_method iou). (only if --use_kalman)",
+)
+@click.option(
+    "--oks_stddev",
+    type=float,
+    default=0.025,
+    help="OKS keypoint-spread normalization constant for `oks` scoring. Larger is more tolerant of localization error (useful with --kf_track_features keypoints). Default: 0.025.",
+)
+@click.option(
     "--kf_init_frame_count",
     type=int,
     default=10,
@@ -1233,6 +1245,7 @@ def _build_tracker_config(kwargs: dict) -> "object":
         scoring_method_explicit=scoring_method_explicit,
         scoring_reduction=kwargs.get("scoring_reduction", "mean"),
         robust_best_instance=kwargs.get("robust_best_instance", 1.0),
+        oks_stddev=kwargs.get("oks_stddev", 0.025),
         track_matching_method=kwargs.get("track_matching_method", "hungarian"),
         max_tracks=max_tracks,
         use_flow=kwargs.get("use_flow", False),
@@ -1240,6 +1253,7 @@ def _build_tracker_config(kwargs: dict) -> "object":
         of_window_size=kwargs.get("of_window_size", 21),
         of_max_levels=kwargs.get("of_max_levels", 3),
         use_kalman=use_kalman,
+        kf_track_features=kwargs.get("kf_track_features", "centroid"),
         kf_init_frame_count=kwargs.get("kf_init_frame_count", 10),
         kf_node_indices=kwargs.get("kf_node_indices"),
         kf_reset_gap_size=kwargs.get("kf_reset_gap_size", 5),
@@ -1925,6 +1939,12 @@ def _common_inference_options(f):
         click.option("--of_window_size", type=int, default=21),
         click.option("--of_max_levels", type=int, default=3),
         click.option("--use_kalman", is_flag=True, default=False),
+        click.option(
+            "--kf_track_features",
+            type=click.Choice(["centroid", "keypoints"]),
+            default="centroid",
+        ),
+        click.option("--oks_stddev", type=float, default=0.025),
         click.option("--kf_init_frame_count", type=int, default=10),
         click.option(
             "--kf_node_indices", type=str, default=None, callback=_parse_int_list

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -922,7 +922,7 @@ def train(
 @click.option(
     "--oks_stddev",
     type=float,
-    default=0.025,
+    default=None,
     help="OKS keypoint-spread normalization constant for `oks` scoring. Larger is more tolerant of localization error (useful with --kf_track_features keypoints). Default: 0.025.",
 )
 @click.option(
@@ -1944,7 +1944,7 @@ def _common_inference_options(f):
             type=click.Choice(["centroid", "keypoints"]),
             default="centroid",
         ),
-        click.option("--oks_stddev", type=float, default=0.025),
+        click.option("--oks_stddev", type=float, default=None),
         click.option("--kf_init_frame_count", type=int, default=10),
         click.option(
             "--kf_node_indices", type=str, default=None, callback=_parse_int_list
@@ -2044,7 +2044,7 @@ def infer(**kwargs):
 @click.option(
     "--oks_stddev",
     type=float,
-    default=0.025,
+    default=None,
     help="Standard deviation for OKS calculation",
 )
 @click.option("--oks_scale", type=float, help="Scale factor for OKS calculation")

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -58,6 +58,7 @@ class TrackerConfig:
     scoring_method: str = "oks"
     scoring_reduction: str = "mean"
     robust_best_instance: float = 1.0
+    oks_stddev: float = 0.025
     track_matching_method: str = "hungarian"
     max_tracks: Optional[int] = None
     use_flow: bool = False
@@ -65,6 +66,7 @@ class TrackerConfig:
     of_window_size: int = 21
     of_max_levels: int = 3
     use_kalman: bool = False
+    kf_track_features: str = "centroid"
     kf_init_frame_count: int = 10
     kf_node_indices: Optional[list] = None
     kf_reset_gap_size: int = 5
@@ -177,6 +179,7 @@ def apply_tracking(
         scoring_method=effective_scoring_method,
         scoring_reduction=config.scoring_reduction,
         robust_best_instance=config.robust_best_instance,
+        oks_stddev=config.oks_stddev,
         track_matching_method=config.track_matching_method,
         max_tracks=config.max_tracks,
         use_flow=config.use_flow,
@@ -184,6 +187,7 @@ def apply_tracking(
         of_window_size=config.of_window_size,
         of_max_levels=config.of_max_levels,
         use_kalman=config.use_kalman,
+        kf_track_features=config.kf_track_features,
         kf_init_frame_count=config.kf_init_frame_count,
         kf_node_indices=config.kf_node_indices,
         kf_reset_gap_size=config.kf_reset_gap_size,

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -58,7 +58,7 @@ class TrackerConfig:
     scoring_method: str = "oks"
     scoring_reduction: str = "mean"
     robust_best_instance: float = 1.0
-    oks_stddev: float = 0.025
+    oks_stddev: Optional[float] = None
     track_matching_method: str = "hungarian"
     max_tracks: Optional[int] = None
     use_flow: bool = False

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -106,6 +106,7 @@ def run_inference(
     scoring_method: str = "oks",
     scoring_reduction: str = "mean",
     robust_best_instance: float = 1.0,
+    oks_stddev: float = 0.025,
     track_matching_method: str = "hungarian",
     max_tracks: Optional[int] = None,
     use_flow: bool = False,
@@ -113,6 +114,7 @@ def run_inference(
     of_window_size: int = 21,
     of_max_levels: int = 3,
     use_kalman: bool = False,
+    kf_track_features: str = "centroid",
     kf_init_frame_count: int = 10,
     kf_node_indices: Optional[List[int]] = None,
     kf_reset_gap_size: int = 5,
@@ -278,10 +280,14 @@ def run_inference(
         of_max_levels: Number of pyramid scale levels to consider. This is different
             from the scale parameter, which determines the initial image scaling.
             Default: 3. (only if `use_flow` is True).
+        oks_stddev: Keypoint-spread normalization constant for `oks` scoring; larger is
+            more tolerant of localization error. Default: 0.025.
         use_kalman: If True, `KalmanShiftTracker` is used, where poses are predicted
             with a per-track constant-velocity Kalman filter. Requires
             `tracking_target_instance_count` (or `max_tracks`/`max_instances`) and is
             mutually exclusive with `use_flow`. Default: `False`.
+        kf_track_features: What the Kalman motion model tracks: `centroid` (default) or
+            `keypoints` (per-node poses; noisier). (only if `use_kalman` is True)
         kf_init_frame_count: Number of warm-up frames tracked with the base path before
             the Kalman filters are fit via EM. Default: 10. (only if `use_kalman` is True)
         kf_node_indices: Skeleton node (row) indices to track with the motion model.
@@ -514,6 +520,7 @@ def run_inference(
                 scoring_method=scoring_method,
                 scoring_reduction=scoring_reduction,
                 robust_best_instance=robust_best_instance,
+                oks_stddev=oks_stddev,
                 track_matching_method=track_matching_method,
                 max_tracks=max_tracks,
                 use_flow=use_flow,
@@ -521,6 +528,7 @@ def run_inference(
                 of_window_size=of_window_size,
                 of_max_levels=of_max_levels,
                 use_kalman=use_kalman,
+                kf_track_features=kf_track_features,
                 kf_init_frame_count=kf_init_frame_count,
                 kf_node_indices=kf_node_indices,
                 kf_reset_gap_size=kf_reset_gap_size,
@@ -701,6 +709,7 @@ def run_inference(
                 scoring_method=scoring_method,
                 scoring_reduction=scoring_reduction,
                 robust_best_instance=robust_best_instance,
+                oks_stddev=oks_stddev,
                 track_matching_method=track_matching_method,
                 max_tracks=max_tracks,
                 use_flow=use_flow,
@@ -708,6 +717,7 @@ def run_inference(
                 of_window_size=of_window_size,
                 of_max_levels=of_max_levels,
                 use_kalman=use_kalman,
+                kf_track_features=kf_track_features,
                 kf_init_frame_count=kf_init_frame_count,
                 kf_node_indices=kf_node_indices,
                 kf_reset_gap_size=kf_reset_gap_size,

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -106,7 +106,7 @@ def run_inference(
     scoring_method: str = "oks",
     scoring_reduction: str = "mean",
     robust_best_instance: float = 1.0,
-    oks_stddev: float = 0.025,
+    oks_stddev: Optional[float] = None,
     track_matching_method: str = "hungarian",
     max_tracks: Optional[int] = None,
     use_flow: bool = False,
@@ -281,7 +281,8 @@ def run_inference(
             from the scale parameter, which determines the initial image scaling.
             Default: 3. (only if `use_flow` is True).
         oks_stddev: Keypoint-spread normalization constant for `oks` scoring; larger is
-            more tolerant of localization error. Default: 0.025.
+            more tolerant of localization error. `None` (default) auto-resolves to 0.1
+            for `kf_track_features="keypoints"` and 0.025 otherwise.
         use_kalman: If True, `KalmanShiftTracker` is used, where poses are predicted
             with a per-track constant-velocity Kalman filter. Requires
             `tracking_target_instance_count` (or `max_tracks`/`max_instances`) and is

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Union, Deque, DefaultDict, Optional
 from collections import defaultdict
+import warnings
 import attrs
 import cv2
 import numpy as np
@@ -82,6 +83,7 @@ class Tracker:
     scoring_reduction: str = "mean"
     track_matching_method: str = "hungarian"
     robust_best_instance: float = 1.0
+    oks_stddev: float = 0.025
     use_flow: bool = False
     is_local_queue: bool = False
     tracking_target_instance_count: Optional[int] = None
@@ -121,6 +123,7 @@ class Tracker:
         scoring_method: str = "oks",
         scoring_reduction: str = "mean",
         robust_best_instance: float = 1.0,
+        oks_stddev: float = 0.025,
         track_matching_method: str = "hungarian",
         max_tracks: Optional[int] = None,
         use_flow: bool = False,
@@ -128,6 +131,7 @@ class Tracker:
         of_window_size: int = 21,
         of_max_levels: int = 3,
         use_kalman: bool = False,
+        kf_track_features: str = "centroid",
         kf_init_frame_count: int = 10,
         kf_node_indices: Optional[List[int]] = None,
         kf_reset_gap_size: int = 5,
@@ -179,10 +183,16 @@ class Tracker:
             of_max_levels: Number of pyramid scale levels to consider. This is different
                 from the scale parameter, which determines the initial image scaling.
                 Default: 3. (only if `use_flow` is True)
+            oks_stddev: Keypoint-spread normalization constant for `oks` scoring;
+                larger is more tolerant of localization error. Default: 0.025.
             use_kalman: If True, `KalmanShiftTracker` is used, where poses are predicted
                 with a per-track constant-velocity Kalman filter. Requires
                 `tracking_target_instance_count` (or `max_tracks`) and is mutually
                 exclusive with `use_flow`. Default: `False`.
+            kf_track_features: What the Kalman motion model tracks: `centroid` (default;
+                rigid translation of the last pose) or `keypoints` (per-node poses;
+                noisier, pair with a larger `oks_stddev` or `features="bboxes"` +
+                `scoring_method="iou"`). (only if `use_kalman` is True)
             kf_init_frame_count: Number of warm-up frames tracked with the base path
                 before the Kalman filters are fit via EM. Default: 10.
                 (only if `use_kalman` is True)
@@ -250,7 +260,9 @@ class Tracker:
                 scoring_method=scoring_method,
                 scoring_reduction=scoring_reduction,
                 robust_best_instance=robust_best_instance,
+                oks_stddev=oks_stddev,
                 track_matching_method=track_matching_method,
+                kf_track_features=kf_track_features,
                 kf_init_frame_count=kf_init_frame_count,
                 kf_node_indices=kf_node_indices,
                 kf_reset_gap_size=kf_reset_gap_size,
@@ -273,6 +285,7 @@ class Tracker:
                 scoring_method=scoring_method,
                 scoring_reduction=scoring_reduction,
                 robust_best_instance=robust_best_instance,
+                oks_stddev=oks_stddev,
                 track_matching_method=track_matching_method,
                 img_scale=of_img_scale,
                 of_window_size=of_window_size,
@@ -290,6 +303,7 @@ class Tracker:
             scoring_method=scoring_method,
             scoring_reduction=scoring_reduction,
             robust_best_instance=robust_best_instance,
+            oks_stddev=oks_stddev,
             track_matching_method=track_matching_method,
             use_flow=use_flow,
             is_local_queue=is_local_queue,
@@ -467,6 +481,11 @@ class Tracker:
             raise ValueError(message)
 
         scoring_method = self._scoring_functions[self.scoring_method]
+        if self.scoring_method == "oks":
+            # OKS tolerance is configurable: a larger stddev is more forgiving of
+            # localization error, which matters for the noisier per-keypoint Kalman
+            # prediction (`kf_track_features="keypoints"`).
+            scoring_method = functools.partial(compute_oks, stddev=self.oks_stddev)
         scoring_reduction = self._scoring_reduction_methods[self.scoring_reduction]
 
         # Get list of features for the `current_instances`.
@@ -832,6 +851,7 @@ class KalmanShiftTracker(Tracker):
         kf_min_velocity_cap_px: Floor (px/frame) for the velocity cap. Default: 15.0.
     """
 
+    kf_track_features: str = "centroid"
     kf_init_frame_count: int = 10
     kf_node_indices: Optional[List[int]] = None
     kf_reset_gap_size: int = 5
@@ -972,25 +992,51 @@ class KalmanShiftTracker(Tracker):
             return [i for i in self.kf_node_indices if i < (self._n_nodes or 0)]
         return list(range(self._n_nodes)) if self._n_nodes else []
 
-    @staticmethod
-    def _build_matrices():
-        """Build the constant-velocity centroid transition/observation matrices.
+    def _num_track_points(self) -> int:
+        """Number of points the motion model tracks per instance.
 
-        State is the centroid and its velocity ``[cx, vcx, cy, vcy]`` (4-dim);
-        the observation is the centroid ``[cx, cy]`` (2-dim). Tracking the centroid
-        with a single filter (rather than every keypoint independently) keeps the
-        fit stable and the predicted pose rigid.
+        1 for ``kf_track_features="centroid"`` (the per-track centroid); one per
+        selected node for ``kf_track_features="keypoints"``.
         """
-        transition = [
-            [1.0, 1.0, 0.0, 0.0],  # cx' = cx + vcx
-            [0.0, 1.0, 0.0, 0.0],  # vcx' = vcx
-            [0.0, 0.0, 1.0, 1.0],  # cy' = cy + vcy
-            [0.0, 0.0, 0.0, 1.0],  # vcy' = vcy
-        ]
-        observation = [
-            [1.0, 0.0, 0.0, 0.0],  # observe cx
-            [0.0, 0.0, 1.0, 0.0],  # observe cy
-        ]
+        if self.kf_track_features == "keypoints":
+            return max(1, len(self._resolved_node_indices))
+        return 1
+
+    def _tracked_points(self, keypoints: np.ndarray) -> np.ndarray:
+        """The points the motion model tracks for an instance, shape (P, 2).
+
+        Centroid mode: the single (visibility-aware) centroid. Keypoints mode: the
+        selected node coordinates as-is (NaN where a node is missing).
+        """
+        if self.kf_track_features == "keypoints":
+            return np.asarray(keypoints, dtype=float)[self._resolved_node_indices, :]
+        return self._centroid(keypoints).reshape(1, 2)
+
+    def _build_matrices(self):
+        """Build constant-velocity transition/observation matrices for P points.
+
+        State is ``[x0, vx0, y0, vy0, x1, vx1, y1, vy1, ...]`` (4*P dims); the
+        observation is the P point positions ``[x0, y0, x1, y1, ...]`` (2*P dims).
+        For ``kf_track_features="centroid"`` P=1 (a single stable centroid filter,
+        whose predicted displacement is applied rigidly to the whole body); for
+        ``"keypoints"`` P is the number of tracked nodes (each node gets its own
+        constant-velocity filter — noisier, but uses the pose directly).
+        """
+        n_points = self._num_track_points()
+        state_dim = 4 * n_points
+        obs_dim = 2 * n_points
+        transition = [[0.0] * state_dim for _ in range(state_dim)]
+        observation = [[0.0] * state_dim for _ in range(obs_dim)]
+        for p in range(n_points):
+            b = 4 * p
+            transition[b][b] = 1.0  # x' = x + vx
+            transition[b][b + 1] = 1.0
+            transition[b + 1][b + 1] = 1.0  # vx' = vx
+            transition[b + 2][b + 2] = 1.0  # y' = y + vy
+            transition[b + 2][b + 3] = 1.0
+            transition[b + 3][b + 3] = 1.0  # vy' = vy
+            observation[2 * p][b] = 1.0  # observe x
+            observation[2 * p + 1][b + 2] = 1.0  # observe y
         return transition, observation
 
     def _centroid(self, keypoints: np.ndarray) -> np.ndarray:
@@ -1013,15 +1059,23 @@ class KalmanShiftTracker(Tracker):
             return np.nanmean(pts, axis=0)
 
     def _obs_vector(self, keypoints: np.ndarray) -> np.ndarray:
-        """Masked centroid observation vector, shape (2,)."""
+        """Masked observation vector of the tracked points, shape (2*P,)."""
         return np.ma.masked_invalid(
-            np.ma.asarray(self._centroid(keypoints), dtype=float)
+            np.ma.asarray(self._tracked_points(keypoints).flatten(), dtype=float)
         )
 
     @staticmethod
-    def _predicted_centroid(mean: np.ndarray) -> np.ndarray:
-        """Extract the centroid position ``[cx, cy]`` from a state mean."""
-        return np.asarray(mean)[::2]
+    def _predicted_points(mean: np.ndarray) -> np.ndarray:
+        """Extract predicted point positions ``[[x0,y0],...]`` from a state mean."""
+        return np.asarray(mean)[::2].reshape(-1, 2)
+
+    def _predicted_centroid(self, mean: np.ndarray) -> np.ndarray:
+        """Centroid of the predicted tracked points, shape (2,) (used for gating)."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            return np.nanmean(self._predicted_points(mean), axis=0)
 
     @staticmethod
     def _cap_velocity(mean: np.ndarray, cap: float) -> np.ndarray:
@@ -1093,32 +1147,53 @@ class KalmanShiftTracker(Tracker):
         if len(window) < 3:
             return False  # need a few contiguous frames for a stable velocity fit
         window = window[-self.kf_init_frame_count :]
-        cents = [self._centroid(h["keypoints"]) for h in window]
-        obs = np.ma.masked_invalid(np.ma.asarray(cents, dtype=float))  # (T, 2)
+        n_points = self._num_track_points()
+        obs_dim = 2 * n_points
+        rows = np.asarray(
+            [self._tracked_points(h["keypoints"]).flatten() for h in window],
+            dtype=float,
+        )  # (T, 2P), NaN where a tracked point is missing
+        obs = np.ma.masked_invalid(rows)
 
         median_step = self._window_median_step(window)
         velocity_cap = max(
             self.kf_min_velocity_cap_px, self.kf_velocity_cap_mult * median_step
         )
 
-        # Seed position from the first finite centroid; velocity from the first pair
-        # of centroids one frame apart that are both finite (so a centroid dropout does
-        # not mislabel a multi-frame step as a one-frame velocity). A dropped node must
-        # not collapse the seed to the image origin.
-        finite = [c for c in cents if not np.isnan(c).any()]
-        if len(finite) < 2:
+        # Need at least two frames with any usable observation.
+        if int(np.sum(~np.isnan(rows).all(axis=1))) < 2:
             return False
-        first = np.asarray(finite[0], dtype=float)
-        seed_vel = np.zeros(2)
-        for i in range(1, len(cents)):
-            if not np.isnan(cents[i]).any() and not np.isnan(cents[i - 1]).any():
-                seed_vel = np.clip(
-                    np.asarray(cents[i] - cents[i - 1], dtype=float),
-                    -velocity_cap,
-                    velocity_cap,
-                )
-                break
-        initial_state_mean = [first[0], seed_vel[0], first[1], seed_vel[1]]
+
+        # Per-coordinate seed: position from the first finite value; velocity from the
+        # first consecutive finite pair (capped) so a dropout does not mislabel a
+        # multi-frame step as a one-frame velocity. Coordinates never seen in the
+        # window are filled with the same-axis mean (never the image origin).
+        first = np.full(obs_dim, np.nan)
+        seed_vel = np.zeros(obs_dim)
+        for c in range(obs_dim):
+            finite_t = np.where(~np.isnan(rows[:, c]))[0]
+            if len(finite_t) == 0:
+                continue
+            first[c] = rows[finite_t[0], c]
+            for t in finite_t:
+                if t + 1 < len(rows) and not np.isnan(rows[t + 1, c]):
+                    seed_vel[c] = np.clip(
+                        rows[t + 1, c] - rows[t, c], -velocity_cap, velocity_cap
+                    )
+                    break
+        if np.isnan(first).all():
+            return False
+        if np.isnan(first).any():
+            fx = np.nanmean(first[0::2]) if not np.isnan(first[0::2]).all() else 0.0
+            fy = np.nanmean(first[1::2]) if not np.isnan(first[1::2]).all() else 0.0
+            first[0::2] = np.where(np.isnan(first[0::2]), fx, first[0::2])
+            first[1::2] = np.where(np.isnan(first[1::2]), fy, first[1::2])
+        initial_state_mean = [0.0] * (4 * n_points)
+        for p in range(n_points):
+            initial_state_mean[4 * p] = float(first[2 * p])
+            initial_state_mean[4 * p + 1] = float(seed_vel[2 * p])
+            initial_state_mean[4 * p + 2] = float(first[2 * p + 1])
+            initial_state_mean[4 * p + 3] = float(seed_vel[2 * p + 1])
 
         transition, observation = self._build_matrices()
         kalman_filter_cls = _get_kalman_filter_cls()
@@ -1319,19 +1394,39 @@ class KalmanShiftTracker(Tracker):
 
             ref = history[-1]
             last_keypoints = np.asarray(ref["keypoints"], dtype=float)
+            blend = self.kf_prediction_blend
             pred_centroid = self._predicted_centroid(mean)
             last_centroid = self._centroid(last_keypoints)
 
             if np.isnan(pred_centroid).any() or np.isnan(last_centroid).any():
-                candidate_keypoints = last_keypoints  # hold last (no valid centroid)
+                candidate_keypoints = last_keypoints  # hold last (no valid prediction)
+            elif self.kf_track_features == "keypoints":
+                # Per-node mode: blend each tracked node's predicted position with its
+                # last observed position; non-tracked nodes are translated rigidly by
+                # the mean tracked displacement. Uses the pose directly (noisier than
+                # the rigid centroid candidate), with a tolerant similarity score
+                # (`oks_stddev`) or bbox/iou recommended.
+                idx = self._resolved_node_indices
+                pred_points = self._predicted_points(mean)  # (K, 2)
+                last_tracked = last_keypoints[idx]
+                disp = pred_points - last_tracked
+                blended = last_tracked + blend * disp
+                blended = np.where(np.isnan(blended), pred_points, blended)
+                candidate_keypoints = last_keypoints.copy()
+                candidate_keypoints[idx] = blended
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", category=RuntimeWarning)
+                    mean_disp = np.nanmean(disp, axis=0)
+                if not np.isnan(mean_disp).any():
+                    mask = np.ones(self._n_nodes, dtype=bool)
+                    mask[idx] = False
+                    candidate_keypoints[mask] = last_keypoints[mask] + blend * mean_disp
             else:
-                # Rigidly translate the last observed pose by a fraction of the
-                # predicted centroid displacement. The weight is constant (NOT scaled
-                # up with staleness): a coasting prediction is *less* reliable, so
-                # amplifying it during gaps just injects swaps under noise.
-                displacement = self.kf_prediction_blend * (
-                    pred_centroid - last_centroid
-                )
+                # Centroid mode: rigidly translate the last observed pose by a fraction
+                # of the predicted centroid displacement. The weight is constant (NOT
+                # scaled up with staleness): a coasting prediction is *less* reliable,
+                # so amplifying it during gaps just injects swaps under noise.
+                displacement = blend * (pred_centroid - last_centroid)
                 candidate_keypoints = last_keypoints + displacement
 
             predicted[track_id].append(
@@ -1420,6 +1515,7 @@ def run_tracker(
     scoring_method: str = "oks",
     scoring_reduction: str = "mean",
     robust_best_instance: float = 1.0,
+    oks_stddev: float = 0.025,
     track_matching_method: str = "hungarian",
     max_tracks: Optional[int] = None,
     use_flow: bool = False,
@@ -1427,6 +1523,7 @@ def run_tracker(
     of_window_size: int = 21,
     of_max_levels: int = 3,
     use_kalman: bool = False,
+    kf_track_features: str = "centroid",
     kf_init_frame_count: int = 10,
     kf_node_indices: Optional[List[int]] = None,
     kf_reset_gap_size: int = 5,
@@ -1477,10 +1574,14 @@ def run_tracker(
         of_max_levels: Number of pyramid scale levels to consider. This is different
             from the scale parameter, which determines the initial image scaling.
                 Default: 3. (only if `use_flow` is True).
+        oks_stddev: Keypoint-spread normalization constant for `oks` scoring; larger is
+            more tolerant of localization error. Default: 0.025.
         use_kalman: If True, `KalmanShiftTracker` is used, where poses are predicted with
             a per-track constant-velocity Kalman filter. Requires
             `tracking_target_instance_count` (or `max_tracks`) and is mutually exclusive
             with `use_flow`. Default: `False`.
+        kf_track_features: What the Kalman motion model tracks: `centroid` (default) or
+            `keypoints` (per-node poses; noisier). (only if `use_kalman` is True)
         kf_init_frame_count: Number of warm-up frames tracked with the base path before
             the Kalman filters are fit via EM. Default: 10. (only if `use_kalman` is True)
         kf_node_indices: Skeleton node (row) indices to track with the motion model.
@@ -1508,6 +1609,7 @@ def run_tracker(
         scoring_method=scoring_method,
         scoring_reduction=scoring_reduction,
         robust_best_instance=robust_best_instance,
+        oks_stddev=oks_stddev,
         track_matching_method=track_matching_method,
         max_tracks=max_tracks,
         use_flow=use_flow,
@@ -1515,6 +1617,7 @@ def run_tracker(
         of_window_size=of_window_size,
         of_max_levels=of_max_levels,
         use_kalman=use_kalman,
+        kf_track_features=kf_track_features,
         kf_init_frame_count=kf_init_frame_count,
         kf_node_indices=kf_node_indices,
         kf_reset_gap_size=kf_reset_gap_size,

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -123,7 +123,7 @@ class Tracker:
         scoring_method: str = "oks",
         scoring_reduction: str = "mean",
         robust_best_instance: float = 1.0,
-        oks_stddev: float = 0.025,
+        oks_stddev: Optional[float] = None,
         track_matching_method: str = "hungarian",
         max_tracks: Optional[int] = None,
         use_flow: bool = False,
@@ -184,7 +184,9 @@ class Tracker:
                 from the scale parameter, which determines the initial image scaling.
                 Default: 3. (only if `use_flow` is True)
             oks_stddev: Keypoint-spread normalization constant for `oks` scoring;
-                larger is more tolerant of localization error. Default: 0.025.
+                larger is more tolerant of localization error. `None` (default)
+                auto-resolves to 0.1 for `kf_track_features="keypoints"` (whose per-node
+                prediction is noisier) and 0.025 otherwise.
             use_kalman: If True, `KalmanShiftTracker` is used, where poses are predicted
                 with a per-track constant-velocity Kalman filter. Requires
                 `tracking_target_instance_count` (or `max_tracks`) and is mutually
@@ -251,6 +253,23 @@ class Tracker:
             )
             logger.error(message)
             raise ValueError(message)
+
+        if use_kalman and kf_track_features not in ("centroid", "keypoints"):
+            message = (
+                f"Invalid kf_track_features={kf_track_features!r}; choose 'centroid' "
+                "(default) or 'keypoints'."
+            )
+            logger.error(message)
+            raise ValueError(message)
+
+        # Resolve the OKS tolerance: the per-node 'keypoints' prediction is noisier, so
+        # the strict default stddev (0.025) collapses its similarity scores; default it
+        # to 0.1 (validated on synthetic + real data). Centroid/base keep 0.025. An
+        # explicit oks_stddev always wins.
+        if oks_stddev is None:
+            oks_stddev = (
+                0.1 if (use_kalman and kf_track_features == "keypoints") else 0.025
+            )
 
         if use_kalman:
             return KalmanShiftTracker(
@@ -1515,7 +1534,7 @@ def run_tracker(
     scoring_method: str = "oks",
     scoring_reduction: str = "mean",
     robust_best_instance: float = 1.0,
-    oks_stddev: float = 0.025,
+    oks_stddev: Optional[float] = None,
     track_matching_method: str = "hungarian",
     max_tracks: Optional[int] = None,
     use_flow: bool = False,
@@ -1575,7 +1594,8 @@ def run_tracker(
             from the scale parameter, which determines the initial image scaling.
                 Default: 3. (only if `use_flow` is True).
         oks_stddev: Keypoint-spread normalization constant for `oks` scoring; larger is
-            more tolerant of localization error. Default: 0.025.
+            more tolerant of localization error. `None` (default) auto-resolves to 0.1
+            for `kf_track_features="keypoints"` and 0.025 otherwise.
         use_kalman: If True, `KalmanShiftTracker` is used, where poses are predicted with
             a per-track constant-velocity Kalman filter. Requires
             `tracking_target_instance_count` (or `max_tracks`) and is mutually exclusive

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -1110,3 +1110,65 @@ def test_kalman_from_config_robustness_knobs():
     assert tracker.kf_min_gate_px == 55.0
     assert tracker.kf_velocity_cap_mult == 2.0
     assert tracker.kf_min_velocity_cap_px == 12.0
+
+
+def test_kalman_keypoints_mode_tracks_per_node():
+    """kf_track_features='keypoints' fits one filter per node and tracks (#572)."""
+    n_nodes = 3
+    tracker = _kalman_tracker(
+        kf_track_features="keypoints", kf_init_frame_count=3, kf_node_indices=None
+    )
+    assert tracker.kf_track_features == "keypoints"
+    per_frame = _run_synthetic_kalman_tracking(tracker, n_frames=10, n_nodes=n_nodes)
+
+    assert tracker._initialized
+    assert len(tracker._kalman_filters) == 2
+    # Per-node state has 4 dims per tracked node (vs 4 total for the centroid model).
+    for result in tracker._last_results.values():
+        assert len(result["means"]) == 4 * n_nodes
+    # Two stable tracks are maintained.
+    assert {name for frame in per_frame for name in frame} == {"track_0", "track_1"}
+
+
+def test_kalman_keypoints_supports_bbox_iou():
+    """Keypoints mode works with the bbox/iou featurization/metric alternative (#572)."""
+    tracker = _kalman_tracker(
+        kf_track_features="keypoints",
+        kf_init_frame_count=3,
+        features="bboxes",
+        scoring_method="iou",
+    )
+    per_frame = _run_synthetic_kalman_tracking(tracker, n_frames=10, n_nodes=3)
+    assert tracker._initialized
+    assert {name for frame in per_frame for name in frame} == {"track_0", "track_1"}
+
+
+def test_kalman_oks_stddev_auto_resolves_by_mode():
+    """oks_stddev auto-resolves: 0.1 for keypoints mode, 0.025 otherwise (#572)."""
+    kp = Tracker.from_config(
+        use_kalman=True, kf_track_features="keypoints", tracking_target_instance_count=2
+    )
+    cen = Tracker.from_config(
+        use_kalman=True, kf_track_features="centroid", tracking_target_instance_count=2
+    )
+    assert kp.oks_stddev == 0.1
+    assert cen.oks_stddev == 0.025
+    assert Tracker.from_config().oks_stddev == 0.025  # base tracker
+    # An explicit value always wins over the auto-resolution.
+    explicit = Tracker.from_config(
+        use_kalman=True,
+        kf_track_features="keypoints",
+        tracking_target_instance_count=2,
+        oks_stddev=0.03,
+    )
+    assert explicit.oks_stddev == 0.03
+
+
+def test_kalman_invalid_track_features_raises():
+    """An unknown kf_track_features value is rejected by from_config (#572)."""
+    with pytest.raises(ValueError):
+        Tracker.from_config(
+            use_kalman=True,
+            kf_track_features="garbage",
+            tracking_target_instance_count=2,
+        )


### PR DESCRIPTION
## Summary

Adds a **poses-as-input option** to `KalmanShiftTracker`: `kf_track_features="keypoints"` runs one constant-velocity filter **per node** (the per-node pose is the candidate) as an alternative to the rigid **centroid** model shipped in #596. Requested even though it's noisier; the OKS degeneracy is mitigated as suggested (tolerant OKS + bbox/iou).

**Stacked on #596** (`fix-572-kalman-correctness`). Centroid mode (the #596 default) is **verified byte-for-byte unchanged**.

## What's added

- `kf_track_features` in `{"centroid"` (default)`, "keypoints"}` — the motion model generalized to track P points (P=1 centroid → rigid translation, identical to #596; P=K nodes → per-node prediction blended with the last observation). All #596 robustness machinery (centroid-distance gating, per-axis velocity cap, gap coasting, reset, contiguous-fresh refit, NaN-robust seeding) is shared.
- Configurable **`oks_stddev`** (OKS keypoint-spread tolerance) on the base `Tracker`. It **auto-resolves**: `0.1` for keypoints mode (the strict `0.025` collapses the noisier per-node poses), `0.025` for centroid/base; an explicit value always wins.
- `features="bboxes" + scoring_method="iou"` works as an alternative metric for the predicted pose.
- Wired through `from_config`, `run_tracker`, `run_inference`, `TrackerConfig`/`apply_tracking`, and both the `track` and `infer` CLIs; `from_config` validates `kf_track_features`.

## Evaluation (synthetic + two real proofread datasets + scoring sweep, via a workflow)

Compared base / centroid / keypoints@oks0.025 / keypoints@oks0.1 / keypoints+bbox-iou:

- **Synthetic stress:** keypoints mode is now *bounded* (no unbounded switch storms — the #596 floors hold). `oks@0.025` is the worst config in every hard regime (occlusion, high-noise, heavy node-drop); **`oks@0.1` recovers it everywhere**; bbox/iou wins on separated-but-noisy scenes but is unsafe on rotation/false-positives.
- **flies13** (2 flies, small bodies): keypoints is a **clear win under noise** — `keypoints+bbox-iou` cut ID switches **162 → 52** and lifted IDF1 **0.951 → 0.974** on the full sequence; `oks@0.1` a strong second; `oks@0.025` worst.
- **hcm** (3 animals, occlusions): keypoints offers **no gain** — base/centroid are ~perfect; keypoints (best, bbox-iou) ~0.98. So centroid/base win here.
- **Verdict:** ship keypoints as an **opt-in alternative, not a replacement**; default `kf_track_features` stays `centroid`.

## Recommended usage (documented in `docs/guides/tracking.md`)

- Default = **centroid** (stable, matches base on real data, best on converging scenes).
- **keypoints** when subjects are small and move distinctively; pair with the auto `oks_stddev=0.1`, or `--features bboxes --scoring_method iou` for noisy, separated, non-rotating subjects.

## Tests

Per-node keypoints tracking (filter state `4·K`), bbox/iou featurization, `oks_stddev` auto-resolution, and `kf_track_features` value validation. Full `tests/tracking/test_tracker.py` + `tests/inference/test_tracking.py`: **42 passed**; `black` / `ruff` (`sleap_nn/`) / `codespell` clean. Centroid-mode sweep verified identical to #596.

> Review note: depends on #596 — review/merge that first (this PR's diff vs `main` includes #596).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
