### PR TITLE
Rename `infer` CLI subcommand to `predict`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,4 +72,4 @@ Configurations are managed via Hydra and can be specified in YAML files (see `do
 - Inference: `sleap_nn/predict.py` - Run inference on trained models
 - CLI: `sleap_nn/cli.py` - Command-line interface (currently minimal)
 - Evaluation: `sleap_nn/evaluation.py` - Model evaluation utilities
-- Centroid-only models: first-class support — train a lone centroid head, `sleap-nn infer` auto-detects a single centroid directory (output collapses to a single-node `'centroid'` skeleton), distance-based eval (`--match_method centroid`), and standalone ONNX/TensorRT export. See `docs/guides/centroid-only-inference.md`.
+- Centroid-only models: first-class support — train a lone centroid head, `sleap-nn predict` auto-detects a single centroid directory (output collapses to a single-node `'centroid'` skeleton), distance-based eval (`--match_method centroid`), and standalone ONNX/TensorRT export. See `docs/guides/centroid-only-inference.md`.

--- a/docs/guides/centroid-only-inference.md
+++ b/docs/guides/centroid-only-inference.md
@@ -66,26 +66,26 @@ sleap-nn train --config-name config_centroid_unet_standalone.yaml
 
 ### 2. Infer
 
-`sleap-nn infer` auto-detects a centroid-only model when `--model_paths` points
+`sleap-nn predict` auto-detects a centroid-only model when `--model_paths` points
 to a single centroid directory. `--centroid_only` is only needed when you also
 pass a centered-instance model but want centroid-only output.
 
 ```bash
 # Auto-detected: a lone centroid model directory → centroid-only output.
-sleap-nn infer \
+sleap-nn predict \
     -i video.mp4 \
     -m models/centroid/ \
     -o centroids.slp
 
 # Emit sio.PredictedCentroid objects instead of single-node instances.
-sleap-nn infer \
+sleap-nn predict \
     -i video.mp4 \
     -m models/centroid/ \
     -o centroids.slp \
     --centroid-output centroid
 
 # Explicit override: both models configured, but only want centroids.
-sleap-nn infer \
+sleap-nn predict \
     -i video.mp4 \
     -m models/centroid/ \
     -m models/centered_instance/ \

--- a/docs/guides/centroid-only-inference.md
+++ b/docs/guides/centroid-only-inference.md
@@ -142,7 +142,7 @@ representation choices:
 sleap-nn export models/centroid -o exports/centroid --format onnx
 
 # Run the exported model. --centroid-output mirrors the checkpoint flow.
-sleap-nn predict exports/centroid video.mp4 -o centroids.slp \
+sleap-nn export predict exports/centroid video.mp4 -o centroids.slp \
     --centroid-output instance
 ```
 

--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -155,8 +155,8 @@ sleap-nn predict EXPORT_DIR VIDEO [options]
 
 !!! tip "Running unexported checkpoints"
     To run inference on a trained checkpoint directory (not an exported
-    ONNX/TensorRT model), prefer the unified [`sleap-nn infer`](inference.md)
-    entry point. `sleap-nn predict` here runs an **exported** model directory.
+    ONNX/TensorRT model), prefer the unified [`sleap-nn predict`](inference.md)
+    entry point. `sleap-nn export predict` here runs an **exported** model directory.
 
 ### Examples
 

--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -63,7 +63,7 @@ sleap-nn export models/my_model -o exports/ --format both
 ### Run Inference
 
 ```bash
-sleap-nn predict exports/my_model video.mp4 -o predictions.slp
+sleap-nn export predict exports/my_model video.mp4 -o predictions.slp
 ```
 
 ---
@@ -124,7 +124,7 @@ sleap-nn export models/centroid -o exports/centroid --format onnx
 #   instance (default) -> single-node PredictedInstance (frontend-compatible)
 #   centroid           -> sio.PredictedCentroid
 #   both               -> both
-sleap-nn predict exports/centroid video.mp4 -o centroids.slp \
+sleap-nn export predict exports/centroid video.mp4 -o centroids.slp \
     --centroid-output instance
 ```
 
@@ -142,7 +142,7 @@ contract.
 ## Inference Options
 
 ```bash
-sleap-nn predict EXPORT_DIR VIDEO [options]
+sleap-nn export predict EXPORT_DIR VIDEO [options]
 ```
 
 | Option | Description | Values | Default |
@@ -162,13 +162,13 @@ sleap-nn predict EXPORT_DIR VIDEO [options]
 
 ```bash
 # Maximum speed with TensorRT
-sleap-nn predict exports/model video.mp4 --runtime tensorrt --batch-size 8
+sleap-nn export predict exports/model video.mp4 --runtime tensorrt --batch-size 8
 
 # CPU inference
-sleap-nn predict exports/model video.mp4 --runtime onnx --device cpu
+sleap-nn export predict exports/model video.mp4 --runtime onnx --device cpu
 
 # First 1000 frames
-sleap-nn predict exports/model video.mp4 --n-frames 1000
+sleap-nn export predict exports/model video.mp4 --n-frames 1000
 ```
 
 ---

--- a/docs/guides/tracking.md
+++ b/docs/guides/tracking.md
@@ -94,7 +94,7 @@ last observed pose **rigidly translated** by that predicted displacement (analog
 optical flow, but using a motion model instead of image displacements):
 
 ```bash
-sleap-nn infer -i video.mp4 -m models/centroid models/centered_instance \
+sleap-nn predict -i video.mp4 -m models/centroid models/centered_instance \
     -t \
     --use_kalman \
     --tracking_target_instance_count 2 \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,9 +18,10 @@ Complete command-line interface documentation.
 |---------|-------------|
 | [`sleap-nn train`](#sleap-nn-train) | Train models |
 | [`sleap-nn track`](#sleap-nn-track) | Run inference/tracking |
+| [`sleap-nn predict`](#sleap-nn-predict) | Run inference on videos/labels |
 | [`sleap-nn eval`](#sleap-nn-eval) | Evaluate predictions |
 | [`sleap-nn export`](#sleap-nn-export) | Export to ONNX/TensorRT |
-| [`sleap-nn predict`](#sleap-nn-predict) | Inference on exported models |
+| [`sleap-nn export predict`](#sleap-nn-export-predict) | Inference on exported models |
 | [`sleap-nn config`](#sleap-nn-config) | Generate training configs (experimental) |
 | [`sleap-nn info`](#sleap-nn-info) | Inspect trained models |
 | [`sleap-nn system`](#sleap-nn-system) | System diagnostics |
@@ -152,6 +153,24 @@ sleap-nn track -i video.mp4 -m models/ --filter_overlapping -t
 
 ---
 
+## `sleap-nn predict`
+
+Run inference on videos or labels files. This is the canonical command for running the unified inference pipeline on trained checkpoint models.
+
+```bash
+sleap-nn predict --data_path INPUT --model_paths MODEL [OPTIONS]
+```
+
+`sleap-nn predict` accepts the same options as [`sleap-nn track`](#sleap-nn-track) (data selection, filtering, device, batch size, etc.). Add `--tracking` to enable tracking.
+
+### Example
+
+```bash
+sleap-nn predict -i video.mp4 -m models/centroid -m models/centered_instance -o predictions.slp
+```
+
+---
+
 ## `sleap-nn eval`
 
 Evaluate predictions against ground truth.
@@ -212,12 +231,12 @@ sleap-nn export models/centroid models/instance -o exports/
 
 ---
 
-## `sleap-nn predict`
+## `sleap-nn export predict`
 
 Run inference on exported models.
 
 ```bash
-sleap-nn predict EXPORT_DIR INPUT_PATH [OPTIONS]
+sleap-nn export predict EXPORT_DIR INPUT_PATH [OPTIONS]
 ```
 
 ### Options
@@ -233,7 +252,7 @@ sleap-nn predict EXPORT_DIR INPUT_PATH [OPTIONS]
 ### Example
 
 ```bash
-sleap-nn predict exports/model video.mp4 -o predictions.slp --runtime tensorrt
+sleap-nn export predict exports/model video.mp4 -o predictions.slp --runtime tensorrt
 ```
 
 ---

--- a/docs/sample_configs/config_centroid_unet_standalone.yaml
+++ b/docs/sample_configs/config_centroid_unet_standalone.yaml
@@ -7,7 +7,7 @@
 # multi-instance "animals-as-points" detection, tracking, or counting where
 # per-keypoint pose is not needed.
 #
-# At inference (`sleap-nn infer` auto-detects a lone centroid model directory),
+# At inference (`sleap-nn predict` auto-detects a lone centroid model directory),
 # the output collapses to a single-node 'centroid' skeleton — see
 # docs/guides/centroid-only-inference.md for the output representation contract,
 # distance-based evaluation, and export.

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -149,7 +149,8 @@ def cli():
     Use subcommands to run different workflows:
 
     train    - Run training workflow (auto-handles multi-GPU)
-    predict  - Run inference/tracking workflow
+    predict  - Run inference workflow (new pipeline)
+    track    - Run inference/tracking workflow (legacy pipeline)
     eval     - Run evaluation workflow
     system   - Display system information and GPU status
     """

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -149,7 +149,7 @@ def cli():
     Use subcommands to run different workflows:
 
     train    - Run training workflow (auto-handles multi-GPU)
-    track    - Run inference/tracking workflow
+    predict  - Run inference/tracking workflow
     eval     - Run evaluation workflow
     system   - Display system information and GPU status
     """
@@ -996,7 +996,7 @@ def track(**kwargs):
     """Run Inference and Tracking workflow (legacy pipeline).
 
     This command uses the legacy ``run_inference`` pipeline. For the new
-    inference pipeline, use ``sleap-nn infer``.
+    inference pipeline, use ``sleap-nn predict``.
     """
     from sleap_nn.predict import frame_list, run_inference
 
@@ -1020,7 +1020,7 @@ def track(**kwargs):
     kwargs.pop("write_interval", None)
     # New-flow-only flags, inert here. `track` cannot do centroid-only
     # inference; a lone centroid model is rejected downstream by run_inference
-    # with a message pointing to `sleap-nn infer`.
+    # with a message pointing to `sleap-nn predict`.
     kwargs.pop("centroid_only", None)
     kwargs.pop("centroid_peak_threshold", None)
     kwargs.pop("centroid_output", None)
@@ -1030,29 +1030,20 @@ def track(**kwargs):
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# PR 10 of #508 — `sleap-nn infer` unified inference command (#518)
+# ``sleap-nn predict`` unified inference command
 # ──────────────────────────────────────────────────────────────────────────
 #
-# `infer`, `predict`, and `track` share an option list and dispatch to one
+# ``predict`` and ``track`` share an option list and dispatch to one
 # implementation. The option list is built programmatically below
-# (``_INFERENCE_OPTIONS``) so the three commands stay in lockstep — adding
-# a flag in one place updates all three.
+# (``_INFERENCE_OPTIONS``) so the commands stay in lockstep — adding
+# a flag in one place updates all of them.
 #
-# The new flags introduced by PR 10:
-#   --paf-workers / --cpu-workers (alias)  → wires to Predictor(paf_workers=)
-#   --stream-to-file                        → triggers Predictor.predict_to_file
-#   --write-interval                        → flush cadence for stream-to-file
-#   --peak-conf-threshold (alias)           → alternate name for --peak_threshold
-#
-# The first two are accepted but warn / error today: the underlying new
-# Predictor wiring lands in PR 14 (#519, blocked-by this PR). When that
-# PR lands, this implementation flips to call
-# ``sleap_nn.inference.predictor.Predictor`` directly without changing
-# the user-facing CLI surface.
+# ``infer`` is kept as a hidden backward-compatible alias that emits a
+# deprecation warning and delegates to the same implementation.
 
 
 def _run_inference_impl(**kwargs):
-    """Implementation for ``sleap-nn infer`` (new pipeline only).
+    """Implementation for ``sleap-nn predict`` (new pipeline only).
 
     Coerces tuple-shaped multi-options into lists, parses the
     ``--frames`` string into a list of int frame indices, and routes to
@@ -1183,7 +1174,7 @@ def _build_tracker_config(kwargs: dict) -> "object":
     """Build a :class:`TrackerConfig` from the CLI ``--tracking_*`` flags.
 
     Replicates the legacy ``run_inference`` edge-layer defaulting (see
-    ``sleap_nn/predict.py`` pre-#530) so the new ``infer`` flow behaves
+    ``sleap_nn/predict.py`` pre-#530) so the new ``predict`` flow behaves
     identically (#582):
 
     * ``--max_tracks`` with no ``--candidates_method`` defaults the method to
@@ -1569,7 +1560,7 @@ def _gui_progress_callback():
 
 
 def _make_rich_progress():
-    """Build a shared Rich ``Progress`` instance for the ``infer`` path.
+    """Build a shared Rich ``Progress`` instance for the ``predict`` path.
 
     Returns the ``Progress`` (already started) — the caller MUST stop it
     in a ``finally`` block.
@@ -1619,7 +1610,7 @@ def _rich_task_callback(progress, description: str = "Predicting..."):
 
 
 def _rich_progress_callback():
-    """Build a Rich progress bar callback for the non-``--gui`` ``infer`` path.
+    """Build a Rich progress bar callback for the non-``--gui`` ``predict`` path.
 
     Returns ``(callback, progress)`` where ``callback(processed, total)`` has
     the per-batch signature the new pipeline uses. The ``Progress`` is started
@@ -1773,8 +1764,8 @@ def _common_inference_options(f):
     """Apply the shared inference flag list to a click command function.
 
     Defined as a function-level decorator (not a ``@click.option`` chain)
-    so the same option set can be reused across ``infer`` / ``predict``
-    / ``track`` without copy-pasting ~70 decorator lines per command.
+    so the same option set can be reused across ``predict`` / ``track``
+    without copy-pasting ~70 decorator lines per command.
     """
     decorators = [
         click.option(
@@ -2071,23 +2062,26 @@ def _common_inference_options(f):
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @_common_inference_options
-def infer(**kwargs):
+def predict(**kwargs):
     """Run inference on videos or labels files.
 
-    Single unified inference entry point. Replaces ``track``, ``predict``,
-    and ``export predict`` (which remain as aliases with deprecation
-    warnings until v0.3).
+    Single unified inference entry point.
     """
     return _run_inference_impl(**kwargs)
 
 
-# NOTE: The `sleap-nn predict` deprecation alias is deferred — a follow-up
-# PR will (a) convert `export` from a single command to a click group,
-# (b) re-home the existing top-level `predict` (which today runs inference
-# on an exported ONNX/TRT model) under `sleap-nn export predict`, and
-# (c) reclaim the top-level `predict` name as an alias for `infer`. PR 10
-# ships `track` deprecation and the canonical `infer` only, so users can
-# migrate via either of those paths first.
+@cli.command("infer", hidden=True, context_settings=CONTEXT_SETTINGS)
+@_common_inference_options
+def infer(**kwargs):
+    """Deprecated alias for ``predict``. Use ``sleap-nn predict`` instead."""
+    import warnings
+
+    warnings.warn(
+        "sleap-nn infer is deprecated. Use sleap-nn predict instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _run_inference_impl(**kwargs)
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
@@ -2182,12 +2176,10 @@ def info(path):
 
 
 def _register_export_commands():
-    """Lazily import and register export subcommands."""
-    from sleap_nn.export.cli import export as export_command
-    from sleap_nn.export.cli import predict as predict_command
+    """Lazily import and register the export command group."""
+    from sleap_nn.export.cli import export as export_group
 
-    cli.add_command(export_command)
-    cli.add_command(predict_command)
+    cli.add_command(export_group)
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)

--- a/sleap_nn/export/cli.py
+++ b/sleap_nn/export/cli.py
@@ -12,7 +12,7 @@ import click
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
-@click.command(context_settings=CONTEXT_SETTINGS)
+@click.command("model", context_settings=CONTEXT_SETTINGS)
 @click.argument(
     "model_paths",
     nargs=-1,
@@ -66,7 +66,7 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
     help="TensorRT builder workspace size in GB. Uses exporter default if unset.",
 )
 @click.option("--verify/--no-verify", default=True, show_default=True)
-def export(
+def export_model(
     model_paths: tuple[Path, ...],
     output: Optional[Path],
     fmt: str,
@@ -848,7 +848,7 @@ def export(
     )
 
 
-@click.command(context_settings=CONTEXT_SETTINGS)
+@click.command("predict", context_settings=CONTEXT_SETTINGS)
 @click.argument(
     "export_dir",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
@@ -942,7 +942,7 @@ def export(
     "(single-node PredictedInstance, frontend-compatible), 'centroid' "
     "(sio.PredictedCentroid), or 'both'. Ignored for non-centroid models.",
 )
-def predict(
+def export_predict(
     export_dir: Path,
     video_path: Path,
     output: Optional[Path],
@@ -1224,3 +1224,13 @@ def _load_lightning_model(
         map_location=device,
         weights_only=False,
     )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+def export():
+    """Export trained models to ONNX/TensorRT formats."""
+    pass
+
+
+export.add_command(export_model, name="model")
+export.add_command(export_predict, name="predict")

--- a/sleap_nn/export/cli.py
+++ b/sleap_nn/export/cli.py
@@ -1226,9 +1226,30 @@ def _load_lightning_model(
     )
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+class _DefaultModelGroup(click.Group):
+    """Click group that defaults to ``model`` for backward compatibility.
+
+    ``sleap-nn export MODEL_PATHS`` (the pre-group syntax) is treated as
+    ``sleap-nn export model MODEL_PATHS``.
+    """
+
+    def parse_args(self, ctx, args):
+        if (
+            args
+            and args[0] not in self.list_commands(ctx)
+            and not args[0].startswith("-")
+        ):
+            args = ["model"] + list(args)
+        return super().parse_args(ctx, args)
+
+
+@click.group(cls=_DefaultModelGroup, context_settings=CONTEXT_SETTINGS)
 def export():
-    """Export trained models to ONNX/TensorRT formats."""
+    """Export trained models to ONNX/TensorRT formats.
+
+    Subcommands: ``model`` (export checkpoints to ONNX/TRT, the default)
+    and ``predict`` (run inference on an exported model).
+    """
     pass
 
 

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -322,7 +322,7 @@ def run_inference(
         * **Streaming to disk**: ``predictor.predict_to_file(...)``
         * **Pure-tracking retrack**: ``Predictor.retrack(labels, tracker_config)``
 
-        ``sleap-nn infer`` / ``sleap-nn track`` already route through the
+        ``sleap-nn predict`` / ``sleap-nn track`` already route through the
         new flow internally; this function is the only remaining
         Python-level legacy entry point.
     """
@@ -613,7 +613,7 @@ def run_inference(
                     "`track` / `run_inference` pipeline (it would silently "
                     "substitute ground-truth centroids and require labeled "
                     "frames). Use the new flow instead:\n"
-                    "  sleap-nn infer --data_path <video|.slp> --model_paths <centroid_dir>\n"
+                    "  sleap-nn predict --data_path <video|.slp> --model_paths <centroid_dir>\n"
                     "or, from Python:\n"
                     "  from sleap_nn.inference.run import predict\n"
                     "  predict(src, model_paths=[centroid_dir], centroid_only=True)"

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -582,7 +582,7 @@ def run_inference(
         # Centroid-only models are unsupported on this legacy pipeline: a lone
         # centroid model builds a GT-dependent FindInstancePeaksGroundTruth stage
         # (predictors.py), silently substituting ground-truth centroids and only
-        # "predicting" labeled frames. Redirect to the new `infer` flow instead of
+        # "predicting" labeled frames. Redirect to the new `predict` flow instead of
         # producing misleading GT-copied output.
         if model_paths:
             from sleap_nn.config.utils import (

--- a/tests/cli/test_aliases.py
+++ b/tests/cli/test_aliases.py
@@ -79,3 +79,32 @@ def test_infer_shim_still_works():
     runner = CliRunner()
     result = runner.invoke(cli, ["infer", "--help"])
     assert result.exit_code == 0, result.output
+
+
+def test_infer_shim_emits_deprecation_warning():
+    """``sleap-nn infer`` emits a DeprecationWarning pointing to ``predict``."""
+    import warnings
+    from unittest.mock import MagicMock
+
+    runner = CliRunner()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with patch(
+            "sleap_nn.inference.run.predict",
+            return_value=MagicMock(),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "infer",
+                    "--data_path",
+                    "/fake/path.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                    "--device",
+                    "cpu",
+                ],
+            )
+    assert result.exit_code == 0, result.output
+    deprecation_msgs = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("sleap-nn predict" in str(w.message) for w in deprecation_msgs)

--- a/tests/cli/test_aliases.py
+++ b/tests/cli/test_aliases.py
@@ -1,8 +1,10 @@
 """Tests for command aliases and routing (PR 10 of #508 / #518).
 
 ``sleap-nn track`` uses the legacy ``run_inference`` pipeline.
-``sleap-nn infer`` uses the new ``Predictor``-based pipeline.
-``sleap-nn predict`` runs inference on exported ONNX/TRT models.
+``sleap-nn predict`` uses the new ``Predictor``-based pipeline.
+``sleap-nn infer`` is a deprecated alias that still works but emits a warning.
+``sleap-nn export model`` exports trained models.
+``sleap-nn export predict`` runs inference on exported ONNX/TRT models.
 """
 
 from __future__ import annotations
@@ -34,8 +36,8 @@ def test_track_routes_to_legacy_run_inference():
     mock_run.assert_called_once()
 
 
-def test_infer_routes_to_new_predict():
-    """``sleap-nn infer`` routes to the new ``predict()`` pipeline."""
+def test_predict_routes_to_new_predict():
+    """``sleap-nn predict`` routes to the new ``predict()`` pipeline."""
     from unittest.mock import MagicMock
 
     runner = CliRunner()
@@ -46,7 +48,7 @@ def test_infer_routes_to_new_predict():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -59,15 +61,21 @@ def test_infer_routes_to_new_predict():
     mock_predict.assert_called_once()
 
 
-def test_export_predict_top_level_still_works():
-    """The legacy top-level ``sleap-nn predict`` (export-trained) is intact.
+def test_export_predict_under_export_group():
+    """``sleap-nn export predict --help`` shows EXPORT_DIR/VIDEO_PATH args.
 
-    PR 10 explicitly does NOT remap top-level ``predict`` — that's a
-    follow-up. ``sleap-nn predict --help`` should still render the
-    export-trained predict command (with EXPORT_DIR + VIDEO_PATH args).
+    The export predict command lives under the ``export`` group and handles
+    inference on exported ONNX/TRT models.
     """
     runner = CliRunner()
-    result = runner.invoke(cli, ["predict", "--help"])
+    result = runner.invoke(cli, ["export", "predict", "--help"])
     assert result.exit_code == 0, result.output
-    # Marker that this is still the export-trained predict, not infer.
+    # Marker that this is the export-trained predict, not the inference predict.
     assert "EXPORT_DIR" in result.output or "VIDEO_PATH" in result.output
+
+
+def test_infer_shim_still_works():
+    """``sleap-nn infer --help`` still works (exit code 0) via the deprecated shim."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["infer", "--help"])
+    assert result.exit_code == 0, result.output

--- a/tests/cli/test_centroid_only_cli.py
+++ b/tests/cli/test_centroid_only_cli.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-1. ``--centroid-only`` is exposed in ``sleap-nn infer --help``.
+1. ``--centroid-only`` is exposed in ``sleap-nn predict --help``.
 2. Setting ``--centroid-only`` threads ``centroid_only=True`` into the
    ``predict()`` call.
 3. Omitting the flag leaves ``centroid_only`` out of the predict kwargs
@@ -19,10 +19,10 @@ from click.testing import CliRunner
 from sleap_nn.cli import cli
 
 
-def test_centroid_only_flag_in_infer_help():
-    """``--centroid-only`` appears in the help output of ``sleap-nn infer``."""
+def test_centroid_only_flag_in_predict_help():
+    """``--centroid-only`` appears in the help output of ``sleap-nn predict``."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["infer", "--help"])
+    result = runner.invoke(cli, ["predict", "--help"])
     assert result.exit_code == 0, result.output
     assert "--centroid-only" in result.output or "--centroid_only" in result.output
 
@@ -37,7 +37,7 @@ def test_centroid_only_flag_propagates_to_predict():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -65,7 +65,7 @@ def test_centroid_only_flag_omitted_is_default_off():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -90,7 +90,7 @@ def test_centroid_only_underscore_variant_accepted():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",

--- a/tests/cli/test_flag_validation.py
+++ b/tests/cli/test_flag_validation.py
@@ -1,4 +1,4 @@
-"""Validation tests for the PR 10 flags introduced on ``sleap-nn infer``.
+"""Validation tests for the PR 10 flags introduced on ``sleap-nn predict``.
 
 * ``--stream-to-file`` is accepted but currently raises a clear
   ``UsageError`` since the new ``Predictor.predict_to_file`` flow lands
@@ -29,7 +29,7 @@ def test_stream_to_file_with_tracking_raises_usage_error():
     result = runner.invoke(
         cli,
         [
-            "infer",
+            "predict",
             "--data_path",
             "/fake/path.mp4",
             "--model_paths",
@@ -53,7 +53,7 @@ def test_stream_to_file_with_no_empty_frames_raises_usage_error():
     result = runner.invoke(
         cli,
         [
-            "infer",
+            "predict",
             "--data_path",
             "/fake/path.mp4",
             "--model_paths",
@@ -73,7 +73,7 @@ def test_write_interval_without_stream_to_file_errors():
     result = runner.invoke(
         cli,
         [
-            "infer",
+            "predict",
             "--data_path",
             "/fake/path.mp4",
             "--model_paths",
@@ -102,7 +102,7 @@ def test_cpu_workers_alias_emits_deprecation_warning():
             result = runner.invoke(
                 cli,
                 [
-                    "infer",
+                    "predict",
                     "--data_path",
                     "/fake/path.mp4",
                     "--model_paths",
@@ -133,7 +133,7 @@ def test_paf_workers_positive_does_not_warn_on_new_flow():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -168,7 +168,7 @@ def test_stream_to_file_invokes_new_predictor_flow(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -188,7 +188,7 @@ def test_unknown_flag_rejected_cleanly():
     result = runner.invoke(
         cli,
         [
-            "infer",
+            "predict",
             "--data_path",
             "/fake/path.mp4",
             "--this-is-not-a-flag",

--- a/tests/cli/test_predict_command.py
+++ b/tests/cli/test_predict_command.py
@@ -1,9 +1,9 @@
-"""Tests for ``sleap-nn infer`` -- the unified inference command (PR 10 #518).
+"""Tests for ``sleap-nn predict`` -- the unified inference command (PR 10 #518).
 
 Coverage:
 
 1. The command is registered and ``--help`` renders.
-2. Every non-new flag from ``sleap-nn track`` is accepted by ``infer``
+2. Every non-new flag from ``sleap-nn track`` is accepted by ``predict``
    (parity with the legacy command's option surface).
 3. The four PR-10 new flags are accepted: ``--paf-workers``, the legacy
    alias ``--cpu-workers``, ``--stream-to-file``, ``--write-interval``,
@@ -21,10 +21,10 @@ from click.testing import CliRunner
 from sleap_nn.cli import cli
 
 
-def test_infer_command_help_renders():
-    """``sleap-nn infer --help`` exits 0 and lists the canonical flags."""
+def test_predict_command_help_renders():
+    """``sleap-nn predict --help`` exits 0 and lists the canonical flags."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["infer", "--help"])
+    result = runner.invoke(cli, ["predict", "--help"])
     assert result.exit_code == 0, result.output
     # A handful of representative flags must appear in --help.
     for flag in [
@@ -36,11 +36,11 @@ def test_infer_command_help_renders():
         "--stream-to-file",
         "--write-interval",
     ]:
-        assert flag in result.output, f"missing {flag} in `infer --help`"
+        assert flag in result.output, f"missing {flag} in `predict --help`"
 
 
-def test_infer_accepts_legacy_track_flag_surface():
-    """Every flag wired into ``track`` is accepted by ``infer`` too.
+def test_predict_accepts_legacy_track_flag_surface():
+    """Every flag wired into ``track`` is accepted by ``predict`` too.
 
     Mocks ``predict()`` and asserts the right kwargs propagate through.
     """
@@ -52,7 +52,7 @@ def test_infer_accepts_legacy_track_flag_surface():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -86,7 +86,7 @@ def test_infer_accepts_legacy_track_flag_surface():
         assert kw["filter_config"].overlapping_method == "oks"
 
 
-def test_infer_peak_conf_threshold_alias():
+def test_predict_peak_conf_threshold_alias():
     """``--peak-conf-threshold`` is an alias for ``--peak_threshold``."""
     runner = CliRunner()
     with patch(
@@ -96,7 +96,7 @@ def test_infer_peak_conf_threshold_alias():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -109,8 +109,8 @@ def test_infer_peak_conf_threshold_alias():
         assert abs(mock_predict.call_args[1]["peak_threshold"] - 0.42) < 1e-9
 
 
-def test_infer_simple_case_uses_predict(tmp_path):
-    """``sleap-nn infer`` without tracking/special flags routes to ``predict()``.
+def test_predict_simple_case_uses_predict(tmp_path):
+    """``sleap-nn predict`` without tracking/special flags routes to ``predict()``.
 
     PR 27 wires the simple case to ``sleap_nn.inference.run.predict(...)``
     instead of the legacy ``run_inference``. This test mocks ``predict()``
@@ -129,7 +129,7 @@ def test_infer_simple_case_uses_predict(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -139,7 +139,7 @@ def test_infer_simple_case_uses_predict(tmp_path):
             ],
         )
     assert result.exit_code == 0, result.output
-    assert mock_predict.called, "predict() was not called for simple infer case"
+    assert mock_predict.called, "predict() was not called for simple predict case"
     # Source is the first positional arg (a VideoProvider for .mp4 files
     # because the CLI default video_input_format="channels_last" is truthy).
     source = mock_predict.call_args[0][0]
@@ -149,7 +149,7 @@ def test_infer_simple_case_uses_predict(tmp_path):
     assert not mock_run_inference.called
 
 
-def test_infer_with_tracking_uses_predict(tmp_path):
+def test_predict_with_tracking_uses_predict(tmp_path):
     """``--tracking`` now routes through ``predict()`` (PR 27).
 
     The predict call receives a ``tracker_config`` and the legacy
@@ -168,7 +168,7 @@ def test_infer_with_tracking_uses_predict(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -193,7 +193,7 @@ def test_infer_with_tracking_uses_predict(tmp_path):
         assert cfg.max_tracks == 3
 
 
-def test_infer_with_tracking_plus_filter_uses_predict(tmp_path):
+def test_predict_with_tracking_plus_filter_uses_predict(tmp_path):
     """``--tracking`` + ``--filter_*`` now route through ``predict()`` (PR 27).
 
     The call should receive both a ``tracker_config`` and a
@@ -212,7 +212,7 @@ def test_infer_with_tracking_plus_filter_uses_predict(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -239,7 +239,7 @@ def test_infer_with_tracking_plus_filter_uses_predict(tmp_path):
         assert abs(fc.overlapping_threshold - 0.5) < 1e-9
 
 
-def test_infer_with_filter_flags_builds_filter_config(tmp_path):
+def test_predict_with_filter_flags_builds_filter_config(tmp_path):
     """``--filter_min_visible_nodes`` etc. build a ``FilterConfig`` for the new flow."""
     out = tmp_path / "out.slp"
     runner = CliRunner()
@@ -251,7 +251,7 @@ def test_infer_with_filter_flags_builds_filter_config(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -273,7 +273,7 @@ def test_infer_with_filter_flags_builds_filter_config(tmp_path):
         assert abs(fc.min_instance_score - 0.6) < 1e-9
 
 
-def test_infer_no_empty_frames_passes_clean_flag(tmp_path):
+def test_predict_no_empty_frames_passes_clean_flag(tmp_path):
     """``--no_empty_frames`` propagates as ``clean_empty_frames=True`` to predict()."""
     out = tmp_path / "out.slp"
     runner = CliRunner()
@@ -285,7 +285,7 @@ def test_infer_no_empty_frames_passes_clean_flag(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -300,7 +300,7 @@ def test_infer_no_empty_frames_passes_clean_flag(tmp_path):
         assert kw["clean_empty_frames"] is True
 
 
-def test_infer_only_suggested_frames_routes_to_predict(tmp_path):
+def test_predict_only_suggested_frames_routes_to_predict(tmp_path):
     """``--only_suggested_frames`` goes through ``predict()`` + LabelsProvider."""
     out = tmp_path / "out.slp"
     runner = CliRunner()
@@ -316,7 +316,7 @@ def test_infer_only_suggested_frames_routes_to_predict(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.slp",
                 "--model_paths",
@@ -336,7 +336,7 @@ def test_infer_only_suggested_frames_routes_to_predict(tmp_path):
         assert provider_kwargs["only_suggested_frames"] is True
 
 
-def test_infer_gui_emits_json_progress(tmp_path):
+def test_predict_gui_emits_json_progress(tmp_path):
     """``--gui`` wires a JSON-progress callback through to ``predict()``."""
     runner = CliRunner()
     with patch(
@@ -346,7 +346,7 @@ def test_infer_gui_emits_json_progress(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -371,7 +371,7 @@ def test_infer_gui_emits_json_progress(tmp_path):
         assert parsed["n_total"] == 10
 
 
-def test_infer_without_gui_attaches_rich_progress_callback(tmp_path):
+def test_predict_without_gui_attaches_rich_progress_callback(tmp_path):
     """No ``--gui`` => ``predict()`` gets a (non-JSON) Rich progress callback (#583)."""
     import io
     import json
@@ -385,7 +385,7 @@ def test_infer_without_gui_attaches_rich_progress_callback(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -406,7 +406,7 @@ def test_infer_without_gui_attaches_rich_progress_callback(tmp_path):
                 json.loads(out)
 
 
-def test_infer_backbone_and_head_ckpt_paths_thread_to_predict(tmp_path):
+def test_predict_backbone_and_head_ckpt_paths_thread_to_predict(tmp_path):
     """``--backbone_ckpt_path`` / ``--head_ckpt_path`` reach ``predict()``."""
     runner = CliRunner()
     with patch(
@@ -416,7 +416,7 @@ def test_infer_backbone_and_head_ckpt_paths_thread_to_predict(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -433,7 +433,7 @@ def test_infer_backbone_and_head_ckpt_paths_thread_to_predict(tmp_path):
         assert kw["head_ckpt_path"] == "/fake/head.ckpt"
 
 
-def test_infer_retrack_only_dispatches_to_predictor_retrack(tmp_path):
+def test_predict_retrack_only_dispatches_to_predictor_retrack(tmp_path):
     """``--tracking`` + no ``model_paths`` + .slp data -> ``Predictor.retrack``."""
     runner = CliRunner()
     fake_labels = MagicMock()
@@ -451,7 +451,7 @@ def test_infer_retrack_only_dispatches_to_predictor_retrack(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.slp",
                 "--tracking",
@@ -471,7 +471,7 @@ def test_infer_retrack_only_dispatches_to_predictor_retrack(tmp_path):
         tracked.save.assert_called_once()
 
 
-def test_infer_paf_workers_zero_no_warning(tmp_path):
+def test_predict_paf_workers_zero_no_warning(tmp_path):
     """``--paf-workers 0`` is the default, must not emit a warning."""
     runner = CliRunner()
     with patch(
@@ -481,7 +481,7 @@ def test_infer_paf_workers_zero_no_warning(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -493,14 +493,14 @@ def test_infer_paf_workers_zero_no_warning(tmp_path):
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# #582 — candidates_method defaulting (infer auto-switch + track regression)
+# #582 — candidates_method defaulting (predict auto-switch + track regression)
 # ─────────────────────────────────────────────────────────────────────────
 
 
-def test_infer_max_tracks_auto_switches_to_local_queues():
-    """`infer --max_tracks N` with no explicit method defaults to local_queues.
+def test_predict_max_tracks_auto_switches_to_local_queues():
+    """`predict --max_tracks N` with no explicit method defaults to local_queues.
 
-    Drives the real CLI wiring (#582): the infer option default is None so
+    Drives the real CLI wiring (#582): the predict option default is None so
     _build_tracker_config can switch fixed_window -> local_queues for max_tracks.
     """
     runner = CliRunner()
@@ -510,7 +510,7 @@ def test_infer_max_tracks_auto_switches_to_local_queues():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -526,7 +526,7 @@ def test_infer_max_tracks_auto_switches_to_local_queues():
         assert cfg.max_tracks == 3
 
 
-def test_infer_explicit_fixed_window_with_max_tracks_respected():
+def test_predict_explicit_fixed_window_with_max_tracks_respected():
     """An explicit `--candidates_method fixed_window` is not overridden (#582)."""
     runner = CliRunner()
     with patch(
@@ -535,7 +535,7 @@ def test_infer_explicit_fixed_window_with_max_tracks_respected():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -613,7 +613,7 @@ def test_track_no_gui_defaults_false():
         assert mock_run.call_args[1]["gui"] is False
 
 
-def test_infer_paf_knobs_thread_to_predict():
+def test_predict_paf_knobs_thread_to_predict():
     """The 5 bottom-up PAF knobs reach run.predict (no longer silent no-ops). #583."""
     runner = CliRunner()
     with patch(
@@ -622,7 +622,7 @@ def test_infer_paf_knobs_thread_to_predict():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -648,7 +648,7 @@ def test_infer_paf_knobs_thread_to_predict():
         assert abs(kw["min_line_scores"] - 0.4) < 1e-9
 
 
-def test_infer_queue_maxsize_accepted_but_not_forwarded():
+def test_predict_queue_maxsize_accepted_but_not_forwarded():
     """`--queue_maxsize` is accepted (compat) but never forwarded to predict. #583."""
     runner = CliRunner()
     with patch(
@@ -657,7 +657,7 @@ def test_infer_queue_maxsize_accepted_but_not_forwarded():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/path.mp4",
                 "--model_paths",
@@ -670,16 +670,16 @@ def test_infer_queue_maxsize_accepted_but_not_forwarded():
         assert "queue_maxsize" not in mock_predict.call_args[1]
 
 
-def test_infer_queue_maxsize_hidden_in_help():
-    """The no-op --queue_maxsize is hidden from `infer --help`. #583."""
+def test_predict_queue_maxsize_hidden_in_help():
+    """The no-op --queue_maxsize is hidden from `predict --help`. #583."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["infer", "--help"])
+    result = runner.invoke(cli, ["predict", "--help"])
     assert result.exit_code == 0
     assert "--queue_maxsize" not in result.output
 
 
-def test_infer_video_index_scopes_and_names_output():
-    """`infer --video_index 1` scopes to that video + suffixes the output. #583."""
+def test_predict_video_index_scopes_and_names_output():
+    """`predict --video_index 1` scopes to that video + suffixes the output. #583."""
     import sleap_io as sio
 
     from sleap_nn.inference.providers import LabelsProvider
@@ -697,7 +697,7 @@ def test_infer_video_index_scopes_and_names_output():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/x.slp",
                 "--model_paths",
@@ -713,7 +713,7 @@ def test_infer_video_index_scopes_and_names_output():
         assert mock_pred.call_args[1]["output_path"].endswith("b.predictions.slp")
 
 
-def test_infer_video_index_out_of_range_errors():
+def test_predict_video_index_out_of_range_errors():
     """An out-of-range --video_index is a clear UsageError. #583."""
     import sleap_io as sio
 
@@ -729,7 +729,7 @@ def test_infer_video_index_out_of_range_errors():
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/x.slp",
                 "--model_paths",
@@ -742,7 +742,7 @@ def test_infer_video_index_out_of_range_errors():
         assert "out of range" in result.output
 
 
-def test_infer_retrack_only_sets_tracking_provenance(tmp_path):
+def test_predict_retrack_only_sets_tracking_provenance(tmp_path):
     """Retrack-only writes tracking-only provenance to the saved .slp. #583."""
     import numpy as np
     import sleap_io as sio
@@ -774,7 +774,7 @@ def test_infer_retrack_only_sets_tracking_provenance(tmp_path):
         result = runner.invoke(
             cli,
             [
-                "infer",
+                "predict",
                 "--data_path",
                 "/fake/preds.slp",
                 "--tracking",

--- a/tests/export/test_cli.py
+++ b/tests/export/test_cli.py
@@ -16,10 +16,10 @@ class TestExportCommandHelp:
 
     def test_export_command_help(self):
         """Test that --help works for export command."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         runner = CliRunner()
-        result = runner.invoke(export, ["--help"])
+        result = runner.invoke(export_model, ["--help"])
 
         assert result.exit_code == 0
         assert (
@@ -33,10 +33,10 @@ class TestPredictCommandHelp:
 
     def test_predict_command_help(self):
         """Test that --help works for predict command."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         runner = CliRunner()
-        result = runner.invoke(predict, ["--help"])
+        result = runner.invoke(export_predict, ["--help"])
 
         assert result.exit_code == 0
         assert (
@@ -45,10 +45,10 @@ class TestPredictCommandHelp:
 
     def test_predict_command_exposes_centroid_output(self):
         """The predict command exposes --centroid-output for centroid models."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         runner = CliRunner()
-        result = runner.invoke(predict, ["--help"])
+        result = runner.invoke(export_predict, ["--help"])
 
         assert result.exit_code == 0
         assert "--centroid-output" in result.output
@@ -62,12 +62,12 @@ class TestExportCommand:
         self, minimal_instance_single_instance_ckpt, tmp_path
     ):
         """Test exporting single_instance model to ONNX."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         output_dir = tmp_path / "export_output"
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_single_instance_ckpt),
                 "-o",
@@ -90,12 +90,12 @@ class TestExportCommand:
         self, minimal_instance_centroid_ckpt, tmp_path
     ):
         """Test exporting centroid model to ONNX."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         output_dir = tmp_path / "export_centroid"
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_centroid_ckpt),
                 "-o",
@@ -112,12 +112,12 @@ class TestExportCommand:
         self, minimal_instance_bottomup_ckpt, tmp_path
     ):
         """Test exporting bottomup model to ONNX."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         output_dir = tmp_path / "export_bottomup"
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_bottomup_ckpt),
                 "-o",
@@ -134,12 +134,12 @@ class TestExportCommand:
         self, minimal_instance_single_instance_ckpt, tmp_path
     ):
         """Test that metadata JSON file is created during export."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         output_dir = tmp_path / "export_with_meta"
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_single_instance_ckpt),
                 "-o",
@@ -169,12 +169,12 @@ class TestExportCommand:
         tmp_path,
     ):
         """Test exporting combined top-down model (centroid + instance)."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         output_dir = tmp_path / "export_topdown"
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_centroid_ckpt),
                 str(minimal_instance_centered_instance_ckpt),
@@ -191,11 +191,11 @@ class TestExportCommand:
 
     def test_export_command_invalid_path(self, tmp_path):
         """Test that non-existent path produces an error."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 "/nonexistent/path/to/model",
                 "-o",
@@ -208,7 +208,7 @@ class TestExportCommand:
 
     def test_export_command_missing_config(self, tmp_path):
         """Test that missing training_config.yaml produces an error."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         # Create empty directory without config
         fake_model_dir = tmp_path / "fake_model"
@@ -216,7 +216,7 @@ class TestExportCommand:
 
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(fake_model_dir),
                 "-o",
@@ -240,11 +240,11 @@ class TestTwoCentroidGuard:
 
     def test_two_centroid_dirs_raises(self, minimal_instance_centroid_ckpt, tmp_path):
         """Passing the same centroid dir twice raises a clear ClickException."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_centroid_ckpt),
                 str(minimal_instance_centroid_ckpt),
@@ -273,14 +273,14 @@ class TestCentroidExportConsistency:
         """
         from omegaconf import OmegaConf
 
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
         from sleap_nn.export.metadata import ExportMetadata
         from sleap_nn.export.utils import resolve_anchor_part, resolve_node_names
 
         output_dir = tmp_path / "export_standalone_centroid"
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_centroid_ckpt),
                 "-o",
@@ -314,12 +314,12 @@ class TestPredictCommand:
     @pytest.fixture
     def exported_model_dir(self, minimal_instance_single_instance_ckpt, tmp_path):
         """Export a model for predict tests."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         output_dir = tmp_path / "exported_for_predict"
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(minimal_instance_single_instance_ckpt),
                 "-o",
@@ -338,12 +338,12 @@ class TestPredictCommand:
         self, exported_model_dir, tiny_video, tmp_path
     ):
         """Test that predict creates output .slp file."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         output_slp = tmp_path / "predictions.slp"
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(exported_model_dir),
                 str(tiny_video),
@@ -360,12 +360,12 @@ class TestPredictCommand:
 
     def test_predict_command_n_frames(self, exported_model_dir, tiny_video, tmp_path):
         """Test that --n-frames limits processing."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         output_slp = tmp_path / "predictions_limited.slp"
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(exported_model_dir),
                 str(tiny_video),
@@ -381,12 +381,12 @@ class TestPredictCommand:
 
     def test_predict_command_batch_size(self, exported_model_dir, tiny_video, tmp_path):
         """Test that --batch-size parameter is accepted."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         output_slp = tmp_path / "predictions_batched.slp"
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(exported_model_dir),
                 str(tiny_video),
@@ -404,11 +404,11 @@ class TestPredictCommand:
 
     def test_predict_command_invalid_export(self, tmp_path, tiny_video):
         """Test that bad export directory produces an error."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(tmp_path / "nonexistent_export"),
                 str(tiny_video),

--- a/tests/export/test_export_accuracy.py
+++ b/tests/export/test_export_accuracy.py
@@ -83,12 +83,12 @@ def exported_bottomup_onnx_dir(bottomup_ckpt_path, tmp_path_factory):
     """Export the bottom-up checkpoint to ONNX and return the export directory."""
     pytest.importorskip("onnx")
 
-    from sleap_nn.export.cli import export
+    from sleap_nn.export.cli import export_model
 
     export_dir = tmp_path_factory.mktemp("export_bottomup_onnx")
     runner = CliRunner()
     result = runner.invoke(
-        export,
+        export_model,
         [
             str(bottomup_ckpt_path),
             "-o",
@@ -345,7 +345,7 @@ def _export_ckpts_to_onnx(
     extra_args: list[str] | None = None,
 ) -> Path:
     """Export checkpoint(s) to ONNX via the CLI and return the export dir."""
-    from sleap_nn.export.cli import export
+    from sleap_nn.export.cli import export_model
 
     runner = CliRunner()
     args = [str(p) for p in ckpt_paths] + [
@@ -358,7 +358,7 @@ def _export_ckpts_to_onnx(
     ]
     if extra_args:
         args.extend(extra_args)
-    result = runner.invoke(export, args)
+    result = runner.invoke(export_model, args)
     assert result.exit_code == 0, f"Export failed:\n{result.output}\n{result.exception}"
     assert (export_dir / "model.onnx").exists()
     return export_dir
@@ -645,12 +645,12 @@ class TestBottomUpTensorRTAccuracy:
     @pytest.fixture(scope="class")
     def exported_trt_dir(self, bottomup_ckpt_path, tmp_path_factory):
         """Export to TensorRT format."""
-        from sleap_nn.export.cli import export
+        from sleap_nn.export.cli import export_model
 
         export_dir = tmp_path_factory.mktemp("export_bottomup_trt")
         runner = CliRunner()
         result = runner.invoke(
-            export,
+            export_model,
             [
                 str(bottomup_ckpt_path),
                 "-o",

--- a/tests/export/test_predict_cli_wiring.py
+++ b/tests/export/test_predict_cli_wiring.py
@@ -71,7 +71,7 @@ class TestPredictWiring:
         self, mock_video_cls, mock_from_export_dir, tmp_path
     ):
         """``--runtime``, ``--device``, and grouping kwargs flow into the factory."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         export_dir = _write_export_dir(tmp_path)
         video_path = _fake_video_path(tmp_path)
@@ -84,7 +84,7 @@ class TestPredictWiring:
 
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(export_dir),
                 str(video_path),
@@ -125,7 +125,7 @@ class TestPredictWiring:
         self, mock_video_cls, mock_from_export_dir, tmp_path
     ):
         """Non-default values for graph-baked flags emit a one-time warning."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         export_dir = _write_export_dir(tmp_path)
         video_path = _fake_video_path(tmp_path)
@@ -137,7 +137,7 @@ class TestPredictWiring:
 
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(export_dir),
                 str(video_path),
@@ -163,7 +163,7 @@ class TestPredictWiring:
         self, mock_video_cls, mock_from_export_dir, tmp_path
     ):
         """Defaults don't trigger the baked-in warning."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         export_dir = _write_export_dir(tmp_path)
         video_path = _fake_video_path(tmp_path)
@@ -175,7 +175,7 @@ class TestPredictWiring:
 
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(export_dir),
                 str(video_path),
@@ -191,7 +191,7 @@ class TestPredictWiring:
 
     def test_missing_metadata_raises_click_exception(self, tmp_path):
         """A bad export dir produces a clean ClickException, not a traceback."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         export_dir = tmp_path / "no_metadata"
         export_dir.mkdir()
@@ -199,7 +199,7 @@ class TestPredictWiring:
 
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(export_dir),
                 str(video_path),
@@ -213,7 +213,7 @@ class TestPredictWiring:
 
     def test_missing_training_config_raises_click_exception(self, tmp_path):
         """Metadata present but no training_config.yaml → ClickException."""
-        from sleap_nn.export.cli import predict
+        from sleap_nn.export.cli import export_predict
 
         export_dir = tmp_path / "no_cfg"
         export_dir.mkdir()
@@ -226,7 +226,7 @@ class TestPredictWiring:
 
         runner = CliRunner()
         result = runner.invoke(
-            predict,
+            export_predict,
             [
                 str(export_dir),
                 str(video_path),

--- a/tests/inference/test_centroid_only.py
+++ b/tests/inference/test_centroid_only.py
@@ -452,7 +452,7 @@ def test_centroid_only_predict_to_file_collapses(tmp_path):
 def test_legacy_run_inference_lone_centroid_raises():
     from sleap_nn.predict import run_inference
 
-    with pytest.raises(ValueError, match="infer"):
+    with pytest.raises(ValueError, match="predict"):
         run_inference(
             data_path=str(SLP_FIXTURE),
             model_paths=[str(CENTROID_CKPT)],
@@ -460,14 +460,14 @@ def test_legacy_run_inference_lone_centroid_raises():
         )
 
 
-def test_cli_infer_has_centroid_output_option():
-    """The new --centroid-output option is wired onto `infer`, and the stale
+def test_cli_predict_has_centroid_output_option():
+    """The new --centroid-output option is wired onto `predict`, and the stale
     'NaN-padded' wording is gone from --centroid_only help."""
     from click.testing import CliRunner
 
     from sleap_nn.cli import cli
 
-    result = CliRunner().invoke(cli, ["infer", "--help"])
+    result = CliRunner().invoke(cli, ["predict", "--help"])
     assert result.exit_code == 0
     assert "--centroid-output" in result.output
     assert "NaN-padded" not in result.output
@@ -478,7 +478,7 @@ def test_cli_infer_has_centroid_output_option():
     reason="centroid ckpt / slp fixture absent",
 )
 def test_cli_track_lone_centroid_errors():
-    """Legacy `track` with a lone centroid model errors, pointing to `infer`."""
+    """Legacy `track` with a lone centroid model errors, pointing to `predict`."""
     from click.testing import CliRunner
 
     from sleap_nn.cli import cli
@@ -489,7 +489,7 @@ def test_cli_track_lone_centroid_errors():
     )
     assert result.exit_code != 0
     assert result.exception is not None
-    assert "infer" in str(result.exception)
+    assert "predict" in str(result.exception)
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -499,8 +499,8 @@ def test_cli_track_lone_centroid_errors():
 
 def test_cli_filter_min_centroid_distance_wired():
     """`--filter_min_centroid_distance` reaches FilterConfig and is registered
-    on the `infer` command."""
-    from sleap_nn.cli import _build_filter_config, infer
+    on the `predict` command."""
+    from sleap_nn.cli import _build_filter_config, predict
 
     cfg = _build_filter_config({"filter_min_centroid_distance": 8.0})
     assert cfg is not None
@@ -508,7 +508,7 @@ def test_cli_filter_min_centroid_distance_wired():
     # Zero / absent -> no-op config (None) when nothing else is set.
     assert _build_filter_config({"filter_min_centroid_distance": 0.0}) is None
 
-    assert "filter_min_centroid_distance" in {p.name for p in infer.params}
+    assert "filter_min_centroid_distance" in {p.name for p in predict.params}
 
 
 def test_emit_centroid_with_tracking_raises():

--- a/tests/inference/test_issue_575.py
+++ b/tests/inference/test_issue_575.py
@@ -2,7 +2,7 @@
 
 ``model_paths`` historically had to be a model *directory* (holding
 ``training_config.{yaml,json}`` + ``best.ckpt``). The inference / tracking entry
-points (``Predictor.from_model_paths``, the new ``sleap-nn infer`` flow, and the
+points (``Predictor.from_model_paths``, the new ``sleap-nn predict`` flow, and the
 legacy ``sleap-nn track`` / ``run_inference`` pipeline) now also accept a path to
 a model's ``best.ckpt`` or ``training_config.{yaml,json}`` file; every form
 resolves to the model directory, which is loaded via ``best.ckpt``.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,7 +229,7 @@ class TestTrackCommand:
     def test_track_and_infer_help_list_kalman_flags(self):
         """Both `track` and `infer` document the Kalman flags (#572)."""
         runner = CliRunner()
-        for command in ("track", "infer"):
+        for command in ("track", "predict"):
             result = runner.invoke(cli, [command, "--help"])
             assert result.exit_code == 0
             assert "--use_kalman" in result.output
@@ -913,7 +913,7 @@ def test_track_command_retrack_only_uses_new_flow(
         "--extra",
         "torch-cpu",
         "sleap-nn",
-        "infer",
+        "predict",
         "--model_paths",
         minimal_instance_centroid_ckpt,
         "--model_paths",
@@ -941,7 +941,7 @@ def test_track_command_retrack_only_uses_new_flow(
         "--extra",
         "torch-cpu",
         "sleap-nn",
-        "infer",
+        "predict",
         "--data_path",
         pred_slp,
         "--tracking",
@@ -974,7 +974,7 @@ def test_track_command_with_tracking_uses_new_flow(
         "--extra",
         "torch-cpu",
         "sleap-nn",
-        "infer",
+        "predict",
         "--model_paths",
         minimal_instance_centroid_ckpt,
         "--model_paths",


### PR DESCRIPTION
## Summary

"Infer" is ML jargon that most SLEAP users (primarily biologists) don't intuitively understand. This PR renames the `sleap-nn infer` subcommand to `sleap-nn predict`, which is more natural and closer to how users think about the task ("predict poses on my video").

## Plan

### Step 1: Re-home `sleap-nn predict` (ONNX/TRT) → `sleap-nn export predict`

There is an existing top-level `predict` command (defined in `export/cli.py`, registered via `_register_export_commands()`) that runs inference on **exported** ONNX/TRT models. This must move under the `export` group to free up the top-level `predict` name.

- Convert `export` from a standalone Click command to a Click group
- Move current top-level `predict` under it as `sleap-nn export predict`
- Remove top-level `predict` registration from `_register_export_commands()`

### Step 2: Rename `infer` → `predict`

- Rename the Click command registration from `infer` to `predict`
- All flags stay identical (shared via `_common_inference_options`)

### Step 3: Add hidden `infer` shim

- Register `infer` as a hidden Click command (`hidden=True`) that delegates to the same `_run_inference_impl()`
- Emit a `DeprecationWarning` to stderr guiding users to `sleap-nn predict`
- All flags work identically — zero behavior difference, just not shown in `--help`

### Step 4: Update `track` deprecation message

- Point `track`'s deprecation warning to `predict` instead of `infer`

## Scope

**Code (3 files):**
- `sleap_nn/cli.py` — command registration, shim, ~7 internal comment/docstring updates
- `sleap_nn/export/cli.py` — restructure `export` as a Click group
- `sleap_nn/predict.py` — update 2 string references

**Tests (7-8 files, ~50 occurrences):**
- `tests/cli/test_infer_command.py` → rename + update invocations
- `tests/cli/test_flag_validation.py`, `test_centroid_only_cli.py`, `test_aliases.py`
- `tests/test_cli.py`, `tests/inference/test_centroid_only.py`, `test_issue_575.py`
- New test for hidden `infer` shim + deprecation warning

**Docs (5 files):**
- `docs/guides/centroid-only-inference.md`, `tracking.md`, `export.md`
- `docs/reference/cli.md`
- `docs/sample_configs/config_centroid_unet_standalone.yaml`

## Migration notes

```bash
# Before
sleap-nn infer -i video.mp4 -m models/centroid -m models/centered_instance -o predictions.slp

# After
sleap-nn predict -i video.mp4 -m models/centroid -m models/centered_instance -o predictions.slp
```

`sleap-nn infer` continues to work (hidden from help, emits deprecation warning). All flags are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)