### PR TITLE
feat: frame-based inference progress + windowed FPS column (#610)

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1631,11 +1631,59 @@ def _gui_progress_callback():
     return cb
 
 
+def _make_fps_column(window_s: float = 5.0, time_fn=None):
+    """Build a Rich ``ProgressColumn`` that shows frames/sec over a window.
+
+    Reports throughput across a trailing ``window_s``-second window rather
+    than the whole-run average, so model warmup / the slow first batch don't
+    drag the number down — it answers "how fast is it *now*". Renders ``--``
+    until two samples spanning a positive interval accrue (#610).
+
+    Samples ``(time, task.completed)`` on each ``render`` and keys the sample
+    history by ``task.id``, so one shared column correctly serves both the
+    "Predicting..." and "Tracking..." tasks. ``rich`` is imported lazily so
+    it doesn't slow ``--help``. ``time_fn`` defaults to ``time.monotonic`` and
+    is injectable for deterministic tests.
+    """
+    from collections import deque
+    from time import monotonic
+
+    from rich.progress import ProgressColumn
+    from rich.text import Text
+
+    if time_fn is None:
+        time_fn = monotonic
+
+    class _FPSColumn(ProgressColumn):
+        def __init__(self, window_s: float, time_fn):
+            super().__init__()
+            self.window_s = window_s
+            self._time_fn = time_fn
+            self._samples: dict = {}  # task_id -> deque[(t, completed)]
+
+        def render(self, task) -> Text:
+            samples = self._samples.setdefault(task.id, deque())
+            t = self._time_fn()
+            samples.append((t, float(task.completed)))
+            while samples and t - samples[0][0] > self.window_s:
+                samples.popleft()
+            if len(samples) < 2:
+                return Text("-- fps", style="progress.percentage")
+            (t0, c0), (t1, c1) = samples[0], samples[-1]
+            dt = t1 - t0
+            if dt <= 0:
+                return Text("-- fps", style="progress.percentage")
+            return Text(f"{(c1 - c0) / dt:5.1f} fps", style="progress.percentage")
+
+    return _FPSColumn(window_s, time_fn)
+
+
 def _make_rich_progress():
     """Build a shared Rich ``Progress`` instance for the ``predict`` path.
 
     Returns the ``Progress`` (already started) — the caller MUST stop it
-    in a ``finally`` block.
+    in a ``finally`` block. Counts are in frames (#610), so the windowed
+    FPS column reads as true frames/sec.
     """
     from rich.progress import (
         BarColumn,
@@ -1651,6 +1699,7 @@ def _make_rich_progress():
         BarColumn(),
         TaskProgressColumn(),
         MofNCompleteColumn(),
+        _make_fps_column(),
         "ETA:",
         TimeRemainingColumn(),
         "Elapsed:",
@@ -1685,15 +1734,16 @@ def _rich_progress_callback():
     """Build a Rich progress bar callback for the non-``--gui`` ``predict`` path.
 
     Returns ``(callback, progress)`` where ``callback(processed, total)`` has
-    the per-batch signature the new pipeline uses. The ``Progress`` is started
-    immediately (so "Predicting..." shows right away) and the caller MUST stop
-    it in a ``finally`` block so the bar closes cleanly on success or error.
-    A ``total <= 0`` (length-less provider) renders an indeterminate bar.
+    the ``(processed_frames, total_frames)`` signature the new pipeline uses.
+    The ``Progress`` is started immediately (so "Predicting..." shows right
+    away) and the caller MUST stop it in a ``finally`` block so the bar closes
+    cleanly on success or error. A ``total <= 0`` (length-less provider)
+    renders an indeterminate bar.
 
     ``rich`` is imported lazily so it doesn't slow ``--help``; the columns
     mirror the legacy ``track`` look-and-feel without importing the heavy
-    legacy ``predictors`` module. Progress is counted in batches (the new
-    callback reports batches, not frames). #583.
+    legacy ``predictors`` module. Progress is counted in frames, so the
+    count / percent / ETA / FPS are all batch-size-invariant (#610). #583.
     """
     progress = _make_rich_progress()
     cb = _rich_task_callback(progress, "Predicting...")

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -85,6 +85,21 @@ def _safe_len(provider: Any) -> int:
         return -1
 
 
+def _safe_num_frames(provider: Any) -> int:
+    """Return ``provider.num_frames()`` or ``-1`` if unavailable/unknown.
+
+    Used to drive frame-based (batch-size-invariant) progress reporting.
+    Falls back to ``-1`` for providers that don't implement ``num_frames``.
+    """
+    fn = getattr(provider, "num_frames", None)
+    if fn is None:
+        return -1
+    try:
+        return fn()
+    except (TypeError, AttributeError):
+        return -1
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Layer builders — one per model type, given a LoadedAssets instance
 # ─────────────────────────────────────────────────────────────────────────
@@ -1094,8 +1109,10 @@ class Predictor:
             clean_empty_frames: When ``True`` and ``make_labels=True``,
                 drop ``LabeledFrame``s with no instances from the
                 returned ``sio.Labels``.
-            progress_callback: Optional ``(processed_batches, total_batches)``
-                callback invoked after each batch.
+            progress_callback: Optional ``(processed_frames, total_frames)``
+                callback invoked after each batch. Counts are in frames
+                (batch-size-invariant); ``total_frames`` is ``-1`` when the
+                provider can't report its length up front.
             tracking_progress_callback: Optional
                 ``(processed_frames, total_frames)`` callback invoked
                 after each frame during tracking.
@@ -1231,7 +1248,7 @@ class Predictor:
             source: ``sio.Video``, ``sio.Labels``, video path string, or
                 a pre-built :class:`Provider`.
             frames: Frame indices (only for video sources).
-            progress_callback: Optional ``(processed_batches, total_batches)``
+            progress_callback: Optional ``(processed_frames, total_frames)``
                 callback.
             peak_threshold: Override peak threshold for all stages.
             centroid_threshold: Override centroid stage threshold (top-down).
@@ -1313,7 +1330,8 @@ class Predictor:
                 ``video_indices`` for the saved labels.
             write_interval: Number of LabeledFrames to buffer before
                 a disk flush.
-            progress_callback: Optional callback per batch.
+            progress_callback: Optional ``(processed_frames, total_frames)``
+                callback invoked after each batch.
 
         Returns:
             The (resolved) destination path string.
@@ -1384,8 +1402,9 @@ class Predictor:
             layer_accepts_instances = False
 
         pipeline = self.filter_pipeline
-        total = _safe_len(provider)
-        for i, batch in enumerate(provider):
+        total = _safe_num_frames(provider)
+        frames_done = 0
+        for batch in provider:
             kwargs: dict = {}
             if batch.instances is not None and layer_accepts_instances:
                 kwargs["instances"] = (
@@ -1398,7 +1417,8 @@ class Predictor:
             outputs = self._stamp_metadata(outputs, batch)
             yield outputs
             if progress_callback is not None:
-                progress_callback(i + 1, total)
+                frames_done += int(batch.images.shape[0])
+                progress_callback(frames_done, total)
 
     # ──────────────────────────────────────────────────────────────────
     # Pipelined bottom-up: GPU stage in main proc, CPU grouping in pool
@@ -1421,7 +1441,7 @@ class Predictor:
         pipeline = self.filter_pipeline
         layer = self.layer
         params = layer.grouping_params()
-        total = _safe_len(provider)
+        total = _safe_num_frames(provider)
 
         # Bound the number of in-flight batches so memory stays O(window),
         # not O(whole video). Submitting every batch before draining (the old
@@ -1431,7 +1451,7 @@ class Predictor:
         # more, preserving submission-order output.
         max_in_flight = max(2 * self.paf_workers, self.paf_workers + 1)
         meta: dict[int, Any] = {}
-        completed = 0
+        frames_done = 0
         with PafGroupingPool(
             n_workers=self.paf_workers, grouping_params=params
         ) as pool:
@@ -1443,24 +1463,26 @@ class Predictor:
                 meta[ordinal] = batch
                 while len(pool) >= max_in_flight:
                     done_ordinal, outputs = pool.drain_one()
+                    done_batch = meta.pop(done_ordinal)
                     outputs = pipeline(outputs)
-                    outputs = self._stamp_metadata(outputs, meta.pop(done_ordinal))
+                    outputs = self._stamp_metadata(outputs, done_batch)
                     yield outputs
-                    completed += 1
                     if progress_callback is not None:
-                        progress_callback(completed, total)
+                        frames_done += int(done_batch.images.shape[0])
+                        progress_callback(frames_done, total)
             # Drain the remaining in-flight batches.
             while True:
                 result = pool.drain_one()
                 if result is None:
                     break
                 done_ordinal, outputs = result
+                done_batch = meta.pop(done_ordinal)
                 outputs = pipeline(outputs)
-                outputs = self._stamp_metadata(outputs, meta.pop(done_ordinal))
+                outputs = self._stamp_metadata(outputs, done_batch)
                 yield outputs
-                completed += 1
                 if progress_callback is not None:
-                    progress_callback(completed, total)
+                    frames_done += int(done_batch.images.shape[0])
+                    progress_callback(frames_done, total)
 
     @staticmethod
     def _stamp_metadata(outputs: Outputs, batch: Any) -> Outputs:

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -68,6 +68,16 @@ class Provider(Protocol):
         """
         ...
 
+    def num_frames(self) -> int:
+        """Return the total number of frames the provider will yield.
+
+        Used by the ``Predictor`` for frame-based progress reporting, which
+        is batch-size-invariant (unlike ``__len__``, which counts batches).
+        Providers over unbounded sources may return ``-1`` to signal unknown
+        length.
+        """
+        ...
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # NumpyProvider — emits a pre-loaded tensor as a single batch
@@ -142,6 +152,10 @@ class VideoProvider:
         """Number of batches; ``ceil(len(frames) / batch_size)``."""
         n = len(self._frame_indices)
         return (n + self.batch_size - 1) // self.batch_size
+
+    def num_frames(self) -> int:
+        """Total number of frames this provider will yield."""
+        return len(self._frame_indices)
 
 
 @attrs.define
@@ -306,6 +320,10 @@ class LabelsProvider:
         n = len(self._labeled_frames)
         return (n + self.batch_size - 1) // self.batch_size
 
+    def num_frames(self) -> int:
+        """Total number of frames over the (filtered) labeled-frame list."""
+        return len(self._labeled_frames)
+
 
 @attrs.define
 class MultiVideoProvider:
@@ -361,6 +379,16 @@ class MultiVideoProvider:
             total += n
         return total
 
+    def num_frames(self) -> int:
+        """Total frames across all sub-providers (or ``-1`` if any unknown)."""
+        total = 0
+        for provider in self.providers:
+            n = provider.num_frames()
+            if n < 0:
+                return -1
+            total += n
+        return total
+
 
 @attrs.define
 class NumpyProvider:
@@ -410,3 +438,7 @@ class NumpyProvider:
         """Number of batches; ``ceil(N / batch_size)``."""
         n = int(self.images.shape[0])
         return (n + self.batch_size - 1) // self.batch_size
+
+    def num_frames(self) -> int:
+        """Total number of frames in the pre-loaded tensor."""
+        return int(self.images.shape[0])

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -141,7 +141,8 @@ def predict(
         tracker_config: :class:`TrackerConfig` for tracking.
         output_path: If set, save the Labels to this ``.slp`` path.
         clean_empty_frames: Drop frames with no instances.
-        progress_callback: ``(processed, total)`` callback per batch.
+        progress_callback: ``(processed_frames, total_frames)`` callback
+            invoked after each batch (counts are in frames).
         tracking_progress_callback: ``(processed_frames, total_frames)``
             callback per frame during tracking.
 

--- a/tests/inference/test_issue_610.py
+++ b/tests/inference/test_issue_610.py
@@ -1,0 +1,176 @@
+"""Regression tests for issue #610 (inference CLI observability).
+
+This PR (PR-A) covers two of the four asks:
+
+* **Frame-based progress** — ``Predictor._batch_iter`` reports
+  ``(processed_frames, total_frames)`` (a running sum of batch sizes) instead
+  of batch indices, so the count / %% / ETA are batch-size-invariant. This
+  relies on each ``Provider`` exposing ``num_frames()``.
+* **Windowed FPS column** — ``sleap_nn.cli._make_fps_column`` builds a Rich
+  column reporting frames/sec over a trailing time window.
+
+(Spin-up logging + run summary are PR-B.)
+"""
+
+from __future__ import annotations
+
+import types
+from unittest import mock
+
+import numpy as np
+
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.predictor import Predictor, _safe_num_frames
+from sleap_nn.inference.providers import (
+    MultiVideoProvider,
+    NumpyProvider,
+)
+
+# ─────────────────────────────────────────────────────────────────────────
+# Provider.num_frames() — frame count is known up front, batch-size-invariant
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_numpy_provider_num_frames_is_batch_size_invariant():
+    """``num_frames`` counts frames, not batches — invariant to batch_size."""
+    images = np.zeros((7, 1, 4, 4), dtype=np.float32)
+    for bs in (1, 3, 4, 10):
+        provider = NumpyProvider(images=images, batch_size=bs)
+        assert provider.num_frames() == 7  # invariant
+        # ...whereas __len__ (batch count) does vary with batch_size:
+        assert len(provider) == (7 + bs - 1) // bs
+
+
+def test_multivideo_provider_num_frames_sums_subproviders():
+    """``MultiVideoProvider`` sums its sub-providers' frame counts."""
+    a = NumpyProvider(images=np.zeros((5, 1, 4, 4), dtype=np.float32), batch_size=2)
+    b = NumpyProvider(images=np.zeros((3, 1, 4, 4), dtype=np.float32), batch_size=2)
+    multi = MultiVideoProvider(providers=[a, b])
+    assert multi.num_frames() == 8
+
+
+def test_safe_num_frames_falls_back_to_minus_one():
+    """``_safe_num_frames`` returns -1 for providers without ``num_frames``."""
+
+    class _NoFrames:
+        def __len__(self):
+            return 3
+
+    assert _safe_num_frames(_NoFrames()) == -1
+    assert _safe_num_frames(object()) == -1
+    assert (
+        _safe_num_frames(NumpyProvider(images=np.zeros((4, 1, 2, 2), dtype=np.float32)))
+        == 4
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _batch_iter — progress callback reports cumulative FRAMES against total
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _FakeLayer:
+    """Minimal layer: echoes an empty ``Outputs`` per batch."""
+
+    def predict(self, images):
+        return Outputs()
+
+
+def test_batch_iter_reports_frame_based_progress():
+    """Callback gets a running frame sum + total frames (ragged last batch ok)."""
+    images = np.zeros((7, 1, 4, 4), dtype=np.float32)
+    provider = NumpyProvider(images=images, batch_size=3)  # batches of 3, 3, 1
+    calls: list = []
+    predictor = Predictor(layer=_FakeLayer())
+
+    # Identity filter pipeline so we exercise only the counting logic.
+    identity = property(lambda self: (lambda outputs: outputs))
+    with mock.patch.object(Predictor, "filter_pipeline", identity):
+        outs = list(predictor._batch_iter(provider, lambda p, t: calls.append((p, t))))
+
+    assert len(outs) == 3  # one Outputs per batch
+    # Cumulative frames, NOT batch indices; total is frame count (7), not 3.
+    assert calls == [(3, 7), (6, 7), (7, 7)]
+
+
+def test_batch_iter_total_is_minus_one_for_lengthless_provider():
+    """A provider without ``num_frames`` still drives a running frame count."""
+
+    class _StreamProvider:
+        """Length-less provider (e.g. a live source)."""
+
+        def __init__(self, batches):
+            self._batches = batches
+
+        def __iter__(self):
+            return iter(self._batches)
+
+    batch = types.SimpleNamespace(
+        images=np.zeros((2, 1, 4, 4), dtype=np.float32),
+        instances=None,
+        frame_indices=None,
+        video_indices=None,
+    )
+    provider = _StreamProvider([batch, batch])
+    calls: list = []
+    predictor = Predictor(layer=_FakeLayer())
+    identity = property(lambda self: (lambda outputs: outputs))
+    with mock.patch.object(Predictor, "filter_pipeline", identity):
+        list(predictor._batch_iter(provider, lambda p, t: calls.append((p, t))))
+
+    # total unknown (-1) but processed still accumulates in frames.
+    assert calls == [(2, -1), (4, -1)]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _make_fps_column — windowed frames/sec
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _task(task_id, completed):
+    return types.SimpleNamespace(id=task_id, completed=completed)
+
+
+def test_fps_column_renders_placeholder_until_two_samples():
+    """First render (one sample) shows the ``--`` placeholder."""
+    from sleap_nn.cli import _make_fps_column
+
+    col = _make_fps_column(time_fn=lambda: 0.0)
+    assert "--" in col.render(_task(1, 0)).plain
+
+
+def test_fps_column_computes_windowed_rate():
+    """Rate is (Δframes / Δt) over the retained window."""
+    from sleap_nn.cli import _make_fps_column
+
+    times = iter([0.0, 1.0, 2.0])
+    col = _make_fps_column(window_s=5.0, time_fn=lambda: next(times))
+    col.render(_task(1, 0))  # t=0, c=0  → placeholder
+    assert "10.0 fps" in col.render(_task(1, 10)).plain  # (10-0)/(1-0)
+    assert "15.0 fps" in col.render(_task(1, 30)).plain  # (30-0)/(2-0)
+
+
+def test_fps_column_drops_samples_outside_window():
+    """Samples older than ``window_s`` are evicted, so the rate is recent."""
+    from sleap_nn.cli import _make_fps_column
+
+    times = iter([0.0, 1.0, 10.0, 11.0])
+    col = _make_fps_column(window_s=5.0, time_fn=lambda: next(times))
+    col.render(_task(1, 0))  # t=0
+    col.render(_task(1, 100))  # t=1
+    # t=10 evicts the t=0 and t=1 samples (both > 5s old) → only this sample.
+    assert "--" in col.render(_task(1, 1000)).plain
+    # t=11 with the t=10 sample retained: (1100-1000)/(11-10) = 100 fps.
+    assert "100.0 fps" in col.render(_task(1, 1100)).plain
+
+
+def test_fps_column_keeps_per_task_history():
+    """Two tasks (Predicting / Tracking) keep independent sample windows."""
+    from sleap_nn.cli import _make_fps_column
+
+    times = iter([0.0, 0.0, 1.0, 1.0])
+    col = _make_fps_column(window_s=5.0, time_fn=lambda: next(times))
+    col.render(_task(1, 0))  # task 1 @ t=0
+    col.render(_task(2, 0))  # task 2 @ t=0
+    assert "5.0 fps" in col.render(_task(1, 5)).plain  # task1: (5-0)/(1-0)
+    assert "20.0 fps" in col.render(_task(2, 20)).plain  # task2: (20-0)/(1-0)


### PR DESCRIPTION
## Summary

PR-A of issue #610 — make the `predict`/`track` CLI progress legible at a glance:

- **Frame-based progress** — the progress bar is now driven by frame count, not batch index, so the count / % / ETA / FPS are all **batch-size-invariant** (the same video no longer shows `45/60` at one `--batch_size` and `180/240` at another).
- **Windowed FPS column** — a new throughput column reports **frames/sec over a trailing 5 s window**, so GPU warmup / the slow first batch don't drag the displayed rate down.

Spin-up logging + run summary (asks 3 & 4 in the issue) land in a follow-up (**PR-B**).

## Changes Made

- **`sleap_nn/inference/providers.py`** — add `num_frames()` to the `Provider` protocol and all four providers (`VideoProvider`, `LabelsProvider`, `NumpyProvider`, `MultiVideoProvider`). The frame total is known up front; `MultiVideoProvider` sums its sub-providers (or `-1` if any is unknown).
- **`sleap_nn/inference/predictor.py`** — `_batch_iter` and the pipelined `_predict_streaming_pipelined` now call `progress_callback(frames_done, total_frames)`, where `frames_done` is a running sum of per-batch sizes (handles the ragged final batch correctly). Added `_safe_num_frames` (mirrors `_safe_len`, falls back to `-1` for length-less sources). Docstrings updated to the `(processed_frames, total_frames)` contract — now consistent with the tracking callback.
- **`sleap_nn/inference/run.py`** — `run_inference` docstring updated to the frame-based contract.
- **`sleap_nn/cli.py`** — new `_make_fps_column` builds a custom Rich `ProgressColumn` with a per-task, time-windowed sample deque (injectable clock for tests); wired into `_make_rich_progress` between the M/N counter and ETA. Renders `-- fps` until two samples accrue.

## Example

```
Predicting... ━━━━━━━━━━━━━╸          45%  115/256   23.4 fps  ETA: 0:00:06  Elapsed: 0:00:05
```

The `115/256` is now **frames** (was batches); the `23.4 fps` is a true windowed frames/sec.

## API Changes

- **`Provider` protocol gains `num_frames() -> int`.** All in-tree providers implement it; `_safe_num_frames` degrades gracefully (`-1`) for any third-party/length-less provider, so this is non-breaking in practice.
- **Inference `progress_callback` contract changes from `(processed_batches, total_batches)` to `(processed_frames, total_frames)`.** Audited all consumers — every callback (`_rich_task_callback`, `_gui_progress_callback`, the `run_inference` pass-through) is generic over `(processed, total)` and only *displays* the numbers; none does batch-specific arithmetic. The change makes the display meaningful and aligns inference with the already-frame-based tracking callback.

## Testing

- New `tests/inference/test_issue_610.py` (9 tests): `num_frames` is batch-size-invariant; `MultiVideoProvider` summing; `_safe_num_frames` fallback; `_batch_iter` reports cumulative frames against the frame total (incl. a length-less `-1`-total provider); `_FPSColumn` placeholder → windowed rate → window eviction → per-task histories (deterministic via injected clock).
- Full `tests/inference` + `tests/cli` sweep: **602 passed, 28 skipped, 1 xfailed**. Pipelined `paf_workers>0` parity tests and e2e video tests included.
- `black` + `ruff` clean.

## Design Decisions

- **FPS column samples in `render()`, keyed by `task.id`.** This keeps the change localized (no callback-signature or call-site churn) and naturally serves both the "Predicting..." and "Tracking..." tasks with independent windows. The clock is injectable so the windowing logic is unit-testable without real time.
- **`frames_done` is summed from actual batch sizes** rather than `batch_index * batch_size`, so the ragged final batch is exact.

## Future Considerations

- **PR-B** (issue #610 asks 3 & 4): spin-up `logger.info` block (model type/backbone/head, device, batch size, thresholds; source, #frames, video shape, fps) and a post-run summary (frames, instances/masks, elapsed, throughput, tracking, output). Planned library-wide in `Predictor`.
- Once those logs exist, honor #324's logger/progress toggles for quieting/redirecting them.

## Related Issues

Part of #610 (PR-A; PR-B to follow).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)