### PR TITLE
Fix: default seed to 42 and warn on seed mismatch during resume

### DIFF
--- a/docs/configuration/trainer.md
+++ b/docs/configuration/trainer.md
@@ -165,7 +165,7 @@ trainer_config:
   min_train_steps_per_epoch: 200  # Minimum steps
   train_steps_per_epoch: null     # Exact steps (null=auto)
   enable_progress_bar: true
-  seed: null                      # Random seed
+  seed: 42                        # Random seed (ensures deterministic train/val splits)
 ```
 
 ---
@@ -263,7 +263,7 @@ trainer_config:
 | `save_ckpt` | bool | `false` | Save model checkpoints |
 | `ckpt_dir` | str | `.` | Directory for checkpoints |
 | `run_name` | str | `null` | Run folder name (auto-generated if null) |
-| `seed` | int | `null` | Random seed for reproducibility |
+| `seed` | int | `42` | Random seed for reproducibility and deterministic train/val splits |
 | `trainer_accelerator` | str | `auto` | Hardware: `auto`, `gpu`, `cpu`, `mps` |
 | `trainer_devices` | int/str | `null` | Number of devices or `auto` |
 | `trainer_device_indices` | list | `null` | Specific device indices (e.g., `[0, 2]`) |

--- a/docs/guides/training.md
+++ b/docs/guides/training.md
@@ -232,6 +232,9 @@ sleap-nn train --config config.yaml \
 
 This restores both model weights and optimizer state.
 
+!!! warning "Ensure the same seed when resuming"
+    The train/val split is regenerated on resume — it is **not** saved in the checkpoint. If you change `trainer_config.seed` between runs (default: `42`), you will get a different split, which can leak training data into validation. Always use the same seed as the original run. `sleap-nn` will warn you if it detects a mismatch.
+
 ---
 
 ## Multi-GPU Training

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -230,6 +230,7 @@ SLEAP-NN uses PyTorch, so it runs on any system where PyTorch is supported. This
     sleap-nn train --config config.yaml \
         trainer_config.resume_ckpt_path=/path/to/checkpoint.ckpt
     ```
