### PR TITLE
feat(seg) 1/4: bottom-up instance segmentation — training stack (refresh of #501)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "sleap-io>=0.7.0,<0.8.0",
+    # Instance segmentation (SegmentationMask / Labels.get_masks) tracks sleap-io
+    # main (0.8.0), which is not yet on PyPI. Pinned to a main commit for
+    # reproducibility; switch to a PyPI version constraint once 0.8.0 releases.
+    "sleap-io>=0.8.0",
     "numpy",
     "torch",
     "torchvision>=0.20.0",
@@ -137,6 +140,10 @@ conflicts = [
 ]
 
 [tool.uv.sources]
+# sleap-io 0.8.0 is not yet released on PyPI; track main for the segmentation
+# (SegmentationMask / Labels.get_masks) APIs. Pinned to a commit for
+# reproducibility — update or drop once sleap-io 0.8.0 is published.
+sleap-io = { git = "https://github.com/talmolab/sleap-io.git", rev = "18aba053f607863654ca233fffed61f1c0dc707e" }
 torch = [
     { index = "pytorch-cpu", extra = "torch-cpu" },
     { index = "pytorch-cu118", extra = "torch-cuda118", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },

--- a/sleap_nn/architectures/heads.py
+++ b/sleap_nn/architectures/heads.py
@@ -594,3 +594,96 @@ class OffsetRefinementHead(Head):
             sigma_threshold=sigma_threshold,
             loss_weight=loss_weight,
         )
+
+
+class SegmentationHead(Head):
+    """Head for predicting binary foreground segmentation masks.
+
+    Outputs a single-channel map with sigmoid activation representing the
+    probability that each pixel belongs to any instance (foreground).
+
+    Attributes:
+        output_stride: Stride of the output head tensor.
+        loss_weight: Weight of the loss term for this head during optimization.
+    """
+
+    def __init__(
+        self,
+        output_stride: int = 2,
+        loss_weight: float = 1.0,
+    ) -> None:
+        """Initialize the object with the specified attributes."""
+        super().__init__(output_stride, loss_weight)
+
+    @property
+    def channels(self) -> int:
+        """Return the number of channels in the tensor output by this head."""
+        return 1
+
+    @property
+    def activation(self) -> str:
+        """Return the activation function of the head output layer."""
+        return "identity"
+
+    @property
+    def loss_function(self) -> str:
+        """Return the name of the loss function to use for this head."""
+        return "bce_dice"
+
+
+class InstanceCenterHead(Head):
+    """Head for predicting instance center heatmaps.
+
+    Outputs a single-channel Gaussian heatmap with peaks at each instance's
+    mask centroid. Similar to CentroidConfmapsHead but for mask-derived centers.
+
+    Attributes:
+        sigma: Standard deviation of the Gaussian in pixels.
+        output_stride: Stride of the output head tensor.
+        loss_weight: Weight of the loss term for this head during optimization.
+    """
+
+    def __init__(
+        self,
+        sigma: float = 10.0,
+        output_stride: int = 2,
+        loss_weight: float = 1.0,
+    ) -> None:
+        """Initialize the object with the specified attributes."""
+        super().__init__(output_stride, loss_weight)
+        self.sigma = sigma
+
+    @property
+    def channels(self) -> int:
+        """Return the number of channels in the tensor output by this head."""
+        return 1
+
+
+class CenterOffsetHead(Head):
+    """Head for predicting per-pixel offset vectors to instance centers.
+
+    Outputs a 2-channel map where each pixel's value is (dx, dy) pointing
+    from the pixel to its instance's center. Only meaningful on foreground pixels.
+
+    Attributes:
+        output_stride: Stride of the output head tensor.
+        loss_weight: Weight of the loss term for this head during optimization.
+    """
+
+    def __init__(
+        self,
+        output_stride: int = 2,
+        loss_weight: float = 0.1,
+    ) -> None:
+        """Initialize the object with the specified attributes."""
+        super().__init__(output_stride, loss_weight)
+
+    @property
+    def channels(self) -> int:
+        """Return the number of channels in the tensor output by this head."""
+        return 2
+
+    @property
+    def loss_function(self) -> str:
+        """Return the name of the loss function to use for this head."""
+        return "smooth_l1"

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -22,6 +22,9 @@ from sleap_nn.architectures.heads import (
     ClassMapsHead,
     ClassVectorsHead,
     OffsetRefinementHead,
+    SegmentationHead,
+    InstanceCenterHead,
+    CenterOffsetHead,
 )
 from sleap_nn.architectures.unet import UNet
 from sleap_nn.architectures.convnext import ConvNextWrapper
@@ -98,8 +101,13 @@ def get_head(model_type: str, head_config: DictConfig) -> Head:
         heads.append(CenteredInstanceConfmapsHead(**head_config.confmaps))
         heads.append(ClassVectorsHead(**head_config.class_vectors))
 
+    elif model_type == "bottomup_segmentation":
+        heads.append(SegmentationHead(**head_config.segmentation))
+        heads.append(InstanceCenterHead(**head_config.center))
+        heads.append(CenterOffsetHead(**head_config.offsets))
+
     else:
-        message = f"{model_type} is not a defined model type. Please choose one of `single_instance`, `centered_instance`, `centroid`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`."
+        message = f"{model_type} is not a defined model type. Please choose one of `single_instance`, `centered_instance`, `centroid`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`."
         logger.error(message)
         raise Exception(message)
 

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -33,6 +33,10 @@ from sleap_nn.config.model_config import (
     ClassMapConfig,
     TopDownCenteredInstanceMultiClassConfig,
     ClassVectorsConfig,
+    BottomUpSegmentationConfig,
+    SegmentationHeadConfig,
+    InstanceCenterConfig,
+    CenterOffsetConfig,
 )
 from sleap_nn.config.data_config import DataConfig, PreprocessingConfig
 from sleap_nn.config.model_config import ModelConfig
@@ -382,9 +386,15 @@ def get_head_configs(head_cfg: Union[str, Dict[str, Any]]):
                 confmaps=CenteredInstanceConfMapsConfig,
                 class_vectors=ClassVectorsConfig,
             )
+        elif head_cfg == "bottomup_segmentation":
+            head_configs.bottomup_segmentation = BottomUpSegmentationConfig(
+                segmentation=SegmentationHeadConfig(),
+                center=InstanceCenterConfig(),
+                offsets=CenterOffsetConfig(),
+            )
         else:
             raise ValueError(
-                f"{head_cfg} is not a valid head type. Please choose one of ['bottomup', 'centered_instance', 'centroid', 'single_instance', 'multi_class_bottomup', 'multi_class_topdown']"
+                f"{head_cfg} is not a valid head type. Please choose one of ['bottomup', 'centered_instance', 'centroid', 'single_instance', 'multi_class_bottomup', 'multi_class_topdown', 'bottomup_segmentation']"
             )
 
     elif isinstance(head_cfg, dict):
@@ -438,6 +448,16 @@ def get_head_configs(head_cfg: Union[str, Dict[str, Any]]):
                 class_vectors=ClassVectorsConfig(
                     **head_cfg["multi_class_topdown"]["class_vectors"]
                 ),
+            )
+        elif (
+            "bottomup_segmentation" in head_cfg
+            and head_cfg["bottomup_segmentation"] is not None
+        ):
+            seg = head_cfg["bottomup_segmentation"]
+            head_configs.bottomup_segmentation = BottomUpSegmentationConfig(
+                segmentation=SegmentationHeadConfig(**seg["segmentation"]),
+                center=InstanceCenterConfig(**seg["center"]),
+                offsets=CenterOffsetConfig(**seg["offsets"]),
             )
 
     return head_configs

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -878,6 +878,54 @@ class ClassVectorsConfig:
 
 
 @define
+class SegmentationHeadConfig:
+    """Configuration for the foreground segmentation head.
+
+    Attributes:
+        output_stride: (int) The stride of the output segmentation maps relative to the
+            input image. Default: 2.
+        loss_weight: (float) Scalar float used to weigh the loss term for this head
+            during training. Default: 1.0.
+    """
+
+    output_stride: int = 2
+    loss_weight: float = 1.0
+
+
+@define
+class InstanceCenterConfig:
+    """Configuration for the instance center heatmap head.
+
+    Attributes:
+        sigma: (float) Standard deviation of the Gaussian distribution used to generate
+            center heatmaps, in pixels at original image resolution. Default: 10.0.
+        output_stride: (int) The stride of the output center heatmaps relative to the
+            input image. Default: 2.
+        loss_weight: (float) Scalar float used to weigh the loss term for this head
+            during training. Default: 1.0.
+    """
+
+    sigma: float = 10.0
+    output_stride: int = 2
+    loss_weight: float = 1.0
+
+
+@define
+class CenterOffsetConfig:
+    """Configuration for the center offset head.
+
+    Attributes:
+        output_stride: (int) The stride of the output offset maps relative to the
+            input image. Default: 2.
+        loss_weight: (float) Scalar float used to weigh the loss term for this head
+            during training. Default: 0.1.
+    """
+
+    output_stride: int = 2
+    loss_weight: float = 0.1
+
+
+@define
 class SingleInstanceConfig:
     """single instance head_config."""
 
@@ -922,6 +970,15 @@ class TopDownCenteredInstanceMultiClassConfig:
     class_vectors: Optional[ClassVectorsConfig] = None
 
 
+@define
+class BottomUpSegmentationConfig:
+    """Head config for bottom-up instance segmentation models."""
+
+    segmentation: Optional[SegmentationHeadConfig] = None
+    center: Optional[InstanceCenterConfig] = None
+    offsets: Optional[CenterOffsetConfig] = None
+
+
 @oneof
 @define
 class HeadConfig:
@@ -936,6 +993,7 @@ class HeadConfig:
         bottomup: An instance of `BottomUpConfig`.
         multi_class_bottomup: An instance of `BottomUpMultiClassConfig`.
         multi_class_topdown: An instance of `TopDownCenteredInstanceMultiClassConfig`.
