### PR TITLE
feat: add --output_format option to save predictions directly as analysis HDF5

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1444,6 +1444,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
                 else f"{src}.slp"
             )
         ),
+        "output_format": kwargs.get("output_format") or "slp",
         # Bottom-up PAF grouping knobs (inert for non-bottom-up models). #583.
         "max_edge_length_ratio": kwargs.get("max_edge_length_ratio", 0.25),
         "dist_penalty_weight": kwargs.get("dist_penalty_weight", 1.0),
@@ -1590,8 +1591,12 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
         tracking_params=_attrs.asdict(tracker_config),
         frames_processed=len(out.labeled_frames),
     )
+    from sleap_nn.inference.run import save_predictions
+
     output_path = kwargs.get("output_path") or f"{src}.slp"
-    out.save(output_path)
+    save_predictions(
+        out, output_path, output_format=kwargs.get("output_format") or "slp"
+    )
     return out
 
 
@@ -1778,6 +1783,11 @@ def _run_stream_to_file(
             "streaming writes each batch to disk and cannot drop empty "
             "frames after the fact. Drop --stream-to-file to use it."
         )
+    if (kwargs.get("output_format") or "slp").lower() != "slp":
+        raise click.UsageError(
+            "--stream-to-file only supports --output_format slp. Drop "
+            "--stream-to-file to write analysis HDF5 via the in-memory path."
+        )
     if not kwargs.get("model_paths"):
         raise click.UsageError("--model_paths is required for --stream-to-file.")
     data_path = kwargs.get("data_path")
@@ -1913,6 +1923,12 @@ def _common_inference_options(f):
             type=str,
             default=None,
             help="Output filename. Defaults to '[data_path].slp'.",
