### PR TITLE
feat(seg) 2/4: carry segmentation masks through Outputs → sio.Labels

### DIFF
--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -85,6 +85,14 @@ class Outputs:
     pred_centroids: Optional[torch.Tensor] = None  # (B, I, 2)
     pred_centroid_values: Optional[torch.Tensor] = None  # (B, I)
 
+    # ── Instance segmentation ────────────────────────────────────────
+    # Per-batch ragged masks: a length-B list, one entry per frame. Each
+    # entry is a list of per-instance dicts ``{"mask": bool ndarray (H, W) at
+    # original-image resolution, "score": float}``. Stored as picklable numpy
+    # (not a dense tensor) so ``slim()`` / the multiprocessing path stay
+    # memory-safe and pickle-clean.
+    pred_masks: Optional[List[List[Dict[str, Any]]]] = None
+
     # ── Instance-level metadata ──────────────────────────────────────
     instance_scores: Optional[torch.Tensor] = None  # (B, I)
     instance_valid: Optional[torch.Tensor] = None  # (B, I), bool
@@ -120,6 +128,12 @@ class Outputs:
         """Compact ``Outputs(...)`` summary listing only populated fields."""
         parts: List[str] = []
         for f in attrs.fields(type(self)):
+            if f.name == "pred_masks":
+                masks = getattr(self, "pred_masks")
+                if masks is not None:
+                    n = sum(len(per_frame) for per_frame in masks)
+                    parts.append(f"pred_masks=list[{len(masks)} frames, {n} masks]")
+                continue
             r = _tensor_repr(f.name, getattr(self, f.name))
             if r is not None:
                 parts.append(r)
@@ -231,7 +245,9 @@ class Outputs:
 
     @property
     def batch_size(self) -> int:
-        """Batch dimension B, or 0 if no keypoint-bearing field is set."""
+        """Batch dimension B, or 0 if no batch-bearing field is set."""
+        if self.pred_masks is not None:
+            return len(self.pred_masks)
         for name in ("pred_keypoints", "pred_centroids", "frame_indices"):
             t = getattr(self, name)
             if t is not None:
@@ -515,6 +531,36 @@ class Outputs:
             )
         return out
 
+    def to_masks(
+        self,
+        batch_index: int = 0,
+    ) -> list["sio.PredictedSegmentationMask"]:
+        """Convert one batch slot's masks into ``sio.PredictedSegmentationMask``s.
+
+        Each entry of ``pred_masks[batch_index]`` is a dict with a boolean
+        ``"mask"`` (original-image resolution) and a float ``"score"``; both
+        become a ``sio.PredictedSegmentationMask`` (stored in
+        ``LabeledFrame.masks``). Returns ``[]`` when there are no masks.
+
+        Args:
+            batch_index: Which sample in the batch to convert.
+        """
+        if self.pred_masks is None or batch_index >= len(self.pred_masks):
+            return []
+        from sleap_nn.inference.segmentation_convert import (
+            build_predicted_segmentation_mask,
+        )
+
+        out: List["sio.PredictedSegmentationMask"] = []
+        for inst in self.pred_masks[batch_index]:
+            mask = inst["mask"]
+            if mask is None or not np.asarray(mask).any():
+                continue
+            out.append(
+                build_predicted_segmentation_mask(mask, float(inst.get("score", 0.0)))
+            )
+        return out
+
     def to_labels(
         self,
         skeleton: "sio.Skeleton",
@@ -586,7 +632,8 @@ class Outputs:
                 if want_centroids
                 else []
             )
-            if not instances and not centroids:
+            masks = self.to_masks(batch_index=b)
+            if not instances and not centroids and not masks:
                 continue
             for inst in instances:
                 trk = getattr(inst, "track", None)
@@ -629,13 +676,17 @@ class Outputs:
                     frame_idx=frame_idx,
                     instances=instances,
                     centroids=centroids,
+                    masks=masks,
                 )
             )
         valid_videos = [v for v in videos if v is not None]
+        # Mask-only (segmentation) models may have no skeleton; emit an empty
+        # skeleton list rather than ``[None]``.
+        skeletons = [pkg_skeleton] if pkg_skeleton is not None else []
         labels = sio.Labels(
             labeled_frames=labeled_frames,
             videos=valid_videos,
-            skeletons=[pkg_skeleton],
+            skeletons=skeletons,
         )
         if used_tracks:
             labels.tracks = used_tracks

