### PR TITLE
feat: add progress bar for tracking in new inference pipeline

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1437,12 +1437,18 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
 
     if kwargs.get("gui"):
         predict_kwargs["progress_callback"] = _gui_progress_callback()
+        if kwargs.get("tracking"):
+            predict_kwargs["tracking_progress_callback"] = _gui_progress_callback()
         return predict(source, **predict_kwargs)
 
     # Non-gui: show a Rich progress bar (parity with legacy `track`'s default
     # progress UX; the plumbing was wired but no callback was attached). #583.
-    cb, progress = _rich_progress_callback()
-    predict_kwargs["progress_callback"] = cb
+    progress = _make_rich_progress()
+    predict_kwargs["progress_callback"] = _rich_task_callback(progress, "Predicting...")
+    if kwargs.get("tracking"):
+        predict_kwargs["tracking_progress_callback"] = _rich_task_callback(
+            progress, "Tracking..."
+        )
     try:
         return predict(source, **predict_kwargs)
     finally:
@@ -1487,12 +1493,24 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
     from sleap_nn.inference.provenance import build_tracking_only_provenance
 
     tracker_config = _build_tracker_config(kwargs)
+
+    if kwargs.get("gui"):
+        tracking_cb = _gui_progress_callback()
+    else:
+        _progress = _make_rich_progress()
+        tracking_cb = _rich_task_callback(_progress, "Tracking...")
+
     _start = datetime.now()
-    out = predictor_cls.retrack(
-        labels,
-        tracker_config,
-        clean_empty_frames=bool(kwargs.get("no_empty_frames")),
-    )
+    try:
+        out = predictor_cls.retrack(
+            labels,
+            tracker_config,
+            clean_empty_frames=bool(kwargs.get("no_empty_frames")),
+            progress_callback=tracking_cb,
+        )
+    finally:
+        if not kwargs.get("gui"):
+            _progress.stop()
     # Attach tracking-only provenance to the retracked .slp (legacy parity —
     # apply_tracking leaves provenance to the caller, and the legacy track path
     # set it; the new retrack flow previously saved with empty provenance). #583.
@@ -1547,19 +1565,11 @@ def _gui_progress_callback():
     return cb
 
 
-def _rich_progress_callback():
-    """Build a Rich progress bar callback for the non-``--gui`` ``infer`` path.
+def _make_rich_progress():
+    """Build a shared Rich ``Progress`` instance for the ``infer`` path.
 
-    Returns ``(callback, progress)`` where ``callback(processed, total)`` has
-    the per-batch signature the new pipeline uses. The ``Progress`` is started
-    immediately (so "Predicting..." shows right away) and the caller MUST stop
-    it in a ``finally`` block so the bar closes cleanly on success or error.
-    A ``total <= 0`` (length-less provider) renders an indeterminate bar.
-
-    ``rich`` is imported lazily so it doesn't slow ``--help``; the columns
-    mirror the legacy ``track`` look-and-feel without importing the heavy
-    legacy ``predictors`` module. Progress is counted in batches (the new
-    callback reports batches, not frames). #583.
+    Returns the ``Progress`` (already started) — the caller MUST stop it
+    in a ``finally`` block.
     """
     from rich.progress import (
         BarColumn,
@@ -1581,16 +1591,46 @@ def _rich_progress_callback():
         TimeElapsedColumn(),
         refresh_per_second=4,
     )
-    task = progress.add_task("Predicting...", total=None)
     progress.start()
-    state = {"total_set": False}
+    return progress
+
+
+def _rich_task_callback(progress, description: str = "Predicting..."):
+    """Build a callback that drives a task on an existing ``Progress``.
+
+    Returns ``callback(processed, total)`` that lazily adds a task with
+    *description* to *progress* on the first call and updates it on each
+    subsequent call. This allows the task to appear only when the phase
+    actually starts (e.g. tracking may not run at all).
+    """
+    state: dict = {"task": None}
 
     def cb(processed: int, total: int) -> None:
-        if not state["total_set"] and total and total > 0:
-            progress.update(task, total=total)
-            state["total_set"] = True
-        progress.update(task, completed=processed)
+        if state["task"] is None:
+            state["task"] = progress.add_task(description, total=total or None)
+        elif total and total > 0:
+            progress.update(state["task"], total=total)
+        progress.update(state["task"], completed=processed)
 
+    return cb
+
+
+def _rich_progress_callback():
+    """Build a Rich progress bar callback for the non-``--gui`` ``infer`` path.
+
+    Returns ``(callback, progress)`` where ``callback(processed, total)`` has
+    the per-batch signature the new pipeline uses. The ``Progress`` is started
+    immediately (so "Predicting..." shows right away) and the caller MUST stop
+    it in a ``finally`` block so the bar closes cleanly on success or error.
+    A ``total <= 0`` (length-less provider) renders an indeterminate bar.
+
+    ``rich`` is imported lazily so it doesn't slow ``--help``; the columns
+    mirror the legacy ``track`` look-and-feel without importing the heavy
+    legacy ``predictors`` module. Progress is counted in batches (the new
+    callback reports batches, not frames). #583.
+    """
+    progress = _make_rich_progress()
+    cb = _rich_task_callback(progress, "Predicting...")
     return cb, progress
 
 

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -984,6 +984,7 @@ class Predictor:
         labels: "sio.Labels",
         tracker_config: TrackerConfig,
         clean_empty_frames: bool = False,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> "sio.Labels":
         """Retrack an existing ``sio.Labels`` without running inference.
 
