### PR TITLE
feat(seg) 1/4: offset-aware mask decode + sleap-io bump (top-down segmentation #622)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,9 +148,12 @@ conflicts = [
 # sleap-io 0.8.0 is not yet released on PyPI; track main for the segmentation
 # (SegmentationMask / Labels.get_masks) APIs. Pinned to a commit for
 # reproducibility — update or drop once sleap-io 0.8.0 is published.
-# Bumped to include render: auto-draw SegmentationMask overlays (#461) + roi_wkb
-# gzip (#465).
-sleap-io = { git = "https://github.com/talmolab/sleap-io.git", rev = "4ee1fb388aefcd3f87691f741e0b6b34db482e8e" }
+# Bumped to include render fixes needed for top-down segmentation viz (#622):
+# color segmentation masks/ROI/bbox by track identity (#470), scope
+# render_image centroids to the rendered video (#468), and render
+# instance-less frames (#466) — on top of mask overlays (#461) + roi_wkb gzip
+# (#465).
+sleap-io = { git = "https://github.com/talmolab/sleap-io.git", rev = "f902a32aef6a089f885adcf4c13916359ad8cbd3" }
 torch = [
     { index = "pytorch-cpu", extra = "torch-cpu" },
     # `cpu`/`gpu` are first-class extras (see [project.optional-dependencies]).

--- a/sleap_nn/inference/segmentation_convert.py
+++ b/sleap_nn/inference/segmentation_convert.py
@@ -60,9 +60,16 @@ def decode_mask_to_image_res(m: "sio.SegmentationMask") -> np.ndarray:
     at output-stride by :class:`SegmentationLayer`), this nearest-neighbor
     resamples it up to its image extent so every consumer — eval IoU
     (:func:`sleap_nn.evaluation._frame_masks`) and the segmentation training data
-    loader — compares masks on a common original-image grid. Scale-1 masks
-    (legacy full-res GT/preds) take a zero-copy fast path, so old ``.slp`` files
-    behave exactly as before.
+    loader — compares masks on a common original-image grid. Scale-1,
+    offset-0 masks (legacy full-res GT/preds, all bottom-up predictions) take a
+    zero-copy fast path, so old ``.slp`` files behave exactly as before.
+
+    A non-identity ``offset`` (the crop origin ``(x, y)`` of a top-down
+    crop-centered mask) is baked in by top-left zero-padding so the mask lands
+    at its full-frame location for IoU/placement; without this, two crops at
+    different offsets would both decode to the origin and collide (sio
+    ``resampled``/``image_extent`` drop the offset). Offset-0 masks are
+    unaffected.
 
     Note:
         ``image_extent`` can differ from the true frame size by +/-1 px because
@@ -72,11 +79,39 @@ def decode_mask_to_image_res(m: "sio.SegmentationMask") -> np.ndarray:
         the actual frame size. For IoU on a shared max-canvas the +/-1 lands on a
         background row/col and does not change the result.
     """
-    scale = getattr(m, "scale", (1.0, 1.0))
-    if tuple(scale) == (1.0, 1.0):
+    scale = tuple(getattr(m, "scale", (1.0, 1.0)))
+    offset = tuple(getattr(m, "offset", (0.0, 0.0)))
+    # Fast path: full-res, origin-anchored masks (legacy full-res GT/preds and
+    # every bottom-up prediction, which always emits offset (0, 0)) are returned
+    # zero-copy, byte-identical to the pre-offset-aware behavior.
+    if scale == (1.0, 1.0) and offset == (0.0, 0.0):
         return np.asarray(m.data, dtype=bool)
-    h, w = m.image_extent
-    return np.asarray(m.resampled(int(h), int(w)).data, dtype=bool)
+
+    # Honor scale: decode up to the mask's image extent.
+    if scale == (1.0, 1.0):
+        arr = np.asarray(m.data, dtype=bool)
+    else:
+        h, w = m.image_extent
+        arr = np.asarray(m.resampled(int(h), int(w)).data, dtype=bool)
+
+    # Honor offset: place the decoded array at its image-space origin by
+    # top-left zero-padding. sio ``offset`` is ``(x, y)`` image pixels
+    # (``image_coord = mask_coord / scale + offset``); ``image_extent``/
+    # ``resampled`` drop it (mask.py), and the eval consumers (``_align_pair`` /
+    # ``_mask_iou``) top-left-align masks on a shared max-canvas. Baking the
+    # offset here is what makes a crop-centered (top-down) mask at offset
+    # ``(x0, y0)`` score at the correct full-frame location instead of colliding
+    # with every other crop at the origin. Negative offsets (a crop spilling off
+    # the top/left edge) are clipped to the in-frame region.
+    ox, oy = int(round(offset[0])), int(round(offset[1]))
+    if ox or oy:
+        sy, sx = max(0, -oy), max(0, -ox)  # drop rows/cols mapped off-frame
+        dy, dx = max(0, oy), max(0, ox)  # pad to the in-frame origin
+        src = arr[sy:, sx:]
+        out = np.zeros((dy + src.shape[0], dx + src.shape[1]), dtype=bool)
+        out[dy:, dx:] = src
+        arr = out
+    return arr
 
 
 def build_predicted_roi(

--- a/tests/inference/test_segmentation_stride_encoding.py
+++ b/tests/inference/test_segmentation_stride_encoding.py
@@ -503,3 +503,94 @@ def test_stride_encoded_slp_trains_with_correct_scale(minimal_instance_seg, tmp_
     inter = (got["foreground_mask"] * ref["foreground_mask"]).sum().item()
     union = ((got["foreground_mask"] + ref["foreground_mask"]) > 0).sum().item()
     assert union > 0 and inter / union > 0.9
+
+
+# ── D. offset-aware decode (#622 top-down crop-centered masks) ────────────────
+#
+# Top-down segmentation is the first producer of non-zero-offset masks (every
+# bottom-up prediction emits offset (0, 0)). `decode_mask_to_image_res` must
+# bake the crop offset into the decoded array so eval IoU / placement is at the
+# correct full-frame location — otherwise two crops collide at the origin.
+
+
+def _fg_bbox(arr):
+    """Top-left (x, y) of the True region of a boolean array (or None)."""
+    ys, xs = np.where(arr)
+    if ys.size == 0:
+        return None
+    return (int(xs.min()), int(ys.min()))
+
+
+def test_decode_offset_zero_byte_identical():
+    """scale-1, offset-0 masks take the zero-copy fast path (unchanged)."""
+    m = np.zeros((40, 50), bool)
+    m[5:30, 8:42] = True
+    sm = build_predicted_segmentation_mask(m, 0.9)  # scale (1,1), offset (0,0)
+    out = decode_mask_to_image_res(sm)
+    assert out.shape == m.shape
+    assert np.array_equal(out, m)
+
+
+def test_decode_offset_places_mask_at_image_origin():
+    """A crop mask at offset (x0, y0) decodes with its content at (x0, y0)."""
+    crop = np.zeros((40, 40), bool)
+    crop[5:35, 5:35] = True
+    sm = build_predicted_segmentation_mask(crop, 0.9, offset=(100.0, 70.0))
+    out = decode_mask_to_image_res(sm)
+    # Content shifted by the offset; array grows to (oy + h, ox + w).
+    assert out.shape == (70 + 40, 100 + 40)
+    assert _fg_bbox(out) == (100 + 5, 70 + 5)
+    # The crop content itself is preserved (just relocated).
+    assert out[70:110, 100:140].sum() == crop.sum()
+
+
+def test_decode_offset_with_scale():
+    """Offset is applied at image resolution after scale up-sampling."""
+    small = np.ones((10, 10), bool)  # stride-2 crop
+    sm = build_predicted_segmentation_mask(
+        small, 0.9, scale=(0.5, 0.5), offset=(60.0, 40.0)
+    )
+    out = decode_mask_to_image_res(sm)
+    # 10x10 @ stride 2 -> 20x20 content, placed at (60, 40).
+    assert _fg_bbox(out) == (60, 40)
+    assert out[40:60, 60:80].all()
+
+
+def test_decode_negative_offset_clips_offframe():
+    """A crop spilling off the top/left edge clips the off-frame rows/cols."""
+    crop = np.ones((30, 30), bool)
+    sm = build_predicted_segmentation_mask(crop, 0.9, offset=(-10.0, -8.0))
+    out = decode_mask_to_image_res(sm)
+    # 10 cols + 8 rows fall off-frame and are dropped.
+    assert out.shape == (30 - 8, 30 - 10)
+    assert out.all()
+
+
+def test_eval_matches_offset_crops_to_correct_gt():
+    """Regression: two crop-centered preds match their own full-frame GT.
+
+    Without offset-aware decode both crops decode to the origin, collide, and
+    the Hungarian match is wrong / IoU ~0. This asserts the fixed behavior.
+    """
+    from sleap_nn.evaluation import match_masks
+
+    H = W = 400
+    # Two well-separated GT instances (full-frame, offset 0).
+    gt_a = np.zeros((H, W), bool)
+    gt_a[100:140, 100:140] = True
+    gt_b = np.zeros((H, W), bool)
+    gt_b[300:340, 300:340] = True
+
+    # Predictions emitted as 40x40 crops at the matching offsets.
+    sq = np.ones((40, 40), bool)
+    pred_a = decode_mask_to_image_res(
+        build_predicted_segmentation_mask(sq, 0.9, offset=(100.0, 100.0))
+    )
+    pred_b = decode_mask_to_image_res(
+        build_predicted_segmentation_mask(sq, 0.8, offset=(300.0, 300.0))
+    )
+
+    mp, mg, up, ug, ious = match_masks([pred_a, pred_b], [gt_a, gt_b], min_iou=0.5)
+    assert sorted(zip(mp.tolist(), mg.tolist())) == [(0, 0), (1, 1)]
+    assert up.size == 0 and ug.size == 0
+    assert (ious >= 0.99).all()


### PR DESCRIPTION
**Stacked series for top-down (crop-centered) instance segmentation (#622) — PR 1 of 4.** Merge in order: 1 → 2 → 3 → 4.

## What
Foundation for the top-down segmentation feature.

- **`decode_mask_to_image_res` is now offset-aware.** It bakes a mask's `offset` into the decoded array (top-left zero-pad, clipping off-frame content) so a mask carrying a non-zero crop offset is scored/placed at its true full-frame location. This was a **latent bug**: every bottom-up prediction emits `offset (0, 0)`, so top-down crop masks (added in PR 3) are the first non-zero-offset producer. The `scale==(1,1) and offset==(0,0)` fast path stays **byte-identical**, so bottom-up/legacy eval numbers are unchanged.
- **Bump the sleap-io pin** to `f902a32a` for the render fixes used by mask viz (color masks/ROI/bbox by track #470, scope centroids #468, render instance-less frames #466).

## Tests
Adds offset-decode + end-to-end eval-matching regression tests to `test_segmentation_stride_encoding.py` (two crops at different offsets match their own GT, no collision; offset=0 path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)