+        bottomup_segmentation: An instance of `BottomUpSegmentationConfig`.
     """
 
     single_instance: Optional[SingleInstanceConfig] = None
@@ -944,6 +1002,7 @@ class HeadConfig:
     bottomup: Optional[BottomUpConfig] = None
     multi_class_bottomup: Optional[BottomUpMultiClassConfig] = None
     multi_class_topdown: Optional[TopDownCenteredInstanceMultiClassConfig] = None
+    bottomup_segmentation: Optional[BottomUpSegmentationConfig] = None
 
 
 @oneof

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -23,6 +23,7 @@ from rich.progress import (
 )
 from rich.console import Console
 import torch
+import torch.nn.functional as F
 import torchvision.transforms as T
 from torch.utils.data import Dataset, DataLoader, DistributedSampler
 import sleap_io as sio
@@ -47,6 +48,12 @@ from sleap_nn.data.augmentation import (
 )
 from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
 from sleap_nn.data.edge_maps import generate_pafs
+from sleap_nn.data.segmentation_maps import (
+    _compute_mask_centroids,
+    generate_foreground_mask,
+    generate_center_heatmap,
+    generate_center_offsets,
+)
 from sleap_nn.data.instance_cropping import make_centered_bboxes
 from sleap_nn.training.utils import is_distributed_initialized
 from sleap_nn.config.get_config import get_aug_config
@@ -332,8 +339,11 @@ class BaseDataset(Dataset):
             if max_instances > self.max_instances:
                 self.max_instances = max_instances
 
-        # Store num_nodes for negative frame generation
-        self.num_nodes = len(labels[0].skeletons[0].nodes) if labels else 0
+        # Store num_nodes for negative frame generation. Guard against mask-only
+        # labels (e.g. instance segmentation) that may carry no skeleton.
+        self.num_nodes = (
+            len(labels[0].skeletons[0].nodes) if labels and labels[0].skeletons else 0
+        )
 
         self.cache_img = cache_img
         self.cache_img_path = cache_img_path
@@ -2062,6 +2072,247 @@ class _RepeatSampler:
             yield from iter(self.sampler)
 
 
+class BottomUpSegmentationDataset(BaseDataset):
+    """Dataset class for bottom-up instance segmentation models.
+
+    Loads per-instance segmentation masks from ``LabeledFrame.masks`` and
+    generates ground truth tensors for a center-offset instance segmentation
+    pipeline (foreground mask, instance-center heatmap, and per-pixel offsets).
+
+    Masks are captured into the sample index at construction time (mirroring how
+    keypoint instances are captured for caching), so ``__getitem__`` never needs
+    a live ``Labels`` handle — this keeps it correct under the memory/disk image
+    caching paths (where ``self.labels_list`` is ``None``).
+
+    Note:
+        Geometric augmentation is unsupported (masks cannot be co-transformed
+        with the image) and is skipped with a warning. Mask resizing to the
+        preprocessed image size handles scaling but is not pad-aware; for v1
+        train with ``scale=1.0`` and input dims divisible by ``max_stride``.
+
+    Attributes:
+        seg_head_config: Configuration for the segmentation head.
+        center_head_config: Configuration for the instance center heatmap head.
+        offset_head_config: Configuration for the center offset head.
+    """
+
+    def __init__(
+        self,
+        labels: List[sio.Labels],
+        seg_head_config: DictConfig,
+        center_head_config: DictConfig,
+        offset_head_config: DictConfig,
+        max_stride: int,
+        user_instances_only: bool = True,
+        ensure_rgb: bool = False,
+        ensure_grayscale: bool = False,
+        intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+        geometric_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+        cache_img: Optional[str] = None,
+        cache_img_path: Optional[str] = None,
+        use_existing_imgs: bool = False,
+        rank: Optional[int] = None,
+        parallel_caching: bool = True,
+        cache_workers: int = 0,
+        use_negative_frames: bool = False,
+    ) -> None:
+        """Initialize class attributes."""
+        self.seg_head_config = seg_head_config
+        self.center_head_config = center_head_config
+        self.offset_head_config = offset_head_config
+        self._warned_geometric_aug = False
+        # Segmentation never uses negative frames (degenerate num_nodes/instances).
+        super().__init__(
+            labels=labels,
+            max_stride=max_stride,
+            user_instances_only=user_instances_only,
+            ensure_rgb=ensure_rgb,
+            ensure_grayscale=ensure_grayscale,
+            intensity_aug=intensity_aug,
+            geometric_aug=geometric_aug,
+            scale=scale,
+            apply_aug=apply_aug,
+            max_hw=max_hw,
+            cache_img=cache_img,
+            cache_img_path=cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+            use_negative_frames=False,
+        )
+
+    def _apply_common_preprocessing(self, sample: Dict) -> Dict:
+        """Apply common preprocessing, skipping geometric augmentation.
+
+        Geometric augmentation spatially transforms the image but cannot be
+        applied to segmentation masks (which are loaded separately). This
+        override disables geometric augmentation and logs a warning when it
+        was configured but skipped.
+
+        Args:
+            sample: Sample dict with at least ``image`` and ``instances`` keys.
+
+        Returns:
+            The sample dict with preprocessing applied in-place.
+        """
+        if (
+            self.apply_aug
+            and self.geometric_aug is not None
+            and not self._warned_geometric_aug
+        ):
+            logger.warning(
+                "Geometric augmentation is configured but not supported for "
+                "BottomUpSegmentationDataset because masks cannot be spatially "
+                "transformed in sync with the image. Geometric augmentation "
+                "will be skipped; only intensity augmentation will be applied."
+            )
+            self._warned_geometric_aug = True
+
+        # Temporarily disable geometric aug, then call base implementation
+        saved_geometric_aug = self.geometric_aug
+        self.geometric_aug = None
+        try:
+            sample = super()._apply_common_preprocessing(sample)
+        finally:
+            self.geometric_aug = saved_geometric_aug
+        return sample
+
+    def _get_lf_idx_list(self, labels: List[sio.Labels]) -> List[Dict]:
+        """Return samples for frames that have segmentation masks.
+
+        Overrides the base class to index frames by their masks rather than
+        keypoint instances. The decoded mask arrays are captured into each
+        sample so ``__getitem__`` does not depend on a live ``Labels`` handle.
+        """
+        lf_idx_list = []
+        for labels_idx, label in enumerate(labels):
+            for lf_idx, lf in enumerate(label):
+                lf_masks = getattr(lf, "masks", None)
+                if not lf_masks:
+                    continue
+                mask_arrays = [np.asarray(m.data, dtype=bool) for m in lf_masks]
+                if len(mask_arrays) == 0:
+                    continue
+                video_idx = label.videos.index(lf.video)
+                sample = {
+                    "labels_idx": labels_idx,
+                    "lf_idx": lf_idx,
+                    "video_idx": video_idx,
+                    "frame_idx": lf.frame_idx,
+                    "is_negative": False,
+                    "instances": None,
+                    "masks": mask_arrays,
+                }
+                lf_idx_list.append(sample)
+
+        return lf_idx_list
+
+    def __getitem__(self, index) -> Dict:
+        """Return dict with image and segmentation GT for given index."""
+        sample = self.lf_idx_list[index]
+        labels_idx = sample["labels_idx"]
+        lf_idx = sample["lf_idx"]
+        video_idx = sample["video_idx"]
+        frame_idx = sample["frame_idx"]
+
+        # Load image
+        if self.cache_img is not None:
+            if self.cache_img == "disk":
+                img = np.array(
+                    Image.open(
+                        f"{self.cache_img_path}/sample_{labels_idx}_{lf_idx}.jpg"
+                    )
+                )
+            elif self.cache_img == "memory":
+                img = self.cache[(labels_idx, lf_idx)].copy()
+        else:
+            lf = self.labels_list[labels_idx][lf_idx]
+            img = lf.image
+
+        if img.ndim == 2:
+            img = np.expand_dims(img, axis=2)
+
+        image = np.transpose(img, (2, 0, 1))  # HWC -> CHW
+        image = np.expand_dims(image, axis=0)  # (1, C, H, W)
+        image = torch.from_numpy(image.copy())
+
+        # Dummy instances tensor (needed for preprocessing compatibility)
+        instances = torch.zeros((1, 1, 1, 2), dtype=torch.float32)
+
+        sample_dict = {
+            "image": image,
+            "instances": instances,
+            "video_idx": torch.tensor(video_idx, dtype=torch.int32),
+            "frame_idx": torch.tensor(frame_idx, dtype=torch.int32),
+            "orig_size": torch.Tensor([image.shape[-2], image.shape[-1]]).unsqueeze(0),
+            "num_instances": 0,
+        }
+
+        # Masks captured at index-build time (decoded bool arrays at orig res).
+        mask_arrays = [np.asarray(m, dtype=bool) for m in sample["masks"]]
+
+        # Record original image size before preprocessing
+        orig_img_hw = (image.shape[-2], image.shape[-1])
+
+        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding)
+        sample_dict = self._apply_common_preprocessing(sample_dict)
+
+        img_hw = sample_dict["image"].shape[-2:]
+
+        # Resize masks to match preprocessed image dimensions if size changed.
+        if img_hw != orig_img_hw and len(mask_arrays) > 0:
+            target_h, target_w = img_hw
+            resized_masks = []
+            for m in mask_arrays:
+                # Convert mask to float tensor: (1, 1, H, W)
+                m_tensor = (
+                    torch.from_numpy(m.astype(np.float32)).unsqueeze(0).unsqueeze(0)
+                )
+                m_resized = F.interpolate(
+                    m_tensor, size=(target_h, target_w), mode="area"
+                )
+                # Threshold back to binary
+                resized_masks.append((m_resized.squeeze().numpy() > 0.5))
+            mask_arrays = resized_masks
+
+        # Pre-compute mask centroids once for both center heatmap and offset heads
+        centers = _compute_mask_centroids(mask_arrays) if len(mask_arrays) > 0 else []
+
+        # Generate GT tensors
+        foreground_mask = generate_foreground_mask(
+            mask_arrays,
+            img_hw=img_hw,
+            output_stride=self.seg_head_config.output_stride,
+        )
+
+        center_heatmap = generate_center_heatmap(
+            mask_arrays,
+            img_hw=img_hw,
+            output_stride=self.center_head_config.output_stride,
+            sigma=self.center_head_config.sigma,
+            centers=centers,
+        )
+
+        center_offsets, foreground_weight = generate_center_offsets(
+            mask_arrays,
+            img_hw=img_hw,
+            output_stride=self.offset_head_config.output_stride,
+            centers=centers,
+        )
+
+        sample_dict["foreground_mask"] = foreground_mask
+        sample_dict["center_heatmap"] = center_heatmap
+        sample_dict["center_offsets"] = center_offsets
+        sample_dict["foreground_weight"] = foreground_weight
+        sample_dict["labels_idx"] = labels_idx
+
+        return sample_dict
+
+
 def get_train_val_datasets(
     train_labels: List[sio.Labels],
     val_labels: List[sio.Labels],
@@ -2455,6 +2706,71 @@ def get_train_val_datasets(
             parallel_caching=parallel_caching,
             cache_workers=cache_workers,
             use_negative_frames=use_negative_frames,
+        )
+
+    elif model_type == "bottomup_segmentation":
+        seg_cfg = config.model_config.head_configs.bottomup_segmentation
+        train_dataset = BottomUpSegmentationDataset(
+            labels=train_labels,
+            seg_head_config=seg_cfg.segmentation,
+            center_head_config=seg_cfg.center,
+            offset_head_config=seg_cfg.offsets,
+            max_stride=config.model_config.backbone_config[f"{backbone_type}"][
+                "max_stride"
+            ],
+            user_instances_only=config.data_config.user_instances_only,
+            ensure_rgb=config.data_config.preprocessing.ensure_rgb,
+            ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
+            intensity_aug=(
+                config.data_config.augmentation_config.intensity
+                if config.data_config.augmentation_config is not None
+                else None
+            ),
+            geometric_aug=(
+                config.data_config.augmentation_config.geometric
+                if config.data_config.augmentation_config is not None
+                else None
+            ),
+            scale=config.data_config.preprocessing.scale,
+            apply_aug=config.data_config.use_augmentations_train,
+            max_hw=(
+                config.data_config.preprocessing.max_height,
+                config.data_config.preprocessing.max_width,
+            ),
+            cache_img=cache_imgs,
+            cache_img_path=train_cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+            use_negative_frames=False,
+        )
+        val_dataset = BottomUpSegmentationDataset(
+            labels=val_labels,
+            seg_head_config=seg_cfg.segmentation,
+            center_head_config=seg_cfg.center,
+            offset_head_config=seg_cfg.offsets,
+            max_stride=config.model_config.backbone_config[f"{backbone_type}"][
+                "max_stride"
+            ],
+            user_instances_only=config.data_config.user_instances_only,
+            ensure_rgb=config.data_config.preprocessing.ensure_rgb,
+            ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
+            intensity_aug=None,
+            geometric_aug=None,
+            scale=config.data_config.preprocessing.scale,
+            apply_aug=False,
+            max_hw=(
+                config.data_config.preprocessing.max_height,
+                config.data_config.preprocessing.max_width,
+            ),
+            cache_img=cache_imgs,
+            cache_img_path=val_cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+            use_negative_frames=False,
         )
 
     else:

--- a/sleap_nn/data/segmentation_maps.py
+++ b/sleap_nn/data/segmentation_maps.py
@@ -1,0 +1,191 @@
+"""Generate ground truth tensors for instance segmentation from SegmentationMask objects."""
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+def generate_foreground_mask(
+    masks: List[np.ndarray],
+    img_hw: Tuple[int, int],
+    output_stride: int = 2,
+) -> torch.Tensor:
+    """Generate binary foreground mask as union of all instance masks.
+
+    Args:
+        masks: List of 2D boolean arrays (H, W), one per instance.
+        img_hw: Original image size as (height, width).
+        output_stride: Stride for downsampling the output mask.
+
+    Returns:
+        Tensor of shape (1, 1, H/s, W/s) with float32 values in [0, 1].
+    """
+    height, width = img_hw
+    out_h = height // output_stride
+    out_w = width // output_stride
+
+    if len(masks) == 0:
+        return torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+
+    # Union of all masks at original resolution
+    union = np.zeros((height, width), dtype=bool)
+    for m in masks:
+        # Handle masks that may be different sizes than image
+        mh, mw = m.shape
+        h_end = min(mh, height)
+        w_end = min(mw, width)
+        union[:h_end, :w_end] |= m[:h_end, :w_end]
+
+    # Convert to tensor and downsample via area interpolation
+    fg = torch.from_numpy(union.astype(np.float32)).unsqueeze(0).unsqueeze(0)
+    if output_stride > 1:
+        fg = F.interpolate(fg, size=(out_h, out_w), mode="area")
+    # Threshold back to binary-ish (area interpolation produces soft values)
+    fg = (fg > 0.5).float()
+
+    return fg  # (1, 1, H/s, W/s)
+
+
+def generate_center_heatmap(
+    masks: List[np.ndarray],
+    img_hw: Tuple[int, int],
+    output_stride: int = 2,
+    sigma: float = 10.0,
+    centers: Optional[List[Tuple[float, float]]] = None,
+) -> torch.Tensor:
+    """Generate Gaussian heatmap at each instance mask centroid.
+
+    Args:
+        masks: List of 2D boolean arrays (H, W), one per instance.
+        img_hw: Original image size as (height, width).
+        output_stride: Stride for downsampling the output.
+        sigma: Standard deviation of the Gaussian in pixels (at original resolution).
+        centers: Pre-computed list of (x, y) centroid coordinates. If None, centroids
+            will be computed from masks via ``_compute_mask_centroids``.
+
+    Returns:
+        Tensor of shape (1, 1, H/s, W/s) with float32 values.
+    """
+    height, width = img_hw
+    out_h = height // output_stride
+    out_w = width // output_stride
+    xv = torch.arange(out_w, dtype=torch.float32) * output_stride + output_stride / 2.0
+    yv = torch.arange(out_h, dtype=torch.float32) * output_stride + output_stride / 2.0
+
+    if len(masks) == 0:
+        return torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+
+    # Compute centroids of each mask if not provided
+    if centers is None:
+        centers = _compute_mask_centroids(masks)  # (N, 2) in (x, y) pixel coords
+
+    # Build heatmap as max of Gaussians
+    heatmap = torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+    xv_grid = xv.reshape(1, 1, 1, -1)  # (1, 1, 1, W/s)
+    yv_grid = yv.reshape(1, 1, -1, 1)  # (1, 1, H/s, 1)
+    scaled_sigma = sigma * output_stride
+
+    for cx, cy in centers:
+        g = torch.exp(
+            -((xv_grid - cx) ** 2 + (yv_grid - cy) ** 2) / (2 * scaled_sigma**2)
+        )
+        heatmap = torch.maximum(heatmap, g)
+
+    return heatmap  # (1, 1, H/s, W/s)
+
+
+def generate_center_offsets(
+    masks: List[np.ndarray],
+    img_hw: Tuple[int, int],
+    output_stride: int = 2,
+    centers: Optional[List[Tuple[float, float]]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Generate per-pixel offset vectors pointing to each pixel's instance center.
+
+    Args:
+        masks: List of 2D boolean arrays (H, W), one per instance.
+        img_hw: Original image size as (height, width).
+        output_stride: Stride for downsampling the output.
+        centers: Pre-computed list of (x, y) centroid coordinates. If None, centroids
+            will be computed from masks via ``_compute_mask_centroids``.
+
+    Returns:
+        Tuple of:
+            offsets: Tensor of shape (1, 2, H/s, W/s) with (dx, dy) offset vectors.
+                Only defined on foreground pixels; background pixels are 0.
+            weight_mask: Tensor of shape (1, 1, H/s, W/s) binary mask indicating
+                where offset loss should be computed (foreground pixels).
+    """
+    height, width = img_hw
+    out_h = height // output_stride
+    out_w = width // output_stride
+
+    offsets = torch.zeros((1, 2, out_h, out_w), dtype=torch.float32)
+    weight_mask = torch.zeros((1, 1, out_h, out_w), dtype=torch.float32)
+
+    if len(masks) == 0:
+        return offsets, weight_mask
+
+    if centers is None:
+        centers = _compute_mask_centroids(masks)
+
+    # Sort by area descending so smaller instances overwrite larger ones in overlaps
+    areas = [m.sum() for m in masks]
+    sorted_indices = sorted(range(len(masks)), key=lambda i: areas[i], reverse=True)
+
+    # Create coordinate grids at output stride resolution
+    # Grid values are in original pixel coordinates
+    yy = torch.arange(out_h, dtype=torch.float32) * output_stride + output_stride / 2.0
+    xx = torch.arange(out_w, dtype=torch.float32) * output_stride + output_stride / 2.0
+    grid_x, grid_y = torch.meshgrid(xx, yy, indexing="xy")  # both (out_h, out_w)
+
+    for idx in sorted_indices:
+        m = masks[idx]
+        # Downsample mask
+        m_tensor = (
+            torch.from_numpy(m[:height, :width].astype(np.float32))
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+        if output_stride > 1:
+            m_ds = F.interpolate(m_tensor, size=(out_h, out_w), mode="area")
+        else:
+            m_ds = m_tensor
+        m_binary = m_ds[0, 0] > 0.5  # (out_h, out_w)
+
+        cx, cy = centers[idx]
+
+        # Offset = center - pixel_coord (so pixel + offset = center)
+        dx = cx - grid_x  # (out_h, out_w)
+        dy = cy - grid_y
+
+        # Only set offsets for this instance's foreground pixels
+        offsets[0, 0][m_binary] = dx[m_binary]
+        offsets[0, 1][m_binary] = dy[m_binary]
+        weight_mask[0, 0][m_binary] = 1.0
+
+    return offsets, weight_mask
+
+
+def _compute_mask_centroids(masks: List[np.ndarray]) -> List[Tuple[float, float]]:
+    """Compute the centroid (center of mass) of each binary mask.
+
+    Args:
+        masks: List of 2D boolean arrays.
+
+    Returns:
+        List of (x, y) centroid coordinates in pixel space.
+    """
+    centers = []
+    for m in masks:
+        ys, xs = np.nonzero(m)
+        if len(xs) == 0:
+            # Empty mask — use image center as fallback
+            cy, cx = m.shape[0] / 2.0, m.shape[1] / 2.0
+        else:
+            cx = float(xs.mean())
+            cy = float(ys.mean())
+        centers.append((cx, cy))
+    return centers

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -1,0 +1,172 @@
+"""Inference utilities for bottom-up instance segmentation."""
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import lightning as L
+
+from sleap_nn.inference.ops.peaks import find_local_peaks_rough
+
+
+def group_instances_from_offsets(
+    foreground: torch.Tensor,
+    center_heatmap: torch.Tensor,
+    offsets: torch.Tensor,
+    fg_threshold: float = 0.5,
+    peak_threshold: float = 0.2,
+    output_stride: int = 2,
+) -> List[Dict]:
+    """Group foreground pixels into instances using center-offset predictions.
+
+    Args:
+        foreground: Foreground probability map. Shape: (1, 1, H, W).
+        center_heatmap: Center heatmap. Shape: (1, 1, H, W).
+        offsets: Offset field (dx, dy). Shape: (1, 2, H, W).
+        fg_threshold: Threshold for foreground binarization.
+        peak_threshold: Minimum peak value for center detection.
+        output_stride: Stride of the output maps relative to the input image.
+
+    Returns:
+        List of dicts, each with:
+            - "mask": (H, W) boolean numpy array (at output stride resolution)
+            - "center": (x, y) tuple in original pixel coordinates
+            - "score": float confidence score (peak value)
+    """
+    h, w = foreground.shape[-2:]
+
+    # 1. Threshold foreground
+    fg_binary = foreground[0, 0] > fg_threshold  # (H, W)
+
+    if fg_binary.sum() == 0:
+        return []
+
+    # 2. Find centers via local peak finding
+    peaks, peak_vals, peak_sample_inds, peak_channel_inds = find_local_peaks_rough(
+        center_heatmap,
+        threshold=peak_threshold,
+    )
+
+    if len(peaks) == 0:
+        return []
+
+    # peaks are in (x, y) format at output stride resolution
+    # Convert to original pixel coords
+    centers = peaks.float()  # (N, 2) in output stride pixel coords
+
+    # 3. For each foreground pixel, compute predicted center
+    fg_coords = torch.nonzero(
+        fg_binary, as_tuple=False
+    )  # (M, 2) as (row, col) = (y, x)
+    fg_y = fg_coords[:, 0]
+    fg_x = fg_coords[:, 1]
+
+    # Get offsets at foreground pixels
+    dx = offsets[0, 0, fg_y, fg_x]  # (M,)
+    dy = offsets[0, 1, fg_y, fg_x]  # (M,)
+
+    # Pixel coordinates in original resolution
+    pixel_x = fg_x.float() * output_stride + output_stride / 2.0
+    pixel_y = fg_y.float() * output_stride + output_stride / 2.0
+
+    # Predicted centers for each foreground pixel
+    pred_center_x = pixel_x + dx  # (M,)
+    pred_center_y = pixel_y + dy  # (M,)
+
+    # 4. Assign each foreground pixel to nearest detected center
+    # centers are already in original pixel coordinates (from peak finding * output_stride)
+    center_x = centers[:, 0] * output_stride + output_stride / 2.0  # (N,)
+    center_y = centers[:, 1] * output_stride + output_stride / 2.0  # (N,)
+
+    # Compute distances: (M, N)
+    dist_x = pred_center_x.unsqueeze(1) - center_x.unsqueeze(0)
+    dist_y = pred_center_y.unsqueeze(1) - center_y.unsqueeze(0)
+    dists = dist_x**2 + dist_y**2
+
+    assignments = dists.argmin(dim=1)  # (M,) index into centers
+
+    # 5. Build per-instance masks
+    instances = []
+    for i in range(len(centers)):
+        member_mask = assignments == i
+        if member_mask.sum() == 0:
+            continue
+
+        instance_mask = torch.zeros((h, w), dtype=torch.bool)
+        instance_mask[fg_y[member_mask], fg_x[member_mask]] = True
+
+        instances.append(
+            {
+                "mask": instance_mask.numpy(),
+                "center": (center_x[i].item(), center_y[i].item()),
+                "score": peak_vals[i].item() if i < len(peak_vals) else 0.0,
+            }
+        )
+
+    return instances
+
+
+class BottomUpSegmentationInferenceModel(L.LightningModule):
+    """Inference model for bottom-up instance segmentation.
+
+    Wraps a trained model and post-processing into a single forward pass.
+    Input images should already be padded to stride before being passed to this
+    model (handled by the predictor's ``_run_inference_on_batch``).
+
+    Attributes:
+        torch_model: Callable model that returns head output dict.
+        fg_threshold: Threshold for foreground binarization.
+        peak_threshold: Minimum peak value for center detection.
+        output_stride: Stride of the model output maps.
+    """
+
+    def __init__(
+        self,
+        torch_model,
+        fg_threshold: float = 0.5,
+        peak_threshold: float = 0.2,
+        output_stride: int = 2,
+    ):
+        """Initialize the inference model."""
+        super().__init__()
+        self.torch_model = torch_model
+        self.fg_threshold = fg_threshold
+        self.peak_threshold = peak_threshold
+        self.output_stride = output_stride
+
+    def forward(self, batch: Dict) -> List[List[Dict]]:
+        """Run inference on a batch of images.
+
+        Args:
+            batch: Dict with "image" key. Shape: (B, C, H, W). Images should
+                already be padded to the model's max stride.
+
+        Returns:
+            List of instance lists (one per batch element). Each instance is a dict
+            with "mask", "center", and "score" keys.
+        """
+        images = batch["image"]
+        if images.dim() == 5:
+            images = images.squeeze(1)
+
+        images = images.to(self.device)
+
+        output = self.torch_model(images.unsqueeze(1))
+
+        foreground = output["SegmentationHead"]
+        center_heatmap = output["InstanceCenterHead"]
+        offsets = output["CenterOffsetHead"]
+
+        batch_results = []
+        for b in range(foreground.shape[0]):
+            instances = group_instances_from_offsets(
+                foreground=foreground[b : b + 1],
+                center_heatmap=center_heatmap[b : b + 1],
+                offsets=offsets[b : b + 1],
+                fg_threshold=self.fg_threshold,
+                peak_threshold=self.peak_threshold,
+                output_stride=self.output_stride,
+            )
+            batch_results.append(instances)
+
+        return batch_results

--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -560,6 +560,7 @@ class UnifiedVizCallback(Callback):
         # Auto-enable model-specific visualizations
         self.viz_pafs = model_type == "bottomup"
         self.viz_class_maps = model_type == "multi_class_bottomup"
+        self.viz_center_heatmap = model_type == "bottomup_segmentation"
 
         # Initialize renderers
         from sleap_nn.training.utils import MatplotlibRenderer, WandBRenderer
@@ -600,6 +601,8 @@ class UnifiedVizCallback(Callback):
             kwargs["include_pafs"] = True
         if self.viz_class_maps:
             kwargs["include_class_maps"] = True
+        if self.viz_center_heatmap:
+            kwargs["include_center_heatmap"] = True
 
         # Access lightning_model lazily from model_trainer
         return self.model_trainer.lightning_model.get_visualization_data(
@@ -637,6 +640,13 @@ class UnifiedVizCallback(Callback):
             fig.savefig(fig_path, format="png")
             plt.close(fig)
 
+        # Center heatmap visualization (for segmentation models)
+        if self.viz_center_heatmap and data.pred_center_heatmap is not None:
+            fig = self._render_center_heatmap(data)
+            fig_path = self.local_save_dir / f"{prefix}.center_heatmap.{epoch:04d}.png"
+            fig.savefig(fig_path, format="png")
+            plt.close(fig)
+
     def _render_class_maps(self, data):
         """Render class maps visualization.
 
@@ -659,6 +669,31 @@ class UnifiedVizCallback(Callback):
         plot_confmaps(
             data.pred_class_maps,
             output_scale=data.pred_class_maps.shape[0] / img.shape[0],
+        )
+        return fig
+
+    def _render_center_heatmap(self, data):
+        """Render center heatmap visualization for segmentation models.
+
+        Args:
+            data: VisualizationData with pred_center_heatmap populated.
+
+        Returns:
+            A matplotlib Figure object.
+        """
+        from sleap_nn.training.utils import plot_img, plot_confmaps
+
+        img = data.image
+        scale = 1.0
+        if img.shape[0] < 512:
+            scale = 2.0
+        if img.shape[0] < 256:
+            scale = 4.0
+
+        fig = plot_img(img, dpi=72 * scale, scale=scale)
+        plot_confmaps(
+            data.pred_center_heatmap,
+            output_scale=data.pred_center_heatmap.shape[0] / img.shape[0],
         )
         return fig
 
@@ -709,6 +744,19 @@ class UnifiedVizCallback(Callback):
                 class_pil, caption=f"{prefix.title()} Class Maps Epoch {epoch}"
             )
 
+        # Center heatmap visualization (for segmentation models)
+        if self.viz_center_heatmap and data.pred_center_heatmap is not None:
+            center_fig = self._render_center_heatmap(data)
+            buf = BytesIO()
+            center_fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+            buf.seek(0)
+            plt.close(center_fig)
+            center_pil = PILImage.open(buf)
+            log_dict[f"viz/{prefix}/center_heatmap"] = wandb.Image(
+                center_pil,
+                caption=f"{prefix.title()} Center Heatmap Epoch {epoch}",
+            )
+
         if log_dict:
             log_dict["epoch"] = epoch
             wandb_logger.experiment.log(log_dict, commit=False)
@@ -728,6 +776,10 @@ class UnifiedVizCallback(Callback):
             if self.viz_class_maps and data.pred_class_maps is not None:
                 columns.append(f"{prefix.title()} Class Maps")
                 table_data[0].append(log_dict.get(f"viz/{prefix}/class_maps"))
+
+            if self.viz_center_heatmap and data.pred_center_heatmap is not None:
+                columns.append(f"{prefix.title()} Center Heatmap")
+                table_data[0].append(log_dict.get(f"viz/{prefix}/center_heatmap"))
 
             table = wandb.Table(columns=columns, data=table_data)
             wandb_logger.experiment.log(

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -3,6 +3,7 @@
 from typing import Optional, Union, Dict, Any, List, Tuple
 import time
 from torch import nn
+import torch.nn.functional as F
 import numpy as np
 import torch
 from omegaconf import OmegaConf, DictConfig
@@ -32,9 +33,14 @@ from sleap_nn.inference.bottomup import (
     BottomUpMultiClassInferenceModel,
 )
 from sleap_nn.inference.paf_grouping import PAFScorer
+from sleap_nn.inference.segmentation import BottomUpSegmentationInferenceModel
 from sleap_nn.architectures.model import Model
 from sleap_nn.data.normalization import normalize_on_gpu
-from sleap_nn.training.losses import compute_ohkm_loss
+from sleap_nn.training.losses import (
+    compute_ohkm_loss,
+    compute_bce_dice_loss,
+    compute_masked_smooth_l1,
+)
 from loguru import logger
 from sleap_nn.training.utils import (
     xavier_init_weights,
@@ -291,10 +297,11 @@ class LightningModel(L.LightningModule):
             "bottomup": BottomUpLightningModule,
             "multi_class_bottomup": BottomUpMultiClassLightningModule,
             "multi_class_topdown": TopDownCenteredInstanceMultiClassLightningModule,
+            "bottomup_segmentation": BottomUpSegmentationLightningModule,
         }
 
         if model_type not in lightning_models:
-            message = f"Incorrect model type. Please check if one of the following keys in the head configs is not None: [`single_instance`, `centroid`, `centered_instance`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`]"
+            message = f"Incorrect model type. Please check if one of the following keys in the head configs is not None: [`single_instance`, `centroid`, `centered_instance`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`]"
             logger.error(message)
             raise ValueError(message)
 
@@ -2702,3 +2709,289 @@ class TopDownCenteredInstanceMultiClassLightningModule(LightningModel):
                         "num_instances": 1,
                     }
                 )
+
+
+class BottomUpSegmentationLightningModule(LightningModel):
+    """Lightning Module for Bottom-Up Instance Segmentation.
+
+    Predicts foreground masks, instance center heatmaps, and per-pixel offset
+    vectors for grouping pixels into instances.
+    """
+
+    def __init__(
+        self,
+        model_type: str,
+        backbone_type: str,
+        backbone_config: Union[str, Dict[str, Any], DictConfig],
+        head_configs: DictConfig,
+        pretrained_backbone_weights: Optional[str] = None,
+        pretrained_head_weights: Optional[str] = None,
+        init_weights: Optional[str] = "xavier",
+        lr_scheduler: Optional[Union[str, DictConfig]] = None,
+        online_mining: Optional[bool] = False,
+        hard_to_easy_ratio: Optional[float] = 2.0,
+        min_hard_keypoints: Optional[int] = 2,
+        max_hard_keypoints: Optional[int] = None,
+        loss_scale: Optional[float] = 5.0,
+        optimizer: Optional[str] = "Adam",
+        learning_rate: Optional[float] = 1e-3,
+        amsgrad: Optional[bool] = False,
+        negative_loss_weight: Optional[float] = 1.0,
+    ):
+        """Initialise the configs and the model."""
+        super().__init__(
+            model_type=model_type,
+            backbone_type=backbone_type,
+            backbone_config=backbone_config,
+            head_configs=head_configs,
+            pretrained_backbone_weights=pretrained_backbone_weights,
+            pretrained_head_weights=pretrained_head_weights,
+            init_weights=init_weights,
+            lr_scheduler=lr_scheduler,
+            online_mining=online_mining,
+            hard_to_easy_ratio=hard_to_easy_ratio,
+            min_hard_keypoints=min_hard_keypoints,
+            max_hard_keypoints=max_hard_keypoints,
+            loss_scale=loss_scale,
+            optimizer=optimizer,
+            learning_rate=learning_rate,
+            amsgrad=amsgrad,
+            negative_loss_weight=negative_loss_weight,
+        )
+
+        seg_cfg = self.head_configs[self.model_type]
+        self.seg_inf_layer = BottomUpSegmentationInferenceModel(
+            torch_model=self.forward,
+            fg_threshold=0.5,
+            peak_threshold=0.1,
+            output_stride=seg_cfg.segmentation.output_stride,
+        )
+
+    def get_visualization_data(
+        self, sample, include_center_heatmap: bool = False
+    ) -> VisualizationData:
+        """Extract visualization data from a sample.
+
+        For segmentation models, the foreground probability map is used as
+        the confidence map overlay, and detected instance centers are shown
+        as predicted peaks.
+
+        Args:
+            sample: A sample dictionary from the data pipeline.
+            include_center_heatmap: If True, include the center heatmap in the
+                returned data for separate visualization.
+
+        Returns:
+            VisualizationData with foreground map and center locations.
+        """
+        ex = sample.copy()
+        for k, v in ex.items():
+            if isinstance(v, torch.Tensor):
+                ex[k] = v.to(device=self.device)
+        ex["image"] = ex["image"].unsqueeze(dim=0)
+
+        # Run forward pass to get predictions
+        with torch.no_grad():
+            img = ex["image"].squeeze(1).to(self.device)
+            img = normalize_on_gpu(img)
+            preds = self.model(img)
+
+        # Foreground probability as confmap overlay (H, W, 1)
+        fg_prob = torch.sigmoid(preds["SegmentationHead"][0]).cpu().numpy()
+        fg_prob = fg_prob.transpose(1, 2, 0)  # (H, W, 1)
+
+        # Get image as (H, W, C)
+        img_np = ex["image"][0, 0].cpu().numpy().transpose(1, 2, 0)
+
+        # Extract GT center locations from center_heatmap
+        from sleap_nn.inference.ops.peaks import find_local_peaks_rough
+        from sleap_nn.inference.segmentation import group_instances_from_offsets
+
+        gt_centers = []
+        if "center_heatmap" in ex:
+            gt_peaks, _, _, _ = find_local_peaks_rough(
+                ex["center_heatmap"].unsqueeze(0), threshold=0.1
+            )
+            if len(gt_peaks) > 0:
+                gt_centers = gt_peaks.cpu().numpy()  # (N, 2) as (x, y)
+
+        # Run instance grouping to get predicted centers
+        seg_cfg = self.head_configs[self.model_type]
+        output_stride = seg_cfg.segmentation.output_stride
+
+        pred_centers = []
+        fg_sigmoid = torch.sigmoid(preds["SegmentationHead"])
+        instances = group_instances_from_offsets(
+            foreground=fg_sigmoid[0:1],
+            center_heatmap=preds["InstanceCenterHead"][0:1],
+            offsets=preds["CenterOffsetHead"][0:1],
+            fg_threshold=0.5,
+            peak_threshold=0.1,
+            output_stride=output_stride,
+        )
+        for inst in instances:
+            # Convert center from original pixel coords to output stride coords
+            cx, cy = inst["center"]
+            pred_centers.append([cx / output_stride, cy / output_stride])
+
+        # Format as (N, 1, 2) arrays for plot_peaks (instances, nodes, 2)
+        if len(gt_centers) > 0:
+            gt_pts = np.array(gt_centers).reshape(-1, 1, 2)
+        else:
+            gt_pts = np.zeros((0, 1, 2))
+
+        if len(pred_centers) > 0:
+            pred_pts = np.array(pred_centers).reshape(-1, 1, 2)
+        else:
+            pred_pts = np.zeros((0, 1, 2))
+
+        # Optionally include center heatmap for separate visualization
+        center_hmap = None
+        if include_center_heatmap:
+            center_hmap = preds["InstanceCenterHead"][0].cpu().numpy()
+            center_hmap = center_hmap.transpose(1, 2, 0)  # (H, W, 1)
+
+        return VisualizationData(
+            image=img_np,
+            pred_confmaps=fg_prob,
+            pred_peaks=pred_pts,
+            pred_peak_values=np.ones(len(pred_centers)),
+            gt_instances=gt_pts,
+            node_names=["center"],
+            output_scale=fg_prob.shape[0] / img_np.shape[0],
+            is_paired=False,
+            pred_center_heatmap=center_hmap,
+        )
+
+    def visualize_example(self, sample):
+        """Visualize segmentation predictions during training."""
+        data = self.get_visualization_data(sample)
+        scale = 1.0
+        if data.image.shape[0] < 512:
+            scale = 2.0
+        if data.image.shape[0] < 256:
+            scale = 4.0
+        fig = plot_img(data.image, dpi=72 * scale, scale=scale)
+        plot_confmaps(data.pred_confmaps, output_scale=data.output_scale)
+        plt.xlim(plt.xlim())
+        plt.ylim(plt.ylim())
+        plot_peaks(data.gt_instances, data.pred_peaks, paired=data.is_paired)
+        return fig
+
+    def forward(self, img):
+        """Forward pass of the model."""
+        img = torch.squeeze(img, dim=1).to(self.device)
+        img = normalize_on_gpu(img)
+        output = self.model(img)
+        return {
+            "SegmentationHead": torch.sigmoid(output["SegmentationHead"]),
+            "InstanceCenterHead": output["InstanceCenterHead"],
+            "CenterOffsetHead": output["CenterOffsetHead"],
+        }
+
+    def training_step(self, batch, batch_idx):
+        """Training step."""
+        X = torch.squeeze(batch["image"], dim=1)
+        y_fg = torch.squeeze(batch["foreground_mask"], dim=1)
+        y_center = torch.squeeze(batch["center_heatmap"], dim=1)
+        y_offsets = torch.squeeze(batch["center_offsets"], dim=1)
+        y_weight = torch.squeeze(batch["foreground_weight"], dim=1)
+
+        X = normalize_on_gpu(X)
+        preds = self.model(X)
+
+        pred_fg = preds["SegmentationHead"]
+        pred_center = preds["InstanceCenterHead"]
+        pred_offsets = preds["CenterOffsetHead"]
+
+        fg_loss = compute_bce_dice_loss(pred_fg, y_fg)
+        center_loss = F.mse_loss(pred_center, y_center)
+        offset_loss = compute_masked_smooth_l1(pred_offsets, y_offsets, y_weight)
+
+        losses = {
+            "SegmentationHead": fg_loss,
+            "InstanceCenterHead": center_loss,
+            "CenterOffsetHead": offset_loss,
+        }
+        seg_cfg = self.head_configs[self.model_type]
+        loss = (
+            seg_cfg.segmentation.loss_weight * losses["SegmentationHead"]
+            + seg_cfg.center.loss_weight * losses["InstanceCenterHead"]
+            + seg_cfg.offsets.loss_weight * losses["CenterOffsetHead"]
+        )
+
+        self.log(
+            "loss", loss, prog_bar=True, on_step=True, on_epoch=False, sync_dist=True
+        )
+        self._accumulate_loss(loss)
+        self.log("train/fg_loss", fg_loss, on_step=False, on_epoch=True, sync_dist=True)
+        self.log(
+            "train/center_loss",
+            center_loss,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
+        self.log(
+            "train/offset_loss",
+            offset_loss,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
+
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        """Validation step."""
+        X = torch.squeeze(batch["image"], dim=1)
+        y_fg = torch.squeeze(batch["foreground_mask"], dim=1)
+        y_center = torch.squeeze(batch["center_heatmap"], dim=1)
+        y_offsets = torch.squeeze(batch["center_offsets"], dim=1)
+        y_weight = torch.squeeze(batch["foreground_weight"], dim=1)
+
+        X = normalize_on_gpu(X)
+        preds = self.model(X)
+
+        pred_fg = preds["SegmentationHead"]
+        pred_center = preds["InstanceCenterHead"]
+        pred_offsets = preds["CenterOffsetHead"]
+
+        fg_loss = compute_bce_dice_loss(pred_fg, y_fg)
+        center_loss = F.mse_loss(pred_center, y_center)
+        offset_loss = compute_masked_smooth_l1(pred_offsets, y_offsets, y_weight)
+
+        losses = {
+            "SegmentationHead": fg_loss,
+            "InstanceCenterHead": center_loss,
+            "CenterOffsetHead": offset_loss,
+        }
+        seg_cfg = self.head_configs[self.model_type]
+        val_loss = (
+            seg_cfg.segmentation.loss_weight * losses["SegmentationHead"]
+            + seg_cfg.center.loss_weight * losses["InstanceCenterHead"]
+            + seg_cfg.offsets.loss_weight * losses["CenterOffsetHead"]
+        )
+
+        self.log(
+            "val/loss",
+            val_loss,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
+        self.log("val/fg_loss", fg_loss, on_step=False, on_epoch=True, sync_dist=True)
+        self.log(
+            "val/center_loss", center_loss, on_step=False, on_epoch=True, sync_dist=True
+        )
+        self.log(
+            "val/offset_loss", offset_loss, on_step=False, on_epoch=True, sync_dist=True
+        )
+
+        # Compute foreground IoU metric
+        pred_fg_binary = (pred_fg > 0.0).float()
+        intersection = (pred_fg_binary * y_fg).sum()
+        union = pred_fg_binary.sum() + y_fg.sum() - intersection
+        iou = intersection / (union + 1e-6)
+        self.log("val/fg_iou", iou, on_step=False, on_epoch=True, sync_dist=True)

--- a/sleap_nn/training/losses.py
+++ b/sleap_nn/training/losses.py
@@ -1,6 +1,7 @@
 """Custom loss functions."""
 
 import torch
+import torch.nn.functional as F
 from typing import Optional
 
 
@@ -58,3 +59,62 @@ def compute_ohkm_loss(
     k_loss = torch.sum(k_loss) / n_elements
 
     return k_loss
+
+
+def compute_bce_dice_loss(
+    y_pred: torch.Tensor,
+    y_gt: torch.Tensor,
+    bce_weight: float = 0.5,
+    dice_weight: float = 0.5,
+    smooth: float = 1.0,
+) -> torch.Tensor:
+    """Compute combined Binary Cross-Entropy and Dice loss for segmentation.
+
+    Args:
+        y_pred: Predicted logits (before sigmoid). Shape: (B, 1, H, W).
+        y_gt: Ground truth binary mask. Shape: (B, 1, H, W).
+        bce_weight: Weight for the BCE component.
+        dice_weight: Weight for the Dice component.
+        smooth: Smoothing factor for Dice loss to avoid division by zero.
+
+    Returns:
+        Scalar loss tensor.
+    """
+    bce_loss = F.binary_cross_entropy_with_logits(y_pred, y_gt, reduction="mean")
+
+    # Dice loss (apply sigmoid to convert logits to probabilities)
+    y_pred_sig = torch.sigmoid(y_pred)
+    intersection = (y_pred_sig * y_gt).sum(dim=(2, 3))
+    union = y_pred_sig.sum(dim=(2, 3)) + y_gt.sum(dim=(2, 3))
+    dice = (2.0 * intersection + smooth) / (union + smooth)
+    dice_loss = 1.0 - dice.mean()
+
+    return bce_weight * bce_loss + dice_weight * dice_loss
+
+
+def compute_masked_smooth_l1(
+    y_pred: torch.Tensor,
+    y_gt: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor:
+    """Compute smooth L1 loss only on masked (foreground) pixels.
+
+    Args:
+        y_pred: Predicted offset field. Shape: (B, 2, H, W).
+        y_gt: Ground truth offset field. Shape: (B, 2, H, W).
+        mask: Binary mask indicating valid pixels. Shape: (B, 1, H, W).
+
+    Returns:
+        Scalar loss tensor. Returns 0 if no foreground pixels.
+    """
+    # Expand mask to match offset channels
+    mask_expanded = mask.expand_as(y_pred)  # (B, 2, H, W)
+
+    n_valid = mask_expanded.sum()
+    if n_valid == 0:
+        return torch.tensor(0.0, device=y_pred.device, requires_grad=True)
+
+    loss = F.smooth_l1_loss(
+        y_pred * mask_expanded, y_gt * mask_expanded, reduction="sum"
+    )
+    return loss / n_valid

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -279,14 +279,18 @@ class ModelTrainer:
         )
 
         # check if all `.slp` file shave same skeleton structure (if multiple slp file paths are provided)
-        skeleton = self.skeletons[0]
-        for index, train_label in enumerate(labels):
-            skel_temp = train_label.skeletons[0]
-            skeletons_equal = skeleton.matches(skel_temp)
-            if not skeletons_equal:
-                message = f"The skeletons in the training labels: {index + 1} do not match the skeleton in the first training label file."
-                logger.error(message)
-                raise ValueError(message)
+        # Mask-only labels (e.g. instance segmentation) may carry no skeleton.
+        if self.skeletons:
+            skeleton = self.skeletons[0]
+            for index, train_label in enumerate(labels):
+                if not train_label.skeletons:
+                    continue
+                skel_temp = train_label.skeletons[0]
+                skeletons_equal = skeleton.matches(skel_temp)
+                if not skeletons_equal:
+                    message = f"The skeletons in the training labels: {index + 1} do not match the skeleton in the first training label file."
+                    logger.error(message)
+                    raise ValueError(message)
 
         # Check for same-data mode (train = val, for intentional overfitting)
         use_same = OmegaConf.select(
@@ -1020,6 +1024,18 @@ class ModelTrainer:
                         "val/class_accuracy",
                     ]
                 )
+            if self.model_type == "bottomup_segmentation":
+                csv_log_keys.extend(
+                    [
+                        "train/fg_loss",
+                        "train/center_loss",
+                        "train/offset_loss",
+                        "val/fg_loss",
+                        "val/center_loss",
+                        "val/offset_loss",
+                        "val/fg_iou",
+                    ]
+                )
             csv_logger = CSVLoggerCallback(
                 filepath=Path(self.config.trainer_config.ckpt_dir)
                 / self.config.trainer_config.run_name
@@ -1160,6 +1176,11 @@ class ModelTrainer:
                         match_threshold=self.config.trainer_config.eval.match_threshold,
                     )
                 )
+            elif self.model_type == "bottomup_segmentation":
+                # Segmentation has no keypoint predictions for OKS/PCK; the
+                # foreground IoU logged in validation_step (val/fg_iou) serves as
+                # the epoch-level quality metric. Skip the keypoint eval callback.
+                pass
             else:
                 # Use standard OKS/PCK evaluation for pose models
                 callbacks.append(

--- a/sleap_nn/training/utils.py
+++ b/sleap_nn/training/utils.py
@@ -262,6 +262,7 @@ class VisualizationData:
         is_paired: Whether GT and predictions can be paired for error visualization.
         pred_pafs: Part affinity fields for bottom-up models, optional.
         pred_class_maps: Class maps for multi-class models, optional.
+        pred_center_heatmap: Center heatmap for segmentation models, optional.
     """
 
     image: np.ndarray
@@ -274,6 +275,7 @@ class VisualizationData:
     is_paired: bool = True
     pred_pafs: Optional[np.ndarray] = None
     pred_class_maps: Optional[np.ndarray] = None
+    pred_center_heatmap: Optional[np.ndarray] = None
 
 
 class MatplotlibRenderer:

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -3,13 +3,55 @@
 from pathlib import Path
 from omegaconf import OmegaConf
 
+import numpy as np
 import pytest
+import sleap_io as sio
 
 
 @pytest.fixture
 def sleap_nn_data_dir(pytestconfig):
     """Dir path to sleap data."""
     return Path(pytestconfig.rootdir) / "tests/assets/datasets"
+
+
+def make_seg_labels_from_slp(src_slp: str, radius: int = 30) -> "sio.Labels":
+    """Build synthetic instance-segmentation labels from a keypoint ``.slp``.
+
+    For the first labeled frame, a circular foreground mask is generated around
+    the mean keypoint location of each instance. The original keypoint instances
+    are retained (so the skeleton is preserved) alongside the new masks.
+
+    Args:
+        src_slp: Path to a source ``.slp`` with keypoint instances + image data.
+        radius: Radius (px) of the synthetic circular mask per instance.
+
+    Returns:
+        ``sio.Labels`` with one frame carrying ``UserSegmentationMask`` objects.
+    """
+    labels = sio.load_slp(src_slp)
+    video = labels.videos[0]
+    lf0 = labels[0]
+    h, w = video.shape[1], video.shape[2]
+    yy, xx = np.ogrid[:h, :w]
+    masks = []
+    for inst in lf0.instances:
+        pts = inst.numpy()
+        cx, cy = np.nanmean(pts[:, 0]), np.nanmean(pts[:, 1])
+        blob = ((yy - cy) ** 2 + (xx - cx) ** 2) <= radius**2
+        masks.append(sio.UserSegmentationMask.from_numpy(blob))
+    seg_lf = sio.LabeledFrame(
+        video=video, frame_idx=lf0.frame_idx, instances=lf0.instances, masks=masks
+    )
+    return sio.Labels(videos=[video], labeled_frames=[seg_lf])
+
+
+@pytest.fixture
+def minimal_instance_seg(minimal_instance, tmp_path):
+    """Path to a synthetic instance-segmentation ``.pkg.slp`` (masks + image)."""
+    seg_labels = make_seg_labels_from_slp(str(minimal_instance))
+    out = Path(tmp_path) / "minimal_instance_seg.pkg.slp"
+    seg_labels.save(out.as_posix(), embed=True)
+    return out
 
 
 @pytest.fixture

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,0 +1,648 @@
+"""Tests for the bottom-up instance segmentation model type (training stack).
+
+Covers ground-truth tensor generation, head modules, loss functions, model
+forward, instance grouping, config, the dataset, the sleap-io mask I/O
+contract, and an end-to-end training smoke test. Inference-pipeline (Predictor)
+roundtrip tests live in ``tests/inference/test_segmentation_inference.py``.
+"""
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+import sleap_io as sio
+
+# ---------------------------------------------------------------------------
+# 1. GT generation (sleap_nn/data/segmentation_maps.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.data.segmentation_maps import (
+    generate_foreground_mask,
+    generate_center_heatmap,
+    generate_center_offsets,
+    _compute_mask_centroids,
+)
+
+
+def test_generate_foreground_mask_basic():
+    """Two non-overlapping rectangular masks produce correct shape and counts."""
+    h, w = 64, 64
+    mask_a = np.zeros((h, w), dtype=bool)
+    mask_a[0:10, 0:10] = True
+    mask_b = np.zeros((h, w), dtype=bool)
+    mask_b[50:60, 50:60] = True
+
+    fg = generate_foreground_mask([mask_a, mask_b], (h, w), output_stride=1)
+
+    assert fg.shape == (1, 1, h, w)
+    assert fg.dtype == torch.float32
+    assert fg.sum().item() == 200.0
+
+
+def test_generate_foreground_mask_empty():
+    """Empty mask list returns all zeros."""
+    fg = generate_foreground_mask([], (32, 32), output_stride=1)
+    assert fg.shape == (1, 1, 32, 32)
+    assert fg.sum().item() == 0.0
+
+
+def test_generate_foreground_mask_overlapping():
+    """Two overlapping masks produce the correct union count."""
+    h, w = 64, 64
+    mask_a = np.zeros((h, w), dtype=bool)
+    mask_a[0:20, 0:20] = True
+    mask_b = np.zeros((h, w), dtype=bool)
+    mask_b[10:30, 10:30] = True
+
+    fg = generate_foreground_mask([mask_a, mask_b], (h, w), output_stride=1)
+    # Union = 400 + 400 - overlap(100) = 700
+    assert fg.sum().item() == 700.0
+
+
+def test_generate_foreground_mask_downsampled():
+    """Output stride downsamples the foreground map."""
+    h, w = 64, 64
+    mask = np.zeros((h, w), dtype=bool)
+    mask[16:48, 16:48] = True
+    fg = generate_foreground_mask([mask], (h, w), output_stride=2)
+    assert fg.shape == (1, 1, 32, 32)
+    assert fg.sum().item() > 0
+
+
+def test_generate_center_heatmap():
+    """Verify shape, peak near centroid, and max value close to 1."""
+    h, w = 64, 64
+    mask = np.zeros((h, w), dtype=bool)
+    mask[20:40, 20:40] = True
+
+    heatmap = generate_center_heatmap([mask], (h, w), output_stride=1, sigma=5.0)
+
+    assert heatmap.shape == (1, 1, h, w)
+    assert heatmap.max().item() > 0.95
+    peak_idx = heatmap[0, 0].argmax().item()
+    assert abs(peak_idx // w - 29.5) <= 1.0
+    assert abs(peak_idx % w - 29.5) <= 1.0
+
+
+def test_generate_center_heatmap_empty():
+    """Empty mask list returns zeros."""
+    heatmap = generate_center_heatmap([], (32, 32), output_stride=1, sigma=5.0)
+    assert heatmap.shape == (1, 1, 32, 32)
+    assert heatmap.sum().item() == 0.0
+
+
+def test_generate_center_offsets():
+    """Offsets point toward centroid; weight mask matches foreground."""
+    h, w = 64, 64
+    mask = np.zeros((h, w), dtype=bool)
+    mask[20:40, 20:40] = True
+
+    offsets, weight_mask = generate_center_offsets([mask], (h, w), output_stride=1)
+
+    assert offsets.shape == (1, 2, h, w)
+    assert weight_mask.shape == (1, 1, h, w)
+    expected_fg = generate_foreground_mask([mask], (h, w), output_stride=1)
+    assert (weight_mask == expected_fg).all()
+    # Pixel (20,20) -> coords (20.5, 20.5); centroid ~ (29.5, 29.5) => dx=dy=9
+    assert abs(offsets[0, 0, 20, 20].item() - 9.0) < 0.5
+    assert abs(offsets[0, 1, 20, 20].item() - 9.0) < 0.5
+
+
+def test_generate_center_offsets_empty():
+    """Empty mask list returns zeros for offsets and weight mask."""
+    offsets, weight_mask = generate_center_offsets([], (32, 32), output_stride=1)
+    assert offsets.sum().item() == 0.0
+    assert weight_mask.sum().item() == 0.0
+
+
+def test_compute_mask_centroids():
+    """Known rectangles produce known centroids."""
+    mask_a = np.zeros((64, 64), dtype=bool)
+    mask_a[0:10, 0:10] = True
+    mask_b = np.zeros((64, 64), dtype=bool)
+    mask_b[20:30, 40:50] = True
+
+    centers = _compute_mask_centroids([mask_a, mask_b])
+    assert len(centers) == 2
+    assert abs(centers[0][0] - 4.5) < 0.1 and abs(centers[0][1] - 4.5) < 0.1
+    assert abs(centers[1][0] - 44.5) < 0.1 and abs(centers[1][1] - 24.5) < 0.1
+
+
+def test_compute_mask_centroids_empty_mask():
+    """Empty mask falls back to image center."""
+    centers = _compute_mask_centroids([np.zeros((64, 80), dtype=bool)])
+    assert abs(centers[0][0] - 40.0) < 0.1 and abs(centers[0][1] - 32.0) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# 2. Head classes (sleap_nn/architectures/heads.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.architectures.heads import (
+    Head,
+    SegmentationHead,
+    InstanceCenterHead,
+    CenterOffsetHead,
+)
+
+
+def test_segmentation_head():
+    """SegmentationHead: channels=1, identity activation, bce_dice loss."""
+    head = SegmentationHead(output_stride=2, loss_weight=1.0)
+    assert head.channels == 1
+    assert head.activation == "identity"
+    assert head.loss_function == "bce_dice"
+    assert head.output_stride == 2 and head.loss_weight == 1.0
+    assert isinstance(head, Head) and head.name == "SegmentationHead"
+
+
+def test_instance_center_head():
+    """InstanceCenterHead: channels=1, stores sigma, mse loss."""
+    head = InstanceCenterHead(sigma=10.0, output_stride=2, loss_weight=1.0)
+    assert head.channels == 1 and head.sigma == 10.0
+    assert head.activation == "identity" and head.loss_function == "mse"
+    assert head.name == "InstanceCenterHead"
+
+
+def test_center_offset_head():
+    """CenterOffsetHead: channels=2, smooth_l1 loss."""
+    head = CenterOffsetHead(output_stride=2, loss_weight=0.1)
+    assert head.channels == 2 and head.loss_function == "smooth_l1"
+    assert head.name == "CenterOffsetHead"
+
+
+@pytest.mark.parametrize(
+    "head_cls,kwargs,out_ch",
+    [
+        (SegmentationHead, dict(output_stride=2, loss_weight=1.0), 1),
+        (InstanceCenterHead, dict(sigma=10.0, output_stride=2), 1),
+        (CenterOffsetHead, dict(output_stride=2, loss_weight=0.1), 2),
+    ],
+)
+def test_head_make_head_forward(head_cls, kwargs, out_ch):
+    """Each head's make_head produces the expected channel count."""
+    sample_input = torch.randn(2, 64, 32, 32)
+    head = head_cls(**kwargs)
+    module = head.make_head(x_in=sample_input.size(1))
+    output = module(sample_input)
+    assert output.shape == (2, out_ch, 32, 32)
+    assert torch.isfinite(output).all()
+
+
+# ---------------------------------------------------------------------------
+# 3. Loss functions (sleap_nn/training/losses.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.training.losses import compute_bce_dice_loss, compute_masked_smooth_l1
+
+
+def test_bce_dice_loss_perfect():
+    """Identical pred (logits) and gt give ~0 loss."""
+    gt = torch.ones(1, 1, 16, 16)
+    pred = torch.full((1, 1, 16, 16), 10.0)
+    assert compute_bce_dice_loss(pred, gt).item() < 0.01
+
+
+def test_bce_dice_loss_worst():
+    """Confidently wrong pred gives high loss."""
+    gt = torch.ones(1, 1, 16, 16)
+    pred = torch.full((1, 1, 16, 16), -10.0)
+    assert compute_bce_dice_loss(pred, gt).item() > 1.0
+
+
+def test_bce_dice_loss_gradient():
+    """Loss supports backpropagation."""
+    pred = torch.full((1, 1, 8, 8), 0.0, requires_grad=True)
+    gt = torch.ones(1, 1, 8, 8)
+    compute_bce_dice_loss(pred, gt).backward()
+    assert pred.grad is not None and pred.grad.shape == pred.shape
+
+
+def test_masked_smooth_l1_basic():
+    """Masked offset loss matches the analytic value on the masked region."""
+    pred = torch.ones(1, 2, 4, 4)
+    gt = torch.zeros(1, 2, 4, 4)
+    mask = torch.zeros(1, 1, 4, 4)
+    mask[0, 0, :2, :2] = 1.0
+    # smooth_l1(1,0)=0.5; mean over 8 valid elements = 0.5
+    assert abs(compute_masked_smooth_l1(pred, gt, mask).item() - 0.5) < 0.01
+
+
+def test_masked_smooth_l1_empty_mask():
+    """Empty mask returns differentiable 0 loss."""
+    pred = torch.ones(1, 2, 4, 4, requires_grad=True)
+    gt = torch.zeros(1, 2, 4, 4)
+    mask = torch.zeros(1, 1, 4, 4)
+    loss = compute_masked_smooth_l1(pred, gt, mask)
+    assert loss.item() == 0.0 and loss.requires_grad
+
+
+# ---------------------------------------------------------------------------
+# 4. Model forward
+# ---------------------------------------------------------------------------
+
+from sleap_nn.architectures.model import Model
+
+
+def _seg_backbone_head_configs():
+    backbone_config = OmegaConf.create(
+        {
+            "in_channels": 1,
+            "kernel_size": 3,
+            "filters": 8,
+            "filters_rate": 1.0,
+            "max_stride": 16,
+            "convs_per_block": 2,
+            "stacks": 1,
+            "stem_stride": None,
+            "middle_block": True,
+            "up_interpolate": True,
+            "output_stride": 2,
+        }
+    )
+    head_configs = OmegaConf.create(
+        {
+            "segmentation": {"output_stride": 2, "loss_weight": 1.0},
+            "center": {"sigma": 10.0, "output_stride": 2, "loss_weight": 1.0},
+            "offsets": {"output_stride": 2, "loss_weight": 0.1},
+        }
+    )
+    return backbone_config, head_configs
+
+
+def test_bottomup_segmentation_model_forward():
+    """Model forward returns the three head outputs at the right shapes."""
+    backbone_config, head_configs = _seg_backbone_head_configs()
+    model = Model(
+        backbone_type="unet",
+        backbone_config=backbone_config,
+        head_configs=head_configs,
+        model_type="bottomup_segmentation",
+    )
+    x = torch.randn(2, 1, 64, 64)
+    outputs = model(x)
+    assert outputs["SegmentationHead"].shape == (2, 1, 32, 32)
+    assert outputs["InstanceCenterHead"].shape == (2, 1, 32, 32)
+    assert outputs["CenterOffsetHead"].shape == (2, 2, 32, 32)
+
+
+def test_bottomup_segmentation_model_three_heads():
+    """Model has exactly three heads of the right types."""
+    backbone_config, head_configs = _seg_backbone_head_configs()
+    model = Model(
+        backbone_type="unet",
+        backbone_config=backbone_config,
+        head_configs=head_configs,
+        model_type="bottomup_segmentation",
+    )
+    assert len(model.heads) == 3
+    assert isinstance(model.heads[0], SegmentationHead)
+    assert isinstance(model.heads[1], InstanceCenterHead)
+    assert isinstance(model.heads[2], CenterOffsetHead)
+
+
+# ---------------------------------------------------------------------------
+# 5. Instance grouping (sleap_nn/inference/segmentation.py)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.inference.segmentation import group_instances_from_offsets
+
+
+def _make_blob_offsets(foreground, centers_rc, output_stride):
+    """Build offsets pointing each fg pixel to the nearest given center."""
+    offsets = torch.zeros(1, 2, *foreground.shape[-2:])
+    fg = foreground[0, 0] > 0.5
+    ys, xs = torch.nonzero(fg, as_tuple=True)
+    for y, x in zip(ys.tolist(), xs.tolist()):
+        # nearest center (in grid coords)
+        cr, cc = min(centers_rc, key=lambda c: (c[0] - y) ** 2 + (c[1] - x) ** 2)
+        px = x * output_stride + output_stride / 2.0
+        py = y * output_stride + output_stride / 2.0
+        cx = cc * output_stride + output_stride / 2.0
+        cy = cr * output_stride + output_stride / 2.0
+        offsets[0, 0, y, x] = cx - px
+        offsets[0, 1, y, x] = cy - py
+    return offsets
+
+
+def test_group_instances_two_blobs():
+    """Two well-separated blobs with correct offsets recover 2 instances."""
+    h, w = 32, 32
+    s = 2
+    foreground = torch.zeros(1, 1, h, w)
+    foreground[0, 0, 2:8, 2:8] = 1.0
+    foreground[0, 0, 22:28, 22:28] = 1.0
+    center_heatmap = torch.zeros(1, 1, h, w)
+    center_heatmap[0, 0, 5, 5] = 1.0
+    center_heatmap[0, 0, 25, 25] = 1.0
+    offsets = _make_blob_offsets(foreground, [(5, 5), (25, 25)], s)
+
+    instances = group_instances_from_offsets(
+        foreground,
+        center_heatmap,
+        offsets,
+        fg_threshold=0.5,
+        peak_threshold=0.5,
+        output_stride=s,
+    )
+    assert len(instances) == 2
+    for inst in instances:
+        assert set(inst) == {"mask", "center", "score"}
+        assert inst["mask"].shape == (h, w)
+        assert inst["score"] >= 0.5
+    assert sorted(int(i["mask"].sum()) for i in instances) == [36, 36]
+
+
+def test_group_instances_no_foreground():
+    """Empty foreground returns empty list."""
+    h, w = 16, 16
+    instances = group_instances_from_offsets(
+        torch.zeros(1, 1, h, w),
+        torch.zeros(1, 1, h, w),
+        torch.zeros(1, 2, h, w),
+        fg_threshold=0.5,
+        peak_threshold=0.2,
+        output_stride=2,
+    )
+    assert instances == []
+
+
+def test_group_instances_no_centers():
+    """Foreground present but no center peaks returns empty list."""
+    h, w = 16, 16
+    instances = group_instances_from_offsets(
+        torch.ones(1, 1, h, w),
+        torch.full((1, 1, h, w), 0.01),
+        torch.zeros(1, 2, h, w),
+        fg_threshold=0.5,
+        peak_threshold=0.5,
+        output_stride=2,
+    )
+    assert instances == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Config
+# ---------------------------------------------------------------------------
+
+from sleap_nn.config.model_config import (
+    BottomUpSegmentationConfig,
+    SegmentationHeadConfig,
+    InstanceCenterConfig,
+    CenterOffsetConfig,
+    HeadConfig,
+)
+
+
+def test_segmentation_config_defaults():
+    """Sub-config defaults match the head defaults."""
+    assert SegmentationHeadConfig().output_stride == 2
+    assert InstanceCenterConfig().sigma == 10.0
+    assert CenterOffsetConfig().loss_weight == 0.1
+
+
+def test_head_config_oneof_bottomup_segmentation():
+    """HeadConfig oneof selects bottomup_segmentation exclusively."""
+    head_cfg = HeadConfig(
+        bottomup_segmentation=BottomUpSegmentationConfig(
+            segmentation=SegmentationHeadConfig(),
+            center=InstanceCenterConfig(),
+            offsets=CenterOffsetConfig(),
+        )
+    )
+    assert head_cfg.bottomup_segmentation is not None
+    assert head_cfg.single_instance is None
+    assert head_cfg.bottomup is None
+    assert head_cfg.multi_class_topdown is None
+
+
+def test_get_head_configs_builder_string():
+    """get_head_configs builds a bottomup_segmentation HeadConfig from a string."""
+    from sleap_nn.config.get_config import get_head_configs
+
+    hc = get_head_configs("bottomup_segmentation")
+    assert hc.bottomup_segmentation is not None
+    assert hc.bottomup_segmentation.segmentation.output_stride == 2
+
+
+def test_get_model_type_from_cfg_segmentation():
+    """Model type is auto-detected from the head config key."""
+    from sleap_nn.config.utils import get_model_type_from_cfg
+
+    cfg = OmegaConf.create(
+        {
+            "model_config": {
+                "head_configs": {
+                    "single_instance": None,
+                    "centroid": None,
+                    "centered_instance": None,
+                    "bottomup": None,
+                    "multi_class_bottomup": None,
+                    "multi_class_topdown": None,
+                    "bottomup_segmentation": {
+                        "segmentation": {"output_stride": 2, "loss_weight": 1.0},
+                        "center": {
+                            "sigma": 5.0,
+                            "output_stride": 2,
+                            "loss_weight": 1.0,
+                        },
+                        "offsets": {"output_stride": 2, "loss_weight": 0.1},
+                    },
+                }
+            }
+        }
+    )
+    assert get_model_type_from_cfg(cfg) == "bottomup_segmentation"
+
+
+# ---------------------------------------------------------------------------
+# 7. sleap-io mask I/O contract
+# ---------------------------------------------------------------------------
+
+
+def test_seg_mask_slp_roundtrip(minimal_instance_seg):
+    """Synthetic seg labels roundtrip through .slp preserving mask data."""
+    labels = sio.load_slp(minimal_instance_seg.as_posix())
+    assert len(labels.masks) >= 1
+    for m in labels.masks:
+        assert isinstance(m, sio.SegmentationMask)
+        assert m.data.dtype == bool
+        assert m.data.any()
+
+
+# ---------------------------------------------------------------------------
+# 8. Dataset (Part A: GT integration, no model)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.data.custom_datasets import BottomUpSegmentationDataset
+
+
+@pytest.mark.parametrize("cache_img", [None, "memory"])
+def test_bottomup_segmentation_dataset(minimal_instance_seg, cache_img, tmp_path):
+    """Dataset yields GT tensors at the output stride for both cache paths."""
+    seg_labels = sio.load_slp(minimal_instance_seg.as_posix())
+    seg_cfg = OmegaConf.create({"output_stride": 2, "loss_weight": 1.0})
+    center_cfg = OmegaConf.create(
+        {"sigma": 5.0, "output_stride": 2, "loss_weight": 1.0}
+    )
+    offset_cfg = OmegaConf.create({"output_stride": 2, "loss_weight": 0.1})
+
+    ds = BottomUpSegmentationDataset(
+        labels=[seg_labels],
+        seg_head_config=seg_cfg,
+        center_head_config=center_cfg,
+        offset_head_config=offset_cfg,
+        max_stride=16,
+        ensure_grayscale=True,
+        cache_img=cache_img,
+        cache_img_path=str(tmp_path) if cache_img == "disk" else None,
+    )
+    assert len(ds) == 1
+    s = ds[0]
+    h, w = s["image"].shape[-2:]
+    oh, ow = h // 2, w // 2
+    assert s["foreground_mask"].shape == (1, 1, oh, ow)
+    assert s["center_heatmap"].shape == (1, 1, oh, ow)
+    assert s["center_offsets"].shape == (1, 2, oh, ow)
+    assert s["foreground_weight"].shape == (1, 1, oh, ow)
+    assert s["foreground_mask"].sum() > 0
+    assert s["center_heatmap"].max() > 0.9
+    # offsets only defined on foreground (weight) pixels
+    assert (s["foreground_weight"] == (s["foreground_mask"] > 0).float()).all()
+
+
+# ---------------------------------------------------------------------------
+# 9. End-to-end training smoke test
+# ---------------------------------------------------------------------------
+
+
+def _seg_train_config(seg_path, tmp_path):
+    return OmegaConf.create(
+        {
+            "data_config": {
+                "provider": "LabelsReader",
+                "train_labels_path": [seg_path],
+                "val_labels_path": [seg_path],
+                "validation_fraction": 0.1,
+                "user_instances_only": True,
+                "data_pipeline_fw": "torch_dataset",
+                "cache_img_path": None,
+                "use_existing_imgs": False,
+                "delete_cache_imgs_after_training": True,
+                "preprocessing": {
+                    "ensure_rgb": False,
+                    "ensure_grayscale": True,
+                    "max_width": None,
+                    "max_height": None,
+                    "scale": 1.0,
+                    "crop_size": None,
+                    "min_crop_size": None,
+                },
+                "use_augmentations_train": False,
+                "augmentation_config": None,
+            },
+            "model_config": {
+                "init_weights": "default",
+                "pretrained_backbone_weights": None,
+                "pretrained_head_weights": None,
+                "backbone_config": {
+                    "unet": {
+                        "in_channels": 1,
+                        "kernel_size": 3,
+                        "filters": 8,
+                        "filters_rate": 1.5,
+                        "max_stride": 16,
+                        "convs_per_block": 2,
+                        "stacks": 1,
+                        "stem_stride": None,
+                        "middle_block": True,
+                        "up_interpolate": True,
+                        "output_stride": 2,
+                    }
+                },
+                "head_configs": {
+                    "single_instance": None,
+                    "centroid": None,
+                    "bottomup": None,
+                    "centered_instance": None,
+                    "multi_class_bottomup": None,
+                    "multi_class_topdown": None,
+                    "bottomup_segmentation": {
+                        "segmentation": {"output_stride": 2, "loss_weight": 1.0},
+                        "center": {
+                            "sigma": 5.0,
+                            "output_stride": 2,
+                            "loss_weight": 1.0,
+                        },
+                        "offsets": {"output_stride": 2, "loss_weight": 0.1},
+                    },
+                },
+            },
+            "trainer_config": {
+                "train_data_loader": {
+                    "batch_size": 1,
+                    "shuffle": True,
+                    "num_workers": 0,
+                },
+                "val_data_loader": {"batch_size": 1, "num_workers": 0},
+                "model_ckpt": {"save_top_k": 1, "save_last": True},
+                "early_stopping": {
+                    "stop_training_on_plateau": False,
+                    "min_delta": 1e-08,
+                    "patience": 20,
+                },
+                "trainer_devices": 1,
+                "trainer_device_indices": None,
+                "trainer_accelerator": "cpu",
+                "enable_progress_bar": False,
+                "min_train_steps_per_epoch": 1,
+                "train_steps_per_epoch": None,
+                "max_epochs": 1,
+                "seed": 1000,
+                "keep_viz": False,
+                "use_wandb": False,
+                "save_ckpt": True,
+                "ckpt_dir": str(tmp_path),
+                "run_name": "seg_smoke",
+                "resume_ckpt_path": None,
+                "optimizer_name": "Adam",
+                "optimizer": {"lr": 1e-3, "amsgrad": False},
+                "lr_scheduler": {
+                    "reduce_lr_on_plateau": {
+                        "threshold": 1e-07,
+                        "threshold_mode": "rel",
+                        "cooldown": 3,
+                        "patience": 5,
+                        "factor": 0.5,
+                        "min_lr": 1e-08,
+                    }
+                },
+                "online_hard_keypoint_mining": {
+                    "online_mining": False,
+                    "hard_to_easy_ratio": 2.0,
+                    "min_hard_keypoints": 2,
+                    "max_hard_keypoints": None,
+                    "loss_scale": 5.0,
+                },
+                "eval": {"enabled": False},
+            },
+        }
+    )
+
+
+def test_bottomup_segmentation_train_smoke(minimal_instance_seg, tmp_path):
+    """ModelTrainer trains a segmentation model for one epoch and writes a ckpt."""
+    from sleap_nn.training.model_trainer import ModelTrainer
+
+    cfg = _seg_train_config(minimal_instance_seg.as_posix(), tmp_path)
+    trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+    trainer.train()
+
+    run_dir = tmp_path / "seg_smoke"
+    assert (run_dir / "best.ckpt").exists()
+    assert (run_dir / "training_config.yaml").exists()
+    # CSV logged the segmentation-specific metrics.
+    csv_text = (run_dir / "training_log.csv").read_text()
+    assert "val/fg_iou" in csv_text
+    assert "train/fg_loss" in csv_text


### PR DESCRIPTION
**Stacked PR 1 of 4** — refreshes #501 (bottom-up, center-offset instance segmentation, Panoptic-DeepLab style) onto current `main` + sleap-io `0.8.0`. This PR is the **trainable foundation**; inference lands in the follow-up PRs.

Base: `main`. Next in stack: #(seg 2/4, outputs IO).

## What's here
Pipeline-agnostic model/GT/loss (ported ~verbatim from #501):
- `architectures/heads.py`: `SegmentationHead`, `InstanceCenterHead`, `CenterOffsetHead`
- `architectures/model.py`: `get_head` `bottomup_segmentation` branch
- `config/model_config.py` + `config/get_config.py`: head configs + `HeadConfig.bottomup_segmentation` + builders
- `data/segmentation_maps.py`: GT foreground / center-heatmap / offset generators
- `training/losses.py`: `compute_bce_dice_loss`, `compute_masked_smooth_l1`
- `training/lightning_modules.py`: `BottomUpSegmentationLightningModule` + dispatch
- `training/callbacks.py` + `utils.py`: center-heatmap viz in `UnifiedVizCallback`
- `inference/segmentation.py`: `group_instances_from_offsets` + inference-model container (used for train-time viz)

Fixed vs #501 (sleap-io API drift + robustness):
- `data/custom_datasets.py`: `BottomUpSegmentationDataset` rewritten to index frames by `LabeledFrame.masks` and capture decoded mask arrays into the sample (drops removed `mask.video`/`frame_idx` and the `self.labels_list` dependency, so memory/disk image-caching works); geometric aug skipped with a warning.
- `custom_datasets.py` / `model_trainer.py`: guard mask-only (no-skeleton) labels; segmentation CSV log keys (`fg`/`center`/`offset` loss, `fg_iou`); skip the keypoint OKS/PCK eval callback for segmentation.

Dependency: `pyproject.toml`/`uv.lock` → sleap-io **main (0.8.0)** via pinned git rev for the `SegmentationMask` / `Labels.get_masks` APIs (not yet on PyPI; torch unchanged). Switch to `>=0.8.0` once released.

## Tests
`tests/test_segmentation.py` (34): GT generators, heads, losses, model forward, instance grouping, config, mask `.slp` roundtrip, dataset (both cache paths), and an end-to-end `ModelTrainer` **train smoke**. No regressions in data/config/architectures/training suites.

## Notes / limitations
- Mask-aware geometric augmentation is future work (aug-off + warning for v1).
- Mask resizing handles input scale but is not pad-aware; train with `scale=1.0` + stride-divisible dims for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)