### PR TITLE
feat(seg): segmentation polish — docs/config, PQ eval, postproc knobs, offset viz

### DIFF
--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -24,6 +24,7 @@ model_config:
     bottomup: null
     multi_class_bottomup: null
     multi_class_topdown: null
+    bottomup_segmentation: null
 ```
 
 ---
@@ -188,6 +189,37 @@ head_configs:
       output_stride: 16   # Match backbone max_stride
       loss_weight: 1.0
 ```
+
+### Bottom-Up Segmentation
+
+Single-stage instance **segmentation** (Panoptic-DeepLab style): a foreground
+head (BCE+Dice), an instance-center heatmap, and a per-pixel center-offset field
+used to group foreground pixels into per-instance masks. Three heads, all sharing
+a fine output stride:
+
+```yaml
+head_configs:
+  bottomup_segmentation:
+    segmentation:        # foreground probability (union of all instance masks)
+      output_stride: 2
+      loss_weight: 1.0
+    center:              # instance-center heatmap
+      sigma: 10.0
+      output_stride: 2
+      loss_weight: 1.0
+    offsets:             # per-pixel (dx, dy) to the instance center
+      output_stride: 2
+      loss_weight: 0.1
+```
+
+Notes:
+
+- `fg_threshold` and `min_mask_area` are **inference-time** post-processing args
+  (`sleap-nn infer --fg_threshold` / `--min_mask_area`), not training config.
+- Train at `scale: 1.0` with input dims divisible by `max_stride` (mask resize is
+  not pad-aware in v1); geometric augmentation is skipped for masks.
+- See the sample config
+  [`config_bottomup_segmentation_unet.yaml`](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_bottomup_segmentation_unet.yaml).
 
 ---
 

--- a/docs/configuration/samples.md
+++ b/docs/configuration/samples.md
@@ -58,6 +58,16 @@ With supervised identity tracking.
 | [multi_class_bottomup](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_multi_class_bottomup_unet.yaml) | Bottom-Up | UNet |
 | [multi_class_topdown](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml) | Top-Down | UNet |
 
+### Segmentation (masks)
+
+Single-stage bottom-up instance **segmentation** (per-instance masks instead of
+keypoints). `fg_threshold` / `min_mask_area` are inference-time args; train at
+`scale: 1.0`.
+
+| Config | Backbone | Notes |
+|--------|----------|-------|
+| [bottomup_segmentation_unet](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_bottomup_segmentation_unet.yaml) | UNet | Foreground + center + offsets heads |
+
 ---
 
 ## Quick Start Templates

--- a/docs/sample_configs/config_bottomup_segmentation_unet.yaml
+++ b/docs/sample_configs/config_bottomup_segmentation_unet.yaml
@@ -1,0 +1,182 @@
+data_config:
+  train_labels_path: null
+  val_labels_path: null
+  validation_fraction: 0.1
+  use_same_data_for_val: false
+  test_file_path: null
+  provider: LabelsReader
+  user_instances_only: true
+  data_pipeline_fw: torch_dataset
+  cache_img_path: null
+  use_existing_imgs: false
+  delete_cache_imgs_after_training: true
+  preprocessing:
+    ensure_rgb: false
+    ensure_grayscale: true
+    max_height: null
+    max_width: null
+    # Mask resize in v1 is not pad-aware: train at scale 1.0 (or a scale that
+    # divides evenly) with input dims divisible by the backbone max_stride.
+    scale: 1.0
+    crop_size: null
+    min_crop_size: null
+  use_augmentations_train: true
+  augmentation_config:
+    intensity:
+      uniform_noise_min: 0.0
+      uniform_noise_max: 0.04
+      uniform_noise_p: 0.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
+      gaussian_noise_p: 0.0
+      contrast_min: 0.9
+      contrast_max: 1.1
+      contrast_p: 0.0
+      brightness_min: 0.9
+      brightness_max: 1.1
+      brightness_p: 0.0
+    # NOTE: geometric augmentation is unsupported for segmentation masks (masks
+    # are not co-transformed) and is skipped with a warning — keep affine_p /
+    # erase_p / mixup_p at 0.0. Only intensity augmentation applies.
+    geometric:
+      rotation_min: -15.0
+      rotation_max: 15.0
+      scale_min: 0.9
+      scale_max: 1.1
+      translate_width: 0.0
+      translate_height: 0.0
+      affine_p: 0.0
+      erase_scale_min: 0.0001
+      erase_scale_max: 0.01
+      erase_ratio_min: 1.0
+      erase_ratio_max: 1.0
+      erase_p: 0.0
+      mixup_lambda_min: 0.01
+      mixup_lambda_max: 0.05
+      mixup_p: 0.0
+  skeletons:
+model_config:
+  init_weights: default
+  pretrained_backbone_weights: null
+  pretrained_head_weights: null
+  backbone_config:
+    unet:
+      in_channels: 1
+      kernel_size: 3
+      filters: 16
+      filters_rate: 2.0
+      max_stride: 16
+      stem_stride: null
+      middle_block: true
+      up_interpolate: true
+      stacks: 1
+      convs_per_block: 2
+      # Fine output stride for dense per-pixel prediction. The backbone stride
+      # is reconciled to the minimum head stride (2). Stride 4 is the lighter
+      # Panoptic-DeepLab-parity option (see issue #617 for tuning).
+      output_stride: 2
+    convnext: null
+    swint: null
+  head_configs:
+    single_instance: null
+    centroid: null
+    centered_instance: null
+    bottomup: null
+    multi_class_bottomup: null
+    multi_class_topdown: null
+    # Panoptic-DeepLab-style bottom-up instance segmentation: a foreground head
+    # (BCE+Dice), an instance-center heatmap (MSE), and a per-pixel center-offset
+    # field (masked smooth-L1). Inference groups foreground pixels by offset to
+    # the nearest detected center.
+    bottomup_segmentation:
+      segmentation:
+        output_stride: 2
+        loss_weight: 1.0
+      center:
+        sigma: 10.0
+        output_stride: 2
+        loss_weight: 1.0
+      offsets:
+        output_stride: 2
+        loss_weight: 0.1
+  total_params: null
+trainer_config:
+  train_data_loader:
+    batch_size: 4
+    shuffle: true
+    num_workers: 0
+  val_data_loader:
+    batch_size: 4
+    shuffle: false
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: false
+  trainer_devices:
+  trainer_device_indices: null
+  trainer_accelerator: auto
+  profiler: null
+  trainer_strategy: auto
+  enable_progress_bar: true
+  min_train_steps_per_epoch: 200
+  train_steps_per_epoch: null
+  visualize_preds_during_training: true
+  keep_viz: false
+  max_epochs: 200
+  seed: null
+  use_wandb: false
+  save_ckpt: true
+  ckpt_dir: models
+  run_name: null
+  resume_ckpt_path: null
+  wandb:
+    entity: null
+    project: null
+    name: null
+    save_viz_imgs_wandb: false
+    api_key: null
+    wandb_mode: null
+    prv_runid: null
+    group: null
+    current_run_id: null
+  optimizer_name: Adam
+  optimizer:
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    step_lr: null
+    reduce_lr_on_plateau:
+      threshold: 1.0e-08
+      threshold_mode: abs
+      cooldown: 3
+      patience: 8
+      factor: 0.5
+      min_lr: 1.0e-08
+  early_stopping:
+    min_delta: 1.0e-08
+    patience: 10
+    stop_training_on_plateau: true
+  online_hard_keypoint_mining:
+    online_mining: false
+    hard_to_easy_ratio: 2.0
+    min_hard_keypoints: 2
+    max_hard_keypoints: null
+    loss_scale: 5.0
+  zmq:
+    controller_port: 9000
+    controller_polling_timeout: 10
+    publish_port: 9001
+  eval:
+    enabled: true
+    frequency: 1
+    oks_stddev: 0.025  # unused for segmentation (keypoint-only)
+    oks_scale: null
+    # For segmentation, match_threshold is reinterpreted as a minimum mask IoU
+    # in (0, 1]. Out-of-range values fall back to 0.5.
+    match_threshold: 0.5
+# fg_threshold and min_mask_area are INFERENCE-time post-processing args
+# (sleap-nn infer --fg_threshold / --min_mask_area), not training config. A
+# min_mask_area around 3000 (original-image px) is a good starting point for
+# suppressing over-segmentation; tune per dataset/scale.
+name: ''
+description: ''

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1453,6 +1453,8 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         # Bottom-up segmentation knobs (inert for non-segmentation models).
         "fg_threshold": kwargs.get("fg_threshold", 0.5),
         "min_mask_area": kwargs.get("min_mask_area", 0),