+        ),
+        click.option(
+            "--output_format",
+            type=click.Choice(["slp", "analysis_h5", "both"], case_sensitive=False),
+            default="slp",
+            help="Output format: 'slp' (SLEAP labels file, the default), 'analysis_h5' (SLEAP Analysis HDF5, one '.analysis.h5' per video), or 'both'.",
         ),
         click.option(
             "--device",

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -28,13 +28,148 @@ Usage::
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
 import sleap_io as sio
+from loguru import logger
 
 if TYPE_CHECKING:
     from sleap_nn.inference.filters import FilterConfig
     from sleap_nn.inference.tracking import TrackerConfig
+
+
+def save_analysis_h5_files(
+    labels: sio.Labels,
+    slp_output_path: Union[str, Path],
+    video_index: Optional[int] = None,
+) -> List[Path]:
+    """Write SLEAP Analysis HDF5 file(s) from a predicted ``Labels`` object.
+
+    Analysis HDF5 files store a single video each, so one file is written per
+    video. The video name is embedded in the filename when more than one video
+    is exported (mirroring the multi-video ``.slp`` naming). Videos with no
+    predicted frames are skipped.
+
+    Args:
+        labels: Predicted ``sio.Labels`` to export.
+        slp_output_path: Path to the canonical ``.slp`` predictions file. The
+            HDF5 path(s) are derived from it by replacing the trailing
+            ``.predictions.slp`` (or ``.slp``) suffix with ``.analysis.h5``.
+        video_index: If not ``None``, only this video is exported. Otherwise all
+            videos with at least one predicted frame are exported.
+
+    Returns:
+        List of ``Path``s that were written.
+    """
+    slp_output_path = Path(slp_output_path)
+
+    # Derive the base name by stripping the predictions/slp suffix.
+    name = slp_output_path.name
+    for suffix in (".predictions.slp", ".slp"):
+        if name.endswith(suffix):
+            base_stem = name[: -len(suffix)]
+            break
+    else:
+        base_stem = slp_output_path.stem
+    base = slp_output_path.parent / base_stem
+
+    # Count predicted frames per video (using identity to avoid relying on
+    # Video equality semantics).
+    frames_per_video = [0] * len(labels.videos)
+    for lf in labels.labeled_frames:
+        for i, video in enumerate(labels.videos):
+            if lf.video is video:
+                frames_per_video[i] += 1
+                break
+
+    # Determine which videos to export.
+    if video_index is not None:
+        candidate_indices = (
+            [video_index] if 0 <= video_index < len(labels.videos) else []
+        )
+    else:
+        candidate_indices = list(range(len(labels.videos)))
+
+    target_indices = [i for i in candidate_indices if frames_per_video[i] > 0]
+    skipped_indices = [i for i in candidate_indices if frames_per_video[i] == 0]
+    if skipped_indices:
+        logger.warning(
+            f"Skipping Analysis HDF5 export for {len(skipped_indices)} video(s) "
+            f"with no predicted frames: {skipped_indices}."
+        )
+
+    # Build the video name embedded in each filename, disambiguating any videos
+    # that share a filename stem by appending the video index.
+    def _video_name(i):
+        filename = labels.videos[i].filename
+        return Path(filename).stem if isinstance(filename, str) else f"video_{i}"
+
+    video_names = {i: _video_name(i) for i in target_indices}
+    name_counts = {}
+    for vname in video_names.values():
+        name_counts[vname] = name_counts.get(vname, 0) + 1
+    video_names = {
+        i: (f"{vname}_{i}" if name_counts[vname] > 1 else vname)
+        for i, vname in video_names.items()
+    }
+
+    written_paths = []
+    embed_video_name = len(target_indices) > 1
+    for i in target_indices:
+        if embed_video_name:
+            h5_path = base.parent / f"{base.name}.{video_names[i]}.analysis.h5"
+        else:
+            h5_path = base.parent / f"{base.name}.analysis.h5"
+        sio.save_analysis_h5(
+            labels,
+            h5_path.as_posix(),
+            video=i,
+            labels_path=slp_output_path.as_posix(),
+        )
+        written_paths.append(h5_path)
+        logger.info(f"Analysis HDF5 output path: {h5_path}")
+    return written_paths
+
+
+def save_predictions(
+    labels: sio.Labels,
+    output_path: Union[str, Path],
+    output_format: str = "slp",
+    video_index: Optional[int] = None,
+) -> List[Path]:
+    """Save predicted ``Labels`` to disk in the requested format(s).
+
+    Args:
+        labels: Predicted ``sio.Labels`` to save.
+        output_path: Canonical ``.slp`` output path. Analysis HDF5 paths are
+            derived from it.
+        output_format: One of ``"slp"`` (the default), ``"analysis_h5"``, or
+            ``"both"``.
+        video_index: Restrict the analysis HDF5 export to a single video index;
+            ``None`` exports every video with predicted frames.
+
+    Returns:
+        The list of analysis HDF5 paths written (empty when
+        ``output_format == "slp"``).
+
+    Raises:
+        ValueError: If ``output_format`` is not one of the valid options.
+    """
+    output_format = str(output_format).lower()
+    valid_output_formats = ("slp", "analysis_h5", "both")
+    if output_format not in valid_output_formats:
+        raise ValueError(
+            f"Invalid output_format: {output_format!r}. Must be one of "
+            f"{valid_output_formats}."
+        )
+
+    if output_format in ("slp", "both"):
+        labels.save(Path(output_path).as_posix())
+
+    h5_paths: List[Path] = []
+    if output_format in ("analysis_h5", "both"):
+        h5_paths = save_analysis_h5_files(labels, output_path, video_index=video_index)
+    return h5_paths
 
 
 def predict(
@@ -84,6 +219,7 @@ def predict(
     tracker_config: Optional["TrackerConfig"] = None,
     # Output
     output_path: Optional[str] = None,
+    output_format: str = "slp",
     clean_empty_frames: bool = False,
     progress_callback: Optional[Callable[[int, int], None]] = None,
     tracking_progress_callback: Optional[Callable[[int, int], None]] = None,
@@ -145,7 +281,11 @@ def predict(
         return_class_vectors: Keep class vectors on Outputs (multi-class top-down).
         filter_config: Post-inference :class:`FilterConfig`.
         tracker_config: :class:`TrackerConfig` for tracking.
-        output_path: If set, save the Labels to this ``.slp`` path.
+        output_path: If set, save the Labels to this path.
+        output_format: Format to save the Labels in when ``output_path`` is set.
+            One of ``"slp"`` (the default), ``"analysis_h5"`` (a SLEAP Analysis
+            HDF5 file, one ``.analysis.h5`` per video), or ``"both"``. Analysis
+            HDF5 paths are derived from ``output_path``.
         clean_empty_frames: Drop frames with no instances.
         progress_callback: ``(processed_frames, total_frames)`` callback
             invoked after each batch (counts are in frames).
@@ -255,6 +395,6 @@ def predict(
     )
 
     if output_path is not None:
-        labels.save(Path(output_path).as_posix())
+        save_predictions(labels, output_path, output_format=output_format)
 
     return labels

--- a/tests/cli/test_predict_command.py
+++ b/tests/cli/test_predict_command.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import click
 from click.testing import CliRunner
 
 from sleap_nn.cli import cli
@@ -790,3 +791,56 @@ def test_predict_retrack_only_sets_tracking_provenance(tmp_path):
     assert "sleap_nn_version" in reloaded.provenance
     assert "tracking_start_timestamp" in reloaded.provenance
     assert reloaded.provenance.get("tracking_config", {}).get("window_size") == 9
+
+
+def test_predict_forwards_output_format(tmp_path):
+    """``--output_format`` propagates to ``predict()`` as the output_format kwarg."""
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        return_value=MagicMock(),
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--output_path",
+                str(out),
+                "--output_format",
+                "both",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.called
+    assert mock_predict.call_args[1]["output_format"] == "both"
+
+
+def test_predict_stream_to_file_rejects_non_slp_format(tmp_path):
+    """``--stream-to-file`` with a non-slp ``--output_format`` is a UsageError."""
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+    # standalone_mode=False re-raises the UsageError instead of letting
+    # rich-click render it to the terminal -- asserting on the exception object
+    # avoids width-dependent line-wrapping of the message across CI runners.
+    result = runner.invoke(
+        cli,
+        [
+            "predict",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--stream-to-file",
+            str(out),
+            "--output_format",
+            "analysis_h5",
+        ],
+        standalone_mode=False,
+    )
+    assert isinstance(result.exception, click.UsageError)
+    assert "only supports --output_format slp" in result.exception.message

--- a/tests/inference/test_run.py
+++ b/tests/inference/test_run.py
@@ -8,11 +8,17 @@ with ``Predictor`` mocked so no checkpoints are loaded.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import sleap_io as sio
 
-from sleap_nn.inference.run import predict
+from sleap_nn.inference.run import (
+    predict,
+    save_analysis_h5_files,
+    save_predictions,
+)
 
 
 def _mock_predictor():
@@ -32,7 +38,8 @@ def test_predict_requires_exactly_one_source():
 
 def test_predict_model_paths_forwards_build_and_override_kwargs():
     """from_model_paths gets construction kwargs (incl. PAF knobs); predict gets
-    the prediction-time overrides; conditional kwargs only when set (#584)."""
+    the prediction-time overrides; conditional kwargs only when set (#584).
+    """
     pred = _mock_predictor()
     with patch(
         "sleap_nn.inference.predictor.Predictor.from_model_paths",
@@ -70,7 +77,8 @@ def test_predict_model_paths_forwards_build_and_override_kwargs():
 
 def test_predict_forwards_conditional_kwargs_when_set():
     """filter_config / tracker_config / anchor_part / centroid_only forwarded
-    only when non-None/truthy."""
+    only when non-None/truthy.
+    """
     from sleap_nn.inference.filters import FilterConfig
     from sleap_nn.inference.tracking import TrackerConfig
 
@@ -163,3 +171,120 @@ def test_predict_device_auto_resolves(monkeypatch):
     ) as mock_factory:
         predict("video.mp4", model_paths=["/m"], device="auto")
     assert mock_factory.call_args[1]["device"] == "cpu"
+
+
+# ── output_format / analysis HDF5 export ───────────────────────────────
+
+
+def _toy_predicted_labels(video_filenames, frames_per_video):
+    """Build a Labels with empty-instance frames for the given videos.
+
+    ``frames_per_video[i]`` LabeledFrames are attached to video ``i``. The
+    analysis-HDF5 path logic only counts frames per video (it does not inspect
+    instances), so empty instance lists are sufficient for naming/skip tests.
+    """
+    skeleton = sio.Skeleton(["A", "B"])
+    videos = [sio.Video.from_filename(fn) for fn in video_filenames]
+    labeled_frames = []
+    for vi, n in enumerate(frames_per_video):
+        for frame_idx in range(n):
+            labeled_frames.append(
+                sio.LabeledFrame(video=videos[vi], frame_idx=frame_idx, instances=[])
+            )
+    return sio.Labels(
+        videos=videos, skeletons=[skeleton], labeled_frames=labeled_frames
+    )
+
+
+def test_save_predictions_invalid_format_raises():
+    """An unknown output_format raises ValueError before any write."""
+    with pytest.raises(ValueError, match="Invalid output_format"):
+        save_predictions(MagicMock(), "out.slp", output_format="csv")
+
+
+def test_save_predictions_both_writes_slp_and_h5(minimal_instance, tmp_path):
+    """output_format='both' writes both a .slp and an analysis .h5 that round-trip."""
+    labels = sio.load_slp(minimal_instance.as_posix())
+    out = tmp_path / "preds.slp"
+    h5_written = save_predictions(labels, out, output_format="both")
+    assert out.exists()
+    assert h5_written == [tmp_path / "preds.analysis.h5"]
+    assert h5_written[0].exists()
+    # Both files round-trip back to Labels.
+    assert isinstance(sio.load_slp(out.as_posix()), sio.Labels)
+    assert isinstance(sio.load_analysis_h5(h5_written[0].as_posix()), sio.Labels)
+
+
+def test_save_predictions_analysis_h5_only_skips_slp(minimal_instance, tmp_path):
+    """output_format='analysis_h5' writes only the .h5 (no .slp)."""
+    labels = sio.load_slp(minimal_instance.as_posix())
+    out = tmp_path / "preds.slp"
+    h5_written = save_predictions(labels, out, output_format="analysis_h5")
+    assert not out.exists()
+    assert h5_written == [tmp_path / "preds.analysis.h5"]
+    assert h5_written[0].exists()
+
+
+def test_save_analysis_h5_files_one_per_video_with_names(tmp_path):
+    """Multi-video predictions write one .h5 per video, with names embedded."""
+    labels = _toy_predicted_labels(
+        ["/data/sessionA.mp4", "/data/sessionB.mp4"], frames_per_video=[2, 3]
+    )
+    out = tmp_path / "out.predictions.slp"
+    with patch("sleap_nn.inference.run.sio.save_analysis_h5") as mock_save:
+        written = save_analysis_h5_files(labels, out)
+    assert written == [
+        tmp_path / "out.sessionA.analysis.h5",
+        tmp_path / "out.sessionB.analysis.h5",
+    ]
+    assert [c.kwargs["video"] for c in mock_save.call_args_list] == [0, 1]
+
+
+def test_save_analysis_h5_files_skips_empty_videos(tmp_path):
+    """A video with no predicted frames is skipped; the single output is unnamed."""
+    labels = _toy_predicted_labels(
+        ["/data/sessionA.mp4", "/data/sessionB.mp4"], frames_per_video=[2, 0]
+    )
+    out = tmp_path / "out.predictions.slp"
+    with patch("sleap_nn.inference.run.sio.save_analysis_h5") as mock_save:
+        written = save_analysis_h5_files(labels, out)
+    # Only the non-empty video 0 is written; single file -> no name embedded.
+    assert written == [tmp_path / "out.analysis.h5"]
+    assert mock_save.call_count == 1
+    assert mock_save.call_args_list[0].kwargs["video"] == 0
+
+
+def test_save_analysis_h5_files_disambiguates_colliding_names(tmp_path):
+    """Videos sharing a filename stem get the video index appended for uniqueness."""
+    labels = _toy_predicted_labels(
+        ["/a/clip.mp4", "/b/clip.mp4"], frames_per_video=[1, 1]
+    )
+    out = tmp_path / "out.predictions.slp"
+    with patch("sleap_nn.inference.run.sio.save_analysis_h5"):
+        written = save_analysis_h5_files(labels, out)
+    assert written == [
+        tmp_path / "out.clip_0.analysis.h5",
+        tmp_path / "out.clip_1.analysis.h5",
+    ]
+    assert len(set(written)) == 2
+
+
+def test_predict_forwards_output_format(tmp_path):
+    """predict() passes output_format through to save_predictions."""
+    pred = _mock_predictor()
+    out = tmp_path / "out.slp"
+    with (
+        patch(
+            "sleap_nn.inference.predictor.Predictor.from_model_paths",
+            return_value=pred,
+        ),
+        patch("sleap_nn.inference.run.save_predictions") as mock_save,
+    ):
+        predict(
+            "video.mp4",
+            model_paths=["/m"],
+            device="cpu",
+            output_path=str(out),
+            output_format="both",
+        )
+    assert mock_save.call_args.kwargs["output_format"] == "both"


### PR DESCRIPTION
## Summary
- Adds an `--output_format {slp,analysis_h5,both}` option to `sleap-nn infer` (and an `output_format` parameter on the public `sleap_nn.inference.run.predict`) so inference results can be saved **directly** as a SLEAP Analysis HDF5 (`.analysis.h5`) file.
- Removes the need for a separate `.slp` → `.h5` conversion pass after large inference jobs — `analysis_h5` skips the `.slp` write entirely, directly addressing the mass-inference bottleneck described in the issue.

## Changes Made
- `sleap_nn/inference/run.py`:
  - New `output_format: str = "slp"` parameter on `predict()`.
  - New `save_predictions()` orchestrator that dispatches on the format, backed by a new `save_analysis_h5_files()` helper wrapping `sio.save_analysis_h5`. Analysis HDF5 files hold one video each, so it writes **one `.analysis.h5` per video**, embedding the video name for multi-video predictions (disambiguated by index on filename-stem collisions) and skipping videos with no predicted frames (with a warning).
- `sleap_nn/cli.py`:
  - New `--output_format` option on `infer` (via `_common_inference_options`), threaded into the in-memory `predict()` path and the tracking-only retrack path (both route through `save_predictions`).
  - `--stream-to-file` only supports `slp`; combining it with a non-slp `--output_format` raises a `UsageError` (consistent with its existing restrictions).
- Tests in `tests/inference/test_run.py` and `tests/cli/test_infer_command.py`.

## Example Usage
```bash
# SLP only (default, unchanged)
sleap-nn infer -i vid.mp4 -m model/ -o out.slp

# Analysis HDF5 only (no .slp written)
sleap-nn infer -i vid.mp4 -m model/ -o out.slp --output_format analysis_h5
#  -> out.analysis.h5

# Both in one run
sleap-nn infer -i vid.mp4 -m model/ -o out.slp --output_format both
#  -> out.slp AND out.analysis.h5
```

Programmatic equivalent:
```python
from sleap_nn.inference.run import predict
predict("vid.mp4", model_paths=["model/"], output_path="out.slp", output_format="both")
```

## API Changes
- New `output_format` parameter on `sleap_nn.inference.run.predict` (default `"slp"`, fully backward compatible).
- New `sleap_nn.inference.run.save_predictions()` and `save_analysis_h5_files()` helpers.
- New `--output_format` CLI option on `sleap-nn infer`.

This is the modern equivalent of old SLEAP's `--save_h5` flag: `--output_format analysis_h5` ≡ `--save_h5`, plus a `both` option the original request didn't include.

## Testing
- New unit/functional tests: format dispatch (`slp`/`analysis_h5`/`both`), invalid-format error, multi-video per-video naming, empty-video skipping, filename-collision disambiguation, and `predict()` forwarding `output_format`. CLI tests cover option propagation and the `--stream-to-file` restriction.
- Verified a real end-to-end run: `infer --output_format both` with real checkpoints writes both a `.slp` and a round-trippable `.analysis.h5`.
- Full `tests/cli/` + `tests/inference/test_run.py` pass (54 tests); `black` and `ruff` clean.

## Design Decisions
- Built on the **new** inference flow (`infer` → `run.predict`), not the deprecated `run_inference`.
- Format dispatch is centralized in `save_predictions` so the in-memory and retrack save sites share one implementation.

## Future Considerations
- `--stream-to-file` (the disk-streaming path) currently supports only `slp`; analysis-HDF5 output there would require building the full `Labels` at finalize and is left as a follow-up. The default in-memory path covers the analysis-HDF5 use case today.

## Related Issues
Closes #609
Closes talmolab/sleap#2729

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)