@@ -999,11 +1000,13 @@ class Predictor:
             tracker_config: :class:`TrackerConfig` to drive the tracker.
             clean_empty_frames: When ``True``, drop empty frames from
                 the result (matches ``--no_empty_frames``).
+            progress_callback: Optional ``(processed_frames, total_frames)``
+                callback invoked after each frame is tracked.
 
         Returns:
             New ``sio.Labels`` with tracks attached.
         """
-        out = apply_tracking(labels, tracker_config)
+        out = apply_tracking(labels, tracker_config, progress_callback)
         if clean_empty_frames:
             out.clean(frames=True, skeletons=False)
         return out
@@ -1022,6 +1025,7 @@ class Predictor:
         videos: Optional[List["sio.Video"]] = None,
         clean_empty_frames: bool = False,
         progress_callback: Optional[Callable[[int, int], None]] = None,
+        tracking_progress_callback: Optional[Callable[[int, int], None]] = None,
         peak_threshold: Optional[float] = None,
         centroid_threshold: Optional[float] = None,
         keypoint_threshold: Optional[float] = None,
@@ -1057,6 +1061,9 @@ class Predictor:
                 returned ``sio.Labels``.
             progress_callback: Optional ``(processed_batches, total_batches)``
                 callback invoked after each batch.
+            tracking_progress_callback: Optional
+                ``(processed_frames, total_frames)`` callback invoked
+                after each frame during tracking.
             peak_threshold: Override peak threshold for all stages. For
                 per-stage control on top-down models, use
                 ``centroid_threshold`` / ``keypoint_threshold`` instead.
@@ -1138,7 +1145,9 @@ class Predictor:
             )
         labels = self.to_labels(outputs_list, videos=videos)
         if self.tracker_config is not None:
-            labels = apply_tracking(labels, self.tracker_config)
+            labels = apply_tracking(
+                labels, self.tracker_config, tracking_progress_callback
+            )
         if clean_empty_frames:
             labels.clean(frames=True, skeletons=False)
         labels.provenance = self._build_inference_provenance(

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -80,6 +80,7 @@ def predict(
     output_path: Optional[str] = None,
     clean_empty_frames: bool = False,
     progress_callback: Optional[Callable[[int, int], None]] = None,
+    tracking_progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> sio.Labels:
     """Build a predictor, run inference, return Labels.
 
