### PR TITLE
feat: inference spin-up + run-summary logging (#610)

### DIFF
--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -37,6 +37,7 @@ from typing import (
 import attrs
 import numpy as np
 import torch
+from loguru import logger
 
 from sleap_nn.inference.filters import FilterConfig, FilterPipeline
 from sleap_nn.inference.layers.backends import TorchBackend
@@ -783,6 +784,26 @@ class Predictor:
             kwargs["filter_config"] = filter_config
         if tracker_config is not None:
             kwargs["tracker_config"] = tracker_config
+
+        # Spin-up log: a one-line record of *what* model is running on *what*,
+        # so a run starts with a legible header instead of silence (#610).
+        n_nodes = len(skeleton.nodes) if skeleton is not None else None
+        spec = [
+            f"type={'+'.join(model_types)}",
+            f"backbone={loaded.backbone_type}",
+            f"nodes={n_nodes}",
+            f"device={device}",
+            f"batch_size={batch_size}",
+            f"peak_threshold={peak_threshold}",
+            f"max_instances={max_instances}",
+            f"integral_refinement={integral_refinement}",
+            f"paf_workers={paf_workers}",
+        ]
+        if "bottomup_segmentation" in model_types:
+            spec.append(f"fg_threshold={fg_threshold}")
+            spec.append(f"min_mask_area={min_mask_area}")
+        logger.info("Loaded inference model | " + " | ".join(spec))
+
         return cls(**kwargs)
 
     @classmethod
@@ -933,6 +954,68 @@ class Predictor:
             inference_params=inference_params,
             tracking_params=tracking_params,
         )
+
+    @staticmethod
+    def _describe_source(source: Any) -> str:
+        """Best-effort human label for a prediction source (#610)."""
+        if isinstance(source, str):
+            return source
+        filename = getattr(source, "filename", None)
+        if filename:
+            return str(filename)
+        return type(source).__name__
+
+    def _log_inference_start(
+        self, source: Any, provider: "Provider", videos: Optional[list]
+    ) -> None:
+        """Log a one-line spin-up record of the source being processed (#610)."""
+        n_frames = _safe_num_frames(provider)
+        parts = [
+            f"source={self._describe_source(source)}",
+            f"frames={n_frames if n_frames >= 0 else '?'}",
+            f"videos={len(videos) if videos else 1}",
+        ]
+        sio_video = getattr(provider, "_sio_video", None)
+        if sio_video is not None:
+            try:
+                shape = tuple(sio_video.shape)  # (N, H, W, C)
+                if len(shape) == 4:
+                    parts.append(f"shape={shape[1]}x{shape[2]}x{shape[3]}")
+            except Exception:  # pragma: no cover — metadata best-effort
+                pass
+            fps = getattr(sio_video, "fps", None)
+            if fps:
+                parts.append(f"fps={fps}")
+        parts.append(f"tracking={self.tracker_config is not None}")
+        logger.info("Starting inference | " + " | ".join(parts))
+
+    def _log_inference_summary(
+        self,
+        *,
+        n_frames: int,
+        elapsed_s: float,
+        output: Optional[str] = None,
+        n_objects: Optional[int] = None,
+        object_label: str = "instances",
+    ) -> None:
+        """Log a one-line post-run summary (#610).
+
+        ``n_objects`` (instances or masks) is optional — the streaming path
+        drops per-frame objects, so it reports frames/throughput only.
+        """
+        fps = n_frames / elapsed_s if elapsed_s > 0 else 0.0
+        parts = [f"frames={n_frames}"]
+        if n_objects is not None:
+            mean = n_objects / n_frames if n_frames > 0 else 0.0
+            parts.append(f"{object_label}={n_objects} ({mean:.2f}/frame)")
+        parts += [
+            f"elapsed={elapsed_s:.1f}s",
+            f"throughput={fps:.1f} fps",
+            f"tracking={self.tracker_config is not None}",
+        ]
+        if output:
+            parts.append(f"output={output}")
+        logger.info("Inference complete | " + " | ".join(parts))
 
     def _make_provider(
         self,
@@ -1185,6 +1268,7 @@ class Predictor:
         if videos is None:
             videos = auto_videos
 
+        self._log_inference_start(source, provider, videos)
         _prov_start = datetime.now()
         with self._postprocess_overrides(
             peak_threshold=peak_threshold,
@@ -1239,6 +1323,24 @@ class Predictor:
                 "integral_patch_size": integral_patch_size,
                 "batch_size": self.batch_size,
             },
+        )
+
+        # Post-run summary (#610). Segmentation emits masks (LabeledFrame.masks);
+        # everything else emits instances (LabeledFrame.instances).
+        n_lf = len(labels.labeled_frames)
+        if self._is_segmentation_layer():
+            n_objects = sum(
+                len(getattr(lf, "masks", None) or []) for lf in labels.labeled_frames
+            )
+            object_label = "masks"
+        else:
+            n_objects = sum(len(lf.instances) for lf in labels.labeled_frames)
+            object_label = "instances"
+        self._log_inference_summary(
+            n_frames=n_lf,
+            elapsed_s=(_prov_end - _prov_start).total_seconds(),
+            n_objects=n_objects,
+            object_label=object_label,
         )
         return labels
 
@@ -1378,6 +1480,7 @@ class Predictor:
         # `videos` (possibly None) is used (#582).
         if videos is None:
             videos = derived
+        self._log_inference_start(source, provider, derived)
         pkg = self._resolve_centroid_packaging()
         writer = IncrementalLabelsWriter(
             path=path,
@@ -1397,13 +1500,21 @@ class Predictor:
                 writer.write(outputs)
             # Attach provenance before the context exit finalizes the .slp, so
             # the streamed output carries lineage like the in-memory path (#583).
+            _prov_end = datetime.now()
             writer.provenance = self._build_inference_provenance(
                 source=source,
                 start_time=_prov_start,
-                end_time=datetime.now(),
+                end_time=_prov_end,
                 n_frames=writer.frame_count,
                 inference_params={"batch_size": self.batch_size},
             )
+        # Post-run summary (#610). The streaming path drops per-frame objects to
+        # keep memory O(window), so report frames / throughput only.
+        self._log_inference_summary(
+            n_frames=writer.frame_count,
+            elapsed_s=(_prov_end - _prov_start).total_seconds(),
+            output=path,
+        )
         return path
 
     # ──────────────────────────────────────────────────────────────────

--- a/tests/inference/test_issue_610_logging.py
+++ b/tests/inference/test_issue_610_logging.py
@@ -1,0 +1,186 @@
+"""Tests for issue #610 PR-B — inference spin-up + run-summary logging.
+
+The ``Predictor`` now emits three ``loguru`` lines per run (library-wide, so
+the ``sleap`` frontend benefits too):
+
+* ``Loaded inference model | ...`` — at ``from_model_paths`` (the spin-up
+  header: model type / backbone / nodes / device / thresholds / ...).
+* ``Starting inference | ...`` — once the provider is built (source, frames,
+  video shape, fps, tracking).
+* ``Inference complete | ...`` — after the run (frames, instances/masks,
+  elapsed, throughput, tracking, output).
+
+Fast unit tests drive the formatting helpers directly; one integration test
+exercises a real ``predict()`` so all three lines are asserted end-to-end.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from _pytest.logging import LogCaptureFixture
+from loguru import logger
+
+from sleap_nn.inference.predictor import Predictor
+from sleap_nn.inference.providers import NumpyProvider
+
+CKPT_ROOT = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
+VIDEO = Path(__file__).resolve().parents[1] / "assets" / "datasets" / "small_robot.mp4"
+SI_CKPT = CKPT_ROOT / "minimal_instance_single_instance"
+
+
+@pytest.fixture
+def caplog(caplog: LogCaptureFixture):
+    """Route loguru records into pytest's ``caplog`` (project convention)."""
+    handler_id = logger.add(
+        caplog.handler,
+        format="{message}",
+        level=0,
+        filter=lambda record: record["level"].no >= caplog.handler.level,
+        enqueue=False,
+    )
+    yield caplog
+    logger.remove(handler_id)
+
+
+class _FakeLayer:
+    """Minimal non-segmentation layer (so ``_is_segmentation_layer`` is False)."""
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _describe_source
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_describe_source_variants():
+    """A str passes through; an object's ``filename`` wins; else the type name."""
+    assert Predictor._describe_source("video.mp4") == "video.mp4"
+    obj = types.SimpleNamespace(filename="/path/to/clip.mp4")
+    assert Predictor._describe_source(obj) == "/path/to/clip.mp4"
+    # No str, no filename → falls back to the type name.
+    assert Predictor._describe_source(object()) == "object"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _log_inference_start
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_log_inference_start_basic(caplog):
+    """The start line carries source, frame count, video count, tracking."""
+    predictor = Predictor(layer=_FakeLayer())
+    provider = NumpyProvider(images=np.zeros((5, 1, 4, 4), dtype=np.float32))
+    predictor._log_inference_start("clip.mp4", provider, videos=None)
+    msg = caplog.text
+    assert "Starting inference" in msg
+    assert "source=clip.mp4" in msg
+    assert "frames=5" in msg
+    assert "videos=1" in msg
+    assert "tracking=False" in msg
+
+
+def test_log_inference_start_includes_video_shape_and_fps(caplog):
+    """A provider with ``_sio_video`` contributes HxWxC shape + fps."""
+    predictor = Predictor(layer=_FakeLayer())
+    # A provider exposing _sio_video with shape (N, H, W, C) + fps.
+    fake_video = types.SimpleNamespace(shape=(10, 64, 48, 3), fps=30.0)
+    provider = types.SimpleNamespace(num_frames=lambda: 10, _sio_video=fake_video)
+    predictor._log_inference_start("v.mp4", provider, videos=[fake_video])
+    msg = caplog.text
+    assert "shape=64x48x3" in msg
+    assert "fps=30.0" in msg
+    assert "videos=1" in msg
+
+
+def test_log_inference_start_reports_tracking_enabled(caplog):
+    """A set ``tracker_config`` surfaces as ``tracking=True``."""
+    predictor = Predictor(layer=_FakeLayer(), tracker_config=object())
+    provider = NumpyProvider(images=np.zeros((2, 1, 4, 4), dtype=np.float32))
+    predictor._log_inference_start("x", provider, videos=None)
+    assert "tracking=True" in caplog.text
+
+
+def test_log_inference_start_unknown_frame_count(caplog):
+    """A length-less provider logs ``frames=?`` rather than -1."""
+    predictor = Predictor(layer=_FakeLayer())
+    provider = object()  # no num_frames → _safe_num_frames returns -1
+    predictor._log_inference_start("src", provider, videos=None)
+    assert "frames=?" in caplog.text
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _log_inference_summary
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_log_inference_summary_with_instances(caplog):
+    """The summary reports instances + per-frame mean + windowed throughput."""
+    predictor = Predictor(layer=_FakeLayer())
+    predictor._log_inference_summary(
+        n_frames=10, elapsed_s=2.0, n_objects=25, object_label="instances"
+    )
+    msg = caplog.text
+    assert "Inference complete" in msg
+    assert "frames=10" in msg
+    assert "instances=25 (2.50/frame)" in msg
+    assert "throughput=5.0 fps" in msg  # 10 frames / 2.0 s
+    assert "tracking=False" in msg
+
+
+def test_log_inference_summary_streaming_frames_only(caplog):
+    """Streaming summary omits object counts but reports output + throughput."""
+    predictor = Predictor(layer=_FakeLayer())
+    predictor._log_inference_summary(n_frames=4, elapsed_s=1.0, output="out.slp")
+    msg = caplog.text
+    assert "frames=4" in msg
+    assert "instances=" not in msg and "masks=" not in msg
+    assert "output=out.slp" in msg
+    assert "throughput=4.0 fps" in msg
+
+
+def test_log_inference_summary_zero_elapsed_no_div_by_zero(caplog):
+    """A zero elapsed time reports 0 fps instead of dividing by zero."""
+    predictor = Predictor(layer=_FakeLayer())
+    predictor._log_inference_summary(n_frames=3, elapsed_s=0.0, n_objects=3)
+    assert "throughput=0.0 fps" in caplog.text
+
+
+def test_log_inference_summary_masks_label(caplog):
+    """Segmentation runs report ``masks`` rather than ``instances``."""
+    predictor = Predictor(layer=_FakeLayer())
+    predictor._log_inference_summary(
+        n_frames=2, elapsed_s=1.0, n_objects=6, object_label="masks"
+    )
+    assert "masks=6 (3.00/frame)" in caplog.text
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Integration: a real predict() emits all three lines
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not (VIDEO.exists() and SI_CKPT.exists()),
+    reason="missing single-instance fixtures",
+)
+def test_predict_emits_spinup_start_and_summary(caplog):
+    """End-to-end: from_model_paths + predict log all three observability lines."""
+    predictor = Predictor.from_model_paths([str(SI_CKPT)], device="cpu", batch_size=4)
+    assert "Loaded inference model" in caplog.text
+    assert "type=single_instance" in caplog.text
+    assert "backbone=" in caplog.text
+    assert "nodes=" in caplog.text
+
+    video = sio.load_video(str(VIDEO))
+    labels = predictor.predict(video, frames=list(range(6)))
+    msg = caplog.text
+    assert "Starting inference" in msg
+    assert "frames=6" in msg
+    assert "Inference complete" in msg
+    assert "instances=" in msg  # in-memory path counts instances
+    assert "throughput=" in msg
+    assert isinstance(labels, sio.Labels)


### PR DESCRIPTION
## Summary

PR-B of issue #610 (follows #626) — give an inference run a legible **header** and **footer** so it's clear *what* ran on *what*, and what came out. Logging is **library-wide** (in `Predictor`, via `loguru`), so the `sleap` frontend and any direct API caller benefit, not just the `sleap-nn` CLI.

Three lines per run:

```
Loaded inference model | type=single_instance | backbone=unet | nodes=2 | device=cpu | batch_size=4 | peak_threshold=0.2 | max_instances=None | integral_refinement=integral | paf_workers=0
Starting inference | source=clip.mp4 | frames=6 | videos=1 | shape=384x384x1 | fps=30.0 | tracking=False
Inference complete | frames=6 | instances=6 (1.00/frame) | elapsed=0.4s | throughput=15.2 fps | tracking=False
```

## Changes Made

- **`sleap_nn/inference/predictor.py`**
  - Add `from loguru import logger` (the module had no logging before — see issue notes).
  - **Spin-up block** in `from_model_paths`, right before constructing the `Predictor`: model type(s), backbone, node count, device, batch size, peak threshold, max instances, integral refinement, paf workers — plus `fg_threshold` / `min_mask_area` for `bottomup_segmentation`.
  - Three small helpers: `_describe_source` (str → path → type name), `_log_inference_start` (source / frame count / video count / `HxWxC` shape / fps / tracking — best-effort metadata via `getattr`, never raises), and `_log_inference_summary` (frames / objects + per-frame mean / elapsed / throughput / tracking / output).
  - Wire `_log_inference_start` into both `predict` and `predict_to_file` (after the provider is built), and `_log_inference_summary` into both (end of run). The in-memory `predict` counts **instances** (or **masks** for segmentation, read from `LabeledFrame.masks`); the streaming `predict_to_file` reports **frames / throughput / output** only, since it intentionally drops per-frame objects to keep memory O(window). Reused the existing `_prov_start`/`_prov_end` timestamps for elapsed (hoisted `_prov_end` in the streaming path so it's available for the summary).

## API Changes

None. Purely additive `logger.info` output; no signatures change. `_log_inference_summary` accepts an optional `n_objects` so the streaming path can omit object counts.

## Testing

- New `tests/inference/test_issue_610_logging.py` (10 tests): `_describe_source` variants; `_log_inference_start` basic / shape+fps / tracking-enabled / unknown-frame-count (`frames=?`); `_log_inference_summary` instances+mean+throughput / streaming-frames-only / zero-elapsed (no div-by-zero) / masks label; and one **integration** test that runs a real `from_model_paths(...).predict(...)` and asserts all three lines. Uses the project's loguru→`caplog` fixture.
- Full `tests/inference` + `tests/cli` sweep: **618 passed, 28 skipped, 1 xfailed**.
- `black` + `ruff` clean.

## Design Decisions

- **Library-wide, not CLI-only** (the DQ2 call on the issue): the detailed model/source/summary records live in `Predictor` so every caller gets them. No duplicate "Starting inference" line was added in `cli.py` — the library log is the single source of truth.
- **Best-effort metadata**: video shape/fps are read defensively (`getattr` + guarded `shape` access) so a provider without a backing `sio.Video` (e.g. a length-less stream → `frames=?`) still logs cleanly.
- **`make_labels=False`** returns before the summary (there are no labels to count), which is correct; the spin-up + start lines still fire.

## Future Considerations

- Once #324 (override loggers / progress bar) lands, these lines should honor its quiet/redirect toggles.
- The streaming summary could optionally report instance/mask counts by scanning the written `.slp`, but that adds I/O for marginal value — deferred.

## Related Issues

Completes issue #610 (PR-A = #626 frame-based progress + FPS; this PR-B = spin-up + summary logging).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)