### PR TITLE
feat(seg): mask-IoU tracker MVP for bottom-up segmentation (#619)

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -2207,13 +2207,22 @@ def _common_inference_options(f):
         # --candidates_method default=None pattern. A single-node / centroid
         # model then resolves these to centroids/euclidean_dist in
         # apply_tracking (#586).
-        click.option("--features", type=str, default=None),
+        click.option(
+            "--features",
+            type=str,
+            default=None,
+            help="Feature for track association: one of keypoints, centroids, "
+            "bboxes, masks. Left unset, single-node/centroid models resolve to "
+            "'centroids' and bottom-up segmentation (mask) models to 'masks'.",
+        ),
         click.option(
             "--scoring_method",
             type=str,
             default=None,
-            help="Track association scoring method. Single-node / centroid "
-            "models resolve to euclidean_dist when left unset.",
+            help="Track association scoring method: one of oks, cosine_sim, "
+            "iou, mask_iou, euclidean_dist. Left unset, single-node/centroid "
+            "models resolve to 'euclidean_dist' and segmentation (mask) models "
+            "to 'mask_iou'.",
         ),
         click.option("--scoring_reduction", type=str, default="mean"),
         click.option("--robust_best_instance", type=float, default=1.0),

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1214,6 +1214,10 @@ def _build_tracker_config(kwargs: dict) -> "object":
 
     # Default candidates_method to local_queues when max_tracks is set but the
     # user did not explicitly choose a method (the click default is None).
+    # Record explicitness so apply_tracking can default mask-mode tracking to
+    # local_queues (much better identity on over-segmented masks) unless the user
+    # explicitly picked a method.
+    candidates_method_explicit = kwargs.get("candidates_method") is not None
     candidates_method = kwargs.get("candidates_method")
     if candidates_method is None:
         candidates_method = "local_queues" if max_tracks is not None else "fixed_window"
@@ -1251,6 +1255,7 @@ def _build_tracker_config(kwargs: dict) -> "object":
         scoring_method=scoring_method,
         features_explicit=features_explicit,
         scoring_method_explicit=scoring_method_explicit,
+        candidates_method_explicit=candidates_method_explicit,
         scoring_reduction=kwargs.get("scoring_reduction", "mean"),
         robust_best_instance=kwargs.get("robust_best_instance", 1.0),
         oks_stddev=kwargs.get("oks_stddev", 0.025),

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1279,16 +1279,8 @@ class Predictor:
             )
 
         # Segmentation emits sio.PredictedSegmentationMask objects to
-        # LabeledFrame.masks; the tracker only handles sio.PredictedInstance and
-        # reads only LabeledFrame.instances, so it would silently drop every
-        # mask. Fail fast rather than write a mask-less tracked .slp.
-        if self.tracker_config is not None and self._is_segmentation_layer():
-            raise ValueError(
-                "Tracking is not yet supported for bottom-up segmentation "
-                "models: masks are emitted to LabeledFrame.masks, which the "
-                "tracker (operating on sio.PredictedInstance objects) would "
-                "drop, producing a mask-less output. Re-run without tracking."
-            )
+        # LabeledFrame.masks; apply_tracking auto-detects the mask-only labels
+        # and tracks them by pixel mask-IoU (#619), so tracking is supported.
 
         provider, auto_videos = self._make_provider(source, frames=frames)
         if videos is None:

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -81,12 +81,13 @@ class TrackerConfig:
     tracking_clean_iou_threshold: float = 0.0
     post_connect_single_breaks: bool = False
 
-    # Single-node (centroid) default resolution ─────────────────────────
+    # Single-node (centroid) / segmentation (mask) default resolution ───
     # True (the default) means the user explicitly chose ``scoring_method`` /
     # ``features`` — direct constructors keep current behavior. The CLI sets
     # these False when the corresponding flag was left at its sentinel, which
-    # lets ``apply_tracking`` substitute single-node-appropriate defaults
-    # (``euclidean_dist`` / ``centroids``) for a 1-node skeleton.
+    # lets ``apply_tracking`` substitute task-appropriate defaults:
+    # ``euclidean_dist``/``centroids`` for a 1-node skeleton, and
+    # ``mask_iou``/``masks`` for a bottom-up segmentation (mask-only) model.
     scoring_method_explicit: bool = True
     features_explicit: bool = True
 
@@ -173,6 +174,51 @@ def apply_tracking(
                 effective_features,
             )
 
+    # Segmentation (mask-only) default resolution. A bottom-up segmentation
+    # model emits sio.PredictedSegmentationMask into LabeledFrame.masks and no
+    # predicted keypoint instances (no skeleton); track masks by pixel mask-IoU.
+    # Detect on the labels content (available here, after prediction), mirroring
+    # the single-node centroid branch.
+    is_mask_mode = any(
+        getattr(lf, "masks", None) for lf in labels.labeled_frames
+    ) and not any(lf.has_predicted_instances for lf in labels.labeled_frames)
+    if is_mask_mode:
+        if not config.scoring_method_explicit:
+            effective_scoring_method = "mask_iou"
+        if not config.features_explicit:
+            effective_features = "masks"
+        if effective_features != "masks" or effective_scoring_method != "mask_iou":
+            raise ValueError(
+                "Tracking a bottom-up segmentation (mask-only) model requires "
+                "features='masks' and scoring_method='mask_iou' (got features="
+                f"{effective_features!r}, scoring_method={effective_scoring_method!r}). "
+                "Leave --features/--scoring_method unset to auto-select them."
+            )
+        # Motion models and pose-shaped cull/clean ops are out of MVP scope for
+        # masks (they call .numpy()/same_pose_as on keypoint instances). Fail
+        # fast with a clear message rather than crash mid-stream.
+        if config.use_flow or config.use_kalman:
+            raise ValueError(
+                "Mask tracking does not support motion models "
+                "(--use_flow/--use_kalman); they are out of scope for the "
+                "segmentation tracker MVP."
+            )
+        if (
+            config.tracking_pre_cull_to_target
+            or config.tracking_clean_instance_count
+            or config.post_connect_single_breaks
+        ):
+            raise ValueError(
+                "Mask tracking does not support the instance cull/clean/connect "
+                "options (tracking_pre_cull_to_target / "
+                "tracking_clean_instance_count / post_connect_single_breaks); "
+                "these operate on keypoint poses, not masks."
+            )
+        logger.info(
+            "Segmentation model detected; applying mask tracking defaults: "
+            "features='masks', scoring_method='mask_iou'."
+        )
+
     tracker = Tracker.from_config(
         window_size=config.window_size,
         min_new_track_points=config.min_new_track_points,
@@ -216,30 +262,45 @@ def apply_tracking(
     n_frames = len(ordered_lfs)
     for i, lf in enumerate(ordered_lfs):
         instances: list = []
-        if lf.has_user_instances:
-            instances_to_track = lf.user_instances
-            if lf.has_predicted_instances:
-                instances = list(lf.predicted_instances)
+        masks: list = []
+        if is_mask_mode:
+            # Track segmentation masks: feed lf.masks through the same tracker
+            # (duck-typed), get back the same mask objects with track /
+            # tracking_score set, and preserve them on the rebuilt frame so
+            # they are NOT dropped (the #614 breakage). Instances stay empty.
+            if lf.masks:
+                masks = tracker.track(
+                    untracked_instances=list(lf.masks),
+                    frame_idx=lf.frame_idx,
+                    image=None,
+                )
         else:
-            instances_to_track = lf.predicted_instances
-        instances.extend(
-            tracker.track(
-                untracked_instances=instances_to_track,
-                frame_idx=lf.frame_idx,
-                image=lf.image if needs_image else None,
+            if lf.has_user_instances:
+                instances_to_track = lf.user_instances
+                if lf.has_predicted_instances:
+                    instances = list(lf.predicted_instances)
+            else:
+                instances_to_track = lf.predicted_instances
+            instances.extend(
+                tracker.track(
+                    untracked_instances=instances_to_track,
+                    frame_idx=lf.frame_idx,
+                    image=lf.image if needs_image else None,
+                )
             )
-        )
         tracked_lfs.append(
             sio.LabeledFrame(
                 video=lf.video,
                 frame_idx=lf.frame_idx,
                 instances=instances,
+                masks=masks,
             )
         )
         if progress_callback is not None:
             progress_callback(i + 1, n_frames)
 
-    if config.tracking_clean_instance_count > 0:
+    # Cull/connect cleanups are pose-only (and rejected above for mask mode).
+    if not is_mask_mode and config.tracking_clean_instance_count > 0:
         tracked_lfs = cull_instances(
             tracked_lfs,
             config.tracking_clean_instance_count,
@@ -250,7 +311,7 @@ def apply_tracking(
                 tracked_lfs, config.tracking_clean_instance_count
             )
 
-    if config.post_connect_single_breaks:
+    if not is_mask_mode and config.post_connect_single_breaks:
         tracked_lfs = connect_single_breaks(
             tracked_lfs, max_instances=config.tracking_target_instance_count
         )

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -95,8 +95,12 @@ class TrackerConfig:
     # lets ``apply_tracking`` substitute task-appropriate defaults:
     # ``euclidean_dist``/``centroids`` for a 1-node skeleton, and
     # ``mask_iou``/``masks`` for a bottom-up segmentation (mask-only) model.
+    # ``candidates_method_explicit`` lets mask mode default the candidate maker to
+    # ``local_queues`` (far better identity on over-segmented masks than the
+    # ``fixed_window`` default) unless the user explicitly chose a method.
     scoring_method_explicit: bool = True
     features_explicit: bool = True
+    candidates_method_explicit: bool = True
 
 
 def apply_tracking(
@@ -166,6 +170,8 @@ def apply_tracking(
     effective_scoring_method = config.scoring_method
     effective_features = config.features
     effective_window_size = config.window_size
+    effective_candidates_method = config.candidates_method
+    effective_max_tracks = config.max_tracks
     if len(labels.skeletons) == 1 and len(labels.skeletons[0].nodes) == 1:
         if not config.scoring_method_explicit:
             effective_scoring_method = "euclidean_dist"
@@ -227,16 +233,31 @@ def apply_tracking(
         # only (a non-default window_size is the user's explicit choice).
         if config.window_size == DEFAULT_WINDOW_SIZE:
             effective_window_size = DEFAULT_MASK_WINDOW_SIZE
+        # `fixed_window` fragments identity badly on over-segmented masks (its
+        # bounded deque forgets any track absent for >window_size frames and mints
+        # a fresh id); `local_queues` keeps `current_tracks` and re-binds across
+        # gaps. Validated on the 5-mice OFT clip (GT-identity purity: fixed_window
+        # 0.28 -> local_queues+cap 0.91). Default to local_queues unless the user
+        # explicitly chose a method; cap at the known target count when available
+        # (the cap is what lifts local_queues from ~0.52 to ~0.91).
+        if not config.candidates_method_explicit:
+            effective_candidates_method = "local_queues"
+        if effective_max_tracks is None and config.tracking_target_instance_count:
+            effective_max_tracks = config.tracking_target_instance_count
         logger.info(
             "Segmentation model detected; applying mask tracking defaults: "
-            "features='masks', scoring_method='mask_iou', window_size=%d.",
+            "features='masks', scoring_method='mask_iou', window_size=%d, "
+            "candidates_method=%r, max_tracks=%s. For best identity, pass the "
+            "known animal count via --max_tracks/--tracking_target_instance_count.",
             effective_window_size,
+            effective_candidates_method,
+            effective_max_tracks,
         )
 
     tracker = Tracker.from_config(
         window_size=effective_window_size,
         min_new_track_points=config.min_new_track_points,
-        candidates_method=config.candidates_method,
+        candidates_method=effective_candidates_method,
         min_match_points=config.min_match_points,
         features=effective_features,
         scoring_method=effective_scoring_method,
@@ -244,7 +265,7 @@ def apply_tracking(
         robust_best_instance=config.robust_best_instance,
         oks_stddev=config.oks_stddev,
         track_matching_method=config.track_matching_method,
-        max_tracks=config.max_tracks,
+        max_tracks=effective_max_tracks,
         use_flow=config.use_flow,
         of_img_scale=config.of_img_scale,
         of_window_size=config.of_window_size,

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -39,6 +39,13 @@ import sleap_io as sio
 
 logger = logging.getLogger(__name__)
 
+# Default candidate window. Mask tracking uses a larger default than the
+# pose/centroid default because bottom-up segmentation is over-segmented (a
+# momentarily over-split or missed instance must survive more frames to keep its
+# identity); the cropped mask-IoU (`MaskFeature`) makes the larger window cheap.
+DEFAULT_WINDOW_SIZE = 5
+DEFAULT_MASK_WINDOW_SIZE = 25
+
 
 @attrs.frozen(eq=False)
 class TrackerConfig:
@@ -50,7 +57,7 @@ class TrackerConfig:
     """
 
     # Tracker.from_config kwargs ────────────────────────────────────────
-    window_size: int = 5
+    window_size: int = DEFAULT_WINDOW_SIZE
     min_new_track_points: int = 0
     candidates_method: str = "fixed_window"
     min_match_points: int = 0
@@ -158,6 +165,7 @@ def apply_tracking(
     # frozen config is never mutated. Multi-node / multi-skeleton: unchanged.
     effective_scoring_method = config.scoring_method
     effective_features = config.features
+    effective_window_size = config.window_size
     if len(labels.skeletons) == 1 and len(labels.skeletons[0].nodes) == 1:
         if not config.scoring_method_explicit:
             effective_scoring_method = "euclidean_dist"
@@ -214,13 +222,19 @@ def apply_tracking(
                 "tracking_clean_instance_count / post_connect_single_breaks); "
                 "these operate on keypoint poses, not masks."
             )
+        # Bottom-up segmentation is over-segmented; a larger candidate window
+        # keeps identities across transient over-splits/misses. Bump the default
+        # only (a non-default window_size is the user's explicit choice).
+        if config.window_size == DEFAULT_WINDOW_SIZE:
+            effective_window_size = DEFAULT_MASK_WINDOW_SIZE
         logger.info(
             "Segmentation model detected; applying mask tracking defaults: "
-            "features='masks', scoring_method='mask_iou'."
+            "features='masks', scoring_method='mask_iou', window_size=%d.",
+            effective_window_size,
         )
 
     tracker = Tracker.from_config(
-        window_size=config.window_size,
+        window_size=effective_window_size,
         min_new_track_points=config.min_new_track_points,
         candidates_method=config.candidates_method,
         min_match_points=config.min_match_points,

--- a/sleap_nn/tracking/candidates/fixed_window.py
+++ b/sleap_nn/tracking/candidates/fixed_window.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, List, Deque, Union
 from sleap_nn.tracking.track_instance import TrackInstances, TrackedInstanceFeature
+from sleap_nn.tracking.utils import count_valid_points
 import sleap_io as sio
 from collections import deque
 import numpy as np
@@ -98,8 +99,9 @@ class FixedWindowCandidates:
         """Add new track IDs to the `TrackInstances` object and to the tracker queue."""
         is_new_track = False
         for i, src_instance in enumerate(current_instances.src_instances):
-            # Spawning a new track only if num visbile points is more than the threshold
-            num_visible_keypoints = (~np.isnan(src_instance.numpy()).any(axis=1)).sum()
+            # Spawn a new track only if support exceeds the threshold (non-NaN
+            # keypoints, or foreground area in px for segmentation masks).
+            num_visible_keypoints = count_valid_points(src_instance)
             if (
                 num_visible_keypoints > self.min_new_track_points
                 and current_instances.track_ids[i] is None

--- a/sleap_nn/tracking/candidates/local_queues.py
+++ b/sleap_nn/tracking/candidates/local_queues.py
@@ -7,6 +7,7 @@ from sleap_nn.tracking.track_instance import (
     TrackInstanceLocalQueue,
     TrackedInstanceFeature,
 )
+from sleap_nn.tracking.utils import count_valid_points
 from collections import defaultdict, deque
 from loguru import logger
 
@@ -103,10 +104,9 @@ class LocalQueueCandidates:
         """Add new track IDs to the `TrackInstanceLocalQueue` objects and to the tracker queue."""
         track_instances = []
         for t in current_instances:
-            # Spawning a new track only if num visbile points is more than the threshold
-            num_visible_keypoints = (
-                ~np.isnan(t.src_instance.numpy()).any(axis=1)
-            ).sum()
+            # Spawn a new track only if support exceeds the threshold (non-NaN
+            # keypoints, or foreground area in px for segmentation masks).
+            num_visible_keypoints = count_valid_points(t.src_instance)
             if num_visible_keypoints > self.min_new_track_points:
                 new_track_id = self.get_new_track_id()
                 if new_track_id is not None:

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -104,11 +104,13 @@ class Tracker:
         "cosine_sim": compute_cosine_sim,
         "euclidean_dist": compute_euclidean_distance,
     }
-    _quantile_method = functools.partial(np.quantile, q=robust_best_instance)
     _scoring_reduction_methods: Dict[str, Any] = {
         "mean": np.nanmean,
         "max": np.nanmax,
-        "robust_quantile": _quantile_method,
+        # `robust_quantile` is resolved per-instance in `get_scores` so it honors
+        # `self.robust_best_instance`; this entry only registers the valid key
+        # (a class-level functools.partial would freeze `q` at the class default).
+        "robust_quantile": np.nanmax,
     }
     _feature_methods: Dict[str, Any] = {
         "keypoints": get_keypoints,
@@ -526,6 +528,13 @@ class Tracker:
             # prediction (`kf_track_features="keypoints"`).
             scoring_method = functools.partial(compute_oks, stddev=self.oks_stddev)
         scoring_reduction = self._scoring_reduction_methods[self.scoring_reduction]
+        if self.scoring_reduction == "robust_quantile":
+            # Resolve at runtime so the per-instance `robust_best_instance` is
+            # honored (a class-level partial freezes `q` at the class default).
+            # `nanquantile` matches the NaN-handling of `nanmean`/`nanmax`.
+            scoring_reduction = functools.partial(
+                np.nanquantile, q=self.robust_best_instance
+            )
 
         # Get list of features for the `current_instances`.
         if self.is_local_queue:
@@ -546,7 +555,13 @@ class Tracker:
                     > self.min_match_points  # candidates with min support (non-NaN
                     # keypoints, or mask area px for segmentation masks)
                 ]
-                score_trackid = scoring_reduction(scores_trackid)  # scoring reduction
+                # An empty candidate list (all filtered by `min_match_points`)
+                # reduces to NaN (-> inf cost in `scores_to_cost_matrix`); guard
+                # explicitly since `np.nanmax([])` / `np.nanquantile([])` raise
+                # (only `np.nanmean([])` returns NaN).
+                score_trackid = (
+                    np.nan if not scores_trackid else scoring_reduction(scores_trackid)
+                )
                 scores[f_idx][t_idx] = score_trackid
 
         return scores

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -34,8 +34,12 @@ from sleap_nn.tracking.utils import (
     get_bbox,
     get_centroid,
     get_keypoints,
+    get_mask,
+    count_valid_points,
+    is_segmentation_mask,
     compute_euclidean_distance,
     compute_iou,
+    compute_mask_iou,
     compute_cosine_sim,
     cull_instances,
     cull_frame_instances,
@@ -53,12 +57,16 @@ class Tracker:
 
     Attributes:
         candidate: Instance of either `FixedWindowCandidates` or `LocalQueueCandidates`.
-        min_match_points: Minimum non-NaN points for match candidates. Default: 0.
+        min_match_points: Minimum support for match candidates: non-NaN keypoints,
+            or foreground area (px) for `features="masks"`. Default: 0.
         features: Feature representation for the candidates to update current detections.
-            One of [`keypoints`, `centroids`, `bboxes`, `image`]. Default: `keypoints`.
+            One of [`keypoints`, `centroids`, `bboxes`, `masks`, `image`]. `masks`
+            tracks bottom-up segmentation `PredictedSegmentationMask` objects.
+            Default: `keypoints`.
         scoring_method: Method to compute association score between features from the
             current frame and the previous tracks. One of [`oks`, `cosine_sim`, `iou`,
-            `euclidean_dist`]. Default: `oks`.
+            `mask_iou`, `euclidean_dist`]. `mask_iou` is the pixel IoU between two
+            segmentation masks (pair with `features="masks"`). Default: `oks`.
         scoring_reduction: Method to aggregate and reduce multiple scores if there are
             several detections associated with the same track. One of [`mean`, `max`,
             `robust_quantile`]. Default: `mean`.
@@ -92,6 +100,7 @@ class Tracker:
     _scoring_functions: Dict[str, Any] = {
         "oks": compute_oks,
         "iou": compute_iou,
+        "mask_iou": compute_mask_iou,
         "cosine_sim": compute_cosine_sim,
         "euclidean_dist": compute_euclidean_distance,
     }
@@ -105,6 +114,7 @@ class Tracker:
         "keypoints": get_keypoints,
         "centroids": get_centroid,
         "bboxes": get_bbox,
+        "masks": get_mask,
     }
     _track_matching_methods: Dict[str, Any] = {
         "hungarian": hungarian_matching,
@@ -150,17 +160,20 @@ class Tracker:
             window_size: Number of frames to look for in the candidate instances to match
                 with the current detections. Default: 5.
             min_new_track_points: We won't spawn a new track for an instance with
-                fewer than this many non-nan points. Default: 0.
+                fewer than this many non-nan points (for `features="masks"`, this
+                is read as a foreground-area floor in px). Default: 0.
             candidates_method: Either of `fixed_window` or `local_queues`. In fixed window
                 method, candidates from the last `window_size` frames. In local queues,
                 last `window_size` instances for each track ID is considered for matching
                 against the current detection. Default: `fixed_window`.
-            min_match_points: Minimum non-NaN points for match candidates. Default: 0.
+            min_match_points: Minimum support for match candidates: non-NaN
+                keypoints, or foreground area (px) for `features="masks"`. Default: 0.
             features: Feature representation for the candidates to update current detections.
-                One of [`keypoints`, `centroids`, `bboxes`, `image`]. Default: `keypoints`.
+                One of [`keypoints`, `centroids`, `bboxes`, `masks`, `image`].
+                Default: `keypoints`.
             scoring_method: Method to compute association score between features from the
                 current frame and the previous tracks. One of [`oks`, `cosine_sim`, `iou`,
-                `euclidean_dist`]. Default: `oks`.
+                `mask_iou`, `euclidean_dist`]. Default: `oks`.
             scoring_reduction: Method to aggregate and reduce multiple scores if there are
                 several detections associated with the same track. One of [`mean`, `max`,
                 `robust_quantile`]. Default: `mean`.
@@ -348,8 +361,15 @@ class Tracker:
         Returns:
             List of `sio.PredictedInstance` objects, each having an assigned track.
         """
+        # Pre-cull is pose-only (cull_frame_instances uses same_pose_as / bbox);
+        # segmentation masks are scoped out of cull for the MVP (apply_tracking
+        # rejects the pre-cull flags in mask mode, so this is belt-and-braces).
+        masks_input = bool(untracked_instances) and is_segmentation_mask(
+            untracked_instances[0]
+        )
         if (
-            self.tracking_target_instance_count is not None
+            not masks_input
+            and self.tracking_target_instance_count is not None
             and self.tracking_target_instance_count
             and self.tracking_pre_cull_to_target
         ):
@@ -431,7 +451,7 @@ class Tracker:
             assigned for the untracked instances and track_id set as `None`.
         """
         if self.features not in self._feature_methods:
-            message = "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes` and `image`"
+            message = "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes`, `masks` and `image`"
             logger.error(message)
             raise ValueError(message)
 
@@ -490,7 +510,7 @@ class Tracker:
             scores: Score matrix of shape (num_new_instances, num_existing_tracks)
         """
         if self.scoring_method not in self._scoring_functions:
-            message = "Invalid `scoring_method` argument. Please provide one of `oks`, `cosine_sim`, `iou`, and `euclidean_dist`."
+            message = "Invalid `scoring_method` argument. Please provide one of `oks`, `cosine_sim`, `iou`, `mask_iou`, and `euclidean_dist`."
             logger.error(message)
             raise ValueError(message)
 
@@ -522,8 +542,9 @@ class Tracker:
                 scores_trackid = [
                     scoring_method(f, x.feature)
                     for x in candidates_feature_dict[track_id]
-                    if (~np.isnan(x.src_predicted_instance.numpy()).any(axis=1)).sum()
-                    > self.min_match_points  # only if the candidates have min non-nan points
+                    if count_valid_points(x.src_predicted_instance)
+                    > self.min_match_points  # candidates with min support (non-NaN
+                    # keypoints, or mask area px for segmentation masks)
                 ]
                 score_trackid = scoring_reduction(scores_trackid)  # scoring reduction
                 scores[f_idx][t_idx] = score_trackid
@@ -771,7 +792,7 @@ class FlowShiftTracker(Tracker):
         """
         # get feature method for the shifted instances
         if self.features not in self._feature_methods:
-            message = "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes` and `image`"
+            message = "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes`, `masks` and `image`"
             logger.error(message)
             raise ValueError(message)
         feature_method = self._feature_methods[self.features]
@@ -945,7 +966,7 @@ class KalmanShiftTracker(Tracker):
             `TrackedInstanceFeature`.
         """
         if self.features not in self._feature_methods:
-            message = "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes` and `image`"
+            message = "Invalid `features` argument. Please provide one of `keypoints`, `centroids`, `bboxes`, `masks` and `image`"
             logger.error(message)
             raise ValueError(message)
         feature_method = self._feature_methods[self.features]

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -557,8 +557,8 @@ class Tracker:
                 ]
                 # An empty candidate list (all filtered by `min_match_points`)
                 # reduces to NaN (-> inf cost in `scores_to_cost_matrix`); guard
-                # explicitly since `np.nanmax([])` / `np.nanquantile([])` raise
-                # (only `np.nanmean([])` returns NaN).
+                # explicitly because `np.nanmax([])` raises (`np.nanmean([])` /
+                # `np.nanquantile([])` return NaN, but `max` must not crash).
                 score_trackid = (
                     np.nan if not scores_trackid else scoring_reduction(scores_trackid)
                 )

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -130,19 +130,32 @@ def get_mask(
     """Return a compact :class:`MaskFeature` for a `PredictedSegmentationMask`.
 
     Mirrors :func:`get_keypoints`/:func:`get_bbox` as the ``"masks"`` feature
-    extractor. The RLE is decoded to a dense mask once, then cropped to its
-    foreground bbox (using the mask's own ``.bbox`` when available, avoiding a
-    scan); the crop is cached as the candidate feature so scoring re-uses it
-    without re-decoding and only touches the foreground region.
+    extractor. The mask is decoded onto the **image-pixel grid** first, then
+    cropped to its foreground bbox (using the mask's own ``.bbox`` when available,
+    avoiding a scan); the crop is cached as the candidate feature so scoring
+    re-uses it without re-decoding and only touches the foreground region.
+
+    The image-grid decode is essential: sio ``.data`` decodes at the mask's
+    *stored* resolution, which for the default inference path
+    (``full_res_masks=False``, masks encoded at output-stride, ``scale~=0.5``) is
+    NOT the image grid, while ``.bbox`` is always in IMAGE space. Cropping the
+    stride-res ``.data`` with image-space bbox indices would slice the wrong
+    region (often entirely out of bounds -> empty -> ``compute_mask_iou`` 1.0 for
+    every pair, scrambling identity). :func:`decode_mask_to_image_res` is a
+    zero-copy passthrough for ``scale==1`` masks (legacy full-res), so that path
+    is unchanged.
     """
     if isinstance(pred_mask, MaskFeature):
         return pred_mask
     if isinstance(pred_mask, np.ndarray):
         return _mask_feature_from_dense(pred_mask)
-    data = np.asarray(pred_mask.data, dtype=bool)
+    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+    data = decode_mask_to_image_res(pred_mask)
     bbox = getattr(pred_mask, "bbox", None)
     if bbox is not None:
-        # PredictedSegmentationMask.bbox is (x, y, width, height) (XYWH).
+        # PredictedSegmentationMask.bbox is (x, y, width, height) (XYWH), in IMAGE
+        # space -- consistent with the image-grid `data` decoded above.
         x, y, w, h = (int(round(float(v))) for v in bbox)
         height, width = data.shape
         y0, x0 = max(0, y), max(0, x)

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -76,6 +76,43 @@ def get_bbox(pred_instance: Union[sio.PredictedInstance, np.ndarray]):
     return bbox
 
 
+def is_segmentation_mask(obj) -> bool:
+    """True if ``obj`` is a segmentation mask rather than a keypoint instance.
+
+    Mask tracking flows ``sio.PredictedSegmentationMask`` objects through the
+    same code paths as ``sio.PredictedInstance``; this is the single predicate
+    used to dispatch the pose-vs-mask differences (no ``.numpy()`` keypoints).
+    """
+    return isinstance(obj, (sio.PredictedSegmentationMask, sio.SegmentationMask))
+
+
+def get_mask(pred_mask: Union[sio.PredictedSegmentationMask, np.ndarray]) -> np.ndarray:
+    """Return the boolean mask array for a `PredictedSegmentationMask`.
+
+    Mirrors :func:`get_keypoints`/:func:`get_bbox` as the ``"masks"`` feature
+    extractor. Decodes the RLE to a dense ``HxW`` bool array once (the result is
+    cached as the candidate feature, so scoring does not re-decode).
+    """
+    if isinstance(pred_mask, np.ndarray):
+        return pred_mask
+    return np.asarray(pred_mask.data, dtype=bool)
+
+
+def count_valid_points(obj) -> int:
+    """Number of valid points used to gate track spawning/matching.
+
+    For a keypoint instance this is the count of non-NaN nodes; for a
+    segmentation mask there are no keypoints, so the mask area (foreground px)
+    is the analogous "support" measure (``min_new_track_points`` /
+    ``min_match_points`` then read as a pixel-area threshold; default 0 keeps
+    every non-empty mask and drops empty ones).
+    """
+    if is_segmentation_mask(obj):
+        return int(obj.area)
+    points = obj if isinstance(obj, np.ndarray) else obj.numpy()
+    return int((~np.isnan(points).any(axis=1)).sum())
+
+
 def compute_euclidean_distance(a, b):
     """Return the negative euclidean distance between a and b points."""
     return -np.linalg.norm(a - b)
@@ -99,6 +136,22 @@ def compute_iou(a, b):
 
     iou = intersection_area / union_area
     return iou
+
+
+def compute_mask_iou(a: np.ndarray, b: np.ndarray) -> float:
+    """Return the IoU of two boolean segmentation masks (higher = more similar).
+
+    Pixel mask-IoU (reuses :func:`sleap_nn.evaluation._mask_iou`: top-left
+    aligned, shape-mismatch safe, empty/empty -> 1.0). This is the ``"mask_iou"``
+    scoring method — a similarity, like ``oks``/``iou``; the cost negation
+    (``cost = -score``) happens in :meth:`Tracker.scores_to_cost_matrix`, so it
+    must NOT be negated here. Pixel IoU (not bbox-IoU on ``mask.bbox``) sidesteps
+    the XYWH-vs-XYXY bbox-format issue and is the literal mask-IoU the tracker
+    needs.
+    """
+    from sleap_nn.evaluation import _mask_iou
+
+    return _mask_iou(np.asarray(a, dtype=bool), np.asarray(b, dtype=bool))
 
 
 def compute_cosine_sim(a, b):

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -86,16 +86,71 @@ def is_segmentation_mask(obj) -> bool:
     return isinstance(obj, (sio.PredictedSegmentationMask, sio.SegmentationMask))
 
 
-def get_mask(pred_mask: Union[sio.PredictedSegmentationMask, np.ndarray]) -> np.ndarray:
-    """Return the boolean mask array for a `PredictedSegmentationMask`.
+class MaskFeature:
+    """Compact mask feature for fast IoU: a tight bbox crop + absolute offset.
+
+    A full-resolution segmentation mask (e.g. 1280x1024) is almost all
+    background, so the per-pair mask-IoU only needs the foreground bbox: store
+    the cropped boolean array (``crop``), its absolute top-left ``(y0, x0)`` in
+    the original image frame, and the foreground ``area`` (px, precomputed). IoU
+    between two features then AND-s only the *overlap* of their bboxes (usually
+    tiny or empty) and reads ``area`` in O(1) — vs. allocating + AND/OR-ing a
+    full-resolution canvas per pair. Coordinates are absolute, so this matches
+    the full-canvas :func:`sleap_nn.evaluation._mask_iou` exactly.
+    """
+
+    __slots__ = ("crop", "y0", "x0", "area")
+
+    def __init__(self, crop: np.ndarray, y0: int, x0: int, area: int):
+        """Store the bbox crop, its absolute top-left ``(y0, x0)`` and area."""
+        self.crop = crop
+        self.y0 = int(y0)
+        self.x0 = int(x0)
+        self.area = int(area)
+
+
+def _mask_feature_from_dense(data: np.ndarray) -> MaskFeature:
+    """Build a :class:`MaskFeature` from a dense bool mask (scans for the bbox)."""
+    data = np.ascontiguousarray(data, dtype=bool)
+    rows = np.any(data, axis=1)
+    if not rows.any():
+        return MaskFeature(np.zeros((0, 0), dtype=bool), 0, 0, 0)
+    cols = np.any(data, axis=0)
+    y0 = int(np.argmax(rows))
+    y1 = len(rows) - int(np.argmax(rows[::-1]))
+    x0 = int(np.argmax(cols))
+    x1 = len(cols) - int(np.argmax(cols[::-1]))
+    crop = data[y0:y1, x0:x1]
+    return MaskFeature(crop, y0, x0, int(np.count_nonzero(crop)))
+
+
+def get_mask(
+    pred_mask: Union["sio.PredictedSegmentationMask", np.ndarray, MaskFeature],
+) -> MaskFeature:
+    """Return a compact :class:`MaskFeature` for a `PredictedSegmentationMask`.
 
     Mirrors :func:`get_keypoints`/:func:`get_bbox` as the ``"masks"`` feature
-    extractor. Decodes the RLE to a dense ``HxW`` bool array once (the result is
-    cached as the candidate feature, so scoring does not re-decode).
+    extractor. The RLE is decoded to a dense mask once, then cropped to its
+    foreground bbox (using the mask's own ``.bbox`` when available, avoiding a
+    scan); the crop is cached as the candidate feature so scoring re-uses it
+    without re-decoding and only touches the foreground region.
     """
-    if isinstance(pred_mask, np.ndarray):
+    if isinstance(pred_mask, MaskFeature):
         return pred_mask
-    return np.asarray(pred_mask.data, dtype=bool)
+    if isinstance(pred_mask, np.ndarray):
+        return _mask_feature_from_dense(pred_mask)
+    data = np.asarray(pred_mask.data, dtype=bool)
+    bbox = getattr(pred_mask, "bbox", None)
+    if bbox is not None:
+        # PredictedSegmentationMask.bbox is (x, y, width, height) (XYWH).
+        x, y, w, h = (int(round(float(v))) for v in bbox)
+        height, width = data.shape
+        y0, x0 = max(0, y), max(0, x)
+        y1, x1 = min(height, y + h), min(width, x + w)
+        if y1 > y0 and x1 > x0:
+            crop = data[y0:y1, x0:x1]
+            return MaskFeature(crop, y0, x0, int(np.count_nonzero(crop)))
+    return _mask_feature_from_dense(data)
 
 
 def count_valid_points(obj) -> int:
@@ -138,20 +193,42 @@ def compute_iou(a, b):
     return iou
 
 
-def compute_mask_iou(a: np.ndarray, b: np.ndarray) -> float:
-    """Return the IoU of two boolean segmentation masks (higher = more similar).
+def compute_mask_iou(a, b) -> float:
+    """Return the IoU of two segmentation masks (higher = more similar).
 
-    Pixel mask-IoU (reuses :func:`sleap_nn.evaluation._mask_iou`: top-left
-    aligned, shape-mismatch safe, empty/empty -> 1.0). This is the ``"mask_iou"``
-    scoring method — a similarity, like ``oks``/``iou``; the cost negation
+    The ``"mask_iou"`` scoring method. Operates on :class:`MaskFeature` (the
+    ``"masks"`` feature); raw dense bool arrays are accepted too (coerced via
+    :func:`get_mask`). The intersection is computed only over the *overlap* of
+    the two foreground bboxes — see :class:`MaskFeature` — which is numerically
+    identical to the full-canvas :func:`sleap_nn.evaluation._mask_iou` (top-left
+    aligned, shape-mismatch safe, empty/empty -> 1.0) but avoids touching the
+    background. This is a similarity, like ``oks``/``iou``; the cost negation
     (``cost = -score``) happens in :meth:`Tracker.scores_to_cost_matrix`, so it
     must NOT be negated here. Pixel IoU (not bbox-IoU on ``mask.bbox``) sidesteps
-    the XYWH-vs-XYXY bbox-format issue and is the literal mask-IoU the tracker
-    needs.
+    the XYWH-vs-XYXY bbox-format issue.
     """
-    from sleap_nn.evaluation import _mask_iou
+    fa = a if isinstance(a, MaskFeature) else get_mask(a)
+    fb = b if isinstance(b, MaskFeature) else get_mask(b)
+    inter = _mask_feature_intersection(fa, fb)
+    union = fa.area + fb.area - inter
+    # union == 0 only when both masks are empty -> identical -> 1.0 (matches the
+    # _mask_iou degenerate contract).
+    return 1.0 if union == 0 else float(inter / union)
 
-    return _mask_iou(np.asarray(a, dtype=bool), np.asarray(b, dtype=bool))
+
+def _mask_feature_intersection(fa: MaskFeature, fb: MaskFeature) -> int:
+    """Foreground-overlap pixel count between two :class:`MaskFeature` (px)."""
+    if fa.area == 0 or fb.area == 0:
+        return 0
+    ay1, ax1 = fa.y0 + fa.crop.shape[0], fa.x0 + fa.crop.shape[1]
+    by1, bx1 = fb.y0 + fb.crop.shape[0], fb.x0 + fb.crop.shape[1]
+    oy0, oy1 = max(fa.y0, fb.y0), min(ay1, by1)
+    ox0, ox1 = max(fa.x0, fb.x0), min(ax1, bx1)
+    if oy1 <= oy0 or ox1 <= ox0:
+        return 0  # bboxes disjoint -> no intersection (no array op)
+    a_sub = fa.crop[oy0 - fa.y0 : oy1 - fa.y0, ox0 - fa.x0 : ox1 - fa.x0]
+    b_sub = fb.crop[oy0 - fb.y0 : oy1 - fb.y0, ox0 - fb.x0 : ox1 - fb.x0]
+    return int(np.count_nonzero(a_sub & b_sub))
 
 
 def compute_cosine_sim(a, b):

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -133,7 +133,7 @@ def get_mask(
     extractor. The mask is decoded onto the **image-pixel grid** first, then
     cropped to its foreground bbox (using the mask's own ``.bbox`` when available,
     avoiding a scan); the crop is cached as the candidate feature so scoring
-    re-uses it without re-decoding and only touches the foreground region.
+    reuses it without re-decoding and only touches the foreground region.
 
     The image-grid decode is essential: sio ``.data`` decodes at the mask's
     *stored* resolution, which for the default inference path

--- a/tests/inference/test_segmentation_inference.py
+++ b/tests/inference/test_segmentation_inference.py
@@ -341,27 +341,45 @@ def test_incremental_writer_finalizes_mask_only_no_skeleton(tmp_path):
     assert isinstance(labels.masks[0], sio.PredictedSegmentationMask)
 
 
-def test_predict_rejects_tracking_for_segmentation():
-    """``predict()`` fails fast when tracking is requested for a seg model.
+def test_segmentation_masks_are_tracked_not_dropped():
+    """Tracking a mask-only seg output assigns track ids and preserves masks.
 
-    Without the guard the tracker (which reads only ``LabeledFrame.instances``)
-    runs over the empty instance lists of mask-only frames and rebuilds them
-    without ``masks=``, silently dropping every mask. Mirrors the existing
-    ``emit_centroid`` guard.
+    Replaces the #614 fail-fast guard (``predict --tracking`` on a seg model
+    used to raise): ``apply_tracking`` now auto-detects mask-only labels and
+    tracks them by mask-IoU (#619), keeping every mask. Exercises the
+    ``apply_tracking`` seam directly (predict() wires it at predictor.py).
     """
-    import pytest
+    from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
 
-    from sleap_nn.inference.predictor import Predictor
+    video = sio.Video.from_filename("dummy.mp4")
 
-    pred = Predictor.__new__(Predictor)
-    pred.layer = SegmentationLayer.__new__(SegmentationLayer)
-    pred.tracker_config = object()  # any non-None config triggers the guard
-    pred.emit_centroid = "instance"  # so the centroid guard passes first
+    def _frame(idx, centers):
+        masks = [
+            sio.PredictedSegmentationMask.from_numpy(
+                _disk(80, 80, cy, cx, 10), score=0.9
+            )
+            for cy, cx in centers
+        ]
+        return sio.LabeledFrame(video=video, frame_idx=idx, masks=masks)
 
-    with pytest.raises(
-        ValueError, match="not yet supported for bottom-up segmentation"
-    ):
-        pred.predict("dummy.mp4", make_labels=True)
+    labels = sio.Labels(
+        videos=[video],
+        labeled_frames=[
+            _frame(0, [(20, 20), (60, 60)]),
+            _frame(1, [(22, 22), (62, 62)]),
+        ],
+    )
+    # features/scoring left implicit so the segmentation auto-default fires.
+    out = apply_tracking(
+        labels,
+        TrackerConfig(
+            window_size=5, features_explicit=False, scoring_method_explicit=False
+        ),
+    )
+    # Masks preserved (not dropped) and every mask carries a track id.
+    assert all(len(lf.masks) == 2 for lf in out.labeled_frames)
+    masks = [m for lf in out.labeled_frames for m in lf.masks]
+    assert all(m.track is not None for m in masks)
 
 
 def test_segmentation_layer_min_mask_area_drops_tiny_masks():

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -425,6 +425,18 @@ def test_build_tracker_config_explicit_sentinels():
     assert cfg2.features == "bboxes"
     assert cfg2.scoring_method == "iou"
 
+    # candidates_method: unset (None) → not explicit; set → explicit.
+    assert (
+        _build_tracker_config({"candidates_method": None}).candidates_method_explicit
+        is False
+    )
+    assert (
+        _build_tracker_config(
+            {"candidates_method": "local_queues"}
+        ).candidates_method_explicit
+        is True
+    )
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Mask-IoU tracking for bottom-up segmentation (#619)
@@ -523,6 +535,61 @@ def test_apply_tracking_masks_bumps_default_window(video, monkeypatch):
     # An explicit non-default window is respected (the user's choice).
     apply_tracking(labels, _mask_cfg(window_size=8))
     assert captured["window_size"] == 8
+
+
+def test_apply_tracking_masks_defaults_local_queues(video, monkeypatch):
+    """Mask mode defaults candidates_method to local_queues when not explicit."""
+    captured = _capture_from_config_kwargs(monkeypatch)
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])
+    apply_tracking(labels, _mask_cfg(window_size=5, candidates_method_explicit=False))
+    assert captured["candidates_method"] == "local_queues"
+
+
+def test_apply_tracking_masks_explicit_candidates_method_respected(video, monkeypatch):
+    """An explicit candidates_method is honored in mask mode (no override)."""
+    captured = _capture_from_config_kwargs(monkeypatch)
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])
+    apply_tracking(
+        labels,
+        _mask_cfg(
+            window_size=5,
+            candidates_method="fixed_window",
+            candidates_method_explicit=True,
+        ),
+    )
+    assert captured["candidates_method"] == "fixed_window"
+
+
+def test_apply_tracking_masks_derives_max_tracks_from_target(video, monkeypatch):
+    """Mask mode caps tracks at the known target count when max_tracks is unset.
+
+    The cap is what lifts local_queues identity from ~0.52 to ~0.91 on the real
+    over-segmented clip; deriving it from the target count makes
+    --tracking_target_instance_count N enough.
+    """
+    captured = _capture_from_config_kwargs(monkeypatch)
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])
+    apply_tracking(
+        labels,
+        _mask_cfg(
+            window_size=5,
+            candidates_method_explicit=False,
+            tracking_target_instance_count=3,
+        ),
+    )
+    assert captured["max_tracks"] == 3
+    # An explicit max_tracks wins over the derived one.
+    captured.clear()
+    apply_tracking(
+        labels,
+        _mask_cfg(
+            window_size=5,
+            candidates_method_explicit=False,
+            max_tracks=2,
+            tracking_target_instance_count=3,
+        ),
+    )
+    assert captured["max_tracks"] == 2
 
 
 def test_apply_tracking_masks_explicit_masks_respected(video):

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -501,6 +501,30 @@ def test_apply_tracking_masks_auto_default(video, caplog):
     assert tracked and all(m.track is not None for m in tracked)
 
 
+def test_apply_tracking_masks_bumps_default_window(video, monkeypatch):
+    """Mask mode raises the default window_size; an explicit value is kept."""
+    import sleap_nn.inference.tracking as trk
+    import sleap_nn.tracking.tracker as trk_mod
+
+    captured = {}
+    real_from_config = trk_mod.Tracker.from_config
+
+    def _spy(*args, **kwargs):
+        captured["window_size"] = kwargs.get("window_size")
+        return real_from_config(*args, **kwargs)
+
+    monkeypatch.setattr(trk_mod.Tracker, "from_config", staticmethod(_spy))
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])
+
+    # Default window (DEFAULT_WINDOW_SIZE) -> bumped to DEFAULT_MASK_WINDOW_SIZE.
+    apply_tracking(labels, _mask_cfg(window_size=trk.DEFAULT_WINDOW_SIZE))
+    assert captured["window_size"] == trk.DEFAULT_MASK_WINDOW_SIZE
+
+    # An explicit non-default window is respected (the user's choice).
+    apply_tracking(labels, _mask_cfg(window_size=8))
+    assert captured["window_size"] == 8
+
+
 def test_apply_tracking_masks_explicit_masks_respected(video):
     """Explicit features='masks'+scoring='mask_iou' is honored (no override/raise)."""
     labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -471,6 +471,88 @@ def _mask_cfg(**kw):
     return TrackerConfig(**kw)
 
 
+def _make_stride_mask_labels(video, frames_pts, h=80, w=80, score=0.9, stride=2):
+    """Like ``_make_mask_labels`` but masks are stored at output-stride resolution
+    (``scale=1/stride``), as the default inference path (``full_res_masks=False``)
+    emits. Disk centers/radius are in IMAGE pixels."""
+    yy, xx = np.ogrid[:h, :w]
+    lfs = []
+    for i, pts in enumerate(frames_pts):
+        masks = []
+        for cy, cx in pts:
+            full = ((yy - cy) ** 2 + (xx - cx) ** 2) <= 10**2
+            small = full[::stride, ::stride]
+            s = 1.0 / stride
+            masks.append(
+                sio.PredictedSegmentationMask.from_numpy(
+                    small, scale=(s, s), score=score
+                )
+            )
+        lfs.append(sio.LabeledFrame(video=video, frame_idx=i, masks=masks))
+    return sio.Labels(videos=[video], labeled_frames=lfs)
+
+
+def test_apply_tracking_stride_masks_keep_identity(video):
+    """Output-stride masks (scale!=1, the default path) must track by image-grid IoU.
+
+    Regression (finalize-review blocker): `get_mask` used to crop stride-res
+    `.data` with image-space bbox indices -> empty features -> IoU 1.0 for every
+    pair -> arbitrary identity. A drifting two-lane scene must yield two stable
+    tracks, exactly as the scale-1 case does.
+    """
+    frames = [[(20 + i, 20 + i), (60 + i, 60 + i)] for i in range(6)]
+    labels = _make_stride_mask_labels(video, frames)
+    # sanity: masks really are stride-stored
+    assert tuple(labels.labeled_frames[0].masks[0].scale) != (1.0, 1.0)
+    out = apply_tracking(labels, _mask_cfg(window_size=5))
+    assert all(len(lf.masks) == 2 for lf in out.labeled_frames)
+    lanes = {}
+    for lf in out.labeled_frames:
+        for m in lf.masks:
+            assert m.track is not None
+            lane = "A" if m.bbox[0] < 40 else "B"
+            lanes.setdefault(lane, set()).add(m.track.name)
+    assert all(len(names) == 1 for names in lanes.values())  # each lane = 1 track
+    assert lanes["A"] != lanes["B"]  # and they are distinct
+    # Decisive bug tell: with the old stride bug every feature decoded to area 0,
+    # so every score was the degenerate empty-vs-empty IoU 1.0. The fix yields
+    # real partial overlap for the drifting disks, so later-frame matches score
+    # strictly below 1.0.
+    later_scores = [m.tracking_score for lf in out.labeled_frames[1:] for m in lf.masks]
+    assert later_scores and all(0.0 < s for s in later_scores)
+    assert any(s < 0.999 for s in later_scores)
+
+
+def test_apply_tracking_masks_derived_cap_e2e(video):
+    """End-to-end: the mask-mode derived `max_tracks` cap actually caps tracks.
+
+    Three non-overlapping lanes (an over-split stand-in). With a target count of 2
+    (candidates_method left unset -> local_queues), exactly 2 tracks survive;
+    uncapped, all 3 spawn. Exercises the REAL tracker, not a NoopTracker.
+    """
+    frames = [[(15, 15), (40, 40), (65, 65)] for _ in range(5)]
+    labels = _make_mask_labels(video, frames)
+
+    capped = apply_tracking(
+        labels,
+        _mask_cfg(candidates_method_explicit=False, tracking_target_instance_count=2),
+    )
+    n_capped = len(
+        {m.track.name for lf in capped.labeled_frames for m in lf.masks if m.track}
+    )
+    assert n_capped == 2
+
+    # reset tracks (apply_tracking mutates the shared mask objects' .track)
+    for lf in labels.labeled_frames:
+        for m in lf.masks:
+            m.track = None
+    uncapped = apply_tracking(labels, _mask_cfg(candidates_method_explicit=False))
+    n_uncapped = len(
+        {m.track.name for lf in uncapped.labeled_frames for m in lf.masks if m.track}
+    )
+    assert n_uncapped == 3
+
+
 def test_apply_tracking_masks_preserved_and_stable(video):
     """Mask tracking preserves every mask and gives a moving pair stable ids."""
     # Two animals drifting; each frame's masks overlap only their predecessor.

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -424,3 +424,139 @@ def test_build_tracker_config_explicit_sentinels():
     assert cfg2.scoring_method_explicit is True
     assert cfg2.features == "bboxes"
     assert cfg2.scoring_method == "iou"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Mask-IoU tracking for bottom-up segmentation (#619)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+def _make_mask_labels(video, frames_pts, h=80, w=80, score=0.9):
+    """Mask-only labels: ``frames_pts`` is a list (per frame) of (cy, cx) disk
+    centers; each becomes a PredictedSegmentationMask. No skeleton, no
+    predicted keypoint instances (a bottom-up segmentation output)."""
+    lfs = []
+    for i, pts in enumerate(frames_pts):
+        masks = [
+            sio.PredictedSegmentationMask.from_numpy(
+                _disk(h, w, cy, cx, 10), score=score
+            )
+            for cy, cx in pts
+        ]
+        lfs.append(sio.LabeledFrame(video=video, frame_idx=i, masks=masks))
+    return sio.Labels(videos=[video], labeled_frames=lfs)
+
+
+def _mask_cfg(**kw):
+    """TrackerConfig with features/scoring left implicit so seg auto-default fires."""
+    kw.setdefault("features_explicit", False)
+    kw.setdefault("scoring_method_explicit", False)
+    return TrackerConfig(**kw)
+
+
+def test_apply_tracking_masks_preserved_and_stable(video):
+    """Mask tracking preserves every mask and gives a moving pair stable ids."""
+    # Two animals drifting; each frame's masks overlap only their predecessor.
+    frames = [[(20 + i, 20 + i), (60 + i, 60 + i)] for i in range(6)]
+    labels = _make_mask_labels(video, frames)
+    out = apply_tracking(labels, _mask_cfg(window_size=5))
+
+    assert len(out.labeled_frames) == 6
+    # No masks dropped; instances stay empty (mask-only model).
+    assert all(len(lf.masks) == 2 for lf in out.labeled_frames)
+    assert all(len(lf.instances) == 0 for lf in out.labeled_frames)
+    # Every tracked mask carries a track + finite tracking_score.
+    all_masks = [m for lf in out.labeled_frames for m in lf.masks]
+    assert all(m.track is not None for m in all_masks)
+    assert all(m.tracking_score is not None for m in all_masks)
+    # Exactly two stable tracks, one per spatial lane across all frames.
+    lanes = {}
+    for lf in out.labeled_frames:
+        for m in lf.masks:
+            lane = "A" if m.bbox[0] < 40 else "B"
+            lanes.setdefault(lane, set()).add(m.track.name)
+    assert all(len(names) == 1 for names in lanes.values())
+    assert lanes["A"] != lanes["B"]
+
+
+def test_apply_tracking_masks_disjoint_extra_new_track(video):
+    """An extra non-overlapping mask spawns a new track id."""
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22), (60, 60)]])
+    out = apply_tracking(labels, _mask_cfg(window_size=5))
+    f1 = sorted(out.labeled_frames, key=lambda lf: lf.frame_idx)[1]
+    by_lane = {("near" if m.bbox[0] < 40 else "far"): m.track.name for m in f1.masks}
+    assert by_lane["near"] != by_lane["far"]
+
+
+def test_apply_tracking_masks_auto_default(video, caplog):
+    """Mask-only labels auto-resolve features='masks'/scoring='mask_iou'."""
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])
+    out = apply_tracking(labels, _mask_cfg(window_size=5))
+    tracked = [m for lf in out.labeled_frames for m in lf.masks]
+    assert tracked and all(m.track is not None for m in tracked)
+
+
+def test_apply_tracking_masks_explicit_masks_respected(video):
+    """Explicit features='masks'+scoring='mask_iou' is honored (no override/raise)."""
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])
+    cfg = TrackerConfig(
+        window_size=5, features="masks", scoring_method="mask_iou"
+    )  # explicit (both *_explicit default True)
+    out = apply_tracking(labels, cfg)
+    assert all(m.track is not None for lf in out.labeled_frames for m in lf.masks)
+
+
+def test_apply_tracking_masks_explicit_incompatible_raises(video):
+    """A seg model with explicit non-mask features fails fast (no silent drop)."""
+    labels = _make_mask_labels(video, [[(20, 20)]])
+    cfg = TrackerConfig(features="keypoints", scoring_method="oks")  # explicit
+    with pytest.raises(ValueError, match="features='masks'"):
+        apply_tracking(labels, cfg)
+
+
+@pytest.mark.parametrize(
+    "kw, match",
+    [
+        ({"use_flow": True}, "motion models"),
+        ({"use_kalman": True, "tracking_target_instance_count": 2}, "motion models"),
+        ({"tracking_clean_instance_count": 2}, "cull/clean"),
+        (
+            {"tracking_pre_cull_to_target": 1, "tracking_target_instance_count": 2},
+            "cull/clean",
+        ),
+    ],
+)
+def test_apply_tracking_masks_forbidden_combos_raise(video, kw, match):
+    """Motion models and pose-shaped cull/clean ops are rejected in mask mode."""
+    labels = _make_mask_labels(video, [[(20, 20)], [(22, 22)]])
+    with pytest.raises(ValueError, match=match):
+        apply_tracking(labels, _mask_cfg(window_size=5, **kw))
+
+
+def test_apply_tracking_masks_empty_frame_passthrough(video):
+    """A mask-less frame mid-sequence passes through (masks=[]) without crashing."""
+    labels = _make_mask_labels(video, [[(20, 20)], [], [(24, 24)]])
+    out = apply_tracking(labels, _mask_cfg(window_size=5))
+    by_idx = {lf.frame_idx: lf for lf in out.labeled_frames}
+    assert len(by_idx[1].masks) == 0
+    assert len(by_idx[0].masks) == 1 and len(by_idx[2].masks) == 1
+
+
+def test_apply_tracking_masks_roundtrip_persistence(video, tmp_path):
+    """Tracked mask track names + tracking scores survive save/load_slp."""
+    labels = _make_mask_labels(video, [[(20, 20), (60, 60)], [(22, 22), (62, 62)]])
+    out = apply_tracking(labels, _mask_cfg(window_size=5))
+    path = tmp_path / "tracked_masks.slp"
+    out.save(path.as_posix())
+    reloaded = sio.load_slp(path.as_posix())
+    masks = [m for lf in reloaded.labeled_frames for m in lf.masks]
+    assert len(masks) == 4
+    assert all(m.track is not None for m in masks)
+    assert all(
+        m.tracking_score is not None and np.isfinite(m.tracking_score) for m in masks
+    )

--- a/tests/tracking/test_mask_tracking.py
+++ b/tests/tracking/test_mask_tracking.py
@@ -1,0 +1,142 @@
+"""Tests for mask-IoU tracking of bottom-up segmentation masks (#619).
+
+Covers the tracking helpers added for ``sio.PredictedSegmentationMask`` —
+``get_mask`` / ``compute_mask_iou`` / ``count_valid_points`` /
+``is_segmentation_mask`` in ``sleap_nn.tracking.utils`` — and end-to-end track
+assignment via ``Tracker`` with ``features="masks"``/``scoring_method="mask_iou"``
+on both candidate makers. ``apply_tracking`` integration (auto-defaults, mask
+preservation, forbidden combos) lives in ``tests/inference/test_tracking.py``.
+"""
+
+import numpy as np
+import pytest
+
+import sleap_io as sio
+
+from sleap_nn.tracking.tracker import Tracker
+from sleap_nn.tracking.utils import (
+    compute_mask_iou,
+    count_valid_points,
+    get_mask,
+    is_segmentation_mask,
+)
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+def _mask(cy, cx, r=10, h=80, w=80, score=0.9):
+    return sio.PredictedSegmentationMask.from_numpy(_disk(h, w, cy, cx, r), score=score)
+
+
+# ---------------------------------------------------------------------------
+# Helper units
+# ---------------------------------------------------------------------------
+
+
+def test_compute_mask_iou_identical_disjoint_partial():
+    """mask-IoU: 1.0 identical, 0.0 disjoint, exact for partial overlap."""
+    a = np.zeros((10, 10), dtype=bool)
+    a[2:6, 2:6] = True  # 16 px
+    assert compute_mask_iou(a, a) == 1.0
+
+    b = np.zeros((10, 10), dtype=bool)
+    b[6:9, 6:9] = True  # disjoint
+    assert compute_mask_iou(a, b) == 0.0
+
+    c = np.zeros((10, 10), dtype=bool)
+    c[4:8, 2:6] = True  # overlaps a in 2 of 4 rows -> inter 8, union 24
+    assert abs(compute_mask_iou(a, c) - (8 / 24)) < 1e-9
+
+
+def test_compute_mask_iou_shape_mismatch_and_empty():
+    """Shape mismatch is top-left aligned; two empty masks -> 1.0 (degenerate)."""
+    a = np.zeros((10, 10), dtype=bool)
+    a[1:4, 1:4] = True
+    big = np.zeros((20, 20), dtype=bool)
+    big[1:4, 1:4] = True
+    assert compute_mask_iou(a, big) == 1.0
+    assert compute_mask_iou(np.zeros((5, 5), bool), np.zeros((5, 5), bool)) == 1.0
+
+
+def test_compute_mask_iou_is_similarity_not_negated():
+    """mask_iou must be higher-is-better (cost negation happens in the tracker)."""
+    a = _disk(40, 40, 20, 20, 10)
+    assert compute_mask_iou(a, a) == 1.0  # not -1.0
+
+
+def test_get_mask_decodes_and_passes_ndarray():
+    """get_mask returns the bool mask data; an ndarray passes through unchanged."""
+    m = _mask(20, 20)
+    data = get_mask(m)
+    assert isinstance(data, np.ndarray) and data.dtype == bool
+    assert int(data.sum()) == int(m.area)
+    arr = _disk(30, 30, 15, 15, 5)
+    assert get_mask(arr) is arr
+
+
+def test_is_segmentation_mask_and_count_valid_points():
+    """Type predicate + validity count dispatch on mask vs keypoint instance."""
+    m = _mask(20, 20, r=10)
+    skel = sio.Skeleton(nodes=["a", "b"])
+    inst = sio.PredictedInstance.from_numpy(
+        np.array([[1.0, 2.0], [np.nan, np.nan]]), skeleton=skel, score=0.9
+    )
+    assert is_segmentation_mask(m) is True
+    assert is_segmentation_mask(inst) is False
+    # Mask: support is foreground area (px); instance: non-NaN keypoint rows.
+    assert count_valid_points(m) == int(m.area) > 0
+    assert count_valid_points(inst) == 1  # one visible node, one NaN
+
+
+# ---------------------------------------------------------------------------
+# Tracker.track() on masks (both candidate makers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("candidates_method", ["fixed_window", "local_queues"])
+def test_tracker_masks_overlapping_same_track(candidates_method):
+    """A mask overlapping its predecessor keeps the same track id."""
+    tracker = Tracker.from_config(
+        features="masks",
+        scoring_method="mask_iou",
+        candidates_method=candidates_method,
+        window_size=5,
+    )
+    out0 = tracker.track([_mask(20, 20)], frame_idx=0)
+    out1 = tracker.track([_mask(22, 22)], frame_idx=1)  # overlaps frame-0 mask
+    assert out0[0].track is not None and out1[0].track is not None
+    assert out0[0].track.name == out1[0].track.name
+    assert out1[0].tracking_score is not None  # mask-IoU of the matched pair
+
+
+@pytest.mark.parametrize("candidates_method", ["fixed_window", "local_queues"])
+def test_tracker_masks_disjoint_extra_spawns_new_track(candidates_method):
+    """An extra non-overlapping detection spawns a NEW track; the overlapping
+    one keeps its track (mask-IoU + Hungarian leaves the disjoint mask
+    unmatched, so it is assigned a fresh id)."""
+    tracker = Tracker.from_config(
+        features="masks",
+        scoring_method="mask_iou",
+        candidates_method=candidates_method,
+        window_size=5,
+    )
+    tracker.track([_mask(20, 20)], frame_idx=0)  # -> track_0
+    out1 = tracker.track([_mask(22, 22), _mask(60, 60)], frame_idx=1)
+    by_lane = {("near" if m.bbox[0] < 40 else "far"): m.track.name for m in out1}
+    assert by_lane["near"] != by_lane["far"]  # disjoint extra -> new track
+
+
+def test_tracker_masks_empty_area_filtered_with_threshold():
+    """min_new_track_points read as a pixel-area floor: a tiny mask below it
+    spawns no track (validity uses mask area, not keypoints)."""
+    tracker = Tracker.from_config(
+        features="masks",
+        scoring_method="mask_iou",
+        candidates_method="fixed_window",
+        min_new_track_points=50,  # require >50 px of foreground
+    )
+    out = tracker.track([_mask(20, 20, r=2)], frame_idx=0)  # ~13 px < 50
+    assert all(m.track is None for m in out) or len(out) == 0

--- a/tests/tracking/test_mask_tracking.py
+++ b/tests/tracking/test_mask_tracking.py
@@ -13,8 +13,10 @@ import pytest
 
 import sleap_io as sio
 
+from sleap_nn.evaluation import _mask_iou
 from sleap_nn.tracking.tracker import Tracker
 from sleap_nn.tracking.utils import (
+    MaskFeature,
     compute_mask_iou,
     count_valid_points,
     get_mask,
@@ -67,14 +69,35 @@ def test_compute_mask_iou_is_similarity_not_negated():
     assert compute_mask_iou(a, a) == 1.0  # not -1.0
 
 
-def test_get_mask_decodes_and_passes_ndarray():
-    """get_mask returns the bool mask data; an ndarray passes through unchanged."""
-    m = _mask(20, 20)
-    data = get_mask(m)
-    assert isinstance(data, np.ndarray) and data.dtype == bool
-    assert int(data.sum()) == int(m.area)
-    arr = _disk(30, 30, 15, 15, 5)
-    assert get_mask(arr) is arr
+def test_get_mask_returns_compact_feature():
+    """get_mask returns a MaskFeature (tight bbox crop + offset + area)."""
+    m = _mask(20, 20, r=10)
+    feat = get_mask(m)
+    assert isinstance(feat, MaskFeature)
+    assert feat.area == int(m.area) > 0
+    # Crop is the foreground bbox, not the full 80x80 canvas.
+    assert feat.crop.dtype == bool
+    assert feat.crop.shape[0] < 80 and feat.crop.shape[1] < 80
+    assert int(feat.crop.sum()) == feat.area
+    # Idempotent on a MaskFeature; dense ndarray -> tight-bbox feature.
+    assert get_mask(feat) is feat
+    arr = _disk(40, 40, 20, 20, 6)
+    f2 = get_mask(arr)
+    assert isinstance(f2, MaskFeature) and f2.area == int(arr.sum())
+
+
+def test_compute_mask_iou_matches_full_canvas_reference():
+    """The cropped fast IoU is numerically identical to _mask_iou (fuzz)."""
+    rng = np.random.RandomState(1)
+    for _ in range(120):
+        h, w = rng.randint(20, 60), rng.randint(20, 60)
+        a = rng.rand(h, w) > rng.uniform(0.3, 0.9)
+        b = rng.rand(h, w) > rng.uniform(0.3, 0.9)
+        if rng.rand() < 0.1:  # exercise empty + shape-mismatch
+            a = np.zeros((h, w), dtype=bool)
+        if rng.rand() < 0.1:
+            b = np.zeros((rng.randint(20, 60), rng.randint(20, 60)), dtype=bool)
+        assert abs(compute_mask_iou(a, b) - _mask_iou(a, b)) < 1e-9
 
 
 def test_is_segmentation_mask_and_count_valid_points():

--- a/tests/tracking/test_mask_tracking.py
+++ b/tests/tracking/test_mask_tracking.py
@@ -17,6 +17,7 @@ from sleap_nn.evaluation import _mask_iou
 from sleap_nn.tracking.tracker import Tracker
 from sleap_nn.tracking.utils import (
     MaskFeature,
+    _mask_feature_from_dense,
     compute_mask_iou,
     count_valid_points,
     get_mask,
@@ -84,6 +85,43 @@ def test_get_mask_returns_compact_feature():
     arr = _disk(40, 40, 20, 20, 6)
     f2 = get_mask(arr)
     assert isinstance(f2, MaskFeature) and f2.area == int(arr.sum())
+
+
+def _stride_mask(cy, cx, r=10, h=80, w=80, score=0.9, stride=2):
+    """A mask stored at output-stride resolution (scale=1/stride), as the default
+    inference path (``full_res_masks=False``) emits."""
+    full = _disk(h, w, cy, cx, r)
+    small = full[::stride, ::stride]
+    s = 1.0 / stride
+    return sio.PredictedSegmentationMask.from_numpy(small, scale=(s, s), score=score)
+
+
+def test_get_mask_decodes_output_stride_to_image_grid():
+    """get_mask decodes stride-stored masks (scale!=1) onto the IMAGE grid.
+
+    Regression (the finalize-review blocker): the bbox-crop shortcut sliced the
+    stride-res ``.data`` with image-space ``.bbox`` indices, yielding an empty
+    feature (area 0) -> ``compute_mask_iou`` 1.0 for every pair -> scrambled
+    identity on the DEFAULT inference path (``full_res_masks=False``, scale~0.5).
+    """
+    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+    m = _stride_mask(40, 40)
+    assert tuple(m.scale) != (1.0, 1.0)  # genuinely stride-stored
+    feat = get_mask(m)
+    ref = _mask_feature_from_dense(decode_mask_to_image_res(m))
+    assert feat.area == ref.area > 0  # NOT the buggy 0
+
+    # Two shifted stride masks: IoU matches the image-grid reference and is a
+    # real partial overlap, not the degenerate empty-vs-empty 1.0.
+    m2 = _stride_mask(46, 46)
+    iou = compute_mask_iou(get_mask(m), get_mask(m2))
+    iou_ref = compute_mask_iou(
+        _mask_feature_from_dense(decode_mask_to_image_res(m)),
+        _mask_feature_from_dense(decode_mask_to_image_res(m2)),
+    )
+    assert np.isclose(iou, iou_ref)
+    assert 0.0 < iou < 1.0
 
 
 def test_compute_mask_iou_matches_full_canvas_reference():

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -654,6 +654,86 @@ def test_post_clean_up(
     assert len(tracked_lfs[0].instances) == 1
 
 
+def test_get_scores_robust_quantile_honors_best_instance():
+    """`robust_quantile` reduction must use the per-instance `robust_best_instance`.
+
+    Regression: `_quantile_method` used to be a class-level
+    `functools.partial(np.quantile, q=robust_best_instance)` that froze `q` at the
+    class default (1.0), so `robust_quantile` was a silent no-op == max. It is now
+    resolved at runtime in `get_scores`.
+    """
+    # One track with three candidates at euclidean distances 1/5/10 from the
+    # current centroid -> scores [-1, -5, -10].
+    cands = [
+        TrackedInstanceFeature(
+            feature=np.array([d, 0.0]),
+            src_predicted_instance=np.array([[0.0, 0.0]]),  # 1 valid point
+            frame_idx=0,
+            tracking_score=1.0,
+        )
+        for d in (1.0, 5.0, 10.0)
+    ]
+    cdict = {0: cands}
+    current = [
+        TrackInstanceLocalQueue(
+            src_instance=np.array([[0.0, 0.0]]),
+            src_instance_idx=0,
+            feature=np.array([0.0, 0.0]),
+            frame_idx=1,
+        )
+    ]
+
+    def score(rbi):
+        t = Tracker.from_config(
+            candidates_method="local_queues",
+            features="centroids",
+            scoring_method="euclidean_dist",
+            scoring_reduction="robust_quantile",
+            robust_best_instance=rbi,
+        )
+        t.candidate.current_tracks = [0]
+        return t.get_scores(current, cdict)[0, 0]
+
+    assert np.isclose(score(1.0), -1.0)  # q=1.0 -> max
+    assert np.isclose(score(0.5), -5.0)  # q=0.5 -> median (was silently -1.0)
+    assert np.isclose(score(0.0), -10.0)  # q=0.0 -> min
+
+
+def test_get_scores_empty_candidate_list_no_crash():
+    """An all-filtered candidate list reduces to NaN (not a crash) for max/quantile.
+
+    `np.nanmax([])` / `np.nanquantile([])` raise; `get_scores` guards the empty
+    case explicitly so a high `min_match_points` (or the `max` mask default) cannot
+    crash mid-stream.
+    """
+    cands = [
+        TrackedInstanceFeature(
+            feature=np.array([1.0, 0.0]),
+            src_predicted_instance=np.array([[0.0, 0.0]]),  # 1 valid point < floor
+            frame_idx=0,
+            tracking_score=1.0,
+        )
+    ]
+    current = [
+        TrackInstanceLocalQueue(
+            src_instance=np.array([[0.0, 0.0]]),
+            src_instance_idx=0,
+            feature=np.array([0.0, 0.0]),
+            frame_idx=1,
+        )
+    ]
+    t = Tracker.from_config(
+        candidates_method="local_queues",
+        features="centroids",
+        scoring_method="euclidean_dist",
+        scoring_reduction="max",
+        min_match_points=100,  # filters out the lone 1-point candidate
+    )
+    t.candidate.current_tracks = [0]
+    scores = t.get_scores(current, {0: cands})
+    assert np.isnan(scores[0, 0])
+
+
 # Tests for connect_single_breaks fix (GitHub issue: sleap#2618)
 from sleap_nn.tracking.tracker import connect_single_breaks
 

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -700,11 +700,11 @@ def test_get_scores_robust_quantile_honors_best_instance():
 
 
 def test_get_scores_empty_candidate_list_no_crash():
-    """An all-filtered candidate list reduces to NaN (not a crash) for max/quantile.
+    """An all-filtered candidate list reduces to NaN (not a crash) under `max`.
 
-    `np.nanmax([])` / `np.nanquantile([])` raise; `get_scores` guards the empty
-    case explicitly so a high `min_match_points` (or the `max` mask default) cannot
-    crash mid-stream.
+    `np.nanmax([])` raises (`np.nanmean([])`/`np.nanquantile([])` return NaN);
+    `get_scores` guards the empty case explicitly so a high `min_match_points`
+    (or an explicit `scoring_reduction="max"`) cannot crash mid-stream.
     """
     cands = [
         TrackedInstanceFeature(


### PR DESCRIPTION
Closes #619. **Rebased onto `main`** (eval base #629, sleap-io pin #633, and the concurrent #632/#634 are merged); this branch's diff is the tracker only.

Track-by-detection tracking for bottom-up segmentation masks. Replaces the **#614 fail-fast guard** (`predict --tracking` on a seg model used to raise) with real mask-IoU tracking: masks are associated across frames by pixel IoU + Hungarian matching, get stable `track`/`tracking_score` written back, and are **preserved** on the output.

## Design

- **Pixel mask-IoU**, reusing the merged `_mask_iou` (#629) — `mask.bbox` is XYWH, so bbox-IoU is avoided entirely.
- **Cropped-bbox fast path** (`MaskFeature`): the "masks" feature is a tight foreground-bbox crop + absolute offset + precomputed area. Per-pair IoU AND-s only the *overlap* of the two bboxes — numerically identical to the full-canvas `_mask_iou` (0.0 error over 400 synthetic + 1510 real-mask pairs), ~9× faster.
- **Duck-typed**: masks flow through the existing `Tracker.track()` unchanged; only the pose-specific `.numpy()` sites are made mask-aware (`get_scores` validity filter + `add_new_tracks` in both candidate makers, via `count_valid_points` = foreground area px).
- **Mask-mode auto-defaults in `apply_tracking`** (applied only when the user left a flag unset): `features='masks'`, `scoring_method='mask_iou'`, `window_size` 5→25, **`candidates_method='local_queues'`**, and **`max_tracks` derived from the target count** (`--max_tracks`/`--tracking_target_instance_count`).
- **Out of scope, fail-fast**: motion models and pose-only cull/clean/connect are rejected in mask mode.

## Validation vs GT identity (`mice_of`, full 3248-frame clip)

Scored by spatially matching each tracked mask to a GT pose, then measuring per-GT-track **purity** (fraction keeping the dominant predicted track) and ID switches.

| input | config | purity | switches | tracks |
|---|---|--:|--:|--:|
| **clean GT-burned masks** (ceiling) | local_queues + cap5 | **0.994** | 12 | 5 |
| model preds (default stride path) | **local_queues + cap5** | **0.910** | 126 | 5 |
| model preds | local_queues (no cap) | 0.518 | — | 10 |
| model preds | `fixed_window` (old default) | 0.278 | 1835 | 39 |

Clean masks track near-perfectly → **no indexing/identity bug**; the real-data error is **mask quality** (predicted masks: 1.59 components/mask, 30.5% multi-component, 12.8% holey, 6.1/frame vs the GT masks' solid 1.006 components / ~0 holes / 4.9/frame — i.e. over-segmentation, #617). `fixed_window` forgets identities (its bounded deque mints a fresh id after `window_size` gaps); `local_queues` + the known-count cap is the single biggest win (0.28 → 0.91).

## Also fixed: output-stride mask decode (default-path correctness)

`get_mask` cropped the mask's *stored-resolution* `.data` with its *image-space* `.bbox`. On the **default** inference path (`full_res_masks=False`, masks encoded at output-stride, `scale≈0.25`) the grids disagree → the crop falls out of bounds → empty feature → `compute_mask_iou` returns **1.0 for every pair** → arbitrary identity. Fixed by decoding via `decode_mask_to_image_res` (the helper eval/data-loader use) before the bbox crop — a **zero-copy passthrough for `scale==1`**, so the full-res path and the fuzz-verified IoU equivalence are unchanged. Confirmed end-to-end: the default stride path now scores **0.910**, identical to full-res.

## Also fixed: `robust_quantile` reduction (all tracking modes)

`scoring_reduction="robust_quantile"` was a silent no-op (≡ `max`): `_quantile_method` froze `q` at the class default (1.0) at class-definition time, so `--robust_best_instance` was ignored. Now resolved per-instance in `get_scores` via `np.nanquantile(q=self.robust_best_instance)`, with an empty-candidate guard (`np.nanmax([])` raises).

## Rendering note (upstream, fixed)

`sio render --color-by track` colored masks by `LabeledFrame.masks` position, not `.track` (poses/centroids/trails were already track-colored). Filed + fixed upstream as **talmolab/sleap-io#469 / #470** (merged). Bumping the sleap-nn sleap-io pin to include #470 is a separate follow-up.

## Files

- `tracking/utils.py`: `MaskFeature` + `get_mask` (now image-grid decode) / `compute_mask_iou` (cropped IoU), `count_valid_points`, `is_segmentation_mask`.
- `tracking/tracker.py`: register `masks`/`mask_iou`; mask-aware validity filter; **`robust_quantile` runtime fix + empty-candidate guard**.
- `tracking/candidates/{fixed_window,local_queues}.py`: mask-aware spawn gate.
- `inference/tracking.py`: mask auto-defaults (features/scoring + window bump + **`local_queues` + `max_tracks`-from-target**) + mask plumbing + forbidden-combo guards; new `candidates_method_explicit` flag.
- `inference/predictor.py`: remove the #614 guard. `cli.py`: thread `candidates_method_explicit`; doc updates.

## Acceptance criteria (#619)

- [x] `predict --tracking` on a seg model produces a `.slp` whose `LabeledFrame.masks` carry tracks; masks not dropped.
- [x] Unit tests: overlapping → same track, disjoint(-extra) → new track; mask-IoU via Hungarian (both candidate makers).
- [x] Pose-model tracking unchanged.
- [x] The #614 `ValueError` guard removed; its test replaced.

## Test plan

`pytest tests/tracking/ tests/inference/test_tracking.py tests/inference/test_segmentation_inference.py` → **102 passed**; black + ruff clean. New coverage: cropped-IoU fuzz-equivalence, mask auto-defaults (incl. `local_queues` default / explicit respected / `max_tracks`-from-target / e2e cap), **output-stride decode** (unit IoU + `apply_tracking` identity), `robust_quantile` honors `robust_best_instance`, empty-candidate no-crash.

## Out of scope (follow-ups)

Over-segmentation reduction (#617, the dominant residual); gap-closing / re-id; motion models on masks; mask-safe cull/NMS; RLE-native intersection; sleap-io pin bump for #470.

_Root-cause investigation + validation: `scratch/2026-06-03-mask-tracker-identity-jumping/`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
