### PR TITLE
docs: add bottom-up segmentation guide

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -12,6 +12,7 @@ Task-oriented guides for common workflows.
 | [Inference](inference.md) | Run predictions on videos and label files |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Python API](inference-api.md) | `Predictor` / `predict` / `Outputs` for embedding inference in code |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Centroid-Only](centroid-only-inference.md) | Run a centroid model standalone |
+| &nbsp;&nbsp;&nbsp;&nbsp;[Bottom-Up Segmentation](segmentation.md) | Train and run instance-mask segmentation models |
 | [Evaluation](evaluation.md) | Assess model performance with metrics |
 | [Tracking](tracking.md) | Assign consistent IDs across frames |
 | [Export](export.md) | ONNX/TensorRT for production inference |

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -152,6 +152,23 @@ sleap-nn track -i video.mp4 -m models/bottomup/
 !!! note "When max_instances applies in bottom-up"
     In bottom-up models, `--max_instances` is applied **after** PAF grouping assembles instances (not during peak detection). All peaks are detected, PAF grouping creates instances, then the top N instances by score are kept.
 
+### Bottom-Up Segmentation
+
+For instance-mask prediction from a single segmentation model:
+
+```bash
+sleap-nn track -i video.mp4 -m models/segmentation/
+```
+
+`sleap-nn track` auto-detects `bottomup_segmentation` checkpoints from the
+model directory. The segmentation-only tuning flags are:
+
+- `--fg_threshold` to binarize the predicted foreground map
+- `--min_mask_area` to drop tiny predicted masks and reduce over-segmentation
+
+See the dedicated [Bottom-Up Segmentation guide](segmentation.md) for the full
+training and inference workflow.
+
 ### Top-Down
 
 For multi-animal videos using centroid + centered instance approach:

--- a/docs/guides/segmentation.md
+++ b/docs/guides/segmentation.md
@@ -1,0 +1,133 @@
+# Bottom-Up Segmentation
+
+Train and run the `bottomup_segmentation` model type when each instance is
+represented by a segmentation mask instead of a keypoint skeleton.
+
+This pipeline predicts three outputs from a single model:
+
+1. A foreground segmentation map
+2. An instance-center heatmap
+3. Per-pixel offsets back to each instance center
+
+At inference time, `sleap-nn track` auto-detects a segmentation checkpoint from
+the model directory. You do not need a special mode flag.
+
+## When to use it
+
+Use bottom-up segmentation when your labels contain instance masks and you want
+per-animal mask predictions instead of pose keypoints.
+
+## Training
+
+### Example config
+
+Start from a normal single-model training config and set
+`head_configs.bottomup_segmentation`.
+
+```yaml
+data_config:
+  train_labels_path:
+    - train.pkg.slp
+  val_labels_path:
+    - val.pkg.slp
+  preprocessing:
+    scale: 1.0
+
+model_config:
+  backbone_config:
+    unet:
+      filters: 32
+      max_stride: 16
+      output_stride: 2
+  head_configs:
+    single_instance: null
+    centroid: null
+    centered_instance: null
+    bottomup: null
+    multi_class_bottomup: null
+    multi_class_topdown: null
+    bottomup_segmentation:
+      segmentation:
+        output_stride: 2
+        loss_weight: 1.0
+      center:
+        sigma: 5.0
+        output_stride: 2
+        loss_weight: 1.0
+      offsets:
+        output_stride: 2
+        loss_weight: 0.1
+
+trainer_config:
+  save_ckpt: true
+  ckpt_dir: models
+  run_name: segmentation
+```
+
+Train it with:
+
+```bash
+sleap-nn train --config segmentation.yaml
+```
+
+### Training caveats
+
+- Use labels that include segmentation masks (`Labels.masks` in `sleap-io`).
+- For the current v1 dataset path, keep `scale: 1.0`.
+- Keep image dimensions divisible by the backbone `max_stride`.
+- Geometric augmentation is skipped for segmentation models because masks cannot
+  be spatially transformed in sync with the image. Intensity augmentation still
+  works.
+
+## Inference
+
+Run inference the same way as other single-model pipelines:
+
+```bash
+sleap-nn track \
+    -i video.mp4 \
+    -m models/segmentation/ \
+    -o preds.slp
+```
+
+### Segmentation-specific flags
+
+Two inference flags only affect `bottomup_segmentation` models:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--fg_threshold` | `0.5` | Binarize the predicted foreground map before grouping masks. |
+| `--min_mask_area` | `0` | Drop tiny predicted masks in original-image pixels. Useful for suppressing over-segmentation. |
+
+Example:
+
+```bash
+sleap-nn track \
+    -i video.mp4 \
+    -m models/segmentation/ \
+    -o preds.slp \
+    --fg_threshold 0.5 \
+    --min_mask_area 3000
+```
+
+`--min_mask_area` is dataset-dependent. A value around `3000` can be a useful
+starting point when you need to suppress small spurious blobs, but it should be
+tuned on your own validation data.
+
+## Viewing mask predictions
+
+The output `.slp` contains predicted segmentation masks, so you can render them
+directly:
+
+```bash
+sio render preds.slp
+```
+
+You can also load the output in Python:
+
+```python
+import sleap_io as sio
+
+labels = sio.load_slp("preds.slp")
+print(len(labels.masks))
+```

--- a/docs/guides/training.md
+++ b/docs/guides/training.md
@@ -154,6 +154,18 @@ sleap-nn train -d /path/to/configs -c centered_instance_unet \
 
 ---
 
+## Bottom-Up Segmentation Training
+
+Use `bottomup_segmentation` when your dataset contains instance masks and you
+want the model to predict masks instead of keypoints.
+
+For the full workflow, including an example config and segmentation-specific
+training caveats, see the dedicated guide:
+
+[:octicons-arrow-right-24: Bottom-Up Segmentation Guide](segmentation.md)
+
+---
+
 ## Monitoring Training
 
 Track training progress with WandB logging, visualizations, and evaluation metrics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - guides/inference.md
       - Python API: guides/inference-api.md
       - Centroid-Only: guides/centroid-only-inference.md
+      - Bottom-Up Segmentation: guides/segmentation.md
       - Performance: guides/inference-performance.md
     - Evaluation: guides/evaluation.md
     - Tracking: guides/tracking.md


### PR DESCRIPTION
## Summary
- add a dedicated bottom-up segmentation guide with a copy-pasteable training config
- document segmentation-specific inference flags and auto-detection behavior
- register the new guide in docs nav and cross-link it from training/inference guides

Closes #621

## Validation
- `uv run --group docs mkdocs build`
- `uv run --group docs mkdocs build --strict` *(fails on pre-existing repo warnings, including existing griffe warnings and an existing broken link in `guides/centroid-only-inference.md`)*