### PR TITLE
feat: error on multi-instance frames in single-instance training

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -359,6 +359,52 @@ class ModelTrainer:
         logger.info(f"# Train Labeled frames: {total_train_lfs}")
         logger.info(f"# Val Labeled frames: {total_val_lfs}")
 
+        # Single-instance models assume exactly one instance per frame; fail fast
+        # with a clear error if any frame has more than one.
+        if self.model_type == "single_instance":
+            self._validate_single_instance_labels(self.train_labels, "train")
+            self._validate_single_instance_labels(self.val_labels, "validation")
+
+    def _validate_single_instance_labels(
+        self, labels: List[sio.Labels], split_name: str
+    ):
+        """Ensure no frame has more than one instance for single-instance models.
+
+        Single-instance confidence-map generation flattens the instance dimension
+        (see `sleap_nn.data.confidence_maps.generate_confmaps`), so a frame with
+        more than one instance would silently merge multiple animals into a single
+        instance with `n_instances * n_nodes` "nodes" and corrupt training. This
+        raises a clear error instead, naming the offending frame.
+
+        Args:
+            labels: List of `sio.Labels` objects to validate.
+            split_name: Name of the split (e.g. "train", "validation") for the
+                error message.
+
+        Raises:
+            ValueError: If any frame contains more than one (non-empty) instance.
+        """
+        user_instances_only = OmegaConf.select(
+            self.config, "data_config.user_instances_only", default=True
+        )
+        for label in labels:
+            for lf in label:
+                if user_instances_only and lf.user_instances is not None:
+                    instances = lf.user_instances
+                else:
+                    instances = lf.instances
+                instances = [inst for inst in instances if not inst.is_empty]
+                if len(instances) > 1:
+                    video_idx = label.videos.index(lf.video)
+                    raise ValueError(
+                        f"Single-instance training requires at most one instance "
+                        f"per frame, but the {split_name} frame at (video index "
+                        f"{video_idx}, frame_idx {lf.frame_idx}) has "
+                        f"{len(instances)} instances. Remove the extra instance(s) "
+                        f"from this frame, or train a multi-instance (top-down or "
+                        f"bottom-up) model instead."
+                    )
+
     def _setup_preprocessing_config(self):
         """Setup preprocessing config."""
         # compute max_heigt, max_width, and crop_size (if not provided in the config)

--- a/tests/training/test_lightning_modules.py
+++ b/tests/training/test_lightning_modules.py
@@ -241,7 +241,7 @@ def test_centroid_model(config, tmp_path: str):
     assert abs(loss - mse_loss(preds, input_cm.squeeze(dim=1))) < 1e-3
 
 
-def test_single_instance_model(config, tmp_path: str):
+def test_single_instance_model(config, tmp_path: str, minimal_instance):
     """Test the SingleInstanceLightningModule training."""
     head_config = config.model_config.head_configs.centered_instance
     del config.model_config.head_configs.centered_instance
@@ -252,7 +252,17 @@ def test_single_instance_model(config, tmp_path: str):
     OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
     OmegaConf.update(config, "trainer_config.run_name", "test_single_instance_model_1")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
-    model_trainer = ModelTrainer.get_model_trainer_from_config(config)
+
+    # Single-instance training requires at most one instance per frame.
+    single_instance_labels = sio.load_slp(minimal_instance)
+    for lf in single_instance_labels:
+        lf.instances = [lf.instances[0]]
+
+    model_trainer = ModelTrainer.get_model_trainer_from_config(
+        config,
+        train_labels=[single_instance_labels],
+        val_labels=[single_instance_labels],
+    )
     train_dataset, val_dataset = get_train_val_datasets(
         train_labels=model_trainer.train_labels,
         val_labels=model_trainer.val_labels,
@@ -299,7 +309,11 @@ def test_single_instance_model(config, tmp_path: str):
     OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
     OmegaConf.update(config, "trainer_config.run_name", "test_single_instance_model_2")
     OmegaConf.update(config, "data_config.data_pipeline_fw", "torch_dataset")
-    model_trainer = ModelTrainer.get_model_trainer_from_config(config)
+    model_trainer = ModelTrainer.get_model_trainer_from_config(
+        config,
+        train_labels=[single_instance_labels],
+        val_labels=[single_instance_labels],
+    )
     train_dataset, val_dataset = get_train_val_datasets(
         train_labels=model_trainer.train_labels,
         val_labels=model_trainer.val_labels,

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -37,18 +37,6 @@ from sleap_nn.data.custom_datasets import (
 )
 from sleap_nn.config.training_job_config import TrainingJobConfig
 
-# Mac CI hangs reproducibly somewhere in this file — Lightning trainer
-# processes don't always terminate cleanly on GitHub-hosted Mac runners
-# (observed three 30-minute hangs across PR 1 + PR 8 of #508). The
-# tests run cleanly on Linux + Windows, so coverage is preserved. We
-# skip the whole module on darwin to keep the Mac CI lane free for the
-# inference-refactor work to land.
-pytestmark = pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="Lightning trainer processes hang intermittently on Mac CI; "
-    "covered by the Linux + Windows lanes",
-)
-
 
 @pytest.fixture
 def caplog(caplog: LogCaptureFixture):
@@ -552,6 +540,54 @@ def test_model_trainer_single_instance(config, tmp_path, minimal_instance):
         / trainer.config.trainer_config.run_name
         / "best.ckpt"
     ).exists()
