### PR TITLE
perf(seg): encode masks at output-stride + opt-in morphology + polygon ROI (#618)

### DIFF
--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -190,6 +190,53 @@ sleap-nn track -i video.mp4 \
         --filter_min_instance_score 0.3
     ```
 
+### Bottom-Up Segmentation
+
+Bottom-up segmentation models predict a per-instance **mask** (plus instance-center
+heatmap/offsets). The mask-specific prediction knobs are:
+
+- `--fg_threshold` (default `0.5`): foreground probability threshold for binarizing the
+  segmentation map.
+- `--min_mask_area` (default `0`): drop masks smaller than this many **original-image** pixels
+  (over-segmentation suppression). The filter is measured at output-stride resolution and converted
+  from original-pixel units, so the threshold means the same thing regardless of stride.
+- `--center_nms_kernel` (default `3`): odd window for instance-center peak NMS; larger merges
+  nearby duplicate centers.
+- `--mask_cleanup` / `--no-mask_cleanup` (default off): keep only each mask's largest connected
+  component and fill interior holes (despeckle).
+- `--mask_cleanup_radius` (default `0`): when `--mask_cleanup` is set, additionally apply a
+  morphological open→close with an elliptical kernel of this radius (output-stride pixels) before
+  keep-largest-CC. `0` keeps the keep-largest+fill behavior. Useful for boundary noise; for
+  disconnected speckle/fragments, keep-largest-CC alone is usually sufficient.
+
+**Mask encoding (output-stride by default).** Predicted masks are stored at the model's
+output-stride resolution, carrying a sio `scale`/`offset` that maps mask coordinates to image
+pixels (`image_coord = mask_coord / scale + offset`). This is **~`stride`× smaller** on disk and
+**lossless at model resolution** — the stored mask *is* the model's native output. Decode a mask to
+the original image grid with sio's `mask.resampled(*mask.image_extent).data` (eval, the training
+data loader, and tracking do this automatically). Note `image_extent` can differ from the true
+frame size by ±1 px (the mask resolution is `round(orig * scale)`), so clamp to the real frame size
+when indexing an image.
+
+- `--full_res_masks` (default off): encode masks at full original resolution instead (legacy
+  behavior). Only needed for external consumers that read `mask.data` assuming original resolution.
+
+**Polygon output (interop).** For polygon-based interop you can emit a Douglas-Peucker-simplified
+`sio.PredictedROI` alongside (or instead of) the RLE mask:
+
+- `--mask_output` (default `mask`): `mask` (RLE masks only), `polygon` (simplified ROIs only), or
+  `both` (exact mask + simplified ROI). The stored mask is always **exact** — polygon simplification
+  applies only to the emitted ROI, so eval/tracking are unaffected.
+- `--polygon_epsilon` (default `0.01`): simplification tolerance as a fraction of each contour's
+  perimeter (larger = coarser).
+
+```bash
+# Smaller .slp via stride encoding (default) + despeckle + a polygon ROI for interop
+sleap-nn track -i video.mp4 -m models/bottomup_segmentation/ \
+    --mask_cleanup --mask_cleanup_radius 2 \
+    --mask_output both --polygon_epsilon 0.02
+```
+
 ---
 
 ## Filtering Instances

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -230,6 +230,15 @@ when indexing an image.
 - `--polygon_epsilon` (default `0.01`): simplification tolerance as a fraction of each contour's
   perimeter (larger = coarser).
 
+!!! warning "Polygon output is CPU-heavy on noisy masks — pair it with `--mask_cleanup`"
+    Building a polygon walks the mask's boundary, so its cost scales with the number of RLE runs.
+    A clean single-blob mask polygonizes in ~10&nbsp;ms; a fragmented/speckled mask (thousands of
+    runs) can be ~10&times; slower per mask and dominate inference time. `--mask_output polygon`/`both`
+    is therefore best paired with **`--mask_cleanup`** (keep-largest-CC removes the speckle, so each
+    instance is a single component). The default `--mask_output mask` does no polygon work and is
+    *cheaper* than the pre-#618 behavior (masks are encoded at output-stride resolution, not upsampled
+    to full resolution first). Memory for the default path is unaffected.
+
 ```bash
 # Smaller .slp via stride encoding (default) + despeckle + a polygon ROI for interop
 sleap-nn track -i video.mp4 -m models/bottomup_segmentation/ \

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -2114,7 +2114,8 @@ def _common_inference_options(f):
             "SegmentationMask in LabeledFrame.masks, default), 'polygon' "
             "(Douglas-Peucker-simplified sio.PredictedROI into LabeledFrame.rois "
             "only), or 'both' (exact mask + simplified ROI for interop). "
-            "Bottom-up segmentation models only.",
+            "polygon/both are CPU-heavy on noisy masks (cost scales with RLE-run "
+            "count) — pair with --mask_cleanup. Bottom-up segmentation models only.",
         ),
         click.option(
             "--polygon_epsilon",

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1455,6 +1455,10 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         "min_mask_area": kwargs.get("min_mask_area", 0),
         "center_nms_kernel": kwargs.get("center_nms_kernel", 3),
         "mask_cleanup": kwargs.get("mask_cleanup", False),
+        "mask_cleanup_radius": kwargs.get("mask_cleanup_radius", 0),
+        "full_res_masks": kwargs.get("full_res_masks", False),
+        "mask_output": kwargs.get("mask_output", "mask"),
+        "polygon_epsilon": kwargs.get("polygon_epsilon", 0.01),
     }
     preprocess_config = _build_preprocess_config(kwargs)
     if preprocess_config is not None:
@@ -1496,6 +1500,10 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
             "n_points",
             "fg_threshold",
             "min_mask_area",
+            "mask_cleanup_radius",
+            "full_res_masks",
+            "mask_output",
+            "polygon_epsilon",
             "backbone_ckpt_path",
             "head_ckpt_path",
             "preprocess_config",
@@ -1810,6 +1818,10 @@ def _run_stream_to_file(
         "min_mask_area": kwargs.get("min_mask_area", 0),
         "center_nms_kernel": kwargs.get("center_nms_kernel", 3),
         "mask_cleanup": kwargs.get("mask_cleanup", False),
+        "mask_cleanup_radius": kwargs.get("mask_cleanup_radius", 0),
+        "full_res_masks": kwargs.get("full_res_masks", False),
+        "mask_output": kwargs.get("mask_output", "mask"),
+        "polygon_epsilon": kwargs.get("polygon_epsilon", 0.01),
     }
     preprocess_config = _build_preprocess_config(kwargs)
     if preprocess_config is not None:
@@ -2047,7 +2059,8 @@ def _common_inference_options(f):
             default=0,
             help="Drop predicted masks smaller than this many original-image "
             "pixels to suppress over-segmentation (bottom-up segmentation "