+    Make sure `trainer_config.seed` matches the original run (default: `42`) so the train/val split stays the same. A mismatched seed will produce a different split and may leak training data into validation.
 
 ??? question "How do I use multiple GPUs?"
     ```yaml

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -664,7 +664,7 @@ def get_trainer_config(
     visualize_preds_during_training: bool = False,
     keep_viz: bool = False,
     max_epochs: int = 10,
-    seed: Optional[int] = None,
+    seed: Optional[int] = 42,
     use_wandb: bool = False,
     save_ckpt: bool = False,
     ckpt_dir: Optional[str] = None,
@@ -732,7 +732,7 @@ def get_trainer_config(
         keep_viz: If set to `True`, the `viz` folder will be kept after training. If `False`, the `viz` folder
             will be deleted after training. Only applies when `visualize_preds_during_training` is `True`.
         max_epochs: Maximum number of epochs to run. Default: 100.
-        seed: Seed value for the current experiment. If None, no seeding is applied. Default: None.
+        seed: Seed value for the current experiment. Ensures deterministic train/val splits across runs. Default: 42.
         save_ckpt: True to enable checkpointing. Default: False.
         ckpt_dir: Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
         run_name: Name of the current run. The ckpts will be created in `<ckpt_dir>/<run_name>`. If `None`, a run name is generated with `<timestamp>_<head_name>`. Default: None.

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -331,7 +331,7 @@ class TrainerConfig:
         visualize_preds_during_training: (bool) If set to `True`, sample predictions (keypoints + confidence maps) are saved to `viz` folder in the ckpt dir and in wandb table. *Default*: `False`.
         keep_viz: (bool) If set to `True`, the `viz` folder will be kept after training. If `False`, the `viz` folder will be deleted after training. Only applies when `visualize_preds_during_training` is `True`. *Default*: `False`.
         max_epochs: (int) Maximum number of epochs to run. *Default*: `100`.
-        seed: (int) Seed value for the current experiment. If None, no seeding is applied. *Default*: `None`.
+        seed: (int) Seed value for the current experiment. This ensures deterministic train/val splits across runs, which is critical for safe checkpoint resume. *Default*: `42`.
         use_wandb: (bool) True to enable wandb logging. *Default*: `False`.
         save_ckpt: (bool) True to enable checkpointing. *Default*: `False`.
         ckpt_dir: (str) Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
@@ -362,7 +362,7 @@ class TrainerConfig:
     visualize_preds_during_training: bool = False
     keep_viz: bool = False
     max_epochs: int = 100
-    seed: Optional[int] = None
+    seed: Optional[int] = 42
     use_wandb: bool = False
     save_ckpt: bool = False
     ckpt_dir: Optional[str] = "."

--- a/sleap_nn/config_generator/generator.py
+++ b/sleap_nn/config_generator/generator.py
@@ -153,7 +153,7 @@ class ConfigGenerator:
         self._ckpt_dir: str = "./models"  # Web app default
         self._run_name: Optional[str] = None
         self._resume_ckpt_path: Optional[str] = None
-        self._seed: Optional[int] = None
+        self._seed: Optional[int] = 42
         self._min_train_steps_per_epoch: int = 200
         self._num_workers: int = 0
         self._enable_progress_bar: bool = True

--- a/sleap_nn/config_generator/tui/state.py
+++ b/sleap_nn/config_generator/tui/state.py
@@ -261,7 +261,7 @@ class ConfigState:
         self._accelerator: str = "auto"
         self._devices: str = "auto"  # Number of GPUs: "auto", "1", "2", etc.
         self._min_steps_per_epoch: int = 200  # Web app default
-        self._random_seed: Optional[int] = None
+        self._random_seed: Optional[int] = 42
         self._enable_progress_bar: bool = True  # Web app default
         self._visualize_preds: bool = True  # Web app default (matches checkbox)
         self._keep_viz: bool = False  # Web app default

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -331,7 +331,7 @@ def train(
     visualize_preds_during_training: bool = False,
     keep_viz: bool = False,
     max_epochs: int = 10,
-    seed: Optional[int] = None,
+    seed: Optional[int] = 42,
     use_wandb: bool = False,
     save_ckpt: bool = False,
     ckpt_dir: Optional[str] = None,
@@ -509,7 +509,7 @@ def train(
             are saved to `viz` folder in the ckpt dir.
         keep_viz: If set to `True`, the `viz` folder containing training visualizations will be kept after training completes. If `False`, the folder will be deleted. This parameter only has an effect when `visualize_preds_during_training` is `True`. Default: `False`.
         max_epochs: Maximum number of epochs to run. Default: 10.
-        seed: Seed value for the current experiment. If None, no seeding is applied. Default: None.
+        seed: Seed value for the current experiment. Ensures deterministic train/val splits across runs. Default: 42.
         save_ckpt: True to enable checkpointing. Default: False.
         ckpt_dir: Directory path where the `<run_name>` folder is created. If `None`, a new folder for the current run is created in the working dir. **Default**: `None`
         run_name: Name of the current run. The ckpts will be created in `<ckpt_dir>/<run_name>`. If `None`, a run name is generated with `<timestamp>_<head_name>`. **Default**: `None`

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -305,14 +305,38 @@ class ModelTrainer:
             val_fraction = OmegaConf.select(
                 self.config, "data_config.validation_fraction", default=0.1
             )
-            seed = (
-                42
-                if (
-                    self.config.trainer_config.seed is None
-                    and self._get_trainer_devices() > 1
-                )
-                else self.config.trainer_config.seed
+            seed = self.config.trainer_config.seed
+
+            # Warn if resuming from a checkpoint with a potentially different seed
+            resume_ckpt = OmegaConf.select(
+                self.config, "trainer_config.resume_ckpt_path", default=None
             )
+            if resume_ckpt is not None:
+                orig_config_path = Path(resume_ckpt).parent / "training_config.yaml"
+                if orig_config_path.exists():
+                    try:
+                        orig_cfg = OmegaConf.load(orig_config_path.as_posix())
+                        orig_seed = OmegaConf.select(
+                            orig_cfg, "trainer_config.seed", default=None
+                        )
+                        if orig_seed != seed:
+                            logger.warning(
+                                f"Current seed ({seed}) differs from the original "
+                                f"training seed ({orig_seed}) in {orig_config_path}. "
+                                f"This will produce a different train/val split and "
+                                f"may cause data leakage between train and val sets. "
+                                f"Set `trainer_config.seed: {orig_seed}` to preserve "
+                                f"the original split."
+                            )
+                    except Exception:
+                        pass
+                else:
+                    logger.warning(
+                        f"Resuming from checkpoint but could not find "
+                        f"{orig_config_path} to verify the train/val split seed. "
+                        f"Ensure `trainer_config.seed` matches the original "
+                        f"training run to avoid data leakage."
+                    )
             for label in labels:
                 train_split, val_split = label.make_training_splits(
                     n_train=1 - val_fraction, n_val=val_fraction, seed=seed

--- a/tests/assets/generated_configs/bottomup.yaml
+++ b/tests/assets/generated_configs/bottomup.yaml
@@ -82,7 +82,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: ./models

--- a/tests/assets/generated_configs/centered_instance.yaml
+++ b/tests/assets/generated_configs/centered_instance.yaml
@@ -76,7 +76,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: ./models

--- a/tests/assets/generated_configs/centroid.yaml
+++ b/tests/assets/generated_configs/centroid.yaml
@@ -72,7 +72,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: ./models

--- a/tests/assets/generated_configs/centroid_only.yaml
+++ b/tests/assets/generated_configs/centroid_only.yaml
@@ -72,7 +72,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: ./models

--- a/tests/assets/generated_configs/multi_class_bottomup.yaml
+++ b/tests/assets/generated_configs/multi_class_bottomup.yaml
@@ -80,7 +80,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: ./models

--- a/tests/assets/generated_configs/multi_class_topdown.yaml
+++ b/tests/assets/generated_configs/multi_class_topdown.yaml
@@ -83,7 +83,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: ./models

--- a/tests/assets/generated_configs/single_instance.yaml
+++ b/tests/assets/generated_configs/single_instance.yaml
@@ -74,7 +74,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: ./models

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -262,7 +262,7 @@ def test_trainer_config(caplog):
     assert conf_structured.val_data_loader.shuffle is False
     assert conf_structured.model_ckpt.save_top_k == 1
     assert conf_structured.max_epochs == 100
-    assert conf_structured.seed is None
+    assert conf_structured.seed == 42
     assert conf_structured.optimizer.lr == 1e-4
     assert conf_structured.lr_scheduler is not None
     assert conf_structured.lr_scheduler.reduce_lr_on_plateau is not None
@@ -346,7 +346,7 @@ def test_trainer_mapper():
     assert config.trainer_accelerator == "auto"
     assert config.enable_progress_bar is True
     assert config.min_train_steps_per_epoch == 200
-    assert config.seed is None
+    assert config.seed == 42
     assert config.use_wandb is False
     assert config.save_ckpt is True
     assert config.resume_ckpt_path is None


### PR DESCRIPTION
## Summary

- Default `trainer_config.seed` from `None` to `42` so train/val splits are deterministic by default, preventing data leakage when resuming from a checkpoint
- Add a warning when resuming from a checkpoint if the current seed differs from the original training run's seed
- Update docs and tests to reflect the new default

## Context

Raised in [Discussion #579](https://github.com/talmolab/sleap-nn/discussions/579): when resuming training with `torch_dataset_cache_img_disk`, the train/val split is regenerated (not restored from the checkpoint). On single-GPU with the old default of `seed: null`, each run produced a different random split — images used for training could end up in validation on resume, silently compromising evaluation metrics.

## Changes Made

**Config defaults** (`seed: None` → `seed: 42`):
- `sleap_nn/config/trainer_config.py`
- `sleap_nn/train.py`
- `sleap_nn/config/get_config.py`
- `sleap_nn/config_generator/generator.py`
- `sleap_nn/config_generator/tui/state.py`

**Resume seed mismatch warning** (`sleap_nn/training/model_trainer.py`):
- When `resume_ckpt_path` is set and no separate val labels are provided, reads `training_config.yaml` from the checkpoint directory
- Warns with the original seed value if it differs from the current seed
- Falls back to a general warning if the config file is missing

**Simplified seed logic** (`sleap_nn/training/model_trainer.py`):
- Removed the multi-GPU special case (`42 if None and multi-GPU`) since the default is now always 42

**Docs**:
- `docs/guides/training.md` — added warning admonition about seed on resume
- `docs/help/faq.md` — added note to resume FAQ
- `docs/configuration/trainer.md` — updated default value and description

**Tests**:
- `tests/config/test_trainer_config.py` — updated seed assertions
- Regenerated golden YAML configs

## Testing

- Full test suite passes (1419 passed, 67 skipped, 4 xfailed)
- Verified `np.random.default_rng(seed=42)` produces identical splits across runs
- Verified `seed=None` produces different splits (confirming the original bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)