+
+
+def _make_single_instance_config(config, tmp_path, run_name):
+    """Convert the shared `config` fixture into a single-instance config."""
+    single_instance_config = config.copy()
+    head_config = single_instance_config.model_config.head_configs.centered_instance
+    del single_instance_config.model_config.head_configs.centered_instance
+    OmegaConf.update(
+        single_instance_config, "model_config.head_configs.single_instance", head_config
+    )
+    del (
+        single_instance_config.model_config.head_configs.single_instance.confmaps.anchor_part
+    )
+    OmegaConf.update(single_instance_config, "trainer_config.run_name", run_name)
+    OmegaConf.update(single_instance_config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    return single_instance_config
+
+
+def test_single_instance_multiple_instances_error(config, tmp_path, minimal_instance):
+    """Single-instance training should error on frames with >1 instance."""
+    single_instance_config = _make_single_instance_config(
+        config, tmp_path, "test_single_instance_multiple_instances_error"
+    )
+
+    # `minimal_instance` has frames with two instances; do NOT strip them.
+    labels = sio.load_slp(minimal_instance)
+
+    with pytest.raises(ValueError, match="at most one instance per frame"):
+        ModelTrainer.get_model_trainer_from_config(
+            single_instance_config, train_labels=[labels], val_labels=[labels]
+        )
+
+
+def test_single_instance_single_instance_ok(config, tmp_path, minimal_instance):
+    """One instance per frame should pass single-instance label validation."""
+    single_instance_config = _make_single_instance_config(
+        config, tmp_path, "test_single_instance_single_instance_ok"
+    )
+
+    labels = sio.load_slp(minimal_instance)
+    for lf in labels:
+        lf.instances = [lf.instances[0]]
+
+    # Should not raise during label setup / validation.
+    trainer = ModelTrainer.get_model_trainer_from_config(
+        single_instance_config, train_labels=[labels], val_labels=[labels]
+    )
+    assert trainer.model_type == "single_instance"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- Raise a clear `ValueError` when a single-instance model is trained on labels containing any frame with **more than one instance**, instead of silently corrupting training.
- The new check runs early (before dataset construction / image caching) and names the offending video + frame so users can fix their labels.
- Also removes the module-level macOS (`darwin`) skip from `tests/training/test_model_trainer.py` so those tests run on Mac too.

## Background
Single-instance confidence-map generation (`sleap_nn/data/confidence_maps.py::generate_confmaps`) flattens the instance dimension:

```python
if instance.ndim != 3:
    instance = instance.view(instance.shape[0], -1, 2)
    # (n_samples, n_instances, n_nodes, 2) -> (n_samples, n_instances*n_nodes, 2)
```

With one instance this is correct. With **two** instances, `(1, 2, n_nodes, 2)` becomes `(1, 2*n_nodes, 2)` — the two animals are merged into a single instance with `2*n_nodes` "nodes", which mismatches the confmap head's channel count and silently trains garbage. This is the failure behind a duplicate/second instance on a frame, e.g. talmolab/sleap discussion #2736.

## Changes Made
- **`sleap_nn/training/model_trainer.py`**
  - New `ModelTrainer._validate_single_instance_labels(labels, split_name)`.
  - Called from `_setup_train_val_labels` for both the train and validation splits, only when `model_type == "single_instance"`.
  - Respects `data_config.user_instances_only` (default `True`) and ignores empty/all-NaN instances, matching existing `_get_lf_idx_list` filtering.
  - Raises a `ValueError` naming the video index and `frame_idx`, suggesting either removing the extra instance(s) or training a multi-instance (top-down / bottom-up) model.
- **`tests/training/test_model_trainer.py`**
  - Removed the module-level `pytestmark = pytest.mark.skipif(sys.platform == "darwin", ...)` so the module runs on macOS (`sys` import kept — still used by the Linux-only skips).
  - Added `test_single_instance_multiple_instances_error` and `test_single_instance_single_instance_ok`, plus a shared `_make_single_instance_config` helper.

## Example
```
ValueError: Single-instance training requires at most one instance per frame,
but the train frame at (video index 0, frame_idx 0) has 2 instances. Remove the
extra instance(s) from this frame, or train a multi-instance (top-down or
bottom-up) model instead.
```

## Testing
- `test_single_instance_multiple_instances_error` — un-stripped multi-instance `minimal_instance` labels → expects `ValueError`.
- `test_single_instance_single_instance_ok` — one instance per frame passes label validation.
- Both pass locally on macOS (`2 passed`). `black` / `ruff` clean; no new lint warnings introduced.

## Design Decisions
- **Validate in `_setup_train_val_labels`**: `self.model_type` is already set there, it has direct access to the full `sio.Labels` for both splits, runs before any expensive dataset/cache work, and mirrors the existing skeleton-mismatch `ValueError` raised in the same method.
- **Hard error (not a warning)**: a multi-instance frame produces silently wrong training, so failing fast is preferable.
- **Both splits checked**: validation labels are checked too, since they flow through the same single-instance pipeline.

## Note on removing the macOS skip
The skip was originally added because the heavier Lightning **training** tests in this module hang intermittently on GitHub-hosted Mac runners. The two new validation tests do not spin up a Lightning trainer (they fail fast during label setup), but removing the blanket skip means the rest of the module now also runs on the Mac CI lane — worth watching in case the hangs resurface.

## Related Issues
Relates to talmolab/sleap discussion #2736.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)