@@ -129,6 +130,8 @@ def predict(
         output_path: If set, save the Labels to this ``.slp`` path.
         clean_empty_frames: Drop frames with no instances.
         progress_callback: ``(processed, total)`` callback per batch.
+        tracking_progress_callback: ``(processed_frames, total_frames)``
+            callback per frame during tracking.
 
     Returns:
         ``sio.Labels`` with predicted instances.
@@ -203,6 +206,7 @@ def predict(
         make_labels=True,
         clean_empty_frames=clean_empty_frames,
         progress_callback=progress_callback,
+        tracking_progress_callback=tracking_progress_callback,
         peak_threshold=peak_threshold,
         centroid_threshold=centroid_threshold,
         keypoint_threshold=keypoint_threshold,

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -31,7 +31,7 @@ What this does NOT cover:
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 import attrs
 
@@ -94,6 +94,7 @@ class TrackerConfig:
 def apply_tracking(
     labels: sio.Labels,
     config: TrackerConfig,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> sio.Labels:
     """Track predicted instances on every frame and run post-cleanup.
 
@@ -108,6 +109,8 @@ def apply_tracking(
             any) are passed through unchanged and are preferred when
             both are present (matching ``run_tracker`` semantics).
         config: Tracking configuration.
+        progress_callback: Optional ``(processed_frames, total_frames)``
+            callback invoked after each frame is tracked.
 
     Returns:
         ``sio.Labels`` with tracked instances. ``videos`` and
@@ -210,7 +213,8 @@ def apply_tracking(
         labels.labeled_frames,
         key=lambda lf: (video_order.get(id(lf.video), 0), lf.frame_idx),
     )
-    for lf in ordered_lfs:
+    n_frames = len(ordered_lfs)
+    for i, lf in enumerate(ordered_lfs):
         instances: list = []
         if lf.has_user_instances:
             instances_to_track = lf.user_instances
@@ -232,6 +236,8 @@ def apply_tracking(
                 instances=instances,
             )
         )
+        if progress_callback is not None:
+            progress_callback(i + 1, n_frames)
 
     if config.tracking_clean_instance_count > 0:
         tracked_lfs = cull_instances(

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -130,6 +130,39 @@ def test_apply_tracking_preserves_videos_and_skeletons(skeleton, video):
     assert list(out.skeletons) == [skeleton]
 
 
+def test_apply_tracking_progress_callback(skeleton, video):
+    n_frames = 5
+    labels = _make_labels(skeleton, video, frames=n_frames, instances_per_frame=2)
+    calls: list[tuple[int, int]] = []
+    out = apply_tracking(
+        labels, TrackerConfig(), progress_callback=lambda p, t: calls.append((p, t))
+    )
+    assert len(out.labeled_frames) == n_frames
+    assert len(calls) == n_frames
+    assert calls[0] == (1, n_frames)
+    assert calls[-1] == (n_frames, n_frames)
+
+
+def test_apply_tracking_no_callback_is_silent(skeleton, video):
+    labels = _make_labels(skeleton, video, frames=3, instances_per_frame=1)
+    out = apply_tracking(labels, TrackerConfig())
+    assert len(out.labeled_frames) == 3
+
+
+def test_retrack_progress_callback(skeleton, video):
+    n_frames = 4
+    labels = _make_labels(skeleton, video, frames=n_frames, instances_per_frame=2)
+    calls: list[tuple[int, int]] = []
+    out = Predictor.retrack(
+        labels,
+        TrackerConfig(),
+        progress_callback=lambda p, t: calls.append((p, t)),
+    )
+    assert len(out.labeled_frames) == n_frames
+    assert len(calls) == n_frames
+    assert calls[-1] == (n_frames, n_frames)
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Predictor — tracker_config wiring
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds an optional `progress_callback` parameter to `apply_tracking()` that reports `(processed_frames, total_frames)` after each frame
- Wires the callback through `Predictor.predict()`, `Predictor.retrack()`, and `run.predict()` so both **inference+tracking** and **track-only** workflows show progress
- CLI shows a Rich "Tracking..." progress bar (terminal) or JSON progress lines (`--gui` mode) during the tracking phase

## Changes Made
- **`sleap_nn/inference/tracking.py`**: Added `progress_callback` parameter to `apply_tracking()`, invoked per-frame in the tracking loop
- **`sleap_nn/inference/predictor.py`**: Added `tracking_progress_callback` to `predict()` and `progress_callback` to `retrack()`, both forwarded to `apply_tracking()`
- **`sleap_nn/inference/run.py`**: Added `tracking_progress_callback` parameter, forwarded to `Predictor.predict()`
- **`sleap_nn/cli.py`**: 
  - Refactored `_rich_progress_callback()` into `_make_rich_progress()` + `_rich_task_callback()` so both inference and tracking phases share a single `Progress` instance
  - Inference+tracking path (`_run_in_memory_new_flow`): creates a "Tracking..." task on the shared progress bar
  - Track-only path (`_run_retrack_only`): creates its own Rich progress bar with "Tracking..."
  - GUI mode: emits separate JSON progress for the tracking phase
- **`tests/inference/test_tracking.py`**: Added 3 new tests covering callback invocation, no-callback silence, and `Predictor.retrack()` callback forwarding

## API Changes
- `apply_tracking(labels, config, progress_callback=None)` — new optional parameter
- `Predictor.predict(..., tracking_progress_callback=None)` — new optional parameter
- `Predictor.retrack(..., progress_callback=None)` — new optional parameter
- `run.predict(..., tracking_progress_callback=None)` — new optional parameter

All new parameters default to `None`, so existing callers are unaffected.

## Testing
- 20/20 tracking tests pass (3 new tests added)
- 25/25 CLI infer command tests pass
- 40/40 main CLI tests pass
- 50/50 related issue tests pass (582, 583, 584)
- All formatting (black) and linting (ruff) checks pass

## Related Issues
Closes #566

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)