### PR TITLE
fix(seg): three bottom-up segmentation inference parity bugs

### DIFF
--- a/sleap_nn/inference/layers/segmentation.py
+++ b/sleap_nn/inference/layers/segmentation.py
@@ -40,6 +40,10 @@ class SegmentationLayer(InferenceLayer):
             mask to be kept. Masks smaller than this are dropped — useful for
             suppressing tiny spurious blobs (over-segmentation). ``0`` disables
             the filter (only empty masks are dropped).
+        max_instances: Optional cap on instances per frame. When more centers
+            are detected, only the highest-scoring ``max_instances`` are kept
+            before grouping. ``None`` keeps all detected centers. Overridable
+            via ``Predictor.predict(max_instances=...)``.
         preprocess_config / postprocess_config: Standard knobs;
             ``postprocess_config.peak_threshold`` is the instance-center peak
             threshold (overridable via ``Predictor.predict(peak_threshold=...)``).
@@ -56,6 +60,7 @@ class SegmentationLayer(InferenceLayer):
         max_stride: int = 1,
         fg_threshold: float = 0.5,
         min_mask_area: int = 0,
+        max_instances: Optional[int] = None,
         preprocess_config: Optional[PreprocessConfig] = None,
         postprocess_config: Optional[PostprocessConfig] = None,
     ) -> None:
@@ -70,6 +75,7 @@ class SegmentationLayer(InferenceLayer):
         )
         self.fg_threshold = fg_threshold
         self.min_mask_area = int(min_mask_area)
+        self.max_instances = max_instances
 
     @property
     def warmup_input_shape(self):
@@ -97,6 +103,12 @@ class SegmentationLayer(InferenceLayer):
         offsets = offsets.detach().cpu()
 
         peak_threshold = self.postprocess_config.peak_threshold
+        # The predict-time override sets ``postprocess_config.max_instances``;
+        # fall back to the value the layer was built with (#582 pattern, mirrors
+        # BottomUpLayer).
+        max_instances = getattr(self.postprocess_config, "max_instances", None)
+        if max_instances is None:
+            max_instances = getattr(self, "max_instances", None)
         B = foreground.shape[0]
         pred_masks: List[List[dict]] = []
         for b in range(B):
@@ -107,6 +119,7 @@ class SegmentationLayer(InferenceLayer):
                 fg_threshold=self.fg_threshold,
                 peak_threshold=peak_threshold,
                 output_stride=self.output_stride,
+                max_instances=max_instances,
             )
             frame_masks: List[dict] = []
             # Drop empty masks and, when ``min_mask_area > 0``, tiny spurious

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -404,6 +404,7 @@ def _build_bottomup_segmentation(
     preprocess_config: Any,
     fg_threshold: float = 0.5,
     min_mask_area: int = 0,
+    max_instances: Optional[int] = None,
 ) -> LoadedAssets:
     """Load a ``BottomUpSegmentationLightningModule`` and wrap it for inference.
 
@@ -442,6 +443,7 @@ def _build_bottomup_segmentation(
         output_stride=output_stride,
         input_scale=config.data_config.preprocessing.scale,
         min_mask_area=min_mask_area,
+        max_instances=max_instances,
     )
     return LoadedAssets(
         inference_model=inference_model,
@@ -869,6 +871,7 @@ def load_model_assets(
             path,
             fg_threshold=fg_threshold,
             min_mask_area=min_mask_area,
+            max_instances=max_instances,
             **common_kwargs,
         )
 

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -237,6 +237,7 @@ def _build_bottomup_segmentation_layer(
         max_stride=max_stride,
         fg_threshold=inf.fg_threshold,
         min_mask_area=getattr(inf, "min_mask_area", 0),
+        max_instances=getattr(inf, "max_instances", None),
         preprocess_config=PreprocessConfig(
             scale=inf.input_scale,
             max_height=_pp_field(predictor, "max_height"),
@@ -1139,6 +1140,18 @@ class Predictor:
                 "sio.PredictedCentroid objects (in LabeledFrame.centroids) that "
                 "would be dropped. Use emit_centroid='instance' (the default) "
                 "for tracking."
+            )
+
+        # Segmentation emits sio.PredictedSegmentationMask objects to
+        # LabeledFrame.masks; the tracker only handles sio.PredictedInstance and
+        # reads only LabeledFrame.instances, so it would silently drop every
+        # mask. Fail fast rather than write a mask-less tracked .slp.
+        if self.tracker_config is not None and self._is_segmentation_layer():
+            raise ValueError(
+                "Tracking is not yet supported for bottom-up segmentation "
+                "models: masks are emitted to LabeledFrame.masks, which the "
+                "tracker (operating on sio.PredictedInstance objects) would "
+                "drop, producing a mask-less output. Re-run without tracking."
             )
 
         provider, auto_videos = self._make_provider(source, frames=frames)

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -60,6 +60,7 @@ def group_instances_from_offsets(
     fg_threshold: float = 0.5,
     peak_threshold: float = 0.2,
     output_stride: int = 2,
+    max_instances: Optional[int] = None,
 ) -> List[Dict]:
     """Group foreground pixels into instances using center-offset predictions.
 