--- a/sleap_nn/inference/segmentation_convert.py
+++ b/sleap_nn/inference/segmentation_convert.py
@@ -1,0 +1,35 @@
+"""sleap-nn → sleap-io conversion helpers for instance segmentation masks.
+
+Single owner of the mapping from a predicted boolean mask array to a
+``sio.PredictedSegmentationMask`` (mirrors ``centroid_convert.py`` for
+centroids). Keeping this in one place means the ``Outputs`` packaging path and
+any future export path emit masks identically.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import sleap_io as sio
+
+
+def build_predicted_segmentation_mask(
+    mask: np.ndarray,
+    score: float,
+) -> "sio.PredictedSegmentationMask":
+    """Build a ``sio.PredictedSegmentationMask`` from a boolean mask array.
+
+    Args:
+        mask: 2-D boolean (or 0/1) array at the original image resolution.
+        score: Detection confidence (the instance-center peak value).
+
+    Returns:
+        A ``sio.PredictedSegmentationMask`` (RLE-backed) carrying ``score``.
+    """
+    import sleap_io as sio
+
+    mask = np.ascontiguousarray(mask, dtype=bool)
+    return sio.PredictedSegmentationMask.from_numpy(mask, score=float(score))

--- a/tests/inference/test_segmentation_outputs.py
+++ b/tests/inference/test_segmentation_outputs.py
@@ -1,0 +1,105 @@
+"""Tests for the ``Outputs`` instance-segmentation mask carrier (PR 2).
+
+Covers the ``pred_masks`` field: repr, batch_size, pickle-safe ``slim()``,
+``to_masks``, and ``to_labels`` mask attachment + ``.slp`` roundtrip.
+"""
+
+import pickle
+
+import numpy as np
+import torch
+
+import sleap_io as sio
+
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.segmentation_convert import build_predicted_segmentation_mask
+
+
+def _two_mask_outputs():
+    m1 = np.zeros((32, 32), dtype=bool)
+    m1[2:10, 2:10] = True
+    m2 = np.zeros((32, 32), dtype=bool)
+    m2[20:28, 20:28] = True
+    pred_masks = [[{"mask": m1, "score": 0.9}, {"mask": m2, "score": 0.7}]]
+    out = Outputs(
+        pred_masks=pred_masks,
+        frame_indices=torch.tensor([3]),
+        video_indices=torch.tensor([0]),
+    )
+    return out, m1, m2
+
+
+def test_build_predicted_segmentation_mask():
+    """Helper produces a PredictedSegmentationMask carrying the score."""
+    m = np.zeros((16, 16), dtype=bool)
+    m[2:8, 2:8] = True
+    pm = build_predicted_segmentation_mask(m, 0.42)
+    assert isinstance(pm, sio.PredictedSegmentationMask)
+    assert abs(pm.score - 0.42) < 1e-5
+    np.testing.assert_array_equal(pm.data, m)
+
+
+def test_outputs_pred_masks_repr_and_batch_size():
+    """pred_masks gives a compact repr and a correct batch size."""
+    out, _, _ = _two_mask_outputs()
+    assert out.batch_size == 1
+    r = repr(out)
+    assert "pred_masks=list[1 frames, 2 masks]" in r
+    # repr must not dump array contents
+    assert "True" not in r and "array(" not in r
+
+
+def test_outputs_slim_keeps_masks_and_is_picklable():
+    """slim() retains masks (they are output, not heavy) and is pickle-safe."""
+    out, _, _ = _two_mask_outputs()
+    slim = out.slim()
+    assert slim.pred_masks is not None and len(slim.pred_masks) == 1
+    pickle.dumps(slim)  # must not raise
+
+
+def test_outputs_to_masks():
+    """to_masks builds PredictedSegmentationMask objects for a batch slot."""
+    out, m1, m2 = _two_mask_outputs()
+    masks = out.to_masks(batch_index=0)
+    assert len(masks) == 2
+    assert all(isinstance(m, sio.PredictedSegmentationMask) for m in masks)
+    assert sorted(round(m.score, 2) for m in masks) == [0.7, 0.9]
+
+
+def test_outputs_to_masks_skips_empty():
+    """Empty masks are dropped by to_masks."""
+    out = Outputs(pred_masks=[[{"mask": np.zeros((8, 8), bool), "score": 0.5}]])
+    assert out.to_masks(0) == []
+
+
+def test_outputs_to_labels_with_masks_roundtrip(tmp_path):
+    """to_labels attaches masks; they roundtrip through .slp (no skeleton)."""
+    out, m1, m2 = _two_mask_outputs()
+    video = sio.Video.from_filename("dummy.mp4")
+    labels = out.to_labels(skeleton=None, videos=[video])
+
+    assert len(labels.masks) == 2
+    assert labels[0].frame_idx == 3
+    # No skeleton for a mask-only model.
+    assert list(labels.skeletons) == []
+
+    out_path = tmp_path / "seg_outputs.slp"
+    labels.save(out_path.as_posix())
+    reloaded = sio.load_slp(out_path.as_posix())
+    assert len(reloaded.masks) == 2
+    assert sorted(round(m.score, 2) for m in reloaded.masks) == [0.7, 0.9]
+    assert sorted(int(m.data.sum()) for m in reloaded.masks) == sorted(
+        [int(m1.sum()), int(m2.sum())]
+    )
+
+
+def test_outputs_to_labels_empty_masks_frame_skipped():
+    """A frame whose only content is empty masks is skipped."""
+    out = Outputs(
+        pred_masks=[[{"mask": np.zeros((8, 8), bool), "score": 0.5}]],
+        frame_indices=torch.tensor([0]),
+        video_indices=torch.tensor([0]),
+    )
+    video = sio.Video.from_filename("dummy.mp4")
+    labels = out.to_labels(skeleton=None, videos=[video])
+    assert len(labels.labeled_frames) == 0


### PR DESCRIPTION
**Stacked PR 2 of 4.** Base: `feat/seg-rebase-train` (#603). Output-side plumbing for instance segmentation, independent of the inference layer (PR 3).

- `inference/outputs.py`: new `Outputs.pred_masks` — a per-batch ragged list of per-instance `{"mask": bool ndarray, "score": float}` (picklable numpy, **not** a dense tensor, so `slim()`/multiprocessing stay memory- and pickle-safe; passes through `slim()`/`numpy()`/`_map()` unchanged). Compact `__repr__` (mask counts), `batch_size` derives B from `pred_masks`, new `to_masks()`, and `to_labels()` attaches `sio.PredictedSegmentationMask`s + extends the per-frame skip-guard + emits an empty skeleton list for mask-only models.
- `inference/segmentation_convert.py`: single owner of the sleap-nn → sio mask mapping (mirrors `centroid_convert.py`).

## Tests
`tests/inference/test_segmentation_outputs.py` (7): repr/batch_size, pickle-safe `slim()`, `to_masks()`, `to_labels → save .slp → load` roundtrip preserving mask data + score. No regressions in `tests/inference/test_outputs.py` + layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)