### PR TITLE
chore(deps): bump sleap-io pin to main (4ee1fb38)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,9 @@ conflicts = [
 # sleap-io 0.8.0 is not yet released on PyPI; track main for the segmentation
 # (SegmentationMask / Labels.get_masks) APIs. Pinned to a commit for
 # reproducibility — update or drop once sleap-io 0.8.0 is published.
-sleap-io = { git = "https://github.com/talmolab/sleap-io.git", rev = "18aba053f607863654ca233fffed61f1c0dc707e" }
+# Bumped to include render: auto-draw SegmentationMask overlays (#461) + roi_wkb
+# gzip (#465).
+sleap-io = { git = "https://github.com/talmolab/sleap-io.git", rev = "4ee1fb388aefcd3f87691f741e0b6b34db482e8e" }
 torch = [
     { index = "pytorch-cpu", extra = "torch-cpu" },
     { index = "pytorch-cu118", extra = "torch-cuda118", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },


### PR DESCRIPTION
Advances the pinned sleap-io commit from `18aba053` (one commit before the segmentation render fix) to current main `4ee1fb388`. `uv.lock` change is **just the rev** (no transitive version changes).

Picks up:
- **render: auto-draw `SegmentationMask` overlays + grayscale fix** (sleap-io #461) — `sio render preds.slp` now overlays `LabeledFrame.masks` (RLE segmentation masks), colored by track, instead of producing bare video. Verified locally on a bottom-up-segmentation tracked `.slp`.
- **perf(slp): gzip-compress the `roi_wkb` dataset** (sleap-io #465).

## Notes
- Surfaced while visualizing the mask-tracking work (#619): the prior pin was exactly one commit shy of the render fix, so `sio render` showed bare video.
- Unrelated caveat tracked separately as **#632**: `uv sync --extra gpu` installs an unimportable torch (missing `libcudnn.so.9`); use `uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130` for a working GPU env. This PR does not touch that.
- Independent of PR #630 (the mask-IoU tracker); intentionally kept as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)