@@ -70,6 +71,10 @@ def group_instances_from_offsets(
         fg_threshold: Threshold for foreground binarization.
         peak_threshold: Minimum peak value for center detection.
         output_stride: Stride of the output maps relative to the input image.
+        max_instances: Optional cap on the number of instances per frame. When
+            more centers than this are detected, only the ``max_instances``
+            highest-scoring (peak-value) centers are kept before grouping.
+            ``None`` keeps all detected centers.
 
     Returns:
         List of dicts, each with:
@@ -90,6 +95,13 @@ def group_instances_from_offsets(
 
     if len(peaks) == 0:
         return []
+
+    # Cap to the top-``max_instances`` centers by peak value, mirroring the
+    # confidence-truncation other bottom-up layers apply (BottomUpLayer /
+    # CentroidLayer). Below the cap, all centers are kept.
+    if max_instances is not None and len(peaks) > int(max_instances):
+        peak_vals, keep = torch.topk(peak_vals, int(max_instances))
+        peaks = peaks[keep]
 
     # peaks are in (x, y) format at output stride resolution
     centers = peaks.float()  # (N, 2) in output stride grid coords
@@ -162,6 +174,9 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
             to ``SegmentationLayer`` to drop tiny spurious masks. ``0`` disables
             it. Not applied here (``forward`` returns output-stride masks for
             training visualization); see ``SegmentationLayer.postprocess``.
+        max_instances: Optional cap on instances per frame (highest-scoring
+            centers kept). Carried through to ``SegmentationLayer``; ``None``
+            keeps all detected centers.
     """
 
     def __init__(
@@ -172,6 +187,7 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         output_stride: int = 2,
         input_scale: float = 1.0,
         min_mask_area: int = 0,
+        max_instances: Optional[int] = None,
     ):
         """Initialize the inference model."""
         super().__init__()
@@ -181,6 +197,7 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         self.output_stride = output_stride
         self.input_scale = input_scale
         self.min_mask_area = int(min_mask_area)
+        self.max_instances = max_instances
 
     def forward(self, batch: Dict) -> List[List[Dict]]:
         """Run inference on a batch of images.
@@ -214,6 +231,7 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
                 fg_threshold=self.fg_threshold,
                 peak_threshold=self.peak_threshold,
                 output_stride=self.output_stride,
+                max_instances=self.max_instances,
             )
             batch_results.append(instances)
 

--- a/sleap_nn/inference/writer.py
+++ b/sleap_nn/inference/writer.py
@@ -188,10 +188,15 @@ class IncrementalLabelsWriter:
         import sleap_io as sio
 
         videos = self._resolve_videos()
+        # Mask-only (segmentation) models may carry no skeleton; emit an empty
+        # skeleton list rather than ``[None]`` (which makes ``sio.Labels.save``
+        # raise ``AttributeError: 'NoneType' has no attribute 'nodes'``). Mirrors
+        # the in-memory path (``Outputs.to_labels``).
+        pkg_skeleton = self.collapse_skeleton or self.skeleton
         labels = sio.Labels(
             labeled_frames=self._all_frames,
             videos=videos,
-            skeletons=[self.collapse_skeleton or self.skeleton],
+            skeletons=[pkg_skeleton] if pkg_skeleton is not None else [],
             provenance=self.provenance or {},
         )
         tmp = self.tmp_path

--- a/tests/inference/test_segmentation_inference.py
+++ b/tests/inference/test_segmentation_inference.py
@@ -153,6 +153,161 @@ def test_segmentation_layer_postprocess_gt_roundtrip():
     assert len(labels.masks) == 2
 
 
+def test_group_instances_max_instances_caps_to_top_scoring():
+    """``max_instances`` keeps only the highest-scoring centers.
+
+    Regression for the parity gap where ``--max_instances`` was silently
+    dropped for segmentation (every other bottom-up layer truncates by
+    confidence). Three centers with distinct peak heights; capping at 2 keeps
+    the two tallest and drops the shortest.
+    """
+    H = W = 24
+    s = 1
+    # (cy, cx, peak_value) — well-separated, distinct heights.
+    spec = [(5, 5, 0.9), (5, 18, 0.6), (18, 11, 0.3)]
+    fg = np.zeros((H, W), dtype=bool)
+    center_hm = np.zeros((H, W), dtype=np.float32)
+    cyx = []
+    for cy, cx, v in spec:
+        fg |= _disk(H, W, cy, cx, 3)
+        center_hm[cy, cx] = v
+        cyx.append((cy, cx))
+    # Offsets: every foreground pixel points to its nearest center.
+    off = np.zeros((2, H, W), dtype=np.float32)
+    ys, xs = np.nonzero(fg)
+    for y, x in zip(ys, xs):
+        cy, cx = cyx[int(np.argmin([(y - a) ** 2 + (x - b) ** 2 for a, b in cyx]))]
+        off[0, y, x] = (cx - x) * 1.0  # dx (pixel-center terms cancel at s=1)
+        off[1, y, x] = (cy - y) * 1.0  # dy
+
+    fg_t = torch.from_numpy(fg.astype(np.float32))[None, None]
+    center_t = torch.from_numpy(center_hm)[None, None]
+    off_t = torch.from_numpy(off)[None]
+
+    def _group(max_instances=None):
+        return group_instances_from_offsets(
+            fg_t,
+            center_t,
+            off_t,
+            fg_threshold=0.5,
+            peak_threshold=0.2,
+            output_stride=s,
+            max_instances=max_instances,
+        )
+
+    # No cap -> all three.
+    assert len(_group()) == 3
+
+    # Cap at 2 -> the two highest-scoring centers (0.9, 0.6) survive.
+    capped = _group(max_instances=2)
+    assert len(capped) == 2
+    assert sorted(round(i["score"], 3) for i in capped) == [0.6, 0.9]
+
+    # Cap above the detected count is a no-op.
+    assert len(_group(max_instances=9)) == 3
+
+
+def test_segmentation_layer_max_instances_caps_count():
+    """Honor ``max_instances`` via the layer attr and the predict-time override.
+
+    Both the value the layer is built with and the predict-time
+    ``postprocess_config.max_instances`` override cap the instance count.
+    """
+    H, W, s = 128, 128, 2
+    masks = [
+        _disk(H, W, 25, 25, 14),
+        _disk(H, W, 25, 95, 14),
+        _disk(H, W, 95, 60, 14),
+    ]
+    fg = generate_foreground_mask(masks, (H, W), output_stride=s)
+    center = generate_center_heatmap(masks, (H, W), output_stride=s, sigma=6.0)
+    offsets, _ = generate_center_offsets(masks, (H, W), output_stride=s)
+    raw = {
+        "SegmentationHead": fg,
+        "InstanceCenterHead": center,
+        "CenterOffsetHead": offsets,
+    }
+    info = PreprocInfo(
+        original_size=(H, W),
+        processed_size=(H, W),
+        eff_scale=torch.tensor([1.0]),
+        input_scale=1.0,
+        output_stride=s,
+    )
+
+    def _layer(*, attr=None, override=None):
+        layer = SegmentationLayer.__new__(SegmentationLayer)
+        layer.output_stride = s
+        layer.fg_threshold = 0.5
+        layer.min_mask_area = 0
+        layer.max_instances = attr
+        layer.postprocess_config = PostprocessConfig(
+            peak_threshold=0.2, max_instances=override
+        )
+        return layer
+
+    # Baseline: no cap -> all three masks.
+    assert len(_layer().postprocess(raw, info).pred_masks[0]) == 3
+    # Layer-attr cap.
+    assert len(_layer(attr=2).postprocess(raw, info).pred_masks[0]) == 2
+    # Override (predict-time) cap takes precedence / works on its own.
+    assert len(_layer(override=2).postprocess(raw, info).pred_masks[0]) == 2
+
+
+def test_incremental_writer_finalizes_mask_only_no_skeleton(tmp_path):
+    """A mask-only (skeleton-free) seg model streams to .slp without crashing.
+
+    Regression for ``IncrementalLabelsWriter._finalize`` building
+    ``skeletons=[None]`` (→ ``sio.Labels.save`` ``AttributeError``) when both the
+    skeleton and collapse-skeleton are ``None``. The finalized list must be
+    empty, mirroring the in-memory ``Outputs.to_labels`` path.
+    """
+    from sleap_nn.inference.outputs import Outputs
+    from sleap_nn.inference.writer import IncrementalLabelsWriter
+
+    mask = _disk(64, 64, 32, 32, 12)
+    outputs = Outputs(
+        pred_masks=[[{"mask": mask, "score": 0.9}]],
+        frame_indices=torch.tensor([0]),
+        video_indices=torch.tensor([0]),
+    )
+    video = sio.Video.from_filename("dummy.mp4")
+    out_path = tmp_path / "seg_stream.slp"
+    writer = IncrementalLabelsWriter(
+        path=out_path.as_posix(), skeleton=None, videos=[video]
+    )
+    with writer:  # __exit__ -> close() -> _finalize() (the previously-crashing path)
+        writer.write(outputs)
+
+    labels = sio.load_slp(out_path.as_posix())
+    assert len(labels.skeletons) == 0  # not [None]
+    assert len(labels.masks) == 1
+    assert isinstance(labels.masks[0], sio.PredictedSegmentationMask)
+
+
+def test_predict_rejects_tracking_for_segmentation():
+    """``predict()`` fails fast when tracking is requested for a seg model.
+
+    Without the guard the tracker (which reads only ``LabeledFrame.instances``)
+    runs over the empty instance lists of mask-only frames and rebuilds them
+    without ``masks=``, silently dropping every mask. Mirrors the existing
+    ``emit_centroid`` guard.
+    """
+    import pytest
+
+    from sleap_nn.inference.predictor import Predictor
+
+    pred = Predictor.__new__(Predictor)
+    pred.layer = SegmentationLayer.__new__(SegmentationLayer)
+    pred.tracker_config = object()  # any non-None config triggers the guard
+    pred.emit_centroid = "instance"  # so the centroid guard passes first
+
+    with pytest.raises(
+        ValueError, match="not yet supported for bottom-up segmentation"
+    ):
+        pred.predict("dummy.mp4", make_labels=True)
+
+
 def test_segmentation_layer_min_mask_area_drops_tiny_masks():
     """``min_mask_area`` drops tiny spurious masks while keeping large ones.
 


### PR DESCRIPTION
## Summary

Three verified defects surfaced while triaging the post-ship segmentation checklist (PRs #603 → #608). All three are small, low-risk, and bring segmentation to parity with how the other model types already behave. Each is covered by a regression test.

## The bugs

### 1. Streaming writer crash on mask-only models
`IncrementalLabelsWriter._finalize` built `skeletons=[self.collapse_skeleton or self.skeleton]`, which is `[None]` for a mask-only segmentation model (no skeleton). `sio.Labels.save` then raises `AttributeError: 'NoneType' object has no attribute 'nodes'`, so **`sleap-nn infer --stream-to-file` on a seg model crashed at finalize**.

The in-memory `predict()` path already handles this correctly (`Outputs.to_labels`, `outputs.py:685`); the streaming writer simply didn't mirror it. Fixed to emit an empty skeleton list when there is no skeleton.

### 2. Tracking silently dropped every mask
`apply_tracking` ran unconditionally in `predict()`, but the tracker only handles `sio.PredictedInstance` and reads only `LabeledFrame.instances`. For a segmentation model — masks live in `LabeledFrame.masks`, and instance lists are empty — it rebuilt frames *without* `masks=`, producing a **mask-less tracked `.slp` with no error or warning** (silent data loss).

Added a fail-fast `ValueError` guard in `predict()`, mirroring the existing `emit_centroid` guard right above it. (A real mask-IoU tracker is a separate, larger feature — see triage notes.)

### 3. `--max_instances` ignored for segmentation
The seg loader / inference model and `SegmentationLayer` never honored `max_instances`, even though `run.predict` and the CLI carry it and every other bottom-up layer (`BottomUpLayer`, `CentroidLayer`) truncates by confidence. So `--max_instances` was a silent no-op for seg.

Threaded it through:
- `group_instances_from_offsets` — keeps the top-`max_instances` centers by peak score before grouping;
- `BottomUpSegmentationInferenceModel`, `_build_bottomup_segmentation`, `load_model_assets` — load-time plumbing for library callers;
- `SegmentationLayer.postprocess` — reads the predict-time `postprocess_config.max_instances` override with the layer attr as fallback, exactly matching `BottomUpLayer` (so `predictor.predict(max_instances=...)` / `--max_instances` now works).

## Tests

Four new regression tests in `tests/inference/test_segmentation_inference.py`:
- `test_group_instances_max_instances_caps_to_top_scoring` — three centers with distinct peak heights; capping at 2 keeps the two tallest, dropping the shortest; cap above the count is a no-op.
- `test_segmentation_layer_max_instances_caps_count` — cap honored via both the layer attr and the predict-time `postprocess_config` override.
- `test_incremental_writer_finalizes_mask_only_no_skeleton` — a skeleton-free seg model streams to `.slp` and reloads with `skeletons == []` and masks intact (guards bug #1).
- `test_predict_rejects_tracking_for_segmentation` — `predict()` raises rather than silently dropping masks (guards bug #2).

All segmentation tests (63) and the touched predictor/writer/tracking/centroid/providers tests (94) pass; `black` + `ruff` clean.

## Notes

This is the first of the post-ship segmentation follow-ups (the "tackle-now" bugs). The remaining checklist items (COCO mask-AP eval, modern postprocessing, polygon/RLE-gzip output, a mask-IoU tracker, seg docs guide, arch/hparam sweep, top-down segmentation) are being triaged separately and will be filed as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)