### PR TITLE
feat(seg) 5/5: post-training mask-IoU evaluation for bottom-up segmentation

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -115,6 +115,114 @@ def match_centroids(
     return matched_pred, matched_gt, unmatched_pred, unmatched_gt
 
 
+def _mask_iou(a: np.ndarray, b: np.ndarray) -> float:
+    """Intersection-over-union of two boolean masks.
+
+    Masks may have differing shapes (e.g. padding differences between GT and
+    prediction). Both segmentation masks are top-left aligned (offset (0, 0)),
+    so they are compared on a common canvas sized to the max H/W of the pair.
+    """
+    if a.shape != b.shape:
+        h = max(a.shape[0], b.shape[0])
+        w = max(a.shape[1], b.shape[1])
+        aa = np.zeros((h, w), dtype=bool)
+        bb = np.zeros((h, w), dtype=bool)
+        aa[: a.shape[0], : a.shape[1]] = a
+        bb[: b.shape[0], : b.shape[1]] = b
+        a, b = aa, bb
+    inter = int(np.logical_and(a, b).sum())
+    union = int(np.logical_or(a, b).sum())
+    # Two empty masks are identical -> IoU 1.0 (consistent with the
+    # "identical masks -> 1.0" contract). In practice neither GT (burned-in,
+    # non-empty) nor predicted (empty masks are dropped at postprocess) masks
+    # are empty, so this only guards the degenerate case.
+    if union == 0:
+        return 1.0
+    return float(inter / union)
+
+
+def _mask_iou_matrix(
+    pred_masks: List[np.ndarray], gt_masks: List[np.ndarray]
+) -> np.ndarray:
+    """Compute the IoU between every ``(pred, gt)`` mask pair.
+
+    Returns:
+        ``(n_pred, n_gt)`` float array of IoU values in ``[0, 1]``.
+    """
+    iou = np.zeros((len(pred_masks), len(gt_masks)), dtype=float)
+    for i, pm in enumerate(pred_masks):
+        for j, gm in enumerate(gt_masks):
+            iou[i, j] = _mask_iou(pm, gm)
+    return iou
+
+
+def match_masks(
+    pred_masks: List[np.ndarray],
+    gt_masks: List[np.ndarray],
+    min_iou: float = 0.5,
+) -> tuple:
+    """Match predicted masks to ground-truth masks by IoU (Hungarian).
+
+    Args:
+        pred_masks: List of boolean arrays, one per predicted instance.
+        gt_masks: List of boolean arrays, one per ground-truth instance.
+        min_iou: Minimum IoU for a matched pair to count as a true positive.
+
+    Returns:
+        Tuple of:
+            - matched_pred_indices: Indices of matched predictions.
+            - matched_gt_indices: Indices of matched ground truth.
+            - unmatched_pred_indices: Unmatched predictions (false positives).
+            - unmatched_gt_indices: Unmatched ground truth (false negatives).
+            - matched_ious: IoU of each matched pair, aligned to
+              ``matched_pred_indices``.
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    n_pred = len(pred_masks)
+    n_gt = len(gt_masks)
+    empty = np.array([], dtype=int)
+    if n_pred == 0 and n_gt == 0:
+        return empty, empty, empty, empty, np.array([])
+    if n_pred == 0:
+        return empty, empty, empty, np.arange(n_gt), np.array([])
+    if n_gt == 0:
+        return empty, empty, np.arange(n_pred), empty, np.array([])
+
+    iou = _mask_iou_matrix(pred_masks, gt_masks)  # (n_pred, n_gt)
+    # Maximize total IoU -> minimize negative IoU.
+    pred_indices, gt_indices = linear_sum_assignment(-iou)
+
+    matched_pred, matched_gt, matched_ious = [], [], []
+    for p_idx, g_idx in zip(pred_indices, gt_indices):
+        if iou[p_idx, g_idx] >= min_iou:
+            matched_pred.append(int(p_idx))
+            matched_gt.append(int(g_idx))
+            matched_ious.append(float(iou[p_idx, g_idx]))
+
+    matched_pred = np.array(matched_pred, dtype=int)
+    matched_gt = np.array(matched_gt, dtype=int)
+    unmatched_pred = np.array(
+        sorted(set(range(n_pred)) - set(matched_pred.tolist())), dtype=int
+    )
+    unmatched_gt = np.array(
+        sorted(set(range(n_gt)) - set(matched_gt.tolist())), dtype=int
+    )
+    return (
+        matched_pred,
+        matched_gt,
+        unmatched_pred,
+        unmatched_gt,
+        np.array(matched_ious),
+    )
+
+
+def _frame_masks(frame: sio.LabeledFrame) -> List[np.ndarray]:
+    """Decode a frame's segmentation masks into boolean arrays (orig res)."""
+    masks = getattr(frame, "masks", None) or []
+    return [np.asarray(m.data, dtype=bool) for m in masks]
+
+
 @attrs.define(auto_attribs=True, slots=True)
 class MatchInstance:
     """Class to have a new structure for sio.Instance object."""
@@ -584,8 +692,10 @@ class Evaluator:
         self.user_labels_only = user_labels_only
         self.match_method = match_method
         self.anchor_ind = anchor_ind
-        # Populated only in centroid mode.
+        # Populated only in centroid / mask mode.
         self.false_positives = []
+        # Matched-pair IoUs, populated only in mask mode.
+        self.mask_ious = np.array([])
 
         self._process_frames()
 
@@ -600,6 +710,10 @@ class Evaluator:
 
         if self.match_method == "centroid":
             self._process_frames_centroid()
+            return
+
+        if self.match_method == "mask":
+            self._process_frames_mask()
             return
 
         self.positive_pairs, self.false_negatives = match_frame_pairs(
@@ -697,6 +811,44 @@ class Evaluator:
             "frame_idxs": [gt.frame_idx for gt, _, _ in self.positive_pairs],
             "video_paths": [gt.video_path for gt, _, _ in self.positive_pairs],
         }
+
+    def _process_frames_mask(self):
+        """Match predicted vs GT segmentation masks by IoU (per frame).
+
+        Pulls per-instance boolean masks from ``LabeledFrame.masks`` on each
+        paired frame and matches them with :func:`match_masks` using
+        ``self.match_threshold`` as the IoU threshold. Populates
+        ``positive_pairs`` as ``(frame_gt, frame_pr, iou)`` 3-tuples (the frame
+        objects are stored only as tokens; detection counting uses the list
+        lengths, and per-pair IoUs feed :meth:`mask_metrics`), plus
+        ``false_negatives`` (unmatched GT masks) and ``false_positives``
+        (unmatched predicted masks). No keypoint distances exist for masks, so
+        ``dists_dict`` is left empty (``distance_metrics`` reports NaN; IoU is
+        reported via :meth:`mask_metrics`).
+        """
+        self.positive_pairs = []
+        self.false_negatives = []
+        self.false_positives = []
+        ious: List[float] = []
+
+        for frame_gt, frame_pr in self.frame_pairs:
+            gt_masks = _frame_masks(frame_gt)
+            pr_masks = _frame_masks(frame_pr)
+
+            _, _, unmatched_pred, unmatched_gt, pair_ious = match_masks(
+                pr_masks, gt_masks, min_iou=self.match_threshold
+            )
+
+            for iou in pair_ious:
+                self.positive_pairs.append((frame_gt, frame_pr, float(iou)))
+                ious.append(float(iou))
+            for _ in unmatched_gt:
+                self.false_negatives.append(frame_gt)
+            for _ in unmatched_pred:
+                self.false_positives.append(frame_pr)
+
+        self.mask_ious = np.asarray(ious, dtype=float)
+        self.dists_dict = {"dists": np.array([]), "frame_idxs": [], "video_paths": []}
 
     @staticmethod
     def _collapse_pred_centroid(points: np.ndarray) -> np.ndarray:
@@ -856,13 +1008,16 @@ class Evaluator:
         return results
 
     def detection_metrics(self) -> dict:
-        """Compute detection metrics for centroid-only / single-point matching.
+        """Compute detection metrics (precision/recall/F1) over TP/FP/FN counts.
 
-        Reuses the same aggregation as
-        ``CentroidEvaluationCallback._compute_metrics``: precision/recall/F1
-        over TP/FP/FN counts, plus localization-error percentiles over the
-        Euclidean distances of the matched centroid pairs. Intended for
-        ``match_method="centroid"``.
+        Used by both ``match_method="centroid"`` and ``match_method="mask"``
+        (it only reads the matched/unmatched list lengths and ``dists_dict``).
+        Mirrors ``CentroidEvaluationCallback._compute_metrics``. For centroid
+        mode the localization-error percentiles are computed over the Euclidean
+        distances of matched centroid pairs; for mask mode ``dists_dict`` is
+        empty so those percentiles are NaN (per-pair IoU is reported separately
+        via :meth:`mask_metrics`). Not used for ``match_method="oks"`` (which
+        reports OKS-based VOC metrics instead).
 
         Returns:
             A dict with ``precision``, ``recall``, ``f1``, ``n_tp``, ``n_fp``,
@@ -904,6 +1059,37 @@ class Evaluator:
             for ptile in (50, 75, 90, 95, 99):
                 results[f"p{ptile}"] = float(np.percentile(non_nans, ptile))
 
+        return results
+
+    def mask_metrics(self) -> dict:
+        """Compute mask-IoU summary statistics over matched (TP) pairs.
+
+        Intended for ``match_method="mask"``. Reports the mean IoU and IoU
+        percentiles over all matched predicted/GT mask pairs (NaN when there
+        are no matches).
+
+        Returns:
+            A dict with ``mean_iou``, ``min``, ``max``, percentiles ``p25``/
+            ``p50``/``p75``, the matched count ``n_matched``, and the raw
+            ``ious`` array.
+        """
+        ious = np.asarray(self.mask_ious, dtype=float)
+        results = {
+            "mean_iou": np.nan,
+            "min": np.nan,
+            "max": np.nan,
+            "p25": np.nan,
+            "p50": np.nan,
+            "p75": np.nan,
+            "n_matched": int(ious.size),
+            "ious": ious,
+        }
+        if ious.size:
+            results["mean_iou"] = float(np.mean(ious))
+            results["min"] = float(np.min(ious))
+            results["max"] = float(np.max(ious))
+            for ptile in (25, 50, 75):
+                results[f"p{ptile}"] = float(np.percentile(ious, ptile))
         return results
 
     def pck_metrics(self, thresholds: np.ndarray = np.linspace(1, 10, 10)):
@@ -977,6 +1163,15 @@ class Evaluator:
             return {
                 "detection_metrics": self.detection_metrics(),
                 "distance_metrics": self.distance_metrics(),
+            }
+
+        if self.match_method == "mask":
+            # Instance segmentation: detection (precision/recall/F1 over
+            # IoU-matched masks) + mask-IoU quality. OKS/PCK/visibility are
+            # keypoint-only and not computed.
+            return {
+                "detection_metrics": self.detection_metrics(),
+                "mask_metrics": self.mask_metrics(),
             }
 
         metrics = {}
@@ -1153,9 +1348,11 @@ def run_evaluation(
         user_labels_only: If False, predicted instances in the GT frame may be
             matched.
         save_metrics: Optional ``.npz`` path to save metrics to.
-        match_method: ``"oks"``, ``"centroid"``, or ``"auto"``. ``"auto"``
-            switches to centroid mode when the PREDICTION skeleton is a
-            single-node skeleton (e.g. ``sio.get_centroid_skeleton()``).
+        match_method: ``"oks"``, ``"centroid"``, ``"mask"``, or ``"auto"``.
+            ``"mask"`` matches predicted vs GT segmentation masks by IoU (for
+            ``bottomup_segmentation`` models). ``"auto"`` switches to centroid
+            mode when the PREDICTION skeleton is a single-node skeleton (e.g.
+            ``sio.get_centroid_skeleton()``).
         anchor_part: Name of the GT skeleton node used to compute GT centroids
             (centroid mode). Resolved against the GT skeleton; ``None`` (or an
             absent name) falls back to the mean of visible nodes (#586).
@@ -1200,6 +1397,11 @@ def run_evaluation(
     if match_method == "centroid" and match_threshold == 0:
         match_threshold = 50.0
 
+    # In mask mode, default the IoU match threshold to 0.5 if the caller left
+    # the OKS default of 0.0.
+    if match_method == "mask" and match_threshold == 0:
+        match_threshold = 0.5
+
     logger.info("Matching videos and frames...")
     # Get match stats before creating evaluator
     match_result = ground_truth_instances.match(predicted_instances)
@@ -1242,6 +1444,29 @@ def run_evaluation(
         logger.info(f"  dist.p90: {dist['p90']:.2f} px")
         logger.info(f"  dist.p95: {dist['p95']:.2f} px")
         logger.info(f"  dist.p99: {dist['p99']:.2f} px")
+
+        if save_metrics:
+            logger.info(f"Saving metrics to {save_metrics}...")
+            save_path = Path(save_metrics)
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            np.savez_compressed(save_path, **{"metrics": metrics})
+            logger.info(f"Metrics saved successfully to {save_path}")
+
+        return metrics
+
+    if match_method == "mask":
+        # Mask mode: report detection (IoU-matched) + mask-IoU metrics only
+        # (no oks_voc.*/mOKS/PCK/visibility keys exist).
+        det = metrics["detection_metrics"]
+        mm = metrics["mask_metrics"]
+        logger.info("Evaluation Results (mask mode):")
+        logger.info(f"  Precision: {det['precision']:.4f}")
+        logger.info(f"  Recall: {det['recall']:.4f}")
+        logger.info(f"  F1: {det['f1']:.4f}")
+        logger.info(f"  Counts: TP={det['n_tp']}, FP={det['n_fp']}, FN={det['n_fn']}")
+        logger.info(f"  Mean mask IoU: {mm['mean_iou']:.4f}")
+        logger.info(f"  mask IoU p50: {mm['p50']:.4f}")
+        logger.info(f"  mask IoU p25: {mm['p25']:.4f}")
 
         if save_metrics:
             logger.info(f"Saving metrics to {save_metrics}...")

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -108,6 +108,111 @@ def _run_centroid_split_eval(
     return metrics
 
 
+def _run_segmentation_split_eval(
+    config: DictConfig,
+    d_name: str,
+    path: str,
+    run_path: Path,
+    pred_path: Path,
+    metrics_path: Path,
+    device: str,
+):
+    """Run post-training eval for a single split of a segmentation model.
+
+    ``bottomup_segmentation`` models predict per-instance masks (not
+    keypoints), so they use the NEW inference flow
+    (``sleap_nn.inference.run.predict``, which auto-detects the segmentation
+    model) and mask-IoU evaluation (``run_evaluation(match_method="mask")``).
+    The mask metrics dict has ``detection_metrics`` (IoU-matched
+    precision/recall/F1) + ``mask_metrics`` (mean IoU) only — no
+    ``voc_metrics``/``mOKS``/``pck``/``visibility`` keys — so every access is
+    guarded and the OKS mAP line is intentionally NOT logged.
+
+    Post-training eval is best-effort: a weak model that predicts no masks (so
+    no frames pair) is logged and skipped rather than aborting the run.
+
+    Args:
+        config: Training configuration.
+        d_name: Split name, e.g. ``"train.0"``/``"val.0"``/``"test.0"``.
+        path: Path to the ground-truth ``.slp`` for this split.
+        run_path: The ``<ckpt_dir>/<run_name>`` directory (the seg model).
+        pred_path: Output path for the predicted ``.slp``.
+        metrics_path: Output path for the saved metrics ``.npz``.
+        device: Torch device string to run inference on.
+
+    Returns:
+        The metrics dict returned by ``run_evaluation`` (mask mode), or ``None``
+        if there were no predicted frames / no matched frames (eval skipped).
+    """
+    # Lazy import of the NEW inference flow (segmentation auto-detected).
+    from sleap_nn.inference.run import predict as predict_new
+
+    pred_labels = predict_new(
+        path,
+        model_paths=[run_path],
+        peak_threshold=0.2,
+        device=device,
+        output_path=pred_path,
+    )
+
+    if not len(pred_labels):
+        logger.info(
+            f"Skipping eval on `{d_name}` dataset as there are no predicted masks..."
+        )
+        return None
+
+    # IoU match threshold for masks must lie in (0, 1]. The shared
+    # `trainer_config.eval.match_threshold` defaults to 50.0 (a centroid PIXEL
+    # distance), which is never a valid IoU and would reject every mask, so we
+    # fall back to 0.5 unless the user explicitly set a value in the IoU range.
+    match_threshold = OmegaConf.select(
+        config, "trainer_config.eval.match_threshold", default=None
+    )
+    if match_threshold is None or not (0.0 < float(match_threshold) <= 1.0):
+        match_threshold = 0.5
+
+    try:
+        metrics = run_evaluation(
+            ground_truth_path=path,
+            predicted_path=pred_path.as_posix(),
+            match_method="mask",
+            match_threshold=match_threshold,
+            save_metrics=metrics_path.as_posix(),
+        )
+    except Exception as e:  # noqa: BLE001 — eval is best-effort post-training.
+        logger.warning(f"Skipping segmentation eval on `{d_name}`: {e}")
+        return None
+
+    # Mask metrics: detection_metrics + mask_metrics only. Guard every access.
+    det = metrics.get("detection_metrics", {}) if metrics is not None else {}
+    mm = metrics.get("mask_metrics", {}) if metrics is not None else {}
+    logger.info(f"---------Evaluation on `{d_name}` dataset (segmentation)---------")
+    logger.info(f"Detection precision: {det.get('precision')}")
+    logger.info(f"Detection recall: {det.get('recall')}")
+    logger.info(f"Detection f1: {det.get('f1')}")
+    logger.info(f"Mean mask IoU: {mm.get('mean_iou')}")
+    logger.info(f"mask IoU p50: {mm.get('p50')}")
+
+    # Log test metrics to wandb summary (mirrors the keypoint OKS path).
+    if (
+        d_name.startswith("test")
+        and config.trainer_config.use_wandb
+        and metrics is not None
+    ):
+        import wandb
+
+        if wandb.run is not None:
+            for key, value in {
+                f"eval/{d_name}/mask_mean_iou": mm.get("mean_iou"),
+                f"eval/{d_name}/detection_precision": det.get("precision"),
+                f"eval/{d_name}/detection_recall": det.get("recall"),
+                f"eval/{d_name}/detection_f1": det.get("f1"),
+            }.items():
+                wandb.run.summary[key] = value
+
+    return metrics
+
+
 def run_training(
     config: DictConfig,
     train_labels: Optional[List[sio.Labels]] = None,
@@ -184,6 +289,18 @@ def run_training(
 
                 if model_type == "centroid":
                     _run_centroid_split_eval(
+                        config=trainer.config,
+                        d_name=d_name,
+                        path=path,
+                        run_path=run_path,
+                        pred_path=pred_path,
+                        metrics_path=metrics_path,
+                        device=str(trainer.trainer.strategy.root_device),
+                    )
+                    continue
+
+                if model_type == "bottomup_segmentation":
+                    _run_segmentation_split_eval(
                         config=trainer.config,
                         d_name=d_name,
                         path=path,

--- a/tests/test_segmentation_eval.py
+++ b/tests/test_segmentation_eval.py
@@ -1,0 +1,303 @@
+"""Tests for mask-IoU evaluation of bottom-up instance-segmentation models.
+
+Covers the ``match_method="mask"`` evaluation path added to
+``sleap_nn.evaluation`` (IoU matching helpers + ``run_evaluation``) and the
+post-training segmentation eval routing in ``sleap_nn.train``.
+"""
+
+import numpy as np
+
+import sleap_io as sio
+
+from sleap_nn.evaluation import _mask_iou, match_masks, run_evaluation
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+# ---------------------------------------------------------------------------
+# _mask_iou / match_masks units
+# ---------------------------------------------------------------------------
+
+
+def test_mask_iou_identical_disjoint_partial():
+    """IoU is 1.0 for identical, 0.0 for disjoint, and exact for partial overlap."""
+    a = np.zeros((10, 10), dtype=bool)
+    a[2:6, 2:6] = True  # 16 px
+    assert _mask_iou(a, a) == 1.0
+
+    b = np.zeros((10, 10), dtype=bool)
+    b[6:9, 6:9] = True  # disjoint from a
+    assert _mask_iou(a, b) == 0.0
+
+    c = np.zeros((10, 10), dtype=bool)
+    c[4:8, 2:6] = True  # overlaps a in rows 4-5 (2 of 4 rows): inter=8
+    # union = 16 + 16 - 8 = 24 -> 8/24 = 1/3
+    assert abs(_mask_iou(a, c) - (8 / 24)) < 1e-9
+
+
+def test_mask_iou_mismatched_shapes_aligned_top_left():
+    """Masks of differing shapes are compared on a common top-left canvas."""
+    a = np.zeros((10, 10), dtype=bool)
+    a[1:4, 1:4] = True
+    big = np.zeros((20, 20), dtype=bool)
+    big[1:4, 1:4] = True
+    assert _mask_iou(a, big) == 1.0
+
+
+def test_match_masks_perfect_and_empty():
+    """Perfect 1:1 IoU matching; empty inputs produce only FN/FP."""
+    g = [_disk(40, 40, 10, 10, 6), _disk(40, 40, 30, 30, 6)]
+    p = [_disk(40, 40, 30, 30, 6), _disk(40, 40, 10, 10, 6)]  # swapped order
+    mp, mg, up, ug, ious = match_masks(p, g, min_iou=0.5)
+    assert len(mp) == 2 and len(up) == 0 and len(ug) == 0
+    assert len(ious) == 2 and np.allclose(ious, 1.0)
+
+    # No predictions -> both GT are false negatives.
+    mp, mg, up, ug, ious = match_masks([], g, min_iou=0.5)
+    assert len(mp) == 0 and len(ug) == 2 and ious.size == 0
+
+
+def test_match_masks_below_threshold_is_unmatched():
+    """A pair whose IoU is below the threshold counts as FP + FN, not a match."""
+    g = [_disk(40, 40, 20, 20, 10)]
+    p = [_disk(40, 40, 20, 20, 4)]  # much smaller -> low IoU
+    mp, mg, up, ug, ious = match_masks(p, g, min_iou=0.5)
+    assert len(mp) == 0
+    assert len(up) == 1 and len(ug) == 1
+
+
+def test_match_masks_hungarian_is_globally_optimal():
+    """Matching is globally optimal (Hungarian), not greedy per-row argmax.
+
+    pred0 overlaps gt0 best of its own row, but pred1 is an EXACT copy of gt0.
+    A greedy matcher that assigns pred0->gt0 first would then strand pred1 on
+    the far gt1 (IoU 0) and leave only one match. The optimal assignment pairs
+    pred1<->gt0 (IoU 1.0) and pred0<->gt1, yielding two matches.
+    """
+    gt = [_disk(60, 60, 30, 20, 10), _disk(60, 60, 30, 40, 10)]
+    pred = [_disk(60, 60, 30, 28, 10), _disk(60, 60, 30, 20, 10)]  # pred1 == gt0
+    mp, mg, up, ug, ious = match_masks(pred, gt, min_iou=0.1)
+    # Greedy would yield 1 match; the optimal assignment yields 2.
+    assert len(mp) == 2 and len(up) == 0 and len(ug) == 0
+    # The exact pair must be pred index 1 <-> gt index 0 with IoU 1.0.
+    pairing = dict(zip(mp.tolist(), mg.tolist()))
+    assert pairing[1] == 0
+    assert any(abs(i - 1.0) < 1e-9 for i in ious)
+
+
+# ---------------------------------------------------------------------------
+# run_evaluation(match_method="mask")
+# ---------------------------------------------------------------------------
+
+FNAME = "synthetic_seg_video.mp4"
+H, W = 48, 48
+
+
+def _make_gt(masks, with_masks=True):
+    """Build GT labels: a 2-node pose per mask (+ UserSeg masks unless disabled).
+
+    The poses are what ``find_frame_pairs`` keys off (it filters GT frames to
+    those with user instances); ``with_masks=False`` yields a poses-only GT
+    frame (still paired) but no GT masks.
+    """
+    skel = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    video = sio.Video.from_filename(FNAME)
+    instances, seg_masks = [], []
+    for m in masks:
+        ys, xs = np.nonzero(m)
+        cy, cx = float(ys.mean()), float(xs.mean())
+        instances.append(
+            sio.Instance.from_numpy(
+                np.array([[cx, cy], [cx + 1, cy + 1]], dtype="float64"), skeleton=skel
+            )
+        )
+        if with_masks:
+            seg_masks.append(sio.UserSegmentationMask.from_numpy(m))
+    lf = sio.LabeledFrame(
+        video=video, frame_idx=0, instances=instances, masks=seg_masks
+    )
+    return sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[lf])
+
+
+def _make_pred(masks, score=0.9):
+    """Build predicted labels: one frame of PredictedSegmentationMasks (no poses)."""
+    video = sio.Video.from_filename(FNAME)
+    seg_masks = [
+        sio.PredictedSegmentationMask.from_numpy(m, score=score) for m in masks
+    ]
+    lf = sio.LabeledFrame(video=video, frame_idx=0, masks=seg_masks)
+    return sio.Labels(videos=[video], labeled_frames=[lf])
+
+
+def test_run_evaluation_mask_perfect(tmp_path):
+    """Identical GT/pred masks -> precision=recall=F1=1.0 and mean IoU=1.0."""
+    masks = [_disk(H, W, 14, 14, 8), _disk(H, W, 34, 34, 8)]
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    _make_gt(masks).save(gt_path.as_posix())
+    _make_pred(masks).save(pr_path.as_posix())
+
+    m = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+        save_metrics=(tmp_path / "metrics.npz").as_posix(),
+    )
+    det, mm = m["detection_metrics"], m["mask_metrics"]
+    assert det["precision"] == 1.0 and det["recall"] == 1.0 and det["f1"] == 1.0
+    assert det["n_tp"] == 2 and det["n_fp"] == 0 and det["n_fn"] == 0
+    assert abs(mm["mean_iou"] - 1.0) < 1e-9 and mm["n_matched"] == 2
+    # All IoU stat fields are 1.0 for a perfect match.
+    for k in ("min", "max", "p25", "p50", "p75"):
+        assert abs(mm[k] - 1.0) < 1e-9
+    # Mask mode reports detection + mask metrics only (no keypoint keys).
+    assert "voc_metrics" not in m and "mOKS" not in m
+    # Metrics file round-trips.
+    assert (tmp_path / "metrics.npz").exists()
+
+
+def test_run_evaluation_mask_disjoint(tmp_path):
+    """Non-overlapping predictions -> zero TP, all FP + FN."""
+    gt = [_disk(H, W, 12, 12, 6)]
+    pr = [_disk(H, W, 40, 40, 6)]  # far away, IoU 0
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    _make_gt(gt).save(gt_path.as_posix())
+    _make_pred(pr).save(pr_path.as_posix())
+
+    m = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+    )
+    det = m["detection_metrics"]
+    assert det["n_tp"] == 0 and det["n_fp"] == 1 and det["n_fn"] == 1
+    assert det["precision"] == 0.0 and det["recall"] == 0.0
+    assert np.isnan(m["mask_metrics"]["mean_iou"])
+
+
+def test_run_evaluation_mask_partial_threshold(tmp_path):
+    """A moderately shrunk prediction matches at IoU 0.5 but not at 0.95."""
+    gt = [_disk(H, W, 24, 24, 12)]
+    pr = [_disk(H, W, 24, 24, 10)]  # concentric, slightly smaller
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    _make_gt(gt).save(gt_path.as_posix())
+    _make_pred(pr).save(pr_path.as_posix())
+
+    lenient = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+        match_threshold=0.5,
+    )
+    assert lenient["detection_metrics"]["n_tp"] == 1
+    iou = lenient["mask_metrics"]["mean_iou"]
+    assert 0.5 <= iou < 1.0
+
+    strict = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+        match_threshold=0.95,
+    )
+    assert strict["detection_metrics"]["n_tp"] == 0
+
+
+def test_run_evaluation_mask_fp_only_frame(tmp_path):
+    """GT frame with poses but no masks -> every prediction is a false positive."""
+    shapes = [_disk(H, W, 14, 14, 8), _disk(H, W, 34, 34, 8)]
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    _make_gt(shapes, with_masks=False).save(gt_path.as_posix())  # poses, no masks
+    _make_pred(shapes).save(pr_path.as_posix())
+
+    m = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+    )
+    det = m["detection_metrics"]
+    assert det["n_tp"] == 0 and det["n_fp"] == 2 and det["n_fn"] == 0
+    assert det["precision"] == 0.0
+    assert np.isnan(m["mask_metrics"]["mean_iou"])
+
+
+def test_run_evaluation_mask_partial_recall(tmp_path):
+    """Pred recovers one of two GT masks -> TP=1, FP=0, FN=1 (recall 0.5)."""
+    gt = [_disk(H, W, 14, 14, 8), _disk(H, W, 34, 34, 8)]
+    pr = [_disk(H, W, 14, 14, 8)]  # only the first GT mask
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    _make_gt(gt).save(gt_path.as_posix())
+    _make_pred(pr).save(pr_path.as_posix())
+
+    m = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+    )
+    det = m["detection_metrics"]
+    assert det["n_tp"] == 1 and det["n_fp"] == 0 and det["n_fn"] == 1
+    assert det["recall"] == 0.5 and det["precision"] == 1.0
+    assert abs(m["mask_metrics"]["mean_iou"] - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Post-training segmentation eval routing (train.py)
+# ---------------------------------------------------------------------------
+
+
+def test_train_routes_segmentation_eval(minimal_instance_seg, tmp_path):
+    """``train()`` on a seg model runs post-training mask eval without error.
+
+    Exercises ``run_training`` -> ``model_type == 'bottomup_segmentation'`` ->
+    ``_run_segmentation_split_eval`` -> new predict flow + ``run_evaluation``.
+    The tiny 1-epoch model is not expected to predict masks, so eval skips
+    gracefully; the point is that the segmentation branch is wired and robust
+    (it neither crashes nor falls through to keypoint OKS evaluation).
+    """
+    from sleap_nn.train import train
+
+    train(
+        train_labels_path=[minimal_instance_seg.as_posix()],
+        use_same_data_for_val=True,
+        head_configs="bottomup_segmentation",
+        backbone_config={
+            "unet": {
+                "in_channels": 1,
+                "filters": 8,
+                "filters_rate": 1.5,
+                "max_stride": 16,
+                "output_stride": 2,
+            }
+        },
+        ensure_grayscale=True,
+        scale=1.0,
+        batch_size=1,
+        max_epochs=1,
+        min_train_steps_per_epoch=1,
+        num_workers=0,
+        save_ckpt=True,
+        ckpt_dir=tmp_path.as_posix(),
+        run_name="seg_eval_route",
+        trainer_accelerator="cpu",
+        visualize_preds_during_training=False,
+        seed=42,
+    )
+    # The seg eval path predicts via the NEW flow and writes labels_pr.*.slp
+    # for each split. The legacy OKS path uses run_inference, which has no
+    # segmentation support and would raise before writing anything — so the
+    # presence of these predicted files (and no exception) confirms the
+    # segmentation branch ran rather than falling through to keypoint OKS eval.
+    run_dir = tmp_path / "seg_eval_route"
+    assert run_dir.exists()
+    pred_files = list(run_dir.glob("labels_pr.*.slp"))
+    assert pred_files, "segmentation eval did not write predicted split files"
+    # Any emitted masks are PredictedSegmentationMasks (not keypoint instances).
+    for pf in pred_files:
+        for mask in sio.load_slp(pf.as_posix()).masks:
+            assert isinstance(mask, sio.PredictedSegmentationMask)


### PR DESCRIPTION
Stacked on #605 (`feat/seg-inference-layer`). Fixes the post-training **evaluation** gap for `bottomup_segmentation` models and adds an end-to-end training smoke validation.

## Problem
`sleap_nn/train.py::run_training` special-cased `centroid` (new flow + distance eval) and sent **everything else** to the legacy `predict` (`run_inference`) + `run_evaluation(match_method="oks")`. For `bottomup_segmentation` that means (a) the legacy predictor has no segmentation support, and (b) OKS keypoint eval is meaningless for masks. (Recorded as the cross-cutting follow-up from the legacy-drop work.)

## Fix
**`sleap_nn/evaluation.py` — new `match_method="mask"`:**
- `_mask_iou` / `_mask_iou_matrix` / `match_masks` — Hungarian matching on IoU with an IoU threshold; masks aligned top-left to a common canvas (offset `(0,0)`).
- `Evaluator._process_frames_mask` + `mask_metrics()`; `evaluate()` returns `{detection_metrics, mask_metrics}` — IoU-matched **precision/recall/F1** + **mean / percentile mask IoU**. No OKS/PCK/visibility (keypoint-only). `detection_metrics` is reused unchanged (it only reads matched/unmatched list lengths + an empty `dists_dict`).
- `run_evaluation`: `match_method="mask"` (default IoU threshold 0.5) + logging/save branch.

**`sleap_nn/train.py` — `_run_segmentation_split_eval`** (mirrors `_run_centroid_split_eval`): predicts via the new flow (`inference.run.predict`, which auto-detects the seg model), evaluates with `match_method="mask"`, logs detection + mask-IoU metrics, logs test metrics to wandb. Routed by `model_type == "bottomup_segmentation"`; best-effort (a weak model that predicts no masks is logged + skipped, never aborts the run).

GT keeps its original pose instances alongside masks — `find_frame_pairs` keys off `user_instances`, so mask-only GT frames would otherwise be dropped; the seg dataset reads only `lf.masks`, so the extra poses are harmless to training.

> **Threshold bug the smoke test caught:** `_run_segmentation_split_eval` initially passed the shared `trainer_config.eval.match_threshold` straight through. Its default is **50.0** — a centroid *pixel distance*. As an **IoU** threshold, 50.0 is unreachable, so every mask was an FP/FN (precision=recall=0, IoU=nan) despite well-aligned predictions. Fixed by coercing the seg IoU threshold to 0.5 unless the user sets a value in `(0, 1]`.

## Validation
Empirically validated on **real data**: poses from `mice_of` (5 mice/frame) were rasterized into per-instance GT masks (skeleton nodes + edges, dilated) and saved to a new `.pkg.slp`; dataloaders were verified (GT center-heatmap peaks recovered exactly #masks on 24/24 frames); then a tiny UNet seg model was overfit and evaluated end-to-end:

| split | precision | recall | F1 | mean mask IoU | TP/FP/FN |
|-------|-----------|--------|----|---------------|----------|
| train.0 | 0.53 | **0.96** | 0.69 | **0.81** | 114/100/5 |

Recall 0.96 + mean IoU 0.81 confirm the masks are well-localized end to end; the low precision (FP=100) is the tiny overfit model **over-segmenting** into small noise blobs — a model-quality artifact, not an eval bug.

## Tests (`tests/test_segmentation_eval.py`, 11)
- Units: `_mask_iou` (identical/disjoint/partial/mismatched-shape), `match_masks` (perfect/empty/below-threshold/**Hungarian global optimality**).
- `run_evaluation(match_method="mask")`: perfect, disjoint, threshold boundary, **FP-only** (GT poses, no masks), **partial recall** (FN counting), mask-metric stat fields.
- Integration: `train()` on a seg model runs post-training mask eval without error and writes predicted-mask `.slp`s (the OKS path would raise on a seg model).

All evaluation + segmentation suites green (77 passed); `black` + `ruff` clean. OKS/centroid eval paths untouched (additive).

## Notes
- The change set was adversarially reviewed by a multi-agent verification pass (review across 4 lenses → independent verification of each finding); confirmed findings (empty-mask IoU semantics, an outdated docstring, and several test gaps) were applied; 4 findings were verified as non-bugs and dropped.
- Follow-up (not here): the seg inference over-segments into tiny spurious masks — a minimum-mask-area filter in `SegmentationLayer.postprocess` would raise precision. Belongs on the inference layer (#605).

🤖 Generated with [Claude Code](https://claude.com/claude-code)