### PR TITLE
fix(deps): make gpu/cpu first-class torch extras so `--extra gpu` attaches cuDNN (#632)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ jobs:
       - name: Set up Python
         run: uv python install 3.13
 
+      - name: Verify uv.lock is current
+        run: uv lock --check
+
+      - name: Assert '--extra gpu' attaches cuDNN in uv.lock (regression guard for #632)
+        # `--extra gpu` must keep a LIVE (single-extra) marker clause attaching
+        # nvidia-cudnn-cu13 to the CUDA-13 torch wheel on linux/x86_64. A bare
+        # substring of the extra name is NOT sufficient — it also appears inside
+        # always-false conflict AND-pairs — so we match the full live disjunct on
+        # the nvidia-cudnn-cu13 dependency line. See #632.
+        run: |
+          grep -F "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-sleap-nn-gpu')" uv.lock \
+            | grep -qF 'nvidia-cudnn-cu13' \
+            || { echo "::error::uv.lock: '--extra gpu' no longer attaches nvidia-cudnn-cu13 on linux/x86_64 (regression of #632)"; exit 1; }
+
       - name: Install dev dependencies and torch
         run: uv sync --extra torch-cpu
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         # substring of the extra name is NOT sufficient — it also appears inside
         # always-false conflict AND-pairs — so we match the full live disjunct on
         # the nvidia-cudnn-cu13 dependency line. See #632.
+        #
+        # We assert ONLY the linux/x86_64 clause on purpose: PyTorch's win_amd64
+        # cu130 wheel bundles cuDNN inside the wheel and declares no separate
+        # nvidia-cudnn-cu13 dependency, so a Windows clause can never exist here.
+        # Do not "fix" this guard by adding one.
         run: |
           grep -F "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-sleap-nn-gpu')" uv.lock \
             | grep -qF 'nvidia-cudnn-cu13' \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -282,13 +282,17 @@ This installs with CUDA 13.0 support. Other backends:
 
 | Extra | Backend |
 |-------|---------|
-| `--extra gpu` | CUDA 13.0 (alias for `torch-cuda130`) |
-| `--extra cpu` | CPU-only (alias for `torch-cpu`) |
+| `--extra gpu` | CUDA 13.0 (same as `--extra torch-cuda130`) |
+| `--extra cpu` | CPU-only / macOS Apple MPS (same as `--extra torch-cpu`) |
 | `--extra torch-cuda128` | CUDA 12.8 |
 | `--extra torch-cuda118` | CUDA 11.8 |
 
 !!! note
     On macOS, use `--extra cpu` — the MPS backend is automatically available.
+
+!!! note
+    `--extra gpu` (CUDA) is for x86-64 / Windows-AMD64 only; NVIDIA CUDA wheels
+    are not published for Linux aarch64. On Linux aarch64 use `--extra cpu`.
 
 **Step 4: Run commands**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -294,6 +294,11 @@ This installs with CUDA 13.0 support. Other backends:
     `--extra gpu` (CUDA) is for x86-64 / Windows-AMD64 only; NVIDIA CUDA wheels
     are not published for Linux aarch64. On Linux aarch64 use `--extra cpu`.
 
+!!! note
+    On Windows the CUDA runtime (including cuDNN) ships *inside* the PyTorch
+    wheel, so you will not see a separate `nvidia-cudnn-cu13` package — that is
+    expected. On Linux it is a separate dependency that `--extra gpu` pulls in.
+
 **Step 4: Run commands**
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,13 @@ readme = { file = ["README.md"], content-type = "text/markdown" }
 
 [project.optional-dependencies]
 torch = ["torch", "torchvision>=0.20.0"]  # redundant (now default deps), kept for backwards compat
-cpu = ["sleap-nn[torch-cpu]"]
-gpu = ["sleap-nn[torch-cuda130]"]
+# First-class extras (NOT aliases): each owns its own torch index source in
+# [tool.uv.sources] below. Defining them as `sleap-nn[torch-cuda130]` aliases
+# left the transitive nvidia-cudnn marker keyed on the `torch-cuda130` extra, so
+# `uv sync --extra gpu` pulled torch+cu130 without cuDNN (#632). Giving gpu/cpu
+# their own source entries makes uv attach the cuDNN markers to these extras.
+cpu = ["torch", "torchvision>=0.20.0"]
+gpu = ["torch", "torchvision>=0.20.0"]
 torch-cpu = ["torch", "torchvision>=0.20.0"]
 torch-cuda118 = ["torch", "torchvision>=0.20.0"]
 torch-cuda128 = ["torch", "torchvision>=0.20.0"]
@@ -148,12 +153,20 @@ conflicts = [
 sleap-io = { git = "https://github.com/talmolab/sleap-io.git", rev = "4ee1fb388aefcd3f87691f741e0b6b34db482e8e" }
 torch = [
     { index = "pytorch-cpu", extra = "torch-cpu" },
+    # `cpu`/`gpu` are first-class extras (see [project.optional-dependencies]).
+    # `cpu` is markerless like `torch-cpu` so macOS resolves the CPU/MPS wheel.
+    # `gpu` mirrors `torch-cuda130` exactly (keep the AMD64 alternative — dropping
+    # it regressed Windows to CPU-only torch in #479).
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu130", extra = "gpu", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },
     { index = "pytorch-cu118", extra = "torch-cuda118", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },
     { index = "pytorch-cu128", extra = "torch-cuda128", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },
     { index = "pytorch-cu130", extra = "torch-cuda130", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },
 ]
 torchvision = [
     { index = "pytorch-cpu", extra = "torch-cpu" },
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu130", extra = "gpu", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },
     { index = "pytorch-cu118", extra = "torch-cuda118", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },
     { index = "pytorch-cu128", extra = "torch-cuda128", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },
     { index = "pytorch-cu130", extra = "torch-cuda130", marker = "(platform_machine == 'x86_64' or platform_machine == 'AMD64') and sys_platform != 'darwin'" },


### PR DESCRIPTION
Fixes #632.

## Problem

`uv sync --extra gpu` installed `torch==2.9.1+cu130` **without** its cuDNN runtime → `ImportError: libcudnn.so.9: cannot open shared object file` on Linux/CUDA.

**Root cause:** `gpu`/`cpu` were pure *alias* extras (`gpu = ["sleap-nn[torch-cuda130]"]`). In `uv.lock`, uv keyed the transitive `nvidia-cudnn-cu13` marker on `extra == 'torch-cuda130'` only — never on `gpu`. So `--extra gpu` pulled the cu130 torch wheel but the cuDNN marker never fired. The old alias was doubly wrong: it mis-attached **CUDA-12** cuDNN to the cu130 `gpu` build, and even attached CUDA-12 cuDNN to the CPU-only `cpu` extra.

## Fix

Promote `cpu`/`gpu` from aliases to **first-class extras** that own their own `[tool.uv.sources]` torch/torchvision index entries, then regenerate `uv.lock`:

- `cpu` → `pytorch-cpu`, **markerless** (so macOS keeps the CPU/MPS wheel, matching `torch-cpu`)
- `gpu` → `pytorch-cu130`, marker **byte-identical** to `torch-cuda130` (keeps the `AMD64` alternative — dropping it regressed Windows to CPU-only torch in #479)

`torch-cpu` / `torch-cuda118` / `torch-cuda128` / `torch-cuda130` and the conflicts block are unchanged.

## Verification (uv 0.11.14, marker evaluation over the regenerated lock)

`nvidia-cudnn-*` inclusion per `--extra` on **linux/x86_64** (old → new):

| extra | cudnn-cu13 | cudnn-cu12 | cudnn-cu11 |
|---|---|---|---|
| `gpu` | **False → True** ✅ | True → **False** ✅ | False |
| `torch-cuda130` | True (unchanged) | False | False |
| `torch-cuda128` | False | True (unchanged) | False |
| `torch-cuda118` | False | False | True (unchanged) |
| `cpu` | False | True → **False** ✅ | False |
| `torch-cpu` | False | False | False |
| _(default)_ | False | True (PyPI cu12) | False |

- The full 15-package `nvidia-*` set (cublas/cufft/nccl/nvshmem/cusparselt/…) attaches to `gpu` on linux-x86_64, not just cuDNN.
- **Zero package version drift** (294 → 294 packages; no adds/removes/bumps — only marker clauses changed). `uv lock --check` passes.
- **No marker changes** on linux-aarch64 / win-AMD64 / darwin.

## Regression guard

Added to the CI `lint` job:
- `uv lock --check` (fails fast on a stale lock)
- a grep assertion that the **live** single-extra cuDNN clause stays attached to `gpu` (a bare substring isn't enough — `extra-8-sleap-nn-gpu` also appears in always-false conflict AND-pairs, so the check pins the full live disjunct on the `nvidia-cudnn-cu13` line).

Also documents that `--extra gpu` (CUDA) is x86-64/AMD64 only (no aarch64 CUDA wheels).

## ⚠️ Not verifiable in CI

There is no active GPU runner (self-hosted GPU is commented out in `ci.yml`), so CI proves cuDNN is **requested/resolved** but cannot confirm `libcudnn.so.9` actually loads at runtime. **@talmo** — could you confirm `uv sync --extra gpu && python -c "import torch; print(torch.cuda.is_available())"` works on your RTX A6000 box?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