-            "models only). 0 disables.",
+            "models only). 0 disables. Measured at output-stride resolution and "
+            "converted from original-pixel units.",
         ),
         click.option(
             "--center_nms_kernel",
@@ -2066,6 +2079,53 @@ def _common_inference_options(f):
             default=False,
             help="Keep only each predicted mask's largest connected component "
             "and fill interior holes (bottom-up segmentation models only).",
+        ),
+        click.option(
+            "--mask_cleanup_radius",
+            "--mask-cleanup-radius",
+            "mask_cleanup_radius",
+            type=int,
+            default=0,
+            help="When --mask_cleanup is set, also apply a morphological "
+            "open->close with an elliptical kernel of this radius (output-stride "
+            "pixels) before keep-largest-CC/fill-holes; despeckles and closes "
+            "pinholes. 0 keeps the keep-largest+fill behavior (bottom-up "
+            "segmentation models only).",
+        ),
+        click.option(
+            "--full_res_masks/--no-full_res_masks",
+            "--full-res-masks/--no-full-res-masks",
+            "full_res_masks",
+            default=False,
+            help="Encode predicted segmentation masks at full ORIGINAL "
+            "resolution instead of the model output-stride grid. Default off: "
+            "output-stride encoding is ~stride^2 smaller and lossless at model "
+            "resolution, carrying the image mapping via sio scale/offset. Enable "
+            "only for legacy consumers that read mask.data assuming original "
+            "resolution (bottom-up segmentation models only).",
+        ),
+        click.option(
+            "--mask_output",
+            "--mask-output",
+            "mask_output",
+            type=click.Choice(["mask", "polygon", "both"]),
+            default="mask",
+            help="Predicted-mask output representation: 'mask' (RLE "
+            "SegmentationMask in LabeledFrame.masks, default), 'polygon' "
+            "(Douglas-Peucker-simplified sio.PredictedROI into LabeledFrame.rois "
+            "only), or 'both' (exact mask + simplified ROI for interop). "
+            "Bottom-up segmentation models only.",
+        ),
+        click.option(
+            "--polygon_epsilon",
+            "--polygon-epsilon",
+            "polygon_epsilon",
+            type=float,
+            default=0.01,
+            help="Douglas-Peucker simplification tolerance for --mask_output "
+            "polygon/both, as a fraction of each contour's perimeter. Larger = "
+            "coarser polygons. 0 disables simplification (bottom-up segmentation "
+            "models only).",
         ),
         click.option(
             "--queue_maxsize",

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -2194,7 +2194,18 @@ class BottomUpSegmentationDataset(BaseDataset):
                 lf_masks = getattr(lf, "masks", None)
                 if not lf_masks:
                     continue
-                mask_arrays = [np.asarray(m.data, dtype=bool) for m in lf_masks]
+                # Scale-aware decode: masks written by the segmentation inference
+                # layer are encoded at output-stride (non-identity scale); decode
+                # them up to the IMAGE-pixel grid so self-training / pseudo-label
+                # ``.slp`` files yield correctly-scaled targets (a stride-res
+                # ``m.data`` would silently mis-scale the GT, since __getitem__'s
+                # resize branch only fires on a preprocessing size change). Scale-1
+                # GT masks take the zero-copy fast path.
+                from sleap_nn.inference.segmentation_convert import (
+                    decode_mask_to_image_res,
+                )
+
+                mask_arrays = [decode_mask_to_image_res(m) for m in lf_masks]
                 if len(mask_arrays) == 0:
                     continue
                 video_idx = label.videos.index(lf.video)

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -218,9 +218,19 @@ def match_masks(
 
 
 def _frame_masks(frame: sio.LabeledFrame) -> List[np.ndarray]:
-    """Decode a frame's segmentation masks into boolean arrays (orig res)."""
+    """Decode a frame's segmentation masks into boolean arrays on the image grid.
+
+    Scale-aware: masks encoded at output-stride (non-identity ``scale``, the
+    default for predicted segmentation masks) are nearest-neighbor resampled up
+    to their image extent, so a stride-res prediction and an original-res
+    ground-truth mask are compared on a common image-pixel grid. Scale-1 masks
+    (legacy full-res GT/preds) take a zero-copy fast path, so existing eval
+    numbers are unchanged.
+    """
+    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
     masks = getattr(frame, "masks", None) or []
-    return [np.asarray(m.data, dtype=bool) for m in masks]
+    return [decode_mask_to_image_res(m) for m in masks]
 
 
 @attrs.define(auto_attribs=True, slots=True)

--- a/sleap_nn/inference/layers/segmentation.py
+++ b/sleap_nn/inference/layers/segmentation.py
@@ -12,6 +12,7 @@ the legacy original-resolution upsample.
 
 from __future__ import annotations
 
+import math
 from typing import List, Optional
 
 import numpy as np
@@ -187,7 +188,12 @@ class SegmentationLayer(InferenceLayer):
                         inst["mask"], info, b
                     )
                     sx, sy = scale
-                    area_floor_stride = max(1, int(round(area_floor * sx * sy)))
+                    # ceil (not round): the stride floor is the smallest integer
+                    # pixel count whose original-pixel area (count / (sx*sy)) still
+                    # meets the floor. round() would round the scaled floor DOWN
+                    # and over-keep sub-floor masks, breaking the integer-scale
+                    # parity with --full_res_masks.
+                    area_floor_stride = max(1, math.ceil(area_floor * sx * sy))
                     if int(mask_out.sum()) < area_floor_stride:
                         continue
                 frame_masks.append(
@@ -207,10 +213,26 @@ class SegmentationLayer(InferenceLayer):
 
         Unlike :meth:`_mask_to_original`, this does NOT upsample. The head map
         covers the bottom-right-padded extent, so the valid region is the
-        top-left ``round(orig * scale)`` block at stride resolution. The sio
-        mapping is ``sx = sy = eff_scale[b] * input_scale / output_stride``
-        (``mask_dim / image_dim``) with ``offset = (0, 0)`` because every
-        preprocessing pad is bottom-right (valid content top-left aligned).
+        top-left block at stride resolution.
+
+        Two subtleties (both verified against the legacy ``_mask_to_original``
+        crop so the default and ``--full_res_masks`` paths keep identical edge
+        content):
+
+        * The valid extent is ``ceil(round(orig * s) / stride)`` stride cells,
+          NOT ``round(orig * s / stride)``: the trailing partial stride cell
+          covers real (non-pad) processed pixels and ``round`` would drop it,
+          truncating masks whose object touches the right/bottom edge.
+        * The stored sio scale is ``valid / orig`` (the exact inverse of the
+          crop), NOT the raw ``s / stride`` ratio. ``sio.image_extent`` recovers
+          the image size as ``int(valid / scale)``; only ``valid / orig`` makes
+          that round-trip to ``orig`` exactly. The raw ratio floor-truncates
+          ``orig`` by up to a full stride cell at large strides.
+
+        ``offset`` is ``(0, 0)`` because every preprocessing pad is bottom-right
+        (valid content top-left aligned). Scales are isotropic today
+        (eff_scale / input_scale / output_stride are scalars) but stored
+        per-axis so each dim's crop inverts exactly.
 
         Returns:
             ``(mask_stride_bool, (sx, sy), (ox, oy))``.
@@ -226,12 +248,18 @@ class SegmentationLayer(InferenceLayer):
         if info.eff_scale is not None and info.eff_scale.numel() > b:
             eff = float(info.eff_scale[b])
         s = eff * float(info.input_scale)
-        # Isotropic today (eff_scale / input_scale / output_stride are scalars),
-        # so sx == sy. A future anisotropic sizematcher must revisit this.
-        sx = sy = s / stride
-        valid_h = min(mask.shape[0], max(1, int(round(orig_h * sy))))
-        valid_w = min(mask.shape[1], max(1, int(round(orig_w * sx))))
+        # Valid (non-pad) processed extent in input pixels, then the number of
+        # output-stride cells that overlap it (ceil — keeps the trailing partial
+        # cell, matching _mask_to_original).
+        scaled_h = max(1, int(round(orig_h * s)))
+        scaled_w = max(1, int(round(orig_w * s)))
+        valid_h = min(mask.shape[0], max(1, math.ceil(scaled_h / stride)))
+        valid_w = min(mask.shape[1], max(1, math.ceil(scaled_w / stride)))
         mask_stride = np.ascontiguousarray(mask[:valid_h, :valid_w], dtype=bool)
+        # Store the scale that exactly inverts this crop (image_extent ->
+        # int(valid / (valid / orig)) == orig).
+        sx = valid_w / float(orig_w)
+        sy = valid_h / float(orig_h)
         return mask_stride, (sx, sy), (0.0, 0.0)
 
     def _mask_to_original(

--- a/sleap_nn/inference/layers/segmentation.py
+++ b/sleap_nn/inference/layers/segmentation.py
@@ -3,8 +3,11 @@
 Wraps a trained ``BottomUpSegmentationLightningModule`` (whose ``forward``
 returns the three head maps, with sigmoid already applied to the foreground
 head). ``postprocess`` groups foreground pixels into instances via the
-predicted instance-center offsets, maps each mask back to original-image
-resolution, and packages them into ``Outputs.pred_masks``.
+predicted instance-center offsets and packages them into ``Outputs.pred_masks``.
+By default each mask is kept at the model output-stride resolution with a sio
+``scale``/``offset`` carrying the mapping back to image pixels (the #618
+~stride^2 RLE win, lossless at model resolution); ``full_res_masks`` restores
+the legacy original-resolution upsample.
 """
 
 from __future__ import annotations
@@ -50,6 +53,19 @@ class SegmentationLayer(InferenceLayer):
         mask_cleanup: When ``True``, keep only each mask's largest connected
             component and fill interior holes (suppresses speckle/fragments).
             Default ``False``.
+        mask_cleanup_radius: Morphological open->close kernel radius (in
+            output-stride pixels) applied during ``mask_cleanup`` before
+            keep-largest-CC. ``0`` (default) keeps the keep-largest+fill behavior.
+        full_res_masks: When ``True``, encode masks at full ORIGINAL resolution
+            (legacy behavior) instead of the model output-stride grid. Default
+            ``False``: output-stride encoding is ~stride^2 smaller and lossless
+            at model resolution, carrying the image mapping via sio scale/offset.
+        mask_output: Output representation — ``"mask"`` (RLE mask, default),
+            ``"polygon"`` (Douglas-Peucker ``sio.PredictedROI`` only), or
+            ``"both"`` (exact mask + simplified ROI). Consumed at packaging time
+            (``Outputs.to_labels``); stored on the layer for the Predictor to read.
+        polygon_epsilon: Douglas-Peucker tolerance (fraction of perimeter) for
+            ``mask_output`` polygon/both. Default ``0.01``.
         preprocess_config / postprocess_config: Standard knobs;
             ``postprocess_config.peak_threshold`` is the instance-center peak
             threshold (overridable via ``Predictor.predict(peak_threshold=...)``).
@@ -69,6 +85,10 @@ class SegmentationLayer(InferenceLayer):
         max_instances: Optional[int] = None,
         center_nms_kernel: int = 3,
         mask_cleanup: bool = False,
+        mask_cleanup_radius: int = 0,
+        full_res_masks: bool = False,
+        mask_output: str = "mask",
+        polygon_epsilon: float = 0.01,
         preprocess_config: Optional[PreprocessConfig] = None,
         postprocess_config: Optional[PostprocessConfig] = None,
     ) -> None:
@@ -86,6 +106,10 @@ class SegmentationLayer(InferenceLayer):
         self.max_instances = max_instances
         self.center_nms_kernel = int(center_nms_kernel)
         self.mask_cleanup = bool(mask_cleanup)
+        self.mask_cleanup_radius = int(mask_cleanup_radius)
+        self.full_res_masks = bool(full_res_masks)
+        self.mask_output = str(mask_output)
+        self.polygon_epsilon = float(polygon_epsilon)
 
     @property
     def warmup_input_shape(self):
@@ -101,8 +125,12 @@ class SegmentationLayer(InferenceLayer):
                 original image resolution.
 
         Returns:
-            ``Outputs`` with ``pred_masks`` populated (a per-batch list of
-            per-instance ``{"mask", "score"}`` dicts at original resolution).
+            ``Outputs`` with ``pred_masks`` populated: a per-batch list of
+            per-instance ``{"mask", "score", "scale", "offset"}`` dicts. By
+            default ``mask`` is at output-stride resolution and ``scale``/
+            ``offset`` map it to image pixels (``image_coord = mask_coord /
+            scale + offset``); with ``full_res_masks`` it is at original
+            resolution with identity scale/offset.
         """
         foreground = raw_out[self._SEG_KEY]  # (B, 1, h, w), already sigmoid
         center_heatmap = raw_out[self._CENTER_KEY]  # (B, 1, h, w)
@@ -119,6 +147,10 @@ class SegmentationLayer(InferenceLayer):
         max_instances = getattr(self.postprocess_config, "max_instances", None)
         if max_instances is None:
             max_instances = getattr(self, "max_instances", None)
+        # New knobs are read via ``getattr`` because some tests build the layer
+        # through ``__new__`` and set only a subset of attributes.
+        full_res_masks = getattr(self, "full_res_masks", False)
+        mask_cleanup_radius = getattr(self, "mask_cleanup_radius", 0)
         B = foreground.shape[0]
         pred_masks: List[List[dict]] = []
         for b in range(B):
@@ -132,20 +164,75 @@ class SegmentationLayer(InferenceLayer):
                 max_instances=max_instances,
                 center_nms_kernel=getattr(self, "center_nms_kernel", 3),
                 mask_cleanup=getattr(self, "mask_cleanup", False),
+                mask_cleanup_radius=mask_cleanup_radius,
             )
             frame_masks: List[dict] = []
-            # Drop empty masks and, when ``min_mask_area > 0``, tiny spurious
-            # masks below the area floor (in original-image pixels). The
-            # ``max(1, ...)`` keeps the empty-mask drop when the filter is off.
+            # ``min_mask_area`` is an ORIGINAL-image-pixel floor. ``max(1, ...)``
+            # keeps the empty-mask drop when the filter is off.
             area_floor = max(1, self.min_mask_area)
             for inst in instances:
-                mask_full = self._mask_to_original(inst["mask"], info, b)
-                if int(mask_full.sum()) < area_floor:
-                    continue
-                frame_masks.append({"mask": mask_full, "score": float(inst["score"])})
+                if full_res_masks:
+                    # Legacy path: materialize the original-resolution mask and
+                    # filter directly in original pixels (scale/offset identity).
+                    mask_out = self._mask_to_original(inst["mask"], info, b)
+                    scale, offset = (1.0, 1.0), (0.0, 0.0)
+                    if int(mask_out.sum()) < area_floor:
+                        continue
+                else:
+                    # Default: keep the mask at output-stride resolution, carrying
+                    # the image mapping via sio scale/offset (the ~stride^2 RLE
+                    # win). Convert the original-pixel area floor to stride units
+                    # (exact when 1/(sx*sy) is integral, i.e. eff*input_scale==1).
+                    mask_out, scale, offset = self._mask_to_stride(
+                        inst["mask"], info, b
+                    )
+                    sx, sy = scale
+                    area_floor_stride = max(1, int(round(area_floor * sx * sy)))
+                    if int(mask_out.sum()) < area_floor_stride:
+                        continue
+                frame_masks.append(
+                    {
+                        "mask": mask_out,
+                        "score": float(inst["score"]),
+                        "scale": scale,
+                        "offset": offset,
+                    }
+                )
             pred_masks.append(frame_masks)
 
         return Outputs(pred_masks=pred_masks, preprocess_info=info)
+
+    def _mask_to_stride(self, mask: np.ndarray, info: PreprocInfo, b: int) -> tuple:
+        """Crop an output-stride mask to its valid (non-pad) extent + scale/offset.
+
+        Unlike :meth:`_mask_to_original`, this does NOT upsample. The head map
+        covers the bottom-right-padded extent, so the valid region is the
+        top-left ``round(orig * scale)`` block at stride resolution. The sio
+        mapping is ``sx = sy = eff_scale[b] * input_scale / output_stride``
+        (``mask_dim / image_dim``) with ``offset = (0, 0)`` because every
+        preprocessing pad is bottom-right (valid content top-left aligned).
+
+        Returns:
+            ``(mask_stride_bool, (sx, sy), (ox, oy))``.
+        """
+        orig_h, orig_w = info.original_size
+        stride = float(info.output_stride)
+        if orig_h == 0 or orig_w == 0:
+            # No metadata: the head map IS the valid extent; map by output_stride.
+            sx = sy = 1.0 / stride
+            return np.ascontiguousarray(mask, dtype=bool), (sx, sy), (0.0, 0.0)
+
+        eff = 1.0
+        if info.eff_scale is not None and info.eff_scale.numel() > b:
+            eff = float(info.eff_scale[b])
+        s = eff * float(info.input_scale)
+        # Isotropic today (eff_scale / input_scale / output_stride are scalars),
+        # so sx == sy. A future anisotropic sizematcher must revisit this.
+        sx = sy = s / stride
+        valid_h = min(mask.shape[0], max(1, int(round(orig_h * sy))))
+        valid_w = min(mask.shape[1], max(1, int(round(orig_w * sx))))
+        mask_stride = np.ascontiguousarray(mask[:valid_h, :valid_w], dtype=bool)
+        return mask_stride, (sx, sy), (0.0, 0.0)
 
     def _mask_to_original(
         self, mask: np.ndarray, info: PreprocInfo, b: int

--- a/sleap_nn/inference/layers/segmentation.py
+++ b/sleap_nn/inference/layers/segmentation.py
@@ -223,16 +223,20 @@ class SegmentationLayer(InferenceLayer):
           NOT ``round(orig * s / stride)``: the trailing partial stride cell
           covers real (non-pad) processed pixels and ``round`` would drop it,
           truncating masks whose object touches the right/bottom edge.
-        * The stored sio scale is ``valid / orig`` (the exact inverse of the
+        * The stored sio scale is ``valid / orig`` (the best inverse of the
           crop), NOT the raw ``s / stride`` ratio. ``sio.image_extent`` recovers
-          the image size as ``int(valid / scale)``; only ``valid / orig`` makes
-          that round-trip to ``orig`` exactly. The raw ratio floor-truncates
-          ``orig`` by up to a full stride cell at large strides.
+          the image size as ``int(valid / scale)``; ``valid / orig`` recovers
+          ``orig`` to within +/-1 px (the float division can floor-truncate to
+          ``orig - 1`` for ~5% of sizes), whereas the raw ratio truncates by up
+          to a full stride cell at large strides. ``image_extent`` is therefore
+          still NOT authoritative for the true frame size (see
+          :func:`sleap_nn.inference.segmentation_convert.decode_mask_to_image_res`);
+          consumers clamp the +/-1.
 
         ``offset`` is ``(0, 0)`` because every preprocessing pad is bottom-right
         (valid content top-left aligned). Scales are isotropic today
         (eff_scale / input_scale / output_stride are scalars) but stored
-        per-axis so each dim's crop inverts exactly.
+        per-axis so each dim inverts its own crop.
 
         Returns:
             ``(mask_stride_bool, (sx, sy), (ox, oy))``.
@@ -256,8 +260,9 @@ class SegmentationLayer(InferenceLayer):
         valid_h = min(mask.shape[0], max(1, math.ceil(scaled_h / stride)))
         valid_w = min(mask.shape[1], max(1, math.ceil(scaled_w / stride)))
         mask_stride = np.ascontiguousarray(mask[:valid_h, :valid_w], dtype=bool)
-        # Store the scale that exactly inverts this crop (image_extent ->
-        # int(valid / (valid / orig)) == orig).
+        # Store the scale that best inverts this crop: image_extent ->
+        # int(valid / (valid / orig)) recovers orig within +/-1 px (float
+        # truncation can give orig - 1; consumers clamp).
         sx = valid_w / float(orig_w)
         sy = valid_h / float(orig_h)
         return mask_stride, (sx, sy), (0.0, 0.0)

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -407,6 +407,10 @@ def _build_bottomup_segmentation(
     max_instances: Optional[int] = None,
     center_nms_kernel: int = 3,
     mask_cleanup: bool = False,
+    mask_cleanup_radius: int = 0,
+    full_res_masks: bool = False,
+    mask_output: str = "mask",
+    polygon_epsilon: float = 0.01,
 ) -> LoadedAssets:
     """Load a ``BottomUpSegmentationLightningModule`` and wrap it for inference.
 
@@ -448,6 +452,10 @@ def _build_bottomup_segmentation(
         max_instances=max_instances,
         center_nms_kernel=center_nms_kernel,
         mask_cleanup=mask_cleanup,
+        mask_cleanup_radius=mask_cleanup_radius,
+        full_res_masks=full_res_masks,
+        mask_output=mask_output,
+        polygon_epsilon=polygon_epsilon,
     )
     return LoadedAssets(
         inference_model=inference_model,
@@ -788,6 +796,10 @@ def load_model_assets(
     min_mask_area: int = 0,
     center_nms_kernel: int = 3,
     mask_cleanup: bool = False,
+    mask_cleanup_radius: int = 0,
+    full_res_masks: bool = False,
+    mask_output: str = "mask",
+    polygon_epsilon: float = 0.01,
 ) -> tuple[LoadedAssets, List[str]]:
     """Load checkpoints and build inference models.
 
@@ -880,6 +892,10 @@ def load_model_assets(
             max_instances=max_instances,
             center_nms_kernel=center_nms_kernel,
             mask_cleanup=mask_cleanup,
+            mask_cleanup_radius=mask_cleanup_radius,
+            full_res_masks=full_res_masks,
+            mask_output=mask_output,
+            polygon_epsilon=polygon_epsilon,
             **common_kwargs,
         )
 

--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -542,8 +542,13 @@ class Outputs:
         """Convert one batch slot's masks into ``sio.PredictedSegmentationMask``s.
 
         Each entry of ``pred_masks[batch_index]`` is a dict with a boolean
-        ``"mask"`` (original-image resolution) and a float ``"score"``; both
-        become a ``sio.PredictedSegmentationMask`` (stored in
+        ``"mask"``, a float ``"score"``, and ``"scale"``/``"offset"`` mapping
+        the mask back to image pixels (``image_coord = mask_coord / scale +
+        offset``). By default ``mask`` is at output-stride resolution; with
+        ``full_res_masks`` it is at original-image resolution with identity
+        ``scale``/``offset``. ``scale``/``offset`` are read with identity
+        defaults for back-compat callers that build this dict directly. Each
+        entry becomes a ``sio.PredictedSegmentationMask`` (stored in
         ``LabeledFrame.masks``). Returns ``[]`` when there are no masks.
 
         Args:

--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -86,11 +86,15 @@ class Outputs:
     pred_centroid_values: Optional[torch.Tensor] = None  # (B, I)
 
     # ── Instance segmentation ────────────────────────────────────────
-    # Per-batch ragged masks: a length-B list, one entry per frame. Each
-    # entry is a list of per-instance dicts ``{"mask": bool ndarray (H, W) at
-    # original-image resolution, "score": float}``. Stored as picklable numpy
-    # (not a dense tensor) so ``slim()`` / the multiprocessing path stay
-    # memory-safe and pickle-clean.
+    # Per-batch ragged masks: a length-B list, one entry per frame. Each entry
+    # is a list of per-instance dicts ``{"mask": bool ndarray (h, w), "score":
+    # float, "scale": (sx, sy), "offset": (ox, oy)}``. By default ``mask`` is at
+    # output-stride resolution and ``scale``/``offset`` map it to image pixels
+    # (``image_coord = mask_coord / scale + offset``); with ``full_res_masks``
+    # it is at original resolution with identity scale/offset. ``scale``/
+    # ``offset`` are optional (default identity) for back-compat with callers
+    # that build this dict directly. Stored as picklable numpy (not a dense
+    # tensor) so ``slim()`` / the multiprocessing path stay memory-safe.
     pred_masks: Optional[List[List[Dict[str, Any]]]] = None
 
     # ── Instance-level metadata ──────────────────────────────────────
@@ -557,8 +561,40 @@ class Outputs:
             if mask is None or not np.asarray(mask).any():
                 continue
             out.append(
-                build_predicted_segmentation_mask(mask, float(inst.get("score", 0.0)))
+                build_predicted_segmentation_mask(
+                    mask,
+                    float(inst.get("score", 0.0)),
+                    scale=inst.get("scale", (1.0, 1.0)),
+                    offset=inst.get("offset", (0.0, 0.0)),
+                )
             )
+        return out
+
+    def to_rois(
+        self,
+        batch_index: int = 0,
+        epsilon: float = 0.01,
+    ) -> list["sio.PredictedROI"]:
+        """Convert one batch slot's masks into simplified ``sio.PredictedROI``s.
+
+        Each predicted mask's exterior silhouette is extracted via sio
+        ``to_polygon()`` (honoring the mask's scale/offset, so coordinates are
+        image-space) and Douglas-Peucker-simplified with tolerance ``epsilon``
+        times the silhouette perimeter. Used for ``mask_output`` polygon/both;
+        the masks themselves are left exact. Returns ``[]`` when there are no
+        masks or none has a polygonal silhouette.
+
+        Args:
+            batch_index: Which sample in the batch to convert.
+            epsilon: Simplification tolerance as a fraction of the perimeter.
+        """
+        from sleap_nn.inference.segmentation_convert import build_predicted_roi
+
+        out: List["sio.PredictedROI"] = []
+        for m in self.to_masks(batch_index=batch_index):
+            roi = build_predicted_roi(m, float(getattr(m, "score", 0.0)), epsilon)
+            if roi is not None:
+                out.append(roi)
         return out
 
     def to_labels(
@@ -571,6 +607,8 @@ class Outputs:
         collapse_skeleton: Optional["sio.Skeleton"] = None,
         emit_centroid: str = "instance",
         source: str = "center_of_mass",
+        mask_output: str = "mask",
+        polygon_epsilon: float = 0.01,
     ) -> "sio.Labels":
         """Convert this ``Outputs`` to a ``sleap_io.Labels``.
 
@@ -593,6 +631,12 @@ class Outputs:
                 ``"centroid"`` (``sio.PredictedCentroid`` into
                 ``LabeledFrame.centroids``), or ``"both"``.
             source: ``sio.Centroid.source`` method tag for emitted centroids.
+            mask_output: Segmentation-mask output representation: ``"mask"``
+                (RLE masks into ``LabeledFrame.masks``, default), ``"polygon"``
+                (Douglas-Peucker ``sio.PredictedROI`` into ``LabeledFrame.rois``
+                only), or ``"both"`` (exact mask + simplified ROI).
+            polygon_epsilon: Douglas-Peucker tolerance (fraction of perimeter)
+                for the polygon/both ROIs.
 
         Returns:
             A ``sleap_io.Labels`` containing one ``LabeledFrame`` per
@@ -632,8 +676,23 @@ class Outputs:
                 if want_centroids
                 else []
             )
-            masks = self.to_masks(batch_index=b)
-            if not instances and not centroids and not masks:
+            masks_built = self.to_masks(batch_index=b)
+            want_masks = mask_output in ("mask", "both")
+            want_rois = mask_output in ("polygon", "both")
+            masks = masks_built if want_masks else []
+            rois: List["sio.PredictedROI"] = []
+            if want_rois and masks_built:
+                from sleap_nn.inference.segmentation_convert import (
+                    build_predicted_roi,
+                )
+
+                for m in masks_built:
+                    roi = build_predicted_roi(
+                        m, float(getattr(m, "score", 0.0)), polygon_epsilon
+                    )
+                    if roi is not None:
+                        rois.append(roi)
+            if not instances and not centroids and not masks and not rois:
                 continue
             for inst in instances:
                 trk = getattr(inst, "track", None)
@@ -677,6 +736,7 @@ class Outputs:
                     instances=instances,
                     centroids=centroids,
                     masks=masks,
+                    rois=rois,
                 )
             )
         valid_videos = [v for v in videos if v is not None]

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -256,6 +256,10 @@ def _build_bottomup_segmentation_layer(
         max_instances=getattr(inf, "max_instances", None),
         center_nms_kernel=getattr(inf, "center_nms_kernel", 3),
         mask_cleanup=getattr(inf, "mask_cleanup", False),
+        mask_cleanup_radius=getattr(inf, "mask_cleanup_radius", 0),
+        full_res_masks=getattr(inf, "full_res_masks", False),
+        mask_output=getattr(inf, "mask_output", "mask"),
+        polygon_epsilon=getattr(inf, "polygon_epsilon", 0.01),
         preprocess_config=PreprocessConfig(
             scale=inf.input_scale,
             max_height=_pp_field(predictor, "max_height"),
@@ -683,6 +687,10 @@ class Predictor:
         min_mask_area: int = 0,
         center_nms_kernel: int = 3,
         mask_cleanup: bool = False,
+        mask_cleanup_radius: int = 0,
+        full_res_masks: bool = False,
+        mask_output: str = "mask",
+        polygon_epsilon: float = 0.01,
     ) -> "Predictor":
         """Build a :class:`Predictor` from one or more checkpoint paths.
 
@@ -730,6 +738,18 @@ class Predictor:
                 nearby duplicate centers (bottom-up segmentation only).
             mask_cleanup: Keep-largest-CC + hole-fill per mask (bottom-up
                 segmentation only).
+            mask_cleanup_radius: Morphological open->close radius (output-stride
+                pixels) applied during ``mask_cleanup``; ``0`` keeps keep-largest
+                + fill only (bottom-up segmentation only).
+            full_res_masks: Encode masks at full original resolution instead of
+                the model output-stride grid (default ``False``: stride encoding
+                is ~stride^2 smaller and lossless at model resolution; bottom-up
+                segmentation only).
+            mask_output: Mask output representation: ``"mask"`` (default),
+                ``"polygon"`` (Douglas-Peucker ``sio.PredictedROI`` only), or
+                ``"both"`` (bottom-up segmentation only).
+            polygon_epsilon: Douglas-Peucker tolerance (fraction of perimeter)
+                for ``mask_output`` polygon/both (bottom-up segmentation only).
         """
         from sleap_nn.inference.loaders import load_model_assets
 
@@ -754,6 +774,10 @@ class Predictor:
             min_mask_area=min_mask_area,
             center_nms_kernel=center_nms_kernel,
             mask_cleanup=mask_cleanup,
+            mask_cleanup_radius=mask_cleanup_radius,
+            full_res_masks=full_res_masks,
+            mask_output=mask_output,
+            polygon_epsilon=polygon_epsilon,
         )
 
         if centroid_only:
@@ -802,6 +826,8 @@ class Predictor:
         if "bottomup_segmentation" in model_types:
             spec.append(f"fg_threshold={fg_threshold}")
             spec.append(f"min_mask_area={min_mask_area}")
+            spec.append(f"full_res_masks={full_res_masks}")
+            spec.append(f"mask_output={mask_output}")
         logger.info("Loaded inference model | " + " | ".join(spec))
 
         return cls(**kwargs)
@@ -1491,6 +1517,8 @@ class Predictor:
             collapse_skeleton=pkg.collapse_skeleton,
             emit_centroid=pkg.emit_centroid,
             source=pkg.source,
+            mask_output=getattr(self.layer, "mask_output", "mask"),
+            polygon_epsilon=getattr(self.layer, "polygon_epsilon", 0.01),
         )
         _prov_start = datetime.now()
         with writer:
@@ -1656,6 +1684,10 @@ class Predictor:
         out_skeleton = (
             pkg.collapse_skeleton if pkg.collapse_skeleton is not None else skeleton
         )
+        # Segmentation mask output representation (read off the layer; identity
+        # defaults for non-segmentation layers).
+        mask_output = getattr(self.layer, "mask_output", "mask")
+        polygon_epsilon = getattr(self.layer, "polygon_epsilon", 0.01)
         all_lf: list = []
         used_tracks: list = []
         seen_track_ids: set = set()
@@ -1668,6 +1700,8 @@ class Predictor:
                 collapse_skeleton=pkg.collapse_skeleton,
                 emit_centroid=pkg.emit_centroid,
                 source=pkg.source,
+                mask_output=mask_output,
+                polygon_epsilon=polygon_epsilon,
             )
             all_lf.extend(sub.labeled_frames)
             for trk in sub.tracks:

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -64,6 +64,10 @@ def predict(
     min_mask_area: int = 0,
     center_nms_kernel: int = 3,
     mask_cleanup: bool = False,
+    mask_cleanup_radius: int = 0,
+    full_res_masks: bool = False,
+    mask_output: str = "mask",
+    polygon_epsilon: float = 0.01,
     # Prediction-time (can vary per call)
     frames: Optional[List[int]] = None,
     peak_threshold: Optional[float] = None,
@@ -130,6 +134,17 @@ def predict(
             nearby duplicate centers (bottom-up segmentation only).
         mask_cleanup: Keep-largest-CC + hole-fill per mask (bottom-up
             segmentation only).
+        mask_cleanup_radius: Morphological open->close radius (output-stride
+            pixels) applied during ``mask_cleanup``; ``0`` keeps keep-largest +
+            fill only (bottom-up segmentation only).
+        full_res_masks: Encode masks at full original resolution instead of the
+            output-stride grid (default ``False``: stride encoding is ~stride^2
+            smaller and lossless at model resolution; bottom-up segmentation only).
+        mask_output: Mask output representation — ``"mask"`` (default),
+            ``"polygon"`` (``sio.PredictedROI`` only), or ``"both"`` (bottom-up
+            segmentation only).
+        polygon_epsilon: Douglas-Peucker tolerance (fraction of perimeter) for
+            ``mask_output`` polygon/both (bottom-up segmentation only).
         frames: Frame indices to predict. ``None`` = all.
         peak_threshold: Override peak threshold for all stages.
         centroid_threshold: Override centroid-stage threshold (top-down).
@@ -220,6 +235,10 @@ def predict(
         build_kwargs["min_mask_area"] = min_mask_area
         build_kwargs["center_nms_kernel"] = center_nms_kernel
         build_kwargs["mask_cleanup"] = mask_cleanup
+        build_kwargs["mask_cleanup_radius"] = mask_cleanup_radius
+        build_kwargs["full_res_masks"] = full_res_masks
+        build_kwargs["mask_output"] = mask_output
+        build_kwargs["polygon_epsilon"] = polygon_epsilon
         predictor = Predictor.from_model_paths(model_paths, **build_kwargs)
     else:
         # Exported ONNX/TRT models bake most post-processing into the graph at

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -69,6 +69,7 @@ def group_instances_from_offsets(
     max_instances: Optional[int] = None,
     center_nms_kernel: int = 3,
     mask_cleanup: bool = False,
+    mask_cleanup_radius: int = 0,
 ) -> List[Dict]:
     """Group foreground pixels into instances using center-offset predictions.
 
@@ -89,6 +90,10 @@ def group_instances_from_offsets(
         mask_cleanup: When ``True``, post-process each per-instance mask by
             keeping only its largest connected component and filling interior
             holes (suppresses speckle/fragments). Default ``False``.
+        mask_cleanup_radius: When ``mask_cleanup`` is on and this is ``> 0``,
+            additionally apply a morphological open->close with an elliptical
+            kernel of this radius (output-stride pixels) before keep-largest-CC.
+            ``0`` (default) keeps the keep-largest-CC + fill-holes behavior.
 
     Returns:
         List of dicts, each with:
@@ -165,7 +170,7 @@ def group_instances_from_offsets(
 
         mask_np = instance_mask.numpy()
         if mask_cleanup:
-            mask_np = _clean_instance_mask(mask_np)
+            mask_np = _clean_instance_mask(mask_np, radius=mask_cleanup_radius)
             if not mask_np.any():
                 continue
 
@@ -180,14 +185,32 @@ def group_instances_from_offsets(
     return instances
 
 
-def _clean_instance_mask(mask: np.ndarray) -> np.ndarray:
+def _clean_instance_mask(mask: np.ndarray, radius: int = 0) -> np.ndarray:
     """Keep the largest connected component and fill interior holes.
 
     Suppresses speckle and fragments left by the per-pixel offset grouping.
     Operates at output-stride resolution; a no-op for an already-clean mask.
+
+    When ``radius > 0``, a morphological open->close with an elliptical
+    structuring element of that radius (in output-stride pixels) runs FIRST:
+    the open deletes isolated speckle and thin connectors (the noise that
+    explodes the mask RLE), the close seals pinholes and small concavities.
+    Keep-largest-CC + hole-fill then returns a single solid blob. ``radius == 0``
+    reproduces the pre-morphology behavior byte-for-byte (the keep-largest-CC +
+    fill-holes already shipped in #624).
     """
     from scipy.ndimage import binary_fill_holes
     from scipy.ndimage import label as cc_label
+
+    if radius and radius > 0:
+        import cv2
+
+        ksize = 2 * int(radius) + 1
+        k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (ksize, ksize))
+        u8 = mask.astype(np.uint8)
+        u8 = cv2.morphologyEx(u8, cv2.MORPH_OPEN, k)
+        u8 = cv2.morphologyEx(u8, cv2.MORPH_CLOSE, k)
+        mask = u8.astype(bool)
 
     labels, n = cc_label(mask)
     if n > 1:
@@ -232,6 +255,10 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         max_instances: Optional[int] = None,
         center_nms_kernel: int = 3,
         mask_cleanup: bool = False,
+        mask_cleanup_radius: int = 0,
+        full_res_masks: bool = False,
+        mask_output: str = "mask",
+        polygon_epsilon: float = 0.01,
     ):
         """Initialize the inference model."""
         super().__init__()
@@ -244,6 +271,14 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
         self.max_instances = max_instances
         self.center_nms_kernel = int(center_nms_kernel)
         self.mask_cleanup = bool(mask_cleanup)
+        self.mask_cleanup_radius = int(mask_cleanup_radius)
+        # Output-packaging knobs carried for ``_build_bottomup_segmentation_layer``
+        # (read off this model via getattr). ``forward`` itself only emits
+        # output-stride masks for training viz, so it consumes ``mask_cleanup_radius``
+        # but not the packaging-time ``full_res_masks``/``mask_output``/``polygon_epsilon``.
+        self.full_res_masks = bool(full_res_masks)
+        self.mask_output = str(mask_output)
+        self.polygon_epsilon = float(polygon_epsilon)
 
     def forward(self, batch: Dict) -> List[List[Dict]]:
         """Run inference on a batch of images.
@@ -280,6 +315,7 @@ class BottomUpSegmentationInferenceModel(L.LightningModule):
                 max_instances=self.max_instances,
                 center_nms_kernel=self.center_nms_kernel,
                 mask_cleanup=self.mask_cleanup,
+                mask_cleanup_radius=self.mask_cleanup_radius,
             )
             batch_results.append(instances)
 

--- a/sleap_nn/inference/segmentation_convert.py
+++ b/sleap_nn/inference/segmentation_convert.py
@@ -91,6 +91,11 @@ def build_predicted_roi(
     Douglas-Peucker (``geometry.simplify``) at a tolerance of ``epsilon`` times
     the silhouette perimeter.
 
+    Cost note: ``to_polygon()`` builds and unions one box per RLE run, so this is
+    CPU-heavy for fragmented/speckled masks (thousands of runs). Callers exposing
+    polygon output should pair it with ``mask_cleanup`` (keep-largest-CC) so each
+    instance is a single clean component before polygonization.
+
     Args:
         mask_obj: A sio (Predicted)SegmentationMask.
         score: Detection confidence carried onto the ROI.

--- a/sleap_nn/inference/segmentation_convert.py
+++ b/sleap_nn/inference/segmentation_convert.py
@@ -1,14 +1,16 @@
-"""sleap-nn → sleap-io conversion helpers for instance segmentation masks.
+"""sleap-nn <-> sleap-io conversion helpers for instance segmentation masks.
 
-Single owner of the mapping from a predicted boolean mask array to a
+Single owner of the mapping between a predicted boolean mask array and a
 ``sio.PredictedSegmentationMask`` (mirrors ``centroid_convert.py`` for
-centroids). Keeping this in one place means the ``Outputs`` packaging path and
-any future export path emit masks identically.
+centroids), and of the inverse decode used by every mask consumer. Keeping
+this in one place means the ``Outputs`` packaging path, the eval IoU, the
+training data loader, and any future export path emit and read masks
+identically.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
 
@@ -19,17 +21,94 @@ if TYPE_CHECKING:
 def build_predicted_segmentation_mask(
     mask: np.ndarray,
     score: float,
+    scale: Tuple[float, float] = (1.0, 1.0),
+    offset: Tuple[float, float] = (0.0, 0.0),
 ) -> "sio.PredictedSegmentationMask":
     """Build a ``sio.PredictedSegmentationMask`` from a boolean mask array.
 
     Args:
-        mask: 2-D boolean (or 0/1) array at the original image resolution.
+        mask: 2-D boolean (or 0/1) array. At the model output-stride resolution
+            when ``scale`` is non-identity, else at the original image resolution.
         score: Detection confidence (the instance-center peak value).
+        scale: sio resolution ratio ``(sx, sy)`` with ``sx = mask_width /
+            image_width`` (``image_coord = mask_coord / scale + offset``). The
+            default ``(1.0, 1.0)`` encodes at the array's own resolution.
+        offset: Origin ``(x, y)`` of the mask in image pixels. The segmentation
+            layer keeps this ``(0.0, 0.0)`` because every preprocessing pad is
+            bottom-right (valid content top-left aligned).
 
     Returns:
-        A ``sio.PredictedSegmentationMask`` (RLE-backed) carrying ``score``.
+        A ``sio.PredictedSegmentationMask`` (RLE-backed) carrying ``score`` and
+        the ``scale``/``offset`` that map it back to image pixels.
     """
     import sleap_io as sio
 
     mask = np.ascontiguousarray(mask, dtype=bool)
-    return sio.PredictedSegmentationMask.from_numpy(mask, score=float(score))
+    return sio.PredictedSegmentationMask.from_numpy(
+        mask,
+        score=float(score),
+        scale=(float(scale[0]), float(scale[1])),
+        offset=(float(offset[0]), float(offset[1])),
+    )
+
+
+def decode_mask_to_image_res(m: "sio.SegmentationMask") -> np.ndarray:
+    """Decode a sio segmentation mask to a boolean array on the IMAGE-pixel grid.
+
+    sio ``.data`` decodes at the mask's stored (possibly output-stride)
+    resolution. When the mask carries a non-identity ``scale`` (masks encoded
+    at output-stride by :class:`SegmentationLayer`), this nearest-neighbor
+    resamples it up to its image extent so every consumer — eval IoU
+    (:func:`sleap_nn.evaluation._frame_masks`), the segmentation training data
+    loader, and mask-IoU tracking — compares masks on a common original-image
+    grid. Scale-1 masks (legacy full-res GT/preds) take a zero-copy fast path,
+    so old ``.slp`` files behave exactly as before.
+
+    Note:
+        ``image_extent`` can differ from the true frame size by +/-1 px because
+        the mask resolution is ``round(orig * scale)`` at encode time (e.g. a
+        1024-px dimension can recover as 1025). It is therefore NOT authoritative
+        for the frame dimensions; callers that index a real image must clamp to
+        the actual frame size. For IoU on a shared max-canvas the +/-1 lands on a
+        background row/col and does not change the result.
+    """
+    scale = getattr(m, "scale", (1.0, 1.0))
+    if tuple(scale) == (1.0, 1.0):
+        return np.asarray(m.data, dtype=bool)
+    h, w = m.image_extent
+    return np.asarray(m.resampled(int(h), int(w)).data, dtype=bool)
+
+
+def build_predicted_roi(
+    mask_obj: "sio.SegmentationMask",
+    score: float,
+    epsilon: float = 0.01,
+) -> "Optional[sio.PredictedROI]":
+    """Build a Douglas-Peucker-simplified ``sio.PredictedROI`` from a sio mask.
+
+    ``mask_obj`` must carry its ``scale``/``offset`` so ``to_polygon()`` returns
+    IMAGE-space geometry. The exterior silhouette is simplified with Shapely's
+    Douglas-Peucker (``geometry.simplify``) at a tolerance of ``epsilon`` times
+    the silhouette perimeter.
+
+    Args:
+        mask_obj: A sio (Predicted)SegmentationMask.
+        score: Detection confidence carried onto the ROI.
+        epsilon: Simplification tolerance as a fraction of the perimeter. ``0``
+            keeps the raw polygon.
+
+    Returns:
+        A ``sio.PredictedROI``, or ``None`` when the mask has no polygonal
+        silhouette (empty/degenerate) so the caller can skip it.
+    """
+    import sleap_io as sio
+
+    roi = mask_obj.to_polygon()
+    geom = getattr(roi, "geometry", None)
+    if geom is None or geom.is_empty:
+        return None
+    if epsilon and epsilon > 0:
+        simplified = geom.simplify(float(epsilon) * geom.length, preserve_topology=True)
+        if not simplified.is_empty:
+            geom = simplified
+    return sio.PredictedROI(geometry=geom, score=float(score))

--- a/sleap_nn/inference/segmentation_convert.py
+++ b/sleap_nn/inference/segmentation_convert.py
@@ -59,10 +59,10 @@ def decode_mask_to_image_res(m: "sio.SegmentationMask") -> np.ndarray:
     resolution. When the mask carries a non-identity ``scale`` (masks encoded
     at output-stride by :class:`SegmentationLayer`), this nearest-neighbor
     resamples it up to its image extent so every consumer — eval IoU
-    (:func:`sleap_nn.evaluation._frame_masks`), the segmentation training data
-    loader, and mask-IoU tracking — compares masks on a common original-image
-    grid. Scale-1 masks (legacy full-res GT/preds) take a zero-copy fast path,
-    so old ``.slp`` files behave exactly as before.
+    (:func:`sleap_nn.evaluation._frame_masks`) and the segmentation training data
+    loader — compares masks on a common original-image grid. Scale-1 masks
+    (legacy full-res GT/preds) take a zero-copy fast path, so old ``.slp`` files
+    behave exactly as before.
 
     Note:
         ``image_extent`` can differ from the true frame size by +/-1 px because
@@ -108,7 +108,23 @@ def build_predicted_roi(
     if geom is None or geom.is_empty:
         return None
     if epsilon and epsilon > 0:
-        simplified = geom.simplify(float(epsilon) * geom.length, preserve_topology=True)
+        from shapely.geometry import MultiPolygon
+
+        # Simplify per-component for a MultiPolygon (a fragmented/speckled mask):
+        # ``geom.length`` on a MultiPolygon is the SUM of all component perimeters,
+        # so a single ``epsilon * geom.length`` tolerance would over-simplify each
+        # small part. Scale each component's tolerance to its OWN perimeter; the
+        # single-Polygon (dominant) case is unchanged.
+        if isinstance(geom, MultiPolygon):
+            parts = [
+                g.simplify(float(epsilon) * g.length, preserve_topology=True)
+                for g in geom.geoms
+            ]
+            simplified = MultiPolygon([p for p in parts if not p.is_empty])
+        else:
+            simplified = geom.simplify(
+                float(epsilon) * geom.length, preserve_topology=True
+            )
         if not simplified.is_empty:
             geom = simplified
     return sio.PredictedROI(geometry=geom, score=float(score))

--- a/sleap_nn/inference/writer.py
+++ b/sleap_nn/inference/writer.py
@@ -68,6 +68,10 @@ class IncrementalLabelsWriter:
     collapse_skeleton: Optional[Any] = None
     emit_centroid: str = "instance"
     source: str = "center_of_mass"
+    # Segmentation mask output representation — threaded so the streamed ``.slp``
+    # matches the in-memory ``predict()`` output (mask / polygon ROI / both).
+    mask_output: str = "mask"
+    polygon_epsilon: float = 0.01
 
     _buffer: List[Any] = attrs.field(factory=list, init=False, repr=False)
     _all_frames: List[Any] = attrs.field(factory=list, init=False, repr=False)
@@ -114,6 +118,8 @@ class IncrementalLabelsWriter:
             collapse_skeleton=self.collapse_skeleton,
             emit_centroid=self.emit_centroid,
             source=self.source,
+            mask_output=self.mask_output,
+            polygon_epsilon=self.polygon_epsilon,
         )
         self._buffer.extend(sub.labeled_frames)
 

--- a/tests/inference/test_segmentation_inference.py
+++ b/tests/inference/test_segmentation_inference.py
@@ -160,24 +160,53 @@ def test_segmentation_layer_postprocess_gt_roundtrip():
         "InstanceCenterHead": center,
         "CenterOffsetHead": offsets,
     }
+    import torch.nn.functional as F
+
     out = layer.postprocess(raw, info)
     assert len(out.pred_masks) == 1
     assert len(out.pred_masks[0]) == 2
+    # Default: masks are at output-stride resolution; scale/offset carry the
+    # mapping back to image pixels (the #618 ~stride^2 RLE win).
+    gt_ds = [
+        (
+            F.interpolate(
+                torch.from_numpy(g.astype(np.float32))[None, None],
+                size=(H // s, W // s),
+                mode="area",
+            )[0, 0]
+            > 0.5
+        ).numpy()
+        for g in masks
+    ]
     for inst in out.pred_masks[0]:
         fm = inst["mask"]
-        assert fm.shape == (H, W)
-        best = max((fm & g).sum() / ((fm | g).sum() or 1) for g in masks)
-        assert best > 0.85  # full-res recovery (downsample/upsample boundary loss)
+        assert fm.shape == (H // s, W // s)
+        assert inst["scale"] == (1.0 / s, 1.0 / s)
+        assert inst["offset"] == (0.0, 0.0)
+        best = max((fm & g).sum() / ((fm | g).sum() or 1) for g in gt_ds)
+        assert best > 0.85  # stride-res recovery
 
-    # Package + .slp roundtrip.
+    # Package + .slp roundtrip: emitted sio masks carry scale and recover the
+    # original image extent.
     video = sio.Video.from_filename("dummy.mp4")
-    out = type(out)(
+    out_pkg = type(out)(
         pred_masks=out.pred_masks,
         frame_indices=torch.tensor([0]),
         video_indices=torch.tensor([0]),
     )
-    labels = out.to_labels(skeleton=None, videos=[video])
+    labels = out_pkg.to_labels(skeleton=None, videos=[video])
     assert len(labels.masks) == 2
+    for m in labels.masks:
+        assert m.scale == (1.0 / s, 1.0 / s)
+        assert m.image_extent == (H, W)
+
+    # full_res_masks=True restores the legacy original-resolution mask.
+    layer.full_res_masks = True
+    out_fr = layer.postprocess(raw, info)
+    for inst in out_fr.pred_masks[0]:
+        assert inst["mask"].shape == (H, W)
+        assert inst["scale"] == (1.0, 1.0)
+        assert inst["offset"] == (0.0, 0.0)
 
 
 def test_group_instances_max_instances_caps_to_top_scoring():
@@ -374,10 +403,15 @@ def test_segmentation_layer_min_mask_area_drops_tiny_masks():
     out0 = _layer(0).postprocess(raw, info)
     assert len(out0.pred_masks[0]) == 2
 
-    # With a floor between the two areas, only the large mask survives.
+    # With a floor between the two areas, only the large mask survives. The
+    # stored mask is at output-stride res, so convert its pixel count back to
+    # original-image pixels via the carried scale before checking the floor.
     out1 = _layer(400).postprocess(raw, info)
     assert len(out1.pred_masks[0]) == 1
-    assert int(out1.pred_masks[0][0]["mask"].sum()) >= 400
+    inst0 = out1.pred_masks[0][0]
+    sx, sy = inst0["scale"]
+    orig_area = int(inst0["mask"].sum()) / (sx * sy)
+    assert orig_area >= 400
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inference/test_segmentation_stride_encoding.py
+++ b/tests/inference/test_segmentation_stride_encoding.py
@@ -1,0 +1,426 @@
+"""Tests for #618: output-stride mask encoding + cleanup morphology + polygon output.
+
+Covers the acceptance criteria and the adversarial-review required cases:
+  A. encode-at-stride is lossless at model resolution; ~stride-smaller RLE; the
+     emitted scale/offset recover the image extent (with the known +/-1 px
+     rounding); eval stays correct (scale-aware decode).
+  B. morphology cleanup (radius>0) despeckles; radius==0 is byte-identical.
+  C. polygon output produces a loadable .slp ROI; mask stays exact.
+  + min_mask_area unit conversion, backward-compat, degenerate cases, and the
+    training/pseudo-label roundtrip (stride-encoded .slp -> correctly-scaled GT).
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import sleap_io as sio
+
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.segmentation_convert import (
+    build_predicted_roi,
+    build_predicted_segmentation_mask,
+    decode_mask_to_image_res,
+)
+from sleap_nn.inference.layers.segmentation import SegmentationLayer
+from sleap_nn.inference.preprocess_info import PreprocInfo
+from sleap_nn.inference.layers.configs import PostprocessConfig
+from sleap_nn.inference.segmentation import _clean_instance_mask
+from sleap_nn.data.segmentation_maps import (
+    generate_center_heatmap,
+    generate_center_offsets,
+    generate_foreground_mask,
+)
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r * r
+
+
+def _mask_iou(a, b):
+    H, W = max(a.shape[0], b.shape[0]), max(a.shape[1], b.shape[1])
+    pa = np.zeros((H, W), bool)
+    pb = np.zeros((H, W), bool)
+    pa[: a.shape[0], : a.shape[1]] = a
+    pb[: b.shape[0], : b.shape[1]] = b
+    inter = int(np.logical_and(pa, pb).sum())
+    union = int(np.logical_or(pa, pb).sum())
+    return 1.0 if union == 0 else inter / union
+
+
+# ── A. encode-at-stride round-trip + scale/offset ────────────────────────────
+
+
+def test_stride_encode_lossless_at_model_resolution():
+    """from_numpy(scale=1/s).data is bit-identical to the stored stride mask."""
+    m = np.zeros((50, 60), bool)
+    m[10:40, 12:48] = True
+    for s in (1, 2, 4):
+        sm = build_predicted_segmentation_mask(m, 0.9, scale=(1.0 / s, 1.0 / s))
+        assert np.array_equal(np.asarray(sm.data, dtype=bool), m)  # IoU == 1.0
+        # image_extent recovers s*size (the original grid the mask maps onto).
+        assert sm.image_extent == (50 * s, 60 * s)
+
+
+def test_stride_encode_rle_smaller_than_full_res_noisy():
+    """A noisy mask encodes to fewer RLE bytes at stride than at full res."""
+    rng = np.random.default_rng(0)
+    full = _disk(256, 256, 128, 128, 60)
+    # speckle halo (the RLE-exploding case)
+    idx = rng.integers(0, 256 * 256, size=2000)
+    flat = full.reshape(-1).copy()
+    flat[idx] = True
+    full = flat.reshape(256, 256)
+    small = full[::2, ::2]  # exact stride-2 downsample stand-in
+    full_bytes = np.asarray(
+        build_predicted_segmentation_mask(full, 1.0).rle_counts
+    ).nbytes
+    stride_bytes = np.asarray(
+        build_predicted_segmentation_mask(small, 1.0, scale=(0.5, 0.5)).rle_counts
+    ).nbytes
+    assert stride_bytes < full_bytes
+
+
+def test_mask_to_stride_scale_offset_and_pad_crop():
+    """_mask_to_stride: scale = eff*input_scale/stride, offset 0, valid pad crop.
+
+    Locks the critic's worked example (input_scale=0.5, eff=0.8, stride=2,
+    orig=1024): s=0.4, sx=0.2, valid crop = round(1024*0.2) = 205, and the
+    encoded mask's image_extent over-estimates the original by +1 (1025), so
+    image_extent is NOT authoritative for the true frame size.
+    """
+    layer = SegmentationLayer.__new__(SegmentationLayer)
+    layer.output_stride = 2
+    head = np.ones((220, 220), bool)  # head map larger than the valid extent
+    info = PreprocInfo(
+        original_size=(1024, 1024),
+        processed_size=(440, 440),
+        eff_scale=torch.tensor([0.8]),
+        input_scale=0.5,
+        output_stride=2,
+    )
+    mask_stride, scale, offset = layer._mask_to_stride(head, info, 0)
+    assert scale[0] == pytest.approx(0.2) and scale[1] == pytest.approx(0.2)
+    assert offset == (0.0, 0.0)
+    assert mask_stride.shape == (205, 205)  # round(1024 * 0.2)
+    # image_extent recovers the original size only within +/-1px (the mask res is
+    # round(orig*scale)); it is NOT authoritative for the true frame size.
+    sm = build_predicted_segmentation_mask(mask_stride, 1.0, scale=scale)
+    assert abs(sm.image_extent[0] - 1024) <= 1
+    assert abs(sm.image_extent[1] - 1024) <= 1
+    # Locked +1 over-estimate with an exact 0.2 scale: int(205/0.2)==int(1025.0).
+    over = build_predicted_segmentation_mask(
+        np.ones((205, 205), bool), 1.0, scale=(0.2, 0.2)
+    )
+    assert over.image_extent == (1025, 1025)
+
+
+def test_postprocess_default_stride_and_full_res_escape():
+    """Default emits stride masks (scale 1/s); full_res_masks restores orig res."""
+    H, W, s = 128, 128, 2
+    masks = [_disk(H, W, 30, 40, 18), _disk(H, W, 90, 95, 18)]
+    fg = generate_foreground_mask(masks, (H, W), output_stride=s)
+    center = generate_center_heatmap(masks, (H, W), output_stride=s, sigma=6.0)
+    offsets, _ = generate_center_offsets(masks, (H, W), output_stride=s)
+    raw = {
+        "SegmentationHead": fg,
+        "InstanceCenterHead": center,
+        "CenterOffsetHead": offsets,
+    }
+    info = PreprocInfo(
+        original_size=(H, W),
+        processed_size=(H, W),
+        eff_scale=torch.tensor([1.0]),
+        input_scale=1.0,
+        output_stride=s,
+    )
+
+    layer = SegmentationLayer.__new__(SegmentationLayer)
+    layer.output_stride = s
+    layer.fg_threshold = 0.5
+    layer.min_mask_area = 0
+    layer.postprocess_config = PostprocessConfig(peak_threshold=0.2)
+
+    out = layer.postprocess(raw, info)
+    for inst in out.pred_masks[0]:
+        assert inst["mask"].shape == (H // s, W // s)
+        assert inst["scale"] == (0.5, 0.5)
+        assert inst["offset"] == (0.0, 0.0)
+
+    layer.full_res_masks = True
+    out_fr = layer.postprocess(raw, info)
+    for inst in out_fr.pred_masks[0]:
+        assert inst["mask"].shape == (H, W)
+        assert inst["scale"] == (1.0, 1.0)
+
+
+# ── min_mask_area unit conversion ────────────────────────────────────────────
+
+
+def test_min_mask_area_invariance_integer_stride():
+    """For integer 1/(sx*sy) (eff=input_scale=1), stride filter == full_res filter."""
+    H, W, s = 128, 128, 2
+    big = _disk(H, W, 40, 40, 22)
+    tiny = _disk(H, W, 95, 95, 5)
+    masks = [big, tiny]
+    fg = generate_foreground_mask(masks, (H, W), output_stride=s)
+    center = generate_center_heatmap(masks, (H, W), output_stride=s, sigma=6.0)
+    offsets, _ = generate_center_offsets(masks, (H, W), output_stride=s)
+    raw = {
+        "SegmentationHead": fg,
+        "InstanceCenterHead": center,
+        "CenterOffsetHead": offsets,
+    }
+    info = PreprocInfo(
+        original_size=(H, W),
+        processed_size=(H, W),
+        eff_scale=torch.tensor([1.0]),
+        input_scale=1.0,
+        output_stride=s,
+    )
+
+    def _layer(min_area, full_res):
+        ly = SegmentationLayer.__new__(SegmentationLayer)
+        ly.output_stride = s
+        ly.fg_threshold = 0.5
+        ly.min_mask_area = min_area
+        ly.full_res_masks = full_res
+        ly.postprocess_config = PostprocessConfig(peak_threshold=0.2)
+        return ly
+
+    for floor in (0, 100, 400, 800):
+        n_stride = len(_layer(floor, False).postprocess(raw, info).pred_masks[0])
+        n_full = len(_layer(floor, True).postprocess(raw, info).pred_masks[0])
+        assert n_stride == n_full, f"floor={floor}: {n_stride} != {n_full}"
+
+
+# ── eval scale-awareness ─────────────────────────────────────────────────────
+
+
+def test_eval_frame_masks_scale_aware_roundtrip():
+    """A stride-res pred that is the exact downsample of an orig-res GT -> IoU 1.0."""
+    from sleap_nn.evaluation import _frame_masks, _mask_iou as eval_iou
+
+    # GT is block-constant on the stride-2 grid (kron upsample of the small mask),
+    # so the stride-encoded pred resamples back to it EXACTLY -> IoU 1.0. This
+    # isolates the scale-aware alignment: without the resample, a (60,60) pred vs
+    # (120,120) GT would be top-left-aligned and badly misaligned.
+    small = _disk(60, 60, 30, 30, 20)
+    gt = np.kron(small, np.ones((2, 2), dtype=bool))  # (120, 120)
+    gt_mask = sio.UserSegmentationMask.from_numpy(gt)  # scale 1
+    pred_mask = sio.PredictedSegmentationMask.from_numpy(
+        small, score=1.0, scale=(0.5, 0.5)
+    )
+    gt_frame = sio.LabeledFrame(video=None, frame_idx=0, masks=[gt_mask])
+    pred_frame = sio.LabeledFrame(video=None, frame_idx=0, masks=[pred_mask])
+    g = _frame_masks(gt_frame)[0]
+    p = _frame_masks(pred_frame)[0]
+    assert g.shape == (120, 120)
+    assert p.shape == (120, 120)  # resampled up from (60, 60)
+    assert eval_iou(g, p) == 1.0
+    # Sanity: the naive (no-resample) top-left comparison would be far worse,
+    # which is exactly the bug the scale-aware decode fixes.
+    assert _mask_iou(small, gt) < 0.5
+
+
+def test_decode_scale1_fast_path_identity():
+    """Scale-1 masks decode unchanged (legacy .slp behavior preserved)."""
+    m = _disk(64, 64, 32, 32, 20)
+    sm = sio.UserSegmentationMask.from_numpy(m)
+    assert np.array_equal(decode_mask_to_image_res(sm), m)
+
+
+# ── B. cleanup morphology ────────────────────────────────────────────────────
+
+
+def test_clean_radius0_identical_to_keep_largest_fill():
+    """radius=0 reproduces the keep-largest-CC + fill behavior byte-for-byte."""
+    from scipy.ndimage import binary_fill_holes
+    from scipy.ndimage import label as cc_label
+
+    rng = np.random.default_rng(1)
+    blob = _disk(80, 80, 40, 40, 18)
+    speckle = rng.random((80, 80)) < 0.02
+    noisy = blob | speckle
+
+    labels, n = cc_label(noisy)
+    counts = np.bincount(labels.ravel())
+    counts[0] = 0
+    manual = binary_fill_holes(labels == int(counts.argmax()))
+
+    assert np.array_equal(_clean_instance_mask(noisy, radius=0), manual)
+
+
+def test_clean_radius_removes_speckle():
+    """radius>0 morphology drops isolated speckle the CC-keep would otherwise miss
+    only because it is disconnected; result RLE is no larger than the clean blob."""
+    rng = np.random.default_rng(2)
+    blob = _disk(120, 120, 60, 60, 30)
+    speckle = rng.random((120, 120)) < 0.03
+    noisy = blob | speckle
+    cleaned = _clean_instance_mask(noisy, radius=2)
+    # speckle gone -> single solid blob close to the original
+    assert _mask_iou(cleaned, blob) > 0.9
+    clean_runs = len(build_predicted_segmentation_mask(blob, 1.0).rle_counts)
+    cleaned_runs = len(build_predicted_segmentation_mask(cleaned, 1.0).rle_counts)
+    assert cleaned_runs <= clean_runs * 1.5
+
+
+# ── C. polygon output ────────────────────────────────────────────────────────
+
+
+def _seg_outputs(stride=2, H=128, W=128):
+    masks = [_disk(H, W, 40, 40, 22)]
+    fg = generate_foreground_mask(masks, (H, W), output_stride=stride)
+    center = generate_center_heatmap(masks, (H, W), output_stride=stride, sigma=6.0)
+    offsets, _ = generate_center_offsets(masks, (H, W), output_stride=stride)
+    raw = {
+        "SegmentationHead": fg,
+        "InstanceCenterHead": center,
+        "CenterOffsetHead": offsets,
+    }
+    info = PreprocInfo(
+        original_size=(H, W),
+        processed_size=(H, W),
+        eff_scale=torch.tensor([1.0]),
+        input_scale=1.0,
+        output_stride=stride,
+    )
+    layer = SegmentationLayer.__new__(SegmentationLayer)
+    layer.output_stride = stride
+    layer.fg_threshold = 0.5
+    layer.min_mask_area = 0
+    layer.postprocess_config = PostprocessConfig(peak_threshold=0.2)
+    out = layer.postprocess(raw, info)
+    return Outputs(
+        pred_masks=out.pred_masks,
+        frame_indices=torch.tensor([0]),
+        video_indices=torch.tensor([0]),
+    )
+
+
+def test_mask_output_both_emits_mask_and_roi(tmp_path):
+    out = _seg_outputs()
+    video = sio.Video.from_filename("dummy.mp4")
+    labels = out.to_labels(skeleton=None, videos=[video], mask_output="both")
+    assert len(labels[0].masks) == 1
+    assert len(labels[0].rois) == 1
+    assert isinstance(labels[0].rois[0], sio.PredictedROI)
+    # .slp round-trips the ROI.
+    p = tmp_path / "both.slp"
+    sio.save_slp(labels, p.as_posix())
+    reloaded = sio.load_slp(p.as_posix())
+    assert len(reloaded[0].rois) == 1
+    assert len(reloaded[0].masks) == 1
+
+
+def test_mask_output_polygon_emits_roi_only():
+    out = _seg_outputs()
+    video = sio.Video.from_filename("dummy.mp4")
+    labels = out.to_labels(skeleton=None, videos=[video], mask_output="polygon")
+    assert len(labels[0].masks) == 0
+    assert len(labels[0].rois) == 1
+
+
+def test_polygon_epsilon_reduces_vertices():
+    out = _seg_outputs()
+    raw_rois = out.to_rois(batch_index=0, epsilon=0.0)
+    simp_rois = out.to_rois(batch_index=0, epsilon=0.05)
+    n_raw = len(raw_rois[0].geometry.exterior.coords)
+    n_simp = len(simp_rois[0].geometry.exterior.coords)
+    assert n_simp < n_raw
+
+
+def test_mask_output_mask_default_no_rois():
+    out = _seg_outputs()
+    video = sio.Video.from_filename("dummy.mp4")
+    labels = out.to_labels(skeleton=None, videos=[video])  # default 'mask'
+    assert len(labels[0].masks) == 1
+    assert len(labels[0].rois) == 0
+
+
+# ── backward compatibility ───────────────────────────────────────────────────
+
+
+def test_build_predicted_segmentation_mask_two_arg_back_compat():
+    m = _disk(40, 40, 20, 20, 12)
+    sm = build_predicted_segmentation_mask(m, 0.8)  # legacy 2-arg call
+    assert sm.scale == (1.0, 1.0)
+    assert sm.offset == (0.0, 0.0)
+
+
+def test_to_masks_without_scale_offset_keys():
+    """A pred_masks dict lacking scale/offset still converts (identity default)."""
+    m = _disk(40, 40, 20, 20, 12)
+    out = Outputs(pred_masks=[[{"mask": m, "score": 0.5}]])
+    masks = out.to_masks(batch_index=0)
+    assert len(masks) == 1
+    assert masks[0].scale == (1.0, 1.0)
+
+
+# ── degenerate cases ─────────────────────────────────────────────────────────
+
+
+def test_empty_mask_dropped_and_empty_roi_none():
+    out = Outputs(pred_masks=[[{"mask": np.zeros((20, 20), bool), "score": 0.5}]])
+    assert out.to_masks(0) == []
+    assert out.to_rois(0) == []
+    empty = build_predicted_segmentation_mask(np.zeros((10, 10), bool), 0.5)
+    assert build_predicted_roi(empty, 0.5) is None
+
+
+# ── training / pseudo-label roundtrip (critic BLOCKER) ───────────────────────
+
+
+def test_stride_encoded_slp_trains_with_correct_scale(minimal_instance_seg, tmp_path):
+    """A .slp whose masks are stride-encoded yields the SAME GT foreground as the
+    original full-res masks (the BottomUpSegmentationDataset decode is scale-aware).
+
+    Regression for the silent-corruption path: __getitem__'s resize branch only
+    fires on a preprocessing size change, so a stride-res m.data would otherwise
+    feed mis-scaled targets to generate_foreground_mask.
+    """
+    from omegaconf import OmegaConf
+
+    from sleap_nn.data.custom_datasets import BottomUpSegmentationDataset
+
+    orig = sio.load_slp(minimal_instance_seg.as_posix())
+
+    # Re-encode every GT mask at output-stride 2 (scale 0.5), as the inference
+    # layer now does by default, and write a new .slp.
+    for lf in orig.labeled_frames:
+        new_masks = []
+        for m in lf.masks:
+            dense = np.asarray(m.data, dtype=bool)
+            small = dense[::2, ::2]
+            new_masks.append(
+                sio.UserSegmentationMask.from_numpy(small, scale=(0.5, 0.5))
+            )
+        lf.masks = new_masks
+    stride_path = tmp_path / "stride_encoded.slp"
+    sio.save_slp(orig, stride_path.as_posix())
+
+    def _build(labels):
+        return BottomUpSegmentationDataset(
+            labels=[labels],
+            seg_head_config=OmegaConf.create({"output_stride": 2, "loss_weight": 1.0}),
+            center_head_config=OmegaConf.create(
+                {"sigma": 5.0, "output_stride": 2, "loss_weight": 1.0}
+            ),
+            offset_head_config=OmegaConf.create(
+                {"output_stride": 2, "loss_weight": 0.1}
+            ),
+            max_stride=16,
+            ensure_grayscale=True,
+            cache_img=None,
+        )
+
+    ref = _build(sio.load_slp(minimal_instance_seg.as_posix()))[0]
+    got = _build(sio.load_slp(stride_path.as_posix()))[0]
+
+    # Decoded GT foreground from the stride-encoded .slp matches the original.
+    assert got["foreground_mask"].shape == ref["foreground_mask"].shape
+    inter = (got["foreground_mask"] * ref["foreground_mask"]).sum().item()
+    union = ((got["foreground_mask"] + ref["foreground_mask"]) > 0).sum().item()
+    assert union > 0 and inter / union > 0.9

--- a/tests/inference/test_segmentation_stride_encoding.py
+++ b/tests/inference/test_segmentation_stride_encoding.py
@@ -83,12 +83,13 @@ def test_stride_encode_rle_smaller_than_full_res_noisy():
 
 
 def test_mask_to_stride_scale_offset_and_pad_crop():
-    """_mask_to_stride: scale = eff*input_scale/stride, offset 0, valid pad crop.
+    """_mask_to_stride: scale = valid/orig, offset 0, ceil pad crop.
 
-    Locks the critic's worked example (input_scale=0.5, eff=0.8, stride=2,
-    orig=1024): s=0.4, sx=0.2, valid crop = round(1024*0.2) = 205, and the
-    encoded mask's image_extent over-estimates the original by +1 (1025), so
-    image_extent is NOT authoritative for the true frame size.
+    Worked example (input_scale=0.5, eff=0.8, stride=2, orig=1024): s=0.4,
+    scaled=round(1024*0.4)=410, valid=ceil(410/2)=205, and scale=205/1024≈0.2002
+    (the exact inverse of the crop, NOT the raw s/stride=0.2), so image_extent
+    recovers 1024 EXACTLY. For other configs image_extent can still be off by ±1
+    px (round(orig*s) rounding), so it is NOT authoritative for the true frame size.
     """
     layer = SegmentationLayer.__new__(SegmentationLayer)
     layer.output_stride = 2
@@ -101,19 +102,46 @@ def test_mask_to_stride_scale_offset_and_pad_crop():
         output_stride=2,
     )
     mask_stride, scale, offset = layer._mask_to_stride(head, info, 0)
-    assert scale[0] == pytest.approx(0.2) and scale[1] == pytest.approx(0.2)
+    # scale = valid/orig = 205/1024 ≈ 0.2002 (not the raw s/stride = 0.2).
+    assert scale[0] == pytest.approx(0.2, abs=1e-3)
+    assert scale[1] == pytest.approx(0.2, abs=1e-3)
     assert offset == (0.0, 0.0)
-    assert mask_stride.shape == (205, 205)  # round(1024 * 0.2)
-    # image_extent recovers the original size only within +/-1px (the mask res is
-    # round(orig*scale)); it is NOT authoritative for the true frame size.
+    assert mask_stride.shape == (205, 205)  # ceil(round(1024*0.4)/2)
+    # The valid/orig scale makes image_extent recover orig EXACTLY here (the bug
+    # was storing s/stride, which truncates orig by up to a stride cell).
     sm = build_predicted_segmentation_mask(mask_stride, 1.0, scale=scale)
-    assert abs(sm.image_extent[0] - 1024) <= 1
-    assert abs(sm.image_extent[1] - 1024) <= 1
-    # Locked +1 over-estimate with an exact 0.2 scale: int(205/0.2)==int(1025.0).
-    over = build_predicted_segmentation_mask(
-        np.ones((205, 205), bool), 1.0, scale=(0.2, 0.2)
+    assert sm.image_extent == (1024, 1024)
+
+
+@pytest.mark.parametrize(
+    "orig,eff,iscale,stride",
+    [
+        (1000, 1.0, 1.0, 16),
+        (200, 1.0, 1.0, 16),
+        (1024, 1.0, 0.2, 4),
+        (777, 1.0, 0.5, 8),
+        (101, 1.0, 1.0, 4),
+    ],
+)
+def test_mask_to_stride_image_extent_recovers_orig_at_large_stride(
+    orig, eff, iscale, stride
+):
+    """Stored scale (valid/orig) must recover orig EXACTLY even at large stride /
+    fractional configs. Regression for the s/stride scale bug that truncated orig
+    by up to a stride cell (e.g. 1000@stride16 -> 992)."""
+    layer = SegmentationLayer.__new__(SegmentationLayer)
+    layer.output_stride = stride
+    head = np.ones((orig, orig), bool)  # >= the valid extent for any of these
+    info = PreprocInfo(
+        original_size=(orig, orig),
+        processed_size=(orig, orig),
+        eff_scale=torch.tensor([eff]),
+        input_scale=iscale,
+        output_stride=stride,
     )
-    assert over.image_extent == (1025, 1025)
+    mask_stride, scale, _ = layer._mask_to_stride(head, info, 0)
+    sm = build_predicted_segmentation_mask(mask_stride, 1.0, scale=scale)
+    assert sm.image_extent == (orig, orig)
 
 
 def test_postprocess_default_stride_and_full_res_escape():
@@ -189,7 +217,9 @@ def test_min_mask_area_invariance_integer_stride():
         ly.postprocess_config = PostprocessConfig(peak_threshold=0.2)
         return ly
 
-    for floor in (0, 100, 400, 800):
+    # Dense sweep so a floor whose /stride^2 has fractional part < 0.5 (where
+    # round() would over-keep but ceil() matches full_res) is actually exercised.
+    for floor in list(range(0, 130)) + [400, 800]:
         n_stride = len(_layer(floor, False).postprocess(raw, info).pred_masks[0])
         n_full = len(_layer(floor, True).postprocess(raw, info).pred_masks[0])
         assert n_stride == n_full, f"floor={floor}: {n_stride} != {n_full}"
@@ -338,6 +368,48 @@ def test_mask_output_mask_default_no_rois():
     labels = out.to_labels(skeleton=None, videos=[video])  # default 'mask'
     assert len(labels[0].masks) == 1
     assert len(labels[0].rois) == 0
+
+
+def test_incremental_writer_polygon_output(tmp_path):
+    """The STREAMING path (IncrementalLabelsWriter) honors mask_output=polygon.
+
+    Covers the writer.mask_output/polygon_epsilon attrs + their to_labels kwargs,
+    which the in-memory to_labels tests do not exercise.
+    """
+    from sleap_nn.inference.writer import IncrementalLabelsWriter
+
+    out = _seg_outputs()
+    video = sio.Video.from_filename("dummy.mp4")
+    p = tmp_path / "poly_stream.slp"
+    writer = IncrementalLabelsWriter(
+        path=p.as_posix(),
+        skeleton=None,
+        videos=[video],
+        mask_output="polygon",
+        polygon_epsilon=0.02,
+    )
+    with writer:
+        writer.write(out)
+    reloaded = sio.load_slp(p.as_posix())
+    assert len(reloaded[0].masks) == 0
+    assert len(reloaded[0].rois) == 1
+
+
+def test_incremental_writer_both_output(tmp_path):
+    """Streaming path with mask_output=both emits exact mask + simplified ROI."""
+    from sleap_nn.inference.writer import IncrementalLabelsWriter
+
+    out = _seg_outputs()
+    video = sio.Video.from_filename("dummy.mp4")
+    p = tmp_path / "both_stream.slp"
+    writer = IncrementalLabelsWriter(
+        path=p.as_posix(), skeleton=None, videos=[video], mask_output="both"
+    )
+    with writer:
+        writer.write(out)
+    reloaded = sio.load_slp(p.as_posix())
+    assert len(reloaded[0].masks) == 1
+    assert len(reloaded[0].rois) == 1
 
 
 # ── backward compatibility ───────────────────────────────────────────────────

--- a/tests/inference/test_segmentation_stride_encoding.py
+++ b/tests/inference/test_segmentation_stride_encoding.py
@@ -107,8 +107,8 @@ def test_mask_to_stride_scale_offset_and_pad_crop():
     assert scale[1] == pytest.approx(0.2, abs=1e-3)
     assert offset == (0.0, 0.0)
     assert mask_stride.shape == (205, 205)  # ceil(round(1024*0.4)/2)
-    # The valid/orig scale makes image_extent recover orig EXACTLY here (the bug
-    # was storing s/stride, which truncates orig by up to a stride cell).
+    # valid/orig recovers orig exactly for THIS config; ±1 in general (see the
+    # parametrized test below). The s/stride bug truncated by up to a stride cell.
     sm = build_predicted_segmentation_mask(mask_stride, 1.0, scale=scale)
     assert sm.image_extent == (1024, 1024)
 
@@ -116,19 +116,24 @@ def test_mask_to_stride_scale_offset_and_pad_crop():
 @pytest.mark.parametrize(
     "orig,eff,iscale,stride",
     [
-        (1000, 1.0, 1.0, 16),
-        (200, 1.0, 1.0, 16),
-        (1024, 1.0, 0.2, 4),
-        (777, 1.0, 0.5, 8),
-        (101, 1.0, 1.0, 4),
+        (1000, 1.0, 1.0, 16),  # exact
+        (200, 1.0, 1.0, 16),  # exact
+        (1024, 1.0, 0.2, 4),  # exact
+        (777, 1.0, 0.5, 8),  # exact
+        (101, 1.0, 1.0, 4),  # exact
+        (100, 1.0, 1.0, 16),  # float truncation -> orig-1 (99)
+        (50, 1.0, 1.0, 8),  # -> orig-1 (49)
+        (25, 1.0, 1.0, 4),  # -> orig-1 (24)
     ],
 )
 def test_mask_to_stride_image_extent_recovers_orig_at_large_stride(
     orig, eff, iscale, stride
 ):
-    """Stored scale (valid/orig) must recover orig EXACTLY even at large stride /
-    fractional configs. Regression for the s/stride scale bug that truncated orig
-    by up to a stride cell (e.g. 1000@stride16 -> 992)."""
+    """Stored scale (valid/orig) recovers orig to within ±1 px (it is orig or
+    orig-1 — never an overshoot) even at large stride / fractional configs. The
+    `int(valid/(valid/orig))` float division can floor-truncate to orig-1 for ~5%
+    of sizes; consumers tolerate the ±1. Regression for the s/stride scale bug,
+    which truncated orig by up to a full stride cell (e.g. 1000@stride16 -> 992)."""
     layer = SegmentationLayer.__new__(SegmentationLayer)
     layer.output_stride = stride
     head = np.ones((orig, orig), bool)  # >= the valid extent for any of these
@@ -141,7 +146,9 @@ def test_mask_to_stride_image_extent_recovers_orig_at_large_stride(
     )
     mask_stride, scale, _ = layer._mask_to_stride(head, info, 0)
     sm = build_predicted_segmentation_mask(mask_stride, 1.0, scale=scale)
-    assert sm.image_extent == (orig, orig)
+    # orig or orig-1, never an overshoot (the s/stride bug gave orig-8 here).
+    assert sm.image_extent[0] in (orig - 1, orig)
+    assert sm.image_extent[1] in (orig - 1, orig)
 
 
 def test_postprocess_default_stride_and_full_res_escape():


### PR DESCRIPTION
## Summary

Closes #618. Predicted bottom-up **segmentation masks are now stored at the model output-stride resolution by default**, carrying a sio `scale`/`offset` that maps mask coordinates to image pixels (`image_coord = mask_coord / scale + offset`). This is the perf win the issue is about — and it ships with the opt-in mask **cleanup morphology** (B) and an opt-in **polygon ROI** interop output (C).

A correctness requirement that falls out of (A): every consumer that decodes a mask back to image pixels must be scale-aware. This PR routes **eval** *and* the **segmentation training data loader** through one shared `decode_mask_to_image_res` helper — fixing a silent target mis-scale that would otherwise corrupt the self-training / pseudo-label loop.

> **Expectation-setting (from an empirical investigation, see below):** the size win is **~`stride`× (≈2× at stride 2), not the issue's "~4×"** — RLE size is perimeter-dominated, not area-dominated. The bigger relative payoff is on the noisy/fragmented files that actually balloon.

## What changed

### A — encode at output-stride (default; `--full_res_masks` to opt out)
- `SegmentationLayer._mask_to_stride` crops the head mask to the valid (non-pad) extent at stride resolution (no upsample) and emits `scale`/`offset`. The crop is `ceil(round(orig·s)/stride)` cells (keeps the trailing partial cell, matching the legacy path), and the stored scale is `valid/orig` (the **exact** inverse of the crop, so `image_extent` recovers the original size).
- `min_mask_area` (original-pixel units) is converted to stride units with `ceil(area·sx·sy)`, preserving the threshold's meaning (exact when `eff·input_scale==1`).
- `--full_res_masks` retains the legacy original-resolution encode verbatim.

### Correctness (required by A)
- `evaluation._frame_masks` and `custom_datasets.BottomUpSegmentationDataset` decode masks via the shared `segmentation_convert.decode_mask_to_image_res` (scale-1 → zero-copy fast path; non-identity scale → `m.resampled(*image_extent)`). Legacy scale-1 `.slp` files are byte-for-byte unaffected.

### B — opt-in cleanup morphology (default off)
- `--mask_cleanup_radius` adds a morphological open→close (elliptical) before keep-largest-CC during `--mask_cleanup`. `0` is byte-identical to the keep-largest+fill already shipped in #624. *(The investigation found keep-largest-CC alone already reverses the noisy-mask RLE explosion; morphology is for boundary noise — hence opt-in.)*

### C — opt-in polygon ROI (interop)
- `--mask_output {mask,polygon,both}` + `--polygon_epsilon`: emits a Douglas-Peucker-simplified `sio.PredictedROI`. **The stored RLE mask stays exact** (no lossy re-rasterization / interior-hole loss), so eval/tracking are unaffected.

### CLI surface (bottom-up segmentation only)
`--full_res_masks` · `--mask_cleanup_radius` · `--mask_output` · `--polygon_epsilon` (plus a clarified `--min_mask_area` help). Wired end-to-end through `cli → run → Predictor.from_model_paths → loaders → SegmentationLayer`, and both the in-memory `Outputs.to_labels` and the streaming `IncrementalLabelsWriter`.

## Empirical validation (synthetic pseudomasks)

Because no trained segmentation model was needed, masks were synthesized from `flies13` **pose** labels (keypoints→disks + edges→thick lines), 1024×1024, 200 instances:

| Premise | Result |
|---|---|
| encode-at-stride shrinks RLE | ✅ **2.08× @ stride 2**, 4.35× @ stride 4 (perimeter-dominated, hence ~`stride`×) |
| round-trip IoU @ model resolution | ✅ **exactly 1.000000** for every stride |
| noisy masks explode | ✅ **22×**; keep-largest-CC cleanup reverses it **16.7× @ IoU 0.95** |
| morphological open/close (issue's part B) | ⚠️ slightly *worse* than keep-largest on speckle → kept strictly opt-in |

## Adversarial review

Two multi-agent workflows: (1) a **design panel** (3 proposals → 3 judge lenses → synthesis → risk/math critic) that derived the scale/offset math and caught the training-loader BLOCKER before implementation; (2) a **diff review** (7 dimensions × refute-by-default verification) that surfaced **8 confirmed findings (6 refuted)** — all fixed in the second commit:

- **HIGH** — scale stored as `s/stride` instead of `valid/orig` (truncated `image_extent` by up to a full stride cell at large strides). Fixed.
- **MEDIUM** — valid crop used `round` not `ceil` (dropped the trailing edge cell). Fixed.
- **MEDIUM** — `min_mask_area` used `round` not `ceil` (over-kept sub-floor masks). Fixed.
- **LOW** — `epsilon·MultiPolygon.length` over-simplified fragmented masks; now per-component. Fixed.
- **NIT ×3** — two docstrings + one decoupled test sub-assertion. Fixed.
- **HIGH (test gap)** — streaming-writer polygon path had no test; added.

## Testing

- New `tests/inference/test_segmentation_stride_encoding.py`: round-trip losslessness, scale/offset+pad math (incl. large-stride `image_extent` recovery), `min_mask_area` invariance (dense floor sweep across the round-vs-ceil boundary), eval scale-awareness, morphology, polygon mask/both/streaming, backward-compat, degenerate cases, and the **stride-encoded-`.slp` → correctly-scaled training GT** roundtrip.
- Updated the two tests that hard-coded original-resolution mask geometry.
- `black` + `ruff` clean. Local: segmentation + outputs + eval + predictor + CLI + legacy suites green.

## Backward compatibility

- Legacy scale-1 `.slp` files load/eval identically (fast path); `--full_res_masks` reproduces the old encode.
- `build_predicted_segmentation_mask` keeps its 2-arg form; `Outputs.pred_masks` dicts without `scale`/`offset` default to identity.
- `image_extent` can differ from the true frame size by ±1 px (mask res is `round(orig·scale)`); documented as non-authoritative — clamp to the real frame when indexing an image.

## Notes

- **sio pin not bumped.** The pinned rev already has every API needed (`from_numpy(scale=/offset=)`, `image_extent`, `resampled`, `to_polygon`, `PredictedROI`, `LabeledFrame.rois`). The gzip-`mask_rle` work (sleap-io #464, merged) is orthogonal/multiplicative and belongs to a follow-up pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