+        "center_nms_kernel": kwargs.get("center_nms_kernel", 3),
+        "mask_cleanup": kwargs.get("mask_cleanup", False),
     }
     preprocess_config = _build_preprocess_config(kwargs)
     if preprocess_config is not None:
@@ -1756,6 +1758,8 @@ def _run_stream_to_file(
         # Bottom-up segmentation knobs (inert for non-segmentation models).
         "fg_threshold": kwargs.get("fg_threshold", 0.5),
         "min_mask_area": kwargs.get("min_mask_area", 0),
+        "center_nms_kernel": kwargs.get("center_nms_kernel", 3),
+        "mask_cleanup": kwargs.get("mask_cleanup", False),
     }
     preprocess_config = _build_preprocess_config(kwargs)
     if preprocess_config is not None:
@@ -1994,6 +1998,24 @@ def _common_inference_options(f):
             help="Drop predicted masks smaller than this many original-image "
             "pixels to suppress over-segmentation (bottom-up segmentation "
             "models only). 0 disables.",
+        ),
+        click.option(
+            "--center_nms_kernel",
+            "--center-nms-kernel",
+            "center_nms_kernel",
+            type=int,
+            default=3,
+            help="Odd window size for instance-center peak NMS; larger values "
+            "merge nearby duplicate centers (bottom-up segmentation models "
+            "only).",
+        ),
+        click.option(
+            "--mask_cleanup/--no-mask_cleanup",
+            "--mask-cleanup/--no-mask-cleanup",
+            "mask_cleanup",
+            default=False,
+            help="Keep only each predicted mask's largest connected component "
+            "and fill interior holes (bottom-up segmentation models only).",
         ),
         click.option(
             "--queue_maxsize",

--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -267,8 +267,13 @@ class EvalConfig:
         frequency: (int) Evaluate every N epochs. *Default*: `1`.
         oks_stddev: (float) OKS standard deviation for evaluation. *Default*: `0.025`.
         oks_scale: (float) OKS scale override. If None, uses default. *Default*: `None`.
-        match_threshold: (float) Maximum distance in pixels for centroid matching.
-            Only used for centroid model evaluation. *Default*: `50.0`.
+        match_threshold: (float) Match threshold for post-training evaluation.
+            For centroid models it is the maximum centroid distance in PIXELS
+            (default `50.0`). For ``bottomup_segmentation`` it is reinterpreted
+            as a minimum mask IoU in ``(0, 1]``; the default `50.0` is out of
+            that range, so segmentation eval falls back to `0.5` unless you set
+            a value in ``(0, 1]`` (see ``train._run_segmentation_split_eval``).
+            *Default*: `50.0`.
     """
 
     enabled: bool = False

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -1062,18 +1062,30 @@ class Evaluator:
         return results
 
     def mask_metrics(self) -> dict:
-        """Compute mask-IoU summary statistics over matched (TP) pairs.
+        """Compute mask-IoU summary statistics for ``match_method="mask"``.
 
-        Intended for ``match_method="mask"``. Reports the mean IoU and IoU
-        percentiles over all matched predicted/GT mask pairs (NaN when there
-        are no matches).
+        Reports two complementary IoU summaries plus panoptic-quality metrics:
+
+        * ``mean_iou`` (and ``min``/``max``/percentiles) over the matched (TP)
+          pairs only — COCO-style segmentation quality, blind to misses.
+        * ``mean_iou_all_gt`` — IoU averaged over *all* ground-truth masks,
+          where an unmatched GT (a miss) contributes ``0``. This penalizes
+          recall and complements the TP-only mean.
+        * Panoptic Quality ``pq = sq * rq`` with ``sq = mean_iou`` (segmentation
+          quality) and ``rq = TP / (TP + 0.5*FP + 0.5*FN)`` (recognition
+          quality, == detection F1). See Kirillov et al., "Panoptic
+          Segmentation" (2019).
 
         Returns:
             A dict with ``mean_iou``, ``min``, ``max``, percentiles ``p25``/
-            ``p50``/``p75``, the matched count ``n_matched``, and the raw
-            ``ious`` array.
+            ``p50``/``p75``, ``mean_iou_all_gt``, ``pq``/``sq``/``rq``, the TP
+            count ``n_matched`` (plus ``n_fp``/``n_fn``), and the raw ``ious``
+            array. Quantities are NaN when undefined (e.g. no matches / no GT).
         """
         ious = np.asarray(self.mask_ious, dtype=float)
+        n_tp = len(self.positive_pairs)
+        n_fp = len(self.false_positives)
+        n_fn = len(self.false_negatives)
         results = {
             "mean_iou": np.nan,
             "min": np.nan,
@@ -1081,7 +1093,13 @@ class Evaluator:
             "p25": np.nan,
             "p50": np.nan,
             "p75": np.nan,
+            "mean_iou_all_gt": np.nan,
+            "pq": np.nan,
+            "sq": np.nan,
+            "rq": np.nan,
             "n_matched": int(ious.size),
+            "n_fp": n_fp,
+            "n_fn": n_fn,
             "ious": ious,
         }
         if ious.size:
@@ -1090,6 +1108,19 @@ class Evaluator:
             results["max"] = float(np.max(ious))
             for ptile in (25, 50, 75):
                 results[f"p{ptile}"] = float(np.percentile(ious, ptile))
+
+        iou_sum = float(np.sum(ious)) if ious.size else 0.0
+        # Miss-penalizing mean: averaged over every GT mask (TP + FN).
+        n_gt = n_tp + n_fn
+        if n_gt > 0:
+            results["mean_iou_all_gt"] = iou_sum / n_gt
+        # Panoptic quality: SQ = TP-only mean IoU, RQ = detection F1, PQ = SQ*RQ
+        # = iou_sum / (TP + 0.5*FP + 0.5*FN).
+        pq_denom = n_tp + 0.5 * n_fp + 0.5 * n_fn
+        if pq_denom > 0:
+            results["sq"] = results["mean_iou"]
+            results["rq"] = n_tp / pq_denom
+            results["pq"] = iou_sum / pq_denom
         return results
 
     def pck_metrics(self, thresholds: np.ndarray = np.linspace(1, 10, 10)):

--- a/sleap_nn/inference/layers/segmentation.py
+++ b/sleap_nn/inference/layers/segmentation.py
@@ -44,6 +44,12 @@ class SegmentationLayer(InferenceLayer):
             are detected, only the highest-scoring ``max_instances`` are kept
             before grouping. ``None`` keeps all detected centers. Overridable
             via ``Predictor.predict(max_instances=...)``.
+        center_nms_kernel: Odd window size for center-peak NMS. Larger values
+            merge nearby duplicate centers (a lever against over-segmentation).
+            Default ``3`` (no behavior change).
+        mask_cleanup: When ``True``, keep only each mask's largest connected
+            component and fill interior holes (suppresses speckle/fragments).
+            Default ``False``.
         preprocess_config / postprocess_config: Standard knobs;
             ``postprocess_config.peak_threshold`` is the instance-center peak
             threshold (overridable via ``Predictor.predict(peak_threshold=...)``).
@@ -61,6 +67,8 @@ class SegmentationLayer(InferenceLayer):
         fg_threshold: float = 0.5,
         min_mask_area: int = 0,
         max_instances: Optional[int] = None,
+        center_nms_kernel: int = 3,
+        mask_cleanup: bool = False,
         preprocess_config: Optional[PreprocessConfig] = None,
         postprocess_config: Optional[PostprocessConfig] = None,
     ) -> None:
@@ -76,6 +84,8 @@ class SegmentationLayer(InferenceLayer):
         self.fg_threshold = fg_threshold
         self.min_mask_area = int(min_mask_area)
         self.max_instances = max_instances
+        self.center_nms_kernel = int(center_nms_kernel)
+        self.mask_cleanup = bool(mask_cleanup)
 
     @property
     def warmup_input_shape(self):
@@ -120,6 +130,8 @@ class SegmentationLayer(InferenceLayer):
                 peak_threshold=peak_threshold,
                 output_stride=self.output_stride,
                 max_instances=max_instances,
+                center_nms_kernel=getattr(self, "center_nms_kernel", 3),
+                mask_cleanup=getattr(self, "mask_cleanup", False),
             )
             frame_masks: List[dict] = []
             # Drop empty masks and, when ``min_mask_area > 0``, tiny spurious

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -405,6 +405,8 @@ def _build_bottomup_segmentation(
     fg_threshold: float = 0.5,
     min_mask_area: int = 0,
     max_instances: Optional[int] = None,
+    center_nms_kernel: int = 3,
+    mask_cleanup: bool = False,
 ) -> LoadedAssets:
     """Load a ``BottomUpSegmentationLightningModule`` and wrap it for inference.
 
@@ -444,6 +446,8 @@ def _build_bottomup_segmentation(
         input_scale=config.data_config.preprocessing.scale,
         min_mask_area=min_mask_area,
         max_instances=max_instances,
+        center_nms_kernel=center_nms_kernel,
+        mask_cleanup=mask_cleanup,
     )
     return LoadedAssets(
         inference_model=inference_model,
@@ -782,6 +786,8 @@ def load_model_assets(
     min_line_scores: float = 0.25,
     fg_threshold: float = 0.5,
     min_mask_area: int = 0,
+    center_nms_kernel: int = 3,
+    mask_cleanup: bool = False,
 ) -> tuple[LoadedAssets, List[str]]:
     """Load checkpoints and build inference models.
 
@@ -872,6 +878,8 @@ def load_model_assets(
             fg_threshold=fg_threshold,
             min_mask_area=min_mask_area,
             max_instances=max_instances,
+            center_nms_kernel=center_nms_kernel,
+            mask_cleanup=mask_cleanup,
             **common_kwargs,
         )
 

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -238,6 +238,8 @@ def _build_bottomup_segmentation_layer(
         fg_threshold=inf.fg_threshold,
         min_mask_area=getattr(inf, "min_mask_area", 0),
         max_instances=getattr(inf, "max_instances", None),
+        center_nms_kernel=getattr(inf, "center_nms_kernel", 3),
+        mask_cleanup=getattr(inf, "mask_cleanup", False),
         preprocess_config=PreprocessConfig(
             scale=inf.input_scale,
             max_height=_pp_field(predictor, "max_height"),
@@ -663,6 +665,8 @@ class Predictor:
         min_line_scores: float = 0.25,
         fg_threshold: float = 0.5,
         min_mask_area: int = 0,
+        center_nms_kernel: int = 3,
+        mask_cleanup: bool = False,
     ) -> "Predictor":
         """Build a :class:`Predictor` from one or more checkpoint paths.
 
@@ -706,6 +710,10 @@ class Predictor:
             min_mask_area: Minimum predicted-mask area in original-image pixels;
                 smaller masks are dropped to suppress over-segmentation. ``0``
                 disables it (bottom-up segmentation only).
+            center_nms_kernel: Odd window size for center-peak NMS; larger merges
+                nearby duplicate centers (bottom-up segmentation only).
+            mask_cleanup: Keep-largest-CC + hole-fill per mask (bottom-up
+                segmentation only).
         """
         from sleap_nn.inference.loaders import load_model_assets
 
@@ -728,6 +736,8 @@ class Predictor:
             min_line_scores=min_line_scores,
             fg_threshold=fg_threshold,
             min_mask_area=min_mask_area,
+            center_nms_kernel=center_nms_kernel,
+            mask_cleanup=mask_cleanup,
         )
 
         if centroid_only:

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -62,6 +62,8 @@ def predict(
     # Bottom-up segmentation knobs (construction-time; segmentation only)
     fg_threshold: float = 0.5,
     min_mask_area: int = 0,
+    center_nms_kernel: int = 3,
+    mask_cleanup: bool = False,
     # Prediction-time (can vary per call)
     frames: Optional[List[int]] = None,
     peak_threshold: Optional[float] = None,
@@ -124,6 +126,10 @@ def predict(
         min_mask_area: Minimum predicted-mask area in original-image pixels;
             smaller masks are dropped to suppress over-segmentation. ``0``
             disables it (bottom-up segmentation only).
+        center_nms_kernel: Odd window size for center-peak NMS; larger merges
+            nearby duplicate centers (bottom-up segmentation only).
+        mask_cleanup: Keep-largest-CC + hole-fill per mask (bottom-up
+            segmentation only).
         frames: Frame indices to predict. ``None`` = all.
         peak_threshold: Override peak threshold for all stages.
         centroid_threshold: Override centroid-stage threshold (top-down).
@@ -211,6 +217,8 @@ def predict(
         # for non-segmentation models (load_model_assets forwards them only there).
         build_kwargs["fg_threshold"] = fg_threshold
         build_kwargs["min_mask_area"] = min_mask_area
+        build_kwargs["center_nms_kernel"] = center_nms_kernel
+        build_kwargs["mask_cleanup"] = mask_cleanup
         predictor = Predictor.from_model_paths(model_paths, **build_kwargs)
     else:
         # Exported ONNX/TRT models bake most post-processing into the graph at

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -9,7 +9,7 @@ import lightning as L
 
 
 def find_center_peaks(
-    center_heatmap: torch.Tensor, threshold: float = 0.2
+    center_heatmap: torch.Tensor, threshold: float = 0.2, kernel_size: int = 3
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Find instance-center peaks robustly (plateau-aware).
 
@@ -17,13 +17,16 @@ def find_center_peaks(
     peak whose maximum spans 2+ tied pixels — which happens routinely for the
     synthetic center heatmap when a centroid lands exactly between grid points
     (the ``+stride/2`` convention). This detector instead keeps every pixel
-    equal to its 3×3-neighborhood max (``>=``) and collapses each connected
+    equal to its neighborhood max (``>=``) and collapses each connected
     plateau of tied maxima to a single representative (its argmax pixel), so a
     flat-topped peak yields exactly one center.
 
     Args:
         center_heatmap: ``(1, 1, H, W)`` instance-center heatmap.
         threshold: Minimum peak value.
+        kernel_size: Odd window size for the max-pool NMS. Larger values suppress
+            nearby duplicate centers (a lever against over-segmentation from a
+            single instance producing two close center peaks). Default ``3``.
 
     Returns:
         ``(peaks, vals)`` where ``peaks`` is ``(N, 2)`` float ``(x, y)`` in grid
@@ -32,7 +35,10 @@ def find_center_peaks(
     from scipy.ndimage import label as cc_label
 
     hm = center_heatmap[0, 0]
-    pooled = F.max_pool2d(hm[None, None], kernel_size=3, stride=1, padding=1)[0, 0]
+    pad = int(kernel_size) // 2
+    pooled = F.max_pool2d(
+        hm[None, None], kernel_size=int(kernel_size), stride=1, padding=pad
+    )[0, 0]
     cand = (hm >= pooled) & (hm > threshold)  # local maxima incl. plateaus
     if not bool(cand.any()):
         return torch.zeros((0, 2), dtype=torch.float32), torch.zeros((0,))
@@ -61,6 +67,8 @@ def group_instances_from_offsets(
     peak_threshold: float = 0.2,
     output_stride: int = 2,
     max_instances: Optional[int] = None,
+    center_nms_kernel: int = 3,
+    mask_cleanup: bool = False,
 ) -> List[Dict]:
     """Group foreground pixels into instances using center-offset predictions.
 
@@ -75,6 +83,12 @@ def group_instances_from_offsets(
             more centers than this are detected, only the ``max_instances``
             highest-scoring (peak-value) centers are kept before grouping.
             ``None`` keeps all detected centers.
+        center_nms_kernel: Odd window size for center-peak NMS (passed to
+            :func:`find_center_peaks`). Larger merges nearby duplicate centers.
+            Default ``3`` (no change vs. the original behavior).
+        mask_cleanup: When ``True``, post-process each per-instance mask by
+            keeping only its largest connected component and filling interior
+            holes (suppresses speckle/fragments). Default ``False``.
 
     Returns:
         List of dicts, each with:
@@ -91,7 +105,9 @@ def group_instances_from_offsets(
         return []
 
     # 2. Find centers via plateau-robust local peak finding
-    peaks, peak_vals = find_center_peaks(center_heatmap, threshold=peak_threshold)
+    peaks, peak_vals = find_center_peaks(
+        center_heatmap, threshold=peak_threshold, kernel_size=center_nms_kernel
+    )
 
     if len(peaks) == 0:
         return []
@@ -147,15 +163,39 @@ def group_instances_from_offsets(
         instance_mask = torch.zeros((h, w), dtype=torch.bool)
         instance_mask[fg_y[member_mask], fg_x[member_mask]] = True
 
+        mask_np = instance_mask.numpy()
+        if mask_cleanup:
+            mask_np = _clean_instance_mask(mask_np)
+            if not mask_np.any():
+                continue
+
         instances.append(
             {
-                "mask": instance_mask.numpy(),
+                "mask": mask_np,
                 "center": (center_x[i].item(), center_y[i].item()),
                 "score": peak_vals[i].item() if i < len(peak_vals) else 0.0,
             }
         )
 
     return instances
+
+
+def _clean_instance_mask(mask: np.ndarray) -> np.ndarray:
+    """Keep the largest connected component and fill interior holes.
+
+    Suppresses speckle and fragments left by the per-pixel offset grouping.
+    Operates at output-stride resolution; a no-op for an already-clean mask.
+    """
+    from scipy.ndimage import binary_fill_holes
+    from scipy.ndimage import label as cc_label
+
+    labels, n = cc_label(mask)
+    if n > 1:
+        # Keep the largest component (component 0 is background).
+        counts = np.bincount(labels.ravel())
+        counts[0] = 0
+        mask = labels == int(counts.argmax())
+    return binary_fill_holes(mask)
 
 
 class BottomUpSegmentationInferenceModel(L.LightningModule):
@@ -177,6 +217,8 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         max_instances: Optional cap on instances per frame (highest-scoring
             centers kept). Carried through to ``SegmentationLayer``; ``None``
             keeps all detected centers.
+        center_nms_kernel: Odd window size for center-peak NMS. Default ``3``.
+        mask_cleanup: Keep-largest-CC + hole-fill per mask. Default ``False``.
     """
 
     def __init__(
@@ -188,6 +230,8 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         input_scale: float = 1.0,
         min_mask_area: int = 0,
         max_instances: Optional[int] = None,
+        center_nms_kernel: int = 3,
+        mask_cleanup: bool = False,
     ):
         """Initialize the inference model."""
         super().__init__()
@@ -198,6 +242,8 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         self.input_scale = input_scale
         self.min_mask_area = int(min_mask_area)
         self.max_instances = max_instances
+        self.center_nms_kernel = int(center_nms_kernel)
+        self.mask_cleanup = bool(mask_cleanup)
 
     def forward(self, batch: Dict) -> List[List[Dict]]:
         """Run inference on a batch of images.
@@ -232,6 +278,8 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
                 peak_threshold=self.peak_threshold,
                 output_stride=self.output_stride,
                 max_instances=self.max_instances,
+                center_nms_kernel=self.center_nms_kernel,
+                mask_cleanup=self.mask_cleanup,
             )
             batch_results.append(instances)
 

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -190,8 +190,10 @@ def _run_segmentation_split_eval(
     logger.info(f"Detection precision: {det.get('precision')}")
     logger.info(f"Detection recall: {det.get('recall')}")
     logger.info(f"Detection f1: {det.get('f1')}")
-    logger.info(f"Mean mask IoU: {mm.get('mean_iou')}")
+    logger.info(f"Mean mask IoU (matched/TP): {mm.get('mean_iou')}")
+    logger.info(f"Mean mask IoU (all GT, miss-penalized): {mm.get('mean_iou_all_gt')}")
     logger.info(f"mask IoU p50: {mm.get('p50')}")
+    logger.info(f"Panoptic Quality (PQ): {mm.get('pq')}")
 
     # Log test metrics to wandb summary (mirrors the keypoint OKS path).
     if (
@@ -204,6 +206,8 @@ def _run_segmentation_split_eval(
         if wandb.run is not None:
             for key, value in {
                 f"eval/{d_name}/mask_mean_iou": mm.get("mean_iou"),
+                f"eval/{d_name}/mask_mean_iou_all_gt": mm.get("mean_iou_all_gt"),
+                f"eval/{d_name}/mask_pq": mm.get("pq"),
                 f"eval/{d_name}/detection_precision": det.get("precision"),
                 f"eval/{d_name}/detection_recall": det.get("recall"),
                 f"eval/{d_name}/detection_f1": det.get("f1"),

--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -561,6 +561,7 @@ class UnifiedVizCallback(Callback):
         self.viz_pafs = model_type == "bottomup"
         self.viz_class_maps = model_type == "multi_class_bottomup"
         self.viz_center_heatmap = model_type == "bottomup_segmentation"
+        self.viz_offsets = model_type == "bottomup_segmentation"
 
         # Initialize renderers
         from sleap_nn.training.utils import MatplotlibRenderer, WandBRenderer
@@ -603,6 +604,8 @@ class UnifiedVizCallback(Callback):
             kwargs["include_class_maps"] = True
         if self.viz_center_heatmap:
             kwargs["include_center_heatmap"] = True
+        if self.viz_offsets:
+            kwargs["include_offsets"] = True
 
         # Access lightning_model lazily from model_trainer
         return self.model_trainer.lightning_model.get_visualization_data(
@@ -644,6 +647,13 @@ class UnifiedVizCallback(Callback):
         if self.viz_center_heatmap and data.pred_center_heatmap is not None:
             fig = self._render_center_heatmap(data)
             fig_path = self.local_save_dir / f"{prefix}.center_heatmap.{epoch:04d}.png"
+            fig.savefig(fig_path, format="png")
+            plt.close(fig)
+
+        # Center-offset field visualization (for segmentation models)
+        if self.viz_offsets and data.pred_offsets is not None:
+            fig = self._mpl_renderer.render_offsets(data)
+            fig_path = self.local_save_dir / f"{prefix}.offsets.{epoch:04d}.png"
             fig.savefig(fig_path, format="png")
             plt.close(fig)
 
@@ -757,6 +767,19 @@ class UnifiedVizCallback(Callback):
                 caption=f"{prefix.title()} Center Heatmap Epoch {epoch}",
             )
 
+        # Center-offset field visualization (for segmentation models)
+        if self.viz_offsets and data.pred_offsets is not None:
+            offsets_fig = self._mpl_renderer.render_offsets(data)
+            buf = BytesIO()
+            offsets_fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+            buf.seek(0)
+            plt.close(offsets_fig)
+            offsets_pil = PILImage.open(buf)
+            log_dict[f"viz/{prefix}/offsets"] = wandb.Image(
+                offsets_pil,
+                caption=f"{prefix.title()} Offset Magnitude Epoch {epoch}",
+            )
+
         if log_dict:
             log_dict["epoch"] = epoch
             wandb_logger.experiment.log(log_dict, commit=False)
@@ -780,6 +803,10 @@ class UnifiedVizCallback(Callback):
             if self.viz_center_heatmap and data.pred_center_heatmap is not None:
                 columns.append(f"{prefix.title()} Center Heatmap")
                 table_data[0].append(log_dict.get(f"viz/{prefix}/center_heatmap"))
+
+            if self.viz_offsets and data.pred_offsets is not None:
+                columns.append(f"{prefix.title()} Offsets")
+                table_data[0].append(log_dict.get(f"viz/{prefix}/offsets"))
 
             table = wandb.Table(columns=columns, data=table_data)
             wandb_logger.experiment.log(

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -2768,7 +2768,10 @@ class BottomUpSegmentationLightningModule(LightningModel):
         )
 
     def get_visualization_data(
-        self, sample, include_center_heatmap: bool = False
+        self,
+        sample,
+        include_center_heatmap: bool = False,
+        include_offsets: bool = False,
     ) -> VisualizationData:
         """Extract visualization data from a sample.
 
@@ -2780,6 +2783,8 @@ class BottomUpSegmentationLightningModule(LightningModel):
             sample: A sample dictionary from the data pipeline.
             include_center_heatmap: If True, include the center heatmap in the
                 returned data for separate visualization.
+            include_offsets: If True, include the center-offset field for a
+                separate offset-magnitude visualization.
 
         Returns:
             VisualizationData with foreground map and center locations.
@@ -2853,6 +2858,12 @@ class BottomUpSegmentationLightningModule(LightningModel):
             center_hmap = preds["InstanceCenterHead"][0].cpu().numpy()
             center_hmap = center_hmap.transpose(1, 2, 0)  # (H, W, 1)
 
+        # Optionally include the center-offset field for an offset-magnitude viz
+        offsets = None
+        if include_offsets:
+            offsets = preds["CenterOffsetHead"][0].cpu().numpy()
+            offsets = offsets.transpose(1, 2, 0)  # (H, W, 2) -> (dx, dy)
+
         return VisualizationData(
             image=img_np,
             pred_confmaps=fg_prob,
@@ -2863,6 +2874,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
             output_scale=fg_prob.shape[0] / img_np.shape[0],
             is_paired=False,
             pred_center_heatmap=center_hmap,
+            pred_offsets=offsets,
         )
 
     def visualize_example(self, sample):

--- a/sleap_nn/training/utils.py
+++ b/sleap_nn/training/utils.py
@@ -263,6 +263,8 @@ class VisualizationData:
         pred_pafs: Part affinity fields for bottom-up models, optional.
         pred_class_maps: Class maps for multi-class models, optional.
         pred_center_heatmap: Center heatmap for segmentation models, optional.
+        pred_offsets: Center-offset field (H, W, 2) for segmentation models,
+            optional. Rendered as a per-pixel offset-magnitude map.
     """
 
     image: np.ndarray
@@ -276,6 +278,7 @@ class VisualizationData:
     pred_pafs: Optional[np.ndarray] = None
     pred_class_maps: Optional[np.ndarray] = None
     pred_center_heatmap: Optional[np.ndarray] = None
+    pred_offsets: Optional[np.ndarray] = None
 
 
 class MatplotlibRenderer:
@@ -345,6 +348,45 @@ class MatplotlibRenderer:
                 -0.5,
                 magnitude.shape[1] / paf_output_scale - 0.5,
                 magnitude.shape[0] / paf_output_scale - 0.5,
+                -0.5,
+            ],
+        )
+        return fig
+
+    def render_offsets(self, data: VisualizationData) -> matplotlib.figure.Figure:
+        """Render the center-offset field magnitude for segmentation models.
+
+        Args:
+            data: VisualizationData with ``pred_offsets`` (H, W, 2) populated.
+
+        Returns:
+            A matplotlib Figure object showing per-pixel offset magnitude.
+        """
+        if data.pred_offsets is None:
+            raise ValueError("pred_offsets is None, cannot render offsets")
+
+        img = data.image
+        scale = 1.0
+        if img.shape[0] < 512:
+            scale = 2.0
+        if img.shape[0] < 256:
+            scale = 4.0
+
+        offsets = data.pred_offsets  # (H, W, 2) -> (dx, dy)
+        magnitude = np.sqrt(offsets[..., 0] ** 2 + offsets[..., 1] ** 2)
+
+        fig = plot_img(img, dpi=72 * scale, scale=scale)
+        ax = plt.gca()
+        offset_output_scale = magnitude.shape[0] / img.shape[0]
+        ax.imshow(
+            magnitude,
+            alpha=0.5,
+            origin="upper",
+            cmap="viridis",
+            extent=[
+                -0.5,
+                magnitude.shape[1] / offset_output_scale - 0.5,
+                magnitude.shape[0] / offset_output_scale - 0.5,
                 -0.5,
             ],
         )

--- a/tests/inference/test_segmentation_inference.py
+++ b/tests/inference/test_segmentation_inference.py
@@ -63,6 +63,33 @@ def test_find_center_peaks_below_threshold():
     assert peaks.shape[0] == 0
 
 
+def test_find_center_peaks_nms_kernel_merges_close_peaks():
+    """A larger ``kernel_size`` suppresses a nearby weaker center peak.
+
+    Two peaks 2 px apart both survive 3x3 NMS (outside each other's window) but
+    the weaker one is merged away by 5x5 NMS — the over-segmentation lever.
+    """
+    hm = torch.zeros(1, 1, 24, 24)
+    hm[0, 0, 10, 10] = 1.0
+    hm[0, 0, 10, 12] = 0.8
+    assert find_center_peaks(hm, threshold=0.2, kernel_size=3)[0].shape[0] == 2
+    assert find_center_peaks(hm, threshold=0.2, kernel_size=5)[0].shape[0] == 1
+
+
+def test_clean_instance_mask_keeps_largest_and_fills_holes():
+    """``mask_cleanup`` keeps the largest component and fills interior holes."""
+    from sleap_nn.inference.segmentation import _clean_instance_mask
+
+    m = np.zeros((20, 20), dtype=bool)
+    m[2:12, 2:12] = True  # main blob
+    m[5:7, 5:7] = False  # interior hole
+    m[16:18, 16:18] = True  # disconnected speckle
+    out = _clean_instance_mask(m)
+    assert out[5, 5]  # hole filled
+    assert not out[16, 16]  # speckle dropped
+    assert out[2:12, 2:12].all()  # main blob kept (and filled)
+
+
 # ---------------------------------------------------------------------------
 # Deterministic GT roundtrip: GT maps -> grouping -> recovered masks
 # ---------------------------------------------------------------------------

--- a/tests/test_segmentation_eval.py
+++ b/tests/test_segmentation_eval.py
@@ -246,6 +246,49 @@ def test_run_evaluation_mask_partial_recall(tmp_path):
     assert abs(m["mask_metrics"]["mean_iou"] - 1.0) < 1e-9
 
 
+def test_run_evaluation_mask_panoptic_quality_perfect(tmp_path):
+    """Perfect match -> PQ = SQ = RQ = 1.0 and miss-penalized IoU = 1.0."""
+    masks = [_disk(H, W, 14, 14, 8), _disk(H, W, 34, 34, 8)]
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    _make_gt(masks).save(gt_path.as_posix())
+    _make_pred(masks).save(pr_path.as_posix())
+
+    mm = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+    )["mask_metrics"]
+    for k in ("pq", "sq", "rq", "mean_iou_all_gt"):
+        assert abs(mm[k] - 1.0) < 1e-9, k
+
+
+def test_run_evaluation_mask_miss_penalized_iou_and_pq(tmp_path):
+    """A miss drags down PQ and the all-GT IoU while TP-only mean IoU stays high.
+
+    One of two GT masks is recovered exactly: TP=1, FN=1, FP=0. TP-only mean IoU
+    is 1.0, but the miss-penalized mean (over both GT) is 0.5, and
+    PQ = iou_sum / (TP + 0.5*FP + 0.5*FN) = 1.0 / 1.5 = 2/3.
+    """
+    gt = [_disk(H, W, 14, 14, 8), _disk(H, W, 34, 34, 8)]
+    pr = [_disk(H, W, 14, 14, 8)]  # only the first GT mask
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    _make_gt(gt).save(gt_path.as_posix())
+    _make_pred(pr).save(pr_path.as_posix())
+
+    mm = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+    )["mask_metrics"]
+    assert abs(mm["mean_iou"] - 1.0) < 1e-9  # TP-only, blind to the miss
+    assert abs(mm["mean_iou_all_gt"] - 0.5) < 1e-9  # penalized over all GT
+    assert abs(mm["rq"] - (1.0 / 1.5)) < 1e-9
+    assert abs(mm["pq"] - (1.0 / 1.5)) < 1e-9
+    assert mm["n_fn"] == 1 and mm["n_fp"] == 0
+
+
 # ---------------------------------------------------------------------------
 # Post-training segmentation eval routing (train.py)
 # ---------------------------------------------------------------------------

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -482,6 +482,55 @@ class TestWandBVizCallbackWithPAFs:
             mock_get_logger.assert_not_called()
 
 
+class TestUnifiedVizCallbackSegmentation:
+    """Segmentation-specific visualization wiring for UnifiedVizCallback."""
+
+    def _callback(self, model_trainer=None):
+        return UnifiedVizCallback(
+            model_trainer=model_trainer or MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="bottomup_segmentation",
+            save_local=False,
+        )
+
+    def test_segmentation_enables_center_heatmap_and_offset_viz(self):
+        """A seg model enables the center-heatmap and offset-field viz modes."""
+        cb = self._callback()
+        assert cb.viz_center_heatmap is True
+        assert cb.viz_offsets is True
+        assert cb.viz_pafs is False
+        assert cb.viz_class_maps is False
+
+    def test_get_viz_data_requests_center_heatmap_and_offsets(self):
+        """``_get_viz_data`` asks the module for the center heatmap + offsets."""
+        mt = MagicMock()
+        cb = self._callback(model_trainer=mt)
+        cb._get_viz_data({"image": np.zeros((1, 8, 8))})
+        mt.lightning_model.get_visualization_data.assert_called_once()
+        _, kwargs = mt.lightning_model.get_visualization_data.call_args
+        assert kwargs.get("include_center_heatmap") is True
+        assert kwargs.get("include_offsets") is True
+
+    def test_render_offsets_produces_figure(self):
+        """``render_offsets`` renders an offset-magnitude figure from (H, W, 2)."""
+        from sleap_nn.training.utils import MatplotlibRenderer, VisualizationData
+
+        data = VisualizationData(
+            image=np.random.rand(64, 64, 3).astype(np.float32),
+            pred_confmaps=np.random.rand(64, 64, 1).astype(np.float32),
+            pred_peaks=np.zeros((0, 1, 2)),
+            pred_peak_values=np.zeros((0,)),
+            gt_instances=np.zeros((0, 1, 2)),
+            pred_offsets=np.random.rand(32, 32, 2).astype(np.float32),
+        )
+        fig = MatplotlibRenderer().render_offsets(data)
+        assert fig is not None
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+
 class TestMatplotlibSaver:
     """Tests for MatplotlibSaver callback."""
 


### PR DESCRIPTION
## Summary

Follow-up to #614 (**stacked on it** — base is `fix/segmentation-inference-parity-bugs`; retarget to `main` once #614 merges). Five small, low-risk, **default-preserving** improvements from the segmentation post-ship triage. All covered by tests; `black`/`ruff` clean.

## What's in it

### 1. Sample config + docs
- New `docs/sample_configs/config_bottomup_segmentation_unet.yaml` (validated through the config parser).
- Documented `bottomup_segmentation` in `model.md` (head list + a "Bottom-Up Segmentation" subsection) and `samples.md`. Calls out the `scale=1.0` / geo-aug-skipped caveats and that `fg_threshold`/`min_mask_area` are inference-time args. (Closes the discoverability half of #621; the full how-to guide remains #621.)

### 2. Panoptic-quality + miss-penalized eval
`evaluation.py` `mask_metrics` now also reports:
- **PQ = SQ·RQ** (SQ = TP-only mean IoU, RQ = detection F1) — both already computed, so this is exact and free.
- **`mean_iou_all_gt`** — IoU averaged over *all* GT (unmatched GT contribute 0), addressing the WRAPUP "TP-only mean IoU is blind to misses" caveat.

Surfaced in `train.py` logging + the wandb eval summary. (The larger COCO mask-AP suite stays as #616.)

### 3. Postprocessing knobs (default-preserving)
- `--center_nms_kernel` (odd window for center-peak NMS; larger merges nearby duplicate centers — a lever against the over-segmentation failure mode).
- `--mask_cleanup` (per-mask keep-largest-connected-component + hole-fill).

Threaded through `group_instances_from_offsets` / `find_center_peaks` / `SegmentationLayer` / `BottomUpSegmentationInferenceModel` / `loaders` / `Predictor.from_model_paths` / `run.predict` and exposed on `sleap-nn infer`. Defaults (`3` / off) preserve current behavior. (The larger clustering/refinement research menu stays as #617.)

### 4. Offset-field training viz
The `CenterOffsetHead` field (the grouping mechanism) was invisible in training viz — only the foreground map + centers were shown. Added `MatplotlibRenderer.render_offsets` + `pred_offsets` on `VisualizationData`, populated by `get_visualization_data(include_offsets=True)` and wired into `UnifiedVizCallback` (local PNG + wandb + table), mirroring the PAF / center-heatmap viz.

### 5. Stale docstring fix
`EvalConfig.match_threshold` is reinterpreted as a mask IoU for segmentation — docstring now says so.

## Tests
- `mask_metrics` PQ/SQ/RQ = 1.0 on perfect match; `mean_iou_all_gt` = 0.5 and PQ = 2/3 on a half-recall case (while TP-only mean IoU stays 1.0).
- `center_nms_kernel`: two peaks 2px apart survive kernel 3 but merge under kernel 5.
- `mask_cleanup`: keeps the largest component, drops a speckle, fills a hole.
- Seg viz wiring: `viz_center_heatmap`/`viz_offsets` flags, `include_*` kwargs forwarded, `render_offsets` produces a figure.

233 related tests pass (seg suite + callbacks + predictor/loaders consumers).

## Not included (deferred per triage)
Persist-inference-knobs-into-config and the arch/hparam sweep were explicitly declined. The instance-mask-overlay viz (the larger half of the wandb-viz finding) is noted but not filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)