### PR TITLE
feat(seg) 2/4: centered_instance_segmentation model type — config, data, training (#622)

### DIFF
--- a/docs/sample_configs/config_topdown_centered_instance_segmentation_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_segmentation_unet.yaml
@@ -1,0 +1,163 @@
+# Top-down (crop-centered) instance segmentation (#622).
+#
+# Reuses the top-down crop pipeline (a `centroid` model detects instances, each
+# crop is centered on one instance) but predicts a single binary foreground mask
+# of the CENTERED instance instead of keypoints. Train this paired with a
+# `centroid` model; at inference `sleap-nn predict` composes the two.
+#
+# Note: geometric augmentation is unsupported in v1 (masks are not co-transformed
+# with the crop), so `augmentation_config.geometric` is null. Train at scale 1.0.
+data_config:
+  train_labels_path: null
+  val_labels_path: null
+  validation_fraction: 0.1
+  use_same_data_for_val: false
+  test_file_path: null
+  provider: LabelsReader
+  user_instances_only: true
+  data_pipeline_fw: torch_dataset
+  cache_img_path: null
+  use_existing_imgs: false
+  delete_cache_imgs_after_training: true
+  preprocessing:
+    ensure_rgb: false
+    ensure_grayscale: false
+    max_height: null
+    max_width: null
+    scale: 1.0
+    crop_size: null
+    min_crop_size: 100
+    crop_padding: null
+  use_augmentations_train: true
+  augmentation_config:
+    intensity:
+      uniform_noise_min: 0.0
+      uniform_noise_max: 0.04
+      uniform_noise_p: 0.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
+      gaussian_noise_p: 0.0
+      contrast_min: 0.9
+      contrast_max: 1.1
+      contrast_p: 1.0
+      brightness_min: 0.9
+      brightness_max: 1.1
+      brightness_p: 0.0
+    # Geometric augmentation is skipped for segmentation in v1 (masks cannot be
+    # co-transformed with the crop). Leave null to disable it cleanly.
+    geometric: null
+  skeletons:
+model_config:
+  init_weights: default
+  pretrained_backbone_weights: null
+  pretrained_head_weights: null
+  backbone_config:
+    unet:
+      in_channels: 1
+      kernel_size: 3
+      filters: 24
+      filters_rate: 2.0
+      max_stride: 16
+      stem_stride: null
+      middle_block: true
+      up_interpolate: true
+      stacks: 1
+      convs_per_block: 2
+      output_stride: 2
+    convnext: null
+    swint: null
+  head_configs:
+    single_instance: null
+    centroid: null
+    centered_instance: null
+    bottomup: null
+    multi_class_bottomup: null
+    multi_class_topdown: null
+    bottomup_segmentation: null
+    # A single foreground-mask head (BCE+Dice) on a centroid crop. `anchor_part`
+    # centers the training crop (null -> mean of each instance's visible nodes;
+    # set to a node name to match your centroid model's anchor).
+    centered_instance_segmentation:
+      segmentation:
+        output_stride: 2
+        loss_weight: 1.0
+        anchor_part: null
+  total_params: null
+trainer_config:
+  train_data_loader:
+    batch_size: 4
+    shuffle: true
+    num_workers: 0
+  val_data_loader:
+    batch_size: 4
+    shuffle: false
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: false
+  trainer_devices:
+  trainer_device_indices: null
+  trainer_accelerator: auto
+  profiler: null
+  trainer_strategy: auto
+  enable_progress_bar: true
+  min_train_steps_per_epoch: 200
+  train_steps_per_epoch: null
+  visualize_preds_during_training: true
+  keep_viz: false
+  max_epochs: 200
+  seed: null
+  use_wandb: false
+  save_ckpt: true
+  ckpt_dir: models
+  run_name: null
+  resume_ckpt_path: null
+  wandb:
+    entity: null
+    project: null
+    name: null
+    save_viz_imgs_wandb: false
+    api_key: null
+    wandb_mode: null
+    prv_runid: null
+    group: null
+    current_run_id: null
+  optimizer_name: Adam
+  optimizer:
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    step_lr: null
+    reduce_lr_on_plateau:
+      threshold: 1.0e-08
+      threshold_mode: abs
+      cooldown: 3
+      patience: 5
+      factor: 0.5
+      min_lr: 1.0e-08
+  early_stopping:
+    min_delta: 1.0e-08
+    patience: 10
+    stop_training_on_plateau: true
+  online_hard_keypoint_mining:
+    online_mining: false
+    hard_to_easy_ratio: 2.0
+    min_hard_keypoints: 2
+    max_hard_keypoints: null
+    loss_scale: 5.0
+  zmq:
+    controller_port: 9000
+    controller_polling_timeout: 10
+    publish_port: 9001
+  # Post-training mask-IoU eval (match_method="mask"). The seg model alone has
+  # no instance detector, so eval crops the GT instances (GT-centroid fallback)
+  # and compares predicted vs GT masks. `match_threshold` is the minimum mask
+  # IoU in (0, 1]. Per-epoch quality is also tracked via val/fg_iou.
+  eval:
+    enabled: true
+    frequency: 1
+    oks_stddev: 0.025
+    oks_scale: null
+    match_threshold: 0.5
+name: ''
+description: ''

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -74,6 +74,8 @@ def get_head(model_type: str, head_config: DictConfig) -> Head:
             - 'bottomup'
             - 'multi_class_bottomup'
             - 'multi_class_topdown'
+            - 'bottomup_segmentation'
+            - 'centered_instance_segmentation'
         head_config (DictConfig): A config for the head.
 
     Returns:
@@ -106,8 +108,19 @@ def get_head(model_type: str, head_config: DictConfig) -> Head:
         heads.append(InstanceCenterHead(**head_config.center))
         heads.append(CenterOffsetHead(**head_config.offsets))
 
+    elif model_type == "centered_instance_segmentation":
+        # Top-down crop-centered segmentation: a lone foreground-mask head on a
+        # centroid crop (the centered instance). `anchor_part` lives in the head
+        # leaf but is a data-pipeline concern, not a SegmentationHead argument.
+        seg = head_config.segmentation
+        heads.append(
+            SegmentationHead(
+                output_stride=seg.output_stride, loss_weight=seg.loss_weight
+            )
+        )
+
     else:
-        message = f"{model_type} is not a defined model type. Please choose one of `single_instance`, `centered_instance`, `centroid`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`."
+        message = f"{model_type} is not a defined model type. Please choose one of `single_instance`, `centered_instance`, `centroid`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`, `centered_instance_segmentation`."
         logger.error(message)
         raise Exception(message)
 

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -34,6 +34,8 @@ from sleap_nn.config.model_config import (
     TopDownCenteredInstanceMultiClassConfig,
     ClassVectorsConfig,
     BottomUpSegmentationConfig,
+    CenteredInstanceSegmentationConfig,
+    CenteredInstanceSegmentationHeadConfig,
     SegmentationHeadConfig,
     InstanceCenterConfig,
     CenterOffsetConfig,
@@ -394,9 +396,15 @@ def get_head_configs(head_cfg: Union[str, Dict[str, Any]]):
                 center=InstanceCenterConfig(),
                 offsets=CenterOffsetConfig(),
             )
+        elif head_cfg == "centered_instance_segmentation":
+            head_configs.centered_instance_segmentation = (
+                CenteredInstanceSegmentationConfig(
+                    segmentation=CenteredInstanceSegmentationHeadConfig()
+                )
+            )
         else:
             raise ValueError(
-                f"{head_cfg} is not a valid head type. Please choose one of ['bottomup', 'centered_instance', 'centroid', 'single_instance', 'multi_class_bottomup', 'multi_class_topdown', 'bottomup_segmentation']"
+                f"{head_cfg} is not a valid head type. Please choose one of ['bottomup', 'centered_instance', 'centroid', 'single_instance', 'multi_class_bottomup', 'multi_class_topdown', 'bottomup_segmentation', 'centered_instance_segmentation']"
             )
 
     elif isinstance(head_cfg, dict):
@@ -460,6 +468,18 @@ def get_head_configs(head_cfg: Union[str, Dict[str, Any]]):
                 segmentation=SegmentationHeadConfig(**seg["segmentation"]),
                 center=InstanceCenterConfig(**seg["center"]),
                 offsets=CenterOffsetConfig(**seg["offsets"]),
+            )
+        elif (
+            "centered_instance_segmentation" in head_cfg
+            and head_cfg["centered_instance_segmentation"] is not None
+        ):
+            seg = head_cfg["centered_instance_segmentation"]
+            head_configs.centered_instance_segmentation = (
+                CenteredInstanceSegmentationConfig(
+                    segmentation=CenteredInstanceSegmentationHeadConfig(
+                        **seg["segmentation"]
+                    )
+                )
             )
 
     return head_configs

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -979,6 +979,43 @@ class BottomUpSegmentationConfig:
     offsets: Optional[CenterOffsetConfig] = None
 
 
+@define
+class CenteredInstanceSegmentationHeadConfig:
+    """Foreground-mask head config for top-down crop-centered segmentation.
+
+    The bottom-up ``SegmentationHeadConfig`` fields plus ``anchor_part``. Keeping
+    ``anchor_part`` INSIDE the head leaf (rather than as a sibling of
+    ``segmentation``) matches ``centered_instance``'s ``confmaps.anchor_part`` and
+    the codebase invariant that every per-type head config is a dict of head-leaf
+    configs each carrying ``output_stride`` — so model/config code that iterates
+    head leaves (loss weights, output strides, etc.) never trips over it.
+
+    Attributes:
+        output_stride: (int) Stride of the output mask relative to the input
+            crop. Default: 2.
+        loss_weight: (float) Scalar weight for the bce-dice loss term. Default: 1.0.
+        anchor_part: (str) Optional node name used to center crops during
+            training. ``None`` (default) centers on the mean of each instance's
+            visible nodes.
+    """
+
+    output_stride: int = 2
+    loss_weight: float = 1.0
+    anchor_part: Optional[str] = None
+
+
+@define
+class CenteredInstanceSegmentationConfig:
+    """Head config for top-down crop-centered instance segmentation models.
+
+    A single foreground-mask head predicting the *centered* instance's mask on a
+    centroid crop (the segmentation analog of ``centered_instance``; composed
+    with a ``centroid`` model for full top-down inference).
+    """
+
+    segmentation: Optional[CenteredInstanceSegmentationHeadConfig] = None
+
+
 @oneof
 @define
 class HeadConfig:
@@ -994,6 +1031,8 @@ class HeadConfig:
         multi_class_bottomup: An instance of `BottomUpMultiClassConfig`.
         multi_class_topdown: An instance of `TopDownCenteredInstanceMultiClassConfig`.
         bottomup_segmentation: An instance of `BottomUpSegmentationConfig`.
+        centered_instance_segmentation: An instance of
+            `CenteredInstanceSegmentationConfig`.
     """
 
     single_instance: Optional[SingleInstanceConfig] = None
@@ -1003,6 +1042,7 @@ class HeadConfig:
     multi_class_bottomup: Optional[BottomUpMultiClassConfig] = None
     multi_class_topdown: Optional[TopDownCenteredInstanceMultiClassConfig] = None
     bottomup_segmentation: Optional[BottomUpSegmentationConfig] = None
+    centered_instance_segmentation: Optional[CenteredInstanceSegmentationConfig] = None
 
 
 @oneof

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -1407,6 +1407,410 @@ class CenteredInstanceDataset(BaseDataset):
         return sample
 
 
+def _bbox_iou(
+    a: Tuple[float, float, float, float], b: Tuple[float, float, float, float]
+) -> float:
+    """IoU of two ``(x0, y0, x1, y1)`` axis-aligned boxes."""
+    ix0, iy0 = max(a[0], b[0]), max(a[1], b[1])
+    ix1, iy1 = min(a[2], b[2]), min(a[3], b[3])
+    iw, ih = max(0.0, ix1 - ix0), max(0.0, iy1 - iy0)
+    inter = iw * ih
+    if inter <= 0:
+        return 0.0
+    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
+    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
+    union = area_a + area_b - inter
+    return float(inter / union) if union > 0 else 0.0
+
+
+def _match_mask_to_instance(
+    inst: sio.Instance, lf_masks: List
+) -> Optional["sio.SegmentationMask"]:
+    """Find the segmentation mask belonging to ``inst`` on a labeled frame.
+
+    Primary key is the one-way ``mask.instance`` identity link (set by sio and by
+    the burned-in pseudo-label data). Falls back to the mask whose image-space
+    bounding box best overlaps the instance's keypoint bounding box, so datasets
+    without the explicit link still associate correctly.
+    """
+    if not lf_masks:
+        return None
+    for m in lf_masks:
+        if getattr(m, "instance", None) is inst:
+            return m
+    # Fallback: max bbox-IoU between the keypoint bbox and each mask's bbox.
+    pts = inst.numpy()
+    vis = pts[~np.isnan(pts).any(axis=1)]
+    if len(vis) == 0:
+        return None
+    inst_box = (
+        float(vis[:, 0].min()),
+        float(vis[:, 1].min()),
+        float(vis[:, 0].max()),
+        float(vis[:, 1].max()),
+    )
+    best, best_iou = None, 0.0
+    for m in lf_masks:
+        mx, my, mw, mh = m.bbox  # image-space (x, y, w, h)
+        iou = _bbox_iou(inst_box, (mx, my, mx + mw, my + mh))
+        if iou > best_iou:
+            best, best_iou = m, iou
+    return best
+
+
+def _kp_bbox(inst: sio.Instance) -> Optional[Tuple[float, float, float, float]]:
+    """Keypoint bounding box ``(x0, y0, x1, y1)`` of an instance, or None."""
+    pts = inst.numpy()
+    vis = pts[~np.isnan(pts).any(axis=1)]
+    if len(vis) == 0:
+        return None
+    return (
+        float(vis[:, 0].min()),
+        float(vis[:, 1].min()),
+        float(vis[:, 0].max()),
+        float(vis[:, 1].max()),
+    )
+
+
+def _associate_masks(
+    instances: List, lf_masks: List
+) -> Dict[int, "sio.SegmentationMask"]:
+    """One-to-one assign each instance at most one mask on a frame (no reuse).
+
+    Identity links (``mask.instance``) are resolved first and their masks removed
+    from the pool; remaining instances are matched to remaining masks by greedy
+    descending bbox-IoU (> 0). This prevents two overlapping instances (the
+    multi-animal case) from both grabbing the same mask, and prevents an unlinked
+    instance from stealing a mask already claimed by another instance's link.
+    """
+    assigned: Dict[int, "sio.SegmentationMask"] = {}
+    used: set = set()
+    # 1) Identity links first.
+    unlinked = []
+    for i, inst in enumerate(instances):
+        if inst.is_empty:
+            continue
+        linked = next(
+            (
+                m
+                for m in lf_masks
+                if id(m) not in used and getattr(m, "instance", None) is inst
+            ),
+            None,
+        )
+        if linked is not None:
+            assigned[i] = linked
+            used.add(id(linked))
+        else:
+            unlinked.append(i)
+    # 2) Greedy max-IoU one-to-one for the rest over the remaining masks.
+    triples = []
+    for i in unlinked:
+        ibox = _kp_bbox(instances[i])
+        if ibox is None:
+            continue
+        for m in lf_masks:
+            if id(m) in used:
+                continue
+            mx, my, mw, mh = m.bbox
+            iou = _bbox_iou(ibox, (mx, my, mx + mw, my + mh))
+            if iou > 0.0:
+                triples.append((iou, i, m))
+    triples.sort(key=lambda t: -t[0])
+    for iou, i, m in triples:
+        if i in assigned or id(m) in used:
+            continue
+        assigned[i] = m
+        used.add(id(m))
+    return assigned
+
+
+class CenteredInstanceSegmentationDataset(CenteredInstanceDataset):
+    """Dataset for top-down (crop-centered) instance segmentation (#622).
+
+    Subclasses :class:`CenteredInstanceDataset`: reuses the centroid-crop
+    pipeline but replaces the keypoint confidence-map GT with a single binary
+    foreground mask of ONLY the centered instance (other instances' foreground
+    inside the crop is background). The centered instance's full-frame mask is
+    captured into the sample index at construction time (via the one-way
+    ``mask.instance`` link, with a bbox-IoU fallback), decoded on access, and
+    carried through the SAME size-matcher / crop / resize / pad operations as the
+    image so it stays pixel-aligned with ``instance_image``; it is then
+    downsampled to the segmentation head's output stride.
+
+    Note:
+        Geometric augmentation is unsupported in v1 (masks are not co-transformed
+        with the image) and is skipped with a warning; intensity augmentation is
+        applied normally. Train at ``scale=1.0`` with crop dims divisible by
+        ``max_stride`` (the mask resize/pad mirror the image but are not
+        sub-pixel pad-aware).
+
+    Attributes:
+        seg_head_config: Configuration for the segmentation head (``output_stride``).
+    """
+
+    def __init__(
+        self,
+        labels: List[sio.Labels],
+        crop_size: int,
+        seg_head_config: DictConfig,
+        max_stride: int,
+        anchor_ind: Optional[int] = None,
+        user_instances_only: bool = True,
+        ensure_rgb: bool = False,
+        ensure_grayscale: bool = False,
+        intensity_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+        geometric_aug: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+        scale: float = 1.0,
+        apply_aug: bool = False,
+        max_hw: Tuple[Optional[int]] = (None, None),
+        cache_img: Optional[str] = None,
+        cache_img_path: Optional[str] = None,
+        use_existing_imgs: bool = False,
+        rank: Optional[int] = None,
+        parallel_caching: bool = True,
+        cache_workers: int = 0,
+    ) -> None:
+        """Initialize class attributes."""
+        self.seg_head_config = seg_head_config
+        self._warned_geometric_aug = False
+        super().__init__(
+            labels=labels,
+            crop_size=crop_size,
+            # The base class only uses confmap_head_config in its (overridden)
+            # __getitem__; reuse the seg head config (it carries `output_stride`).
+            confmap_head_config=seg_head_config,
+            max_stride=max_stride,
+            anchor_ind=anchor_ind,
+            user_instances_only=user_instances_only,
+            ensure_rgb=ensure_rgb,
+            ensure_grayscale=ensure_grayscale,
+            intensity_aug=intensity_aug,
+            geometric_aug=geometric_aug,
+            scale=scale,
+            apply_aug=apply_aug,
+            max_hw=max_hw,
+            cache_img=cache_img,
+            cache_img_path=cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+        )
+
+    def _get_instance_idx_list(self, labels: List[sio.Labels]) -> List[Dict]:
+        """Index per (frame, instance), capturing each instance's mask object.
+
+        The associated ``sio.SegmentationMask`` (RLE-compact, picklable) is stored
+        in each sample so ``__getitem__`` never needs a live ``Labels`` handle
+        (correct under the memory/disk image caching paths). Instances with no
+        associated mask are skipped.
+        """
+        instance_idx_list = []
+        n_missing = 0
+        for labels_idx, label in enumerate(labels):
+            for lf_idx, lf in enumerate(label):
+                if self.user_instances_only:
+                    if lf.user_instances is not None and len(lf.user_instances) > 0:
+                        lf.instances = lf.user_instances
+                    else:
+                        continue
+                lf_masks = getattr(lf, "masks", None) or []
+                # One-to-one mask<->instance assignment per frame (no mask reused
+                # across overlapping instances).
+                assigned = _associate_masks(lf.instances, lf_masks)
+                for inst_idx, inst in enumerate(lf.instances):
+                    if inst.is_empty:
+                        continue
+                    mask_obj = assigned.get(inst_idx)
+                    if mask_obj is None:
+                        n_missing += 1
+                        continue
+                    video_idx = labels[labels_idx].videos.index(lf.video)
+                    instance_idx_list.append(
+                        {
+                            "labels_idx": labels_idx,
+                            "lf_idx": lf_idx,
+                            "inst_idx": inst_idx,
+                            "video_idx": video_idx,
+                            "instances": (
+                                lf.instances if self.cache_img is not None else None
+                            ),
+                            "frame_idx": lf.frame_idx,
+                            "mask_obj": mask_obj,
+                        }
+                    )
+        if n_missing:
+            logger.warning(
+                f"CenteredInstanceSegmentationDataset: skipped {n_missing} "
+                f"instance(s) with no associated segmentation mask."
+            )
+        return instance_idx_list
+
+    def __getitem__(self, index) -> Dict:
+        """Return dict with cropped image and the centered-instance mask GT."""
+        from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+        meta = self.instance_idx_list[index]
+        labels_idx = meta["labels_idx"]
+        lf_idx = meta["lf_idx"]
+        inst_idx = meta["inst_idx"]
+        video_idx = meta["video_idx"]
+        lf_frame_idx = meta["frame_idx"]
+
+        if self.cache_img is not None:
+            instances_list = meta["instances"]
+            if self.cache_img == "disk":
+                img = np.array(
+                    Image.open(
+                        f"{self.cache_img_path}/sample_{labels_idx}_{lf_idx}.jpg"
+                    )
+                )
+            elif self.cache_img == "memory":
+                img = self.cache[(labels_idx, lf_idx)].copy()
+        else:
+            lf = self.labels_list[labels_idx][lf_idx]
+            instances_list = lf.instances
+            img = lf.image
+        if img.ndim == 2:
+            img = np.expand_dims(img, axis=2)
+
+        image = np.transpose(img, (2, 0, 1))  # HWC -> CHW
+        instances = np.stack([inst.numpy() for inst in instances_list], axis=0)
+        image = np.expand_dims(image, axis=0)  # (1, C, H, W)
+        instances = np.expand_dims(instances, axis=0)  # (1, num, nodes, 2)
+        instances = torch.from_numpy(instances.astype("float32"))
+        image = torch.from_numpy(image.copy())
+
+        num_instances = instances.shape[1]
+        orig_img_height, orig_img_width = image.shape[-2:]
+        instances = instances[:, inst_idx]
+
+        # Decode the centered instance's mask and place it on the EXACT full-frame
+        # canvas so it shares the image's pixel grid. `decode_mask_to_image_res`
+        # returns a partial-frame array for masks carrying a non-identity
+        # scale/offset (e.g. a pseudo-label `.slp` written by a top-down seg
+        # model); without this placement the mask desyncs from the (full-frame)
+        # image under the shared size-matcher/crop and the GT is silently
+        # corrupted. Clamp to frame bounds (decoded extent can be +/-1 px).
+        mask_np = decode_mask_to_image_res(meta["mask_obj"])
+        if mask_np.shape[:2] != (orig_img_height, orig_img_width):
+            full = np.zeros((orig_img_height, orig_img_width), dtype=bool)
+            h0 = min(mask_np.shape[0], orig_img_height)
+            w0 = min(mask_np.shape[1], orig_img_width)
+            full[:h0, :w0] = mask_np[:h0, :w0]
+            mask_np = full
+        mask_t = torch.from_numpy(np.ascontiguousarray(mask_np, dtype=np.float32))[
+            None, None
+        ]
+
+        if self.ensure_rgb:
+            image = convert_to_rgb(image)
+        elif self.ensure_grayscale:
+            image = convert_to_grayscale(image)
+
+        # Size matcher (apply the SAME geometry to image and mask).
+        image, eff_scale = apply_sizematcher(
+            image, max_height=self.max_hw[0], max_width=self.max_hw[1]
+        )
+        mask_t, _ = apply_sizematcher(
+            mask_t, max_height=self.max_hw[0], max_width=self.max_hw[1]
+        )
+        instances = instances * eff_scale
+
+        centroids = generate_centroids(instances, anchor_ind=self.anchor_ind)
+        instance, centroid = instances[0], centroids[0]
+
+        # Oversized (sqrt(2)) crop for rotation headroom — kept for parity with
+        # CenteredInstanceDataset even though geometric aug is skipped here.
+        crop_size_aug = (
+            (np.array([self.crop_size, self.crop_size]) * np.sqrt(2))
+            .astype(np.int32)
+            .tolist()
+        )
+        sample = generate_crops(image, instance, centroid, crop_size_aug)
+        # Carry the mask through the IDENTICAL crop bbox.
+        mask_t = crop_and_resize(
+            mask_t, boxes=sample["instance_bbox"], size=crop_size_aug
+        )
+
+        sample["frame_idx"] = torch.tensor(lf_frame_idx, dtype=torch.int32)
+        sample["video_idx"] = torch.tensor(video_idx, dtype=torch.int32)
+        sample["num_instances"] = num_instances
+        sample["orig_size"] = torch.Tensor([orig_img_height, orig_img_width]).unsqueeze(
+            0
+        )
+        sample["eff_scale"] = torch.tensor(eff_scale, dtype=torch.float32)
+
+        # Intensity augmentation on the image only (mask is intensity-invariant).
+        if self.apply_aug and self.intensity_aug is not None:
+            (
+                sample["instance_image"],
+                sample["instance"],
+            ) = apply_intensity_augmentation(
+                sample["instance_image"], sample["instance"], **self.intensity_aug
+            )
+        # Geometric augmentation is unsupported in v1 (mask co-transform deferred).
+        if (
+            self.apply_aug
+            and self.geometric_aug is not None
+            and not self._warned_geometric_aug
+        ):
+            logger.warning(
+                "Geometric augmentation is configured but not supported for "
+                "CenteredInstanceSegmentationDataset (masks are not co-transformed "
+                "with the crop in v1); it is skipped. Only intensity augmentation "
+                "is applied."
+            )
+            self._warned_geometric_aug = True
+
+        # Re-crop to the exact crop size (same bbox for image and mask).
+        sample["instance_bbox"] = torch.unsqueeze(
+            make_centered_bboxes(sample["centroid"][0], self.crop_size, self.crop_size),
+            0,
+        )
+        sample["instance_image"] = crop_and_resize(
+            sample["instance_image"],
+            boxes=sample["instance_bbox"],
+            size=(self.crop_size, self.crop_size),
+        )
+        mask_t = crop_and_resize(
+            mask_t, boxes=sample["instance_bbox"], size=(self.crop_size, self.crop_size)
+        )
+        point = sample["instance_bbox"][0][0]
+        sample["instance"] = sample["instance"] - point
+        sample["centroid"] = sample["centroid"] - point
+
+        # Resize image + keypoints by scale; match the mask to the image size.
+        sample["instance_image"], sample["instance"] = apply_resizer(
+            sample["instance_image"], sample["instance"], scale=self.scale
+        )
+        tgt_hw = sample["instance_image"].shape[-2:]
+        if tuple(mask_t.shape[-2:]) != tuple(tgt_hw):
+            mask_t = F.interpolate(
+                mask_t, size=(int(tgt_hw[0]), int(tgt_hw[1])), mode="area"
+            )
+
+        # Pad both to the model's max stride (bottom-right).
+        sample["instance_image"] = apply_pad_to_stride(
+            sample["instance_image"], max_stride=self.max_stride
+        )
+        mask_t = apply_pad_to_stride(mask_t, max_stride=self.max_stride)
+
+        img_hw = sample["instance_image"].shape[-2:]
+        mask_bool = mask_t[0, 0].numpy() > 0.5
+        # Single-element list -> the centered instance's mask only (no union),
+        # downsampled + thresholded to the seg head's output stride.
+        sample["foreground_mask"] = generate_foreground_mask(
+            [mask_bool],
+            img_hw=img_hw,
+            output_stride=self.seg_head_config.output_stride,
+        )
+        sample["labels_idx"] = labels_idx
+
+        return sample
+
+
 class TopDownCenteredInstanceMultiClassDataset(CenteredInstanceDataset):
     """Dataset class for instance-centered confidence map ID models.
 
@@ -2398,6 +2802,7 @@ def get_train_val_datasets(
     if use_negative_frames and model_type in (
         "centered_instance",
         "multi_class_topdown",
+        "centered_instance_segmentation",
     ):
         logger.warning(
             f"use_negative_frames is enabled but model_type='{model_type}' "
@@ -2813,6 +3218,75 @@ def get_train_val_datasets(
             parallel_caching=parallel_caching,
             cache_workers=cache_workers,
             use_negative_frames=False,
+        )
+
+    elif model_type == "centered_instance_segmentation":
+        seg_cfg = config.model_config.head_configs.centered_instance_segmentation
+        anchor_part = seg_cfg.segmentation.anchor_part
+        if anchor_part is not None:
+            nodes = [x["name"] for x in config.data_config.skeletons[0]["nodes"]]
+            anchor_ind = nodes.index(anchor_part)
+        else:
+            anchor_ind = None
+        train_dataset = CenteredInstanceSegmentationDataset(
+            labels=train_labels,
+            crop_size=config.data_config.preprocessing.crop_size,
+            seg_head_config=seg_cfg.segmentation,
+            max_stride=config.model_config.backbone_config[f"{backbone_type}"][
+                "max_stride"
+            ],
+            anchor_ind=anchor_ind,
+            user_instances_only=config.data_config.user_instances_only,
+            ensure_rgb=config.data_config.preprocessing.ensure_rgb,
+            ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
+            intensity_aug=(
+                config.data_config.augmentation_config.intensity
+                if config.data_config.augmentation_config is not None
+                else None
+            ),
+            geometric_aug=(
+                config.data_config.augmentation_config.geometric
+                if config.data_config.augmentation_config is not None
+                else None
+            ),
+            scale=config.data_config.preprocessing.scale,
+            apply_aug=config.data_config.use_augmentations_train,
+            max_hw=(
+                config.data_config.preprocessing.max_height,
+                config.data_config.preprocessing.max_width,
+            ),
+            cache_img=cache_imgs,
+            cache_img_path=train_cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
+        )
+        val_dataset = CenteredInstanceSegmentationDataset(
+            labels=val_labels,
+            crop_size=config.data_config.preprocessing.crop_size,
+            seg_head_config=seg_cfg.segmentation,
+            max_stride=config.model_config.backbone_config[f"{backbone_type}"][
+                "max_stride"
+            ],
+            anchor_ind=anchor_ind,
+            user_instances_only=config.data_config.user_instances_only,
+            ensure_rgb=config.data_config.preprocessing.ensure_rgb,
+            ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
+            intensity_aug=None,
+            geometric_aug=None,
+            scale=config.data_config.preprocessing.scale,
+            apply_aug=False,
+            max_hw=(
+                config.data_config.preprocessing.max_height,
+                config.data_config.preprocessing.max_width,
+            ),
+            cache_img=cache_imgs,
+            cache_img_path=val_cache_img_path,
+            use_existing_imgs=use_existing_imgs,
+            rank=rank,
+            parallel_caching=parallel_caching,
+            cache_workers=cache_workers,
         )
 
     else:

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -298,10 +298,11 @@ class LightningModel(L.LightningModule):
             "multi_class_bottomup": BottomUpMultiClassLightningModule,
             "multi_class_topdown": TopDownCenteredInstanceMultiClassLightningModule,
             "bottomup_segmentation": BottomUpSegmentationLightningModule,
+            "centered_instance_segmentation": TopDownCenteredInstanceSegmentationLightningModule,
         }
 
         if model_type not in lightning_models:
-            message = f"Incorrect model type. Please check if one of the following keys in the head configs is not None: [`single_instance`, `centroid`, `centered_instance`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`]"
+            message = f"Incorrect model type. Please check if one of the following keys in the head configs is not None: [`single_instance`, `centroid`, `centered_instance`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`, `bottomup_segmentation`, `centered_instance_segmentation`]"
             logger.error(message)
             raise ValueError(message)
 
@@ -3009,3 +3010,138 @@ class BottomUpSegmentationLightningModule(LightningModel):
         union = pred_fg_binary.sum() + y_fg.sum() - intersection
         iou = intersection / (union + 1e-6)
         self.log("val/fg_iou", iou, on_step=False, on_epoch=True, sync_dist=True)
+
+
+class TopDownCenteredInstanceSegmentationLightningModule(LightningModel):
+    """Lightning Module for top-down (crop-centered) instance segmentation (#622).
+
+    Predicts a single binary foreground mask of the centered instance on a
+    centroid crop. Combines the crop I/O of
+    :class:`TopDownCenteredInstanceLightningModule` (``instance_image`` input)
+    with the bce-dice foreground loss / IoU metric of
+    :class:`BottomUpSegmentationLightningModule`. Composed with a ``centroid``
+    model for full top-down inference; the head emits logits.
+    """
+
+    def __init__(
+        self,
+        model_type: str,
+        backbone_type: str,
+        backbone_config: Union[str, Dict[str, Any], DictConfig],
+        head_configs: DictConfig,
+        pretrained_backbone_weights: Optional[str] = None,
+        pretrained_head_weights: Optional[str] = None,
+        init_weights: Optional[str] = "xavier",
+        lr_scheduler: Optional[Union[str, DictConfig]] = None,
+        online_mining: Optional[bool] = False,
+        hard_to_easy_ratio: Optional[float] = 2.0,
+        min_hard_keypoints: Optional[int] = 2,
+        max_hard_keypoints: Optional[int] = None,
+        loss_scale: Optional[float] = 5.0,
+        optimizer: Optional[str] = "Adam",
+        learning_rate: Optional[float] = 1e-3,
+        amsgrad: Optional[bool] = False,
+        negative_loss_weight: Optional[float] = 1.0,
+    ):
+        """Initialise the configs and the model."""
+        super().__init__(
+            model_type=model_type,
+            backbone_type=backbone_type,
+            backbone_config=backbone_config,
+            head_configs=head_configs,
+            pretrained_backbone_weights=pretrained_backbone_weights,
+            pretrained_head_weights=pretrained_head_weights,
+            init_weights=init_weights,
+            lr_scheduler=lr_scheduler,
+            online_mining=online_mining,
+            hard_to_easy_ratio=hard_to_easy_ratio,
+            min_hard_keypoints=min_hard_keypoints,
+            max_hard_keypoints=max_hard_keypoints,
+            loss_scale=loss_scale,
+            optimizer=optimizer,
+            learning_rate=learning_rate,
+            amsgrad=amsgrad,
+            negative_loss_weight=negative_loss_weight,
+        )
+        self.seg_output_stride = self.head_configs[
+            self.model_type
+        ].segmentation.output_stride
+
+    def forward(self, img):
+        """Forward pass of the model returning foreground-mask LOGITS."""
+        img = torch.squeeze(img, dim=1).to(self.device)
+        img = normalize_on_gpu(img)
+        return self.model(img)["SegmentationHead"]
+
+    def training_step(self, batch, batch_idx):
+        """Training step (bce-dice on the centered-instance foreground mask)."""
+        X = torch.squeeze(batch["instance_image"], dim=1)
+        y_fg = torch.squeeze(batch["foreground_mask"], dim=1)
+        X = normalize_on_gpu(X)
+        pred_fg = self.model(X)["SegmentationHead"]  # logits
+        loss = compute_bce_dice_loss(pred_fg, y_fg)
+
+        self.log(
+            "loss", loss, prog_bar=True, on_step=True, on_epoch=False, sync_dist=True
+        )
+        self._accumulate_loss(loss)
+        self.log("train/fg_loss", loss, on_step=False, on_epoch=True, sync_dist=True)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        """Validation step (val loss + foreground IoU)."""
+        X = torch.squeeze(batch["instance_image"], dim=1)
+        y_fg = torch.squeeze(batch["foreground_mask"], dim=1)
+        X = normalize_on_gpu(X)
+        pred_fg = self.model(X)["SegmentationHead"]  # logits
+        val_loss = compute_bce_dice_loss(pred_fg, y_fg)
+
+        self.log(
+            "val/loss",
+            val_loss,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
+        self.log("val/fg_loss", val_loss, on_step=False, on_epoch=True, sync_dist=True)
+
+        pred_fg_binary = (pred_fg > 0.0).float()
+        intersection = (pred_fg_binary * y_fg).sum()
+        union = pred_fg_binary.sum() + y_fg.sum() - intersection
+        iou = intersection / (union + 1e-6)
+        self.log("val/fg_iou", iou, on_step=False, on_epoch=True, sync_dist=True)
+
+    def get_visualization_data(self, sample) -> VisualizationData:
+        """Crop-flavored viz: image + predicted foreground probability overlay."""
+        ex = sample.copy()
+        for k, v in ex.items():
+            if isinstance(v, torch.Tensor):
+                ex[k] = v.to(device=self.device)
+        ex["instance_image"] = ex["instance_image"].unsqueeze(dim=0)
+        with torch.no_grad():
+            logits = self.forward(ex["instance_image"])
+            fg_prob = torch.sigmoid(logits)[0].cpu().numpy().transpose(1, 2, 0)
+        img_np = ex["instance_image"][0, 0].cpu().numpy().transpose(1, 2, 0)
+        return VisualizationData(
+            image=img_np,
+            pred_confmaps=fg_prob,
+            pred_peaks=np.zeros((0, 1, 2)),
+            pred_peak_values=np.zeros((0,)),
+            gt_instances=np.zeros((0, 1, 2)),
+            node_names=["mask"],
+            output_scale=fg_prob.shape[0] / img_np.shape[0],
+            is_paired=False,
+        )
+
+    def visualize_example(self, sample):
+        """Visualize the predicted foreground mask over the crop during training."""
+        data = self.get_visualization_data(sample)
+        scale = 1.0
+        if data.image.shape[0] < 512:
+            scale = 2.0
+        if data.image.shape[0] < 256:
+            scale = 4.0
+        fig = plot_img(data.image, dpi=72 * scale, scale=scale)
+        plot_confmaps(data.pred_confmaps, output_scale=data.output_scale)
+        return fig

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -410,9 +410,10 @@ class ModelTrainer:
         # compute max_heigt, max_width, and crop_size (if not provided in the config)
         max_height = self.config.data_config.preprocessing.max_height
         max_width = self.config.data_config.preprocessing.max_width
-        if (
-            self.model_type == "centered_instance"
-            or self.model_type == "multi_class_topdown"
+        if self.model_type in (
+            "centered_instance",
+            "multi_class_topdown",
+            "centered_instance_segmentation",
         ):
             crop_size = self.config.data_config.preprocessing.crop_size
 
@@ -429,9 +430,10 @@ class ModelTrainer:
                 if current_max_w > max_w:
                     max_w = current_max_w
 
-            if (
-                self.model_type == "centered_instance"
-                or self.model_type == "multi_class_topdown"
+            if self.model_type in (
+                "centered_instance",
+                "multi_class_topdown",
+                "centered_instance_segmentation",
             ):
                 # compute crop size if not provided in config
                 if crop_size is None:
@@ -510,9 +512,14 @@ class ModelTrainer:
             self.config.data_config.preprocessing.max_width = max_w
 
         if (
-            self.model_type == "centered_instance"
-            or self.model_type == "multi_class_topdown"
-        ) and crop_size is None:
+            self.model_type
+            in (
+                "centered_instance",
+                "multi_class_topdown",
+                "centered_instance_segmentation",
+            )
+            and crop_size is None
+        ):
             self.config.data_config.preprocessing.crop_size = max_crop_size
 
     def _setup_head_config(self):
@@ -1082,6 +1089,14 @@ class ModelTrainer:
                         "val/fg_iou",
                     ]
                 )
+            if self.model_type == "centered_instance_segmentation":
+                csv_log_keys.extend(
+                    [
+                        "train/fg_loss",
+                        "val/fg_loss",
+                        "val/fg_iou",
+                    ]
+                )
             csv_logger = CSVLoggerCallback(
                 filepath=Path(self.config.trainer_config.ckpt_dir)
                 / self.config.trainer_config.run_name
@@ -1222,7 +1237,10 @@ class ModelTrainer:
                         match_threshold=self.config.trainer_config.eval.match_threshold,
                     )
                 )
-            elif self.model_type == "bottomup_segmentation":
+            elif self.model_type in (
+                "bottomup_segmentation",
+                "centered_instance_segmentation",
+            ):
                 # Segmentation has no keypoint predictions for OKS/PCK; the
                 # foreground IoU logged in validation_step (val/fg_iou) serves as
                 # the epoch-level quality metric. Skip the keypoint eval callback.

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -388,6 +388,7 @@ def test_group_instances_no_centers():
 
 from sleap_nn.config.model_config import (
     BottomUpSegmentationConfig,
+    CenteredInstanceSegmentationConfig,
     SegmentationHeadConfig,
     InstanceCenterConfig,
     CenterOffsetConfig,
@@ -454,6 +455,275 @@ def test_get_model_type_from_cfg_segmentation():
         }
     )
     assert get_model_type_from_cfg(cfg) == "bottomup_segmentation"
+
+
+# ---------------------------------------------------------------------------
+# 6b. Top-down (crop-centered) segmentation config + head (#622)
+# ---------------------------------------------------------------------------
+
+
+def test_head_config_oneof_centered_instance_segmentation():
+    """HeadConfig oneof selects centered_instance_segmentation exclusively."""
+    head_cfg = HeadConfig(
+        centered_instance_segmentation=CenteredInstanceSegmentationConfig(
+            segmentation=SegmentationHeadConfig(),
+        )
+    )
+    assert head_cfg.centered_instance_segmentation is not None
+    assert head_cfg.bottomup_segmentation is None
+    assert head_cfg.centered_instance is None
+    assert head_cfg.centroid is None
+
+
+def test_get_head_configs_builder_centered_instance_segmentation():
+    """get_head_configs builds the config from both a string and a dict."""
+    from sleap_nn.config.get_config import get_head_configs
+
+    hc = get_head_configs("centered_instance_segmentation")
+    assert hc.centered_instance_segmentation is not None
+    assert hc.centered_instance_segmentation.segmentation.output_stride == 2
+    assert hc.centered_instance_segmentation.segmentation.anchor_part is None
+
+    # Dict path round-trips an explicit anchor_part (inside the head leaf).
+    hc2 = get_head_configs(
+        {
+            "centered_instance_segmentation": {
+                "segmentation": {
+                    "output_stride": 4,
+                    "loss_weight": 2.0,
+                    "anchor_part": "thorax",
+                },
+            }
+        }
+    )
+    seg = hc2.centered_instance_segmentation.segmentation
+    assert seg.output_stride == 4
+    assert seg.loss_weight == 2.0
+    assert seg.anchor_part == "thorax"
+
+
+def test_get_model_type_from_cfg_centered_instance_segmentation():
+    """Model type is auto-detected from the head config key."""
+    from sleap_nn.config.utils import get_model_type_from_cfg
+
+    cfg = OmegaConf.create(
+        {
+            "model_config": {
+                "head_configs": {
+                    "single_instance": None,
+                    "centroid": None,
+                    "centered_instance": None,
+                    "bottomup": None,
+                    "multi_class_bottomup": None,
+                    "multi_class_topdown": None,
+                    "bottomup_segmentation": None,
+                    "centered_instance_segmentation": {
+                        "segmentation": {
+                            "output_stride": 2,
+                            "loss_weight": 1.0,
+                            "anchor_part": None,
+                        },
+                    },
+                }
+            }
+        }
+    )
+    assert get_model_type_from_cfg(cfg) == "centered_instance_segmentation"
+
+
+def test_centered_instance_segmentation_model_single_head_forward():
+    """Model has exactly ONE SegmentationHead and forwards at stride-2 shape."""
+    backbone_config, _ = _seg_backbone_head_configs()
+    head_configs = OmegaConf.create(
+        {"segmentation": {"output_stride": 2, "loss_weight": 1.0}}
+    )
+    model = Model(
+        backbone_type="unet",
+        backbone_config=backbone_config,
+        head_configs=head_configs,
+        model_type="centered_instance_segmentation",
+    )
+    assert len(model.heads) == 1
+    assert isinstance(model.heads[0], SegmentationHead)
+    # Crop input (B, C, crop, crop) -> single foreground logit map at stride 2.
+    x = torch.randn(2, 1, 64, 64)
+    outputs = model(x)
+    assert set(outputs) == {"SegmentationHead"}
+    assert outputs["SegmentationHead"].shape == (2, 1, 32, 32)
+
+
+# ---------------------------------------------------------------------------
+# 6c. Top-down (crop-centered) segmentation dataset (#622)
+# ---------------------------------------------------------------------------
+
+from sleap_nn.data.custom_datasets import (
+    CenteredInstanceSegmentationDataset,
+    _match_mask_to_instance,
+    _associate_masks,
+    _bbox_iou,
+)
+
+
+def _disk_mask(h, w, cx, cy, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r * r
+
+
+def _two_instance_seg_labels(minimal_instance, centers, radius=18):
+    """Build Labels with two instances + linked disk masks at given centers."""
+    src = sio.load_slp(minimal_instance.as_posix())
+    video = src.videos[0]
+    sk = src.skeletons[0]
+    h, w = video.shape[1], video.shape[2]
+    n = len(sk.nodes)
+    insts, masks = [], []
+    for cx, cy in centers:
+        pts = np.tile([cx, cy], (n, 1)).astype("float32")
+        pts += np.linspace(-3, 3, n)[:, None]  # spread nodes so bbox is non-degenerate
+        inst = sio.Instance.from_numpy(pts, skeleton=sk)
+        insts.append(inst)
+        blob = _disk_mask(h, w, cx, cy, radius)
+        masks.append(sio.UserSegmentationMask.from_numpy(blob, instance=inst))
+    lf = sio.LabeledFrame(
+        video=video, frame_idx=src[0].frame_idx, instances=insts, masks=masks
+    )
+    return sio.Labels(videos=[video], skeletons=[sk], labeled_frames=[lf])
+
+
+def _build_seg_dataset(labels, crop_size=160, output_stride=2, max_stride=16):
+    seg_cfg = OmegaConf.create({"output_stride": output_stride, "loss_weight": 1.0})
+    return CenteredInstanceSegmentationDataset(
+        labels=[labels],
+        crop_size=crop_size,
+        seg_head_config=seg_cfg,
+        max_stride=max_stride,
+        anchor_ind=None,  # mean of visible nodes
+        ensure_grayscale=True,
+        apply_aug=False,
+        scale=1.0,
+        cache_img=None,
+    )
+
+
+def test_match_mask_to_instance_identity_and_fallback(minimal_instance):
+    """Identity link is primary; bbox-IoU is the fallback."""
+    labels = _two_instance_seg_labels(minimal_instance, [(120, 192), (260, 192)])
+    lf = labels[0]
+    inst0, inst1 = lf.instances
+    m0, m1 = lf.masks
+    # Identity link resolves each instance to its own mask.
+    assert _match_mask_to_instance(inst0, lf.masks) is m0
+    assert _match_mask_to_instance(inst1, lf.masks) is m1
+    # With the links cleared, the bbox-IoU fallback still picks the nearer mask.
+    m0.instance = None
+    m1.instance = None
+    assert _match_mask_to_instance(inst0, lf.masks) is m0
+    assert _match_mask_to_instance(inst1, lf.masks) is m1
+    # Unit sanity for the IoU helper.
+    assert _bbox_iou((0, 0, 10, 10), (0, 0, 10, 10)) == pytest.approx(1.0)
+    assert _bbox_iou((0, 0, 10, 10), (20, 20, 30, 30)) == 0.0
+
+
+def test_associate_masks_no_double_assignment(minimal_instance):
+    """One-to-one assignment: an unlinked instance can't steal a linked mask."""
+    # Two overlapping instances; one mask, linked to instance 0.
+    labels = _two_instance_seg_labels(minimal_instance, [(160, 192), (175, 192)])
+    lf = labels[0]
+    inst0, inst1 = lf.instances
+    m0, m1 = lf.masks
+    lf.masks = [m0]  # only one mask, linked to inst0
+    assigned = _associate_masks([inst0, inst1], lf.masks)
+    assert assigned.get(0) is m0
+    assert assigned.get(1) is None  # inst1 does NOT steal inst0's linked mask
+
+    # Two unlinked overlapping instances + one mask -> only one instance gets it.
+    m0.instance = None
+    assigned2 = _associate_masks([inst0, inst1], [m0])
+    claimants = [i for i in (0, 1) if assigned2.get(i) is m0]
+    assert len(claimants) == 1  # mask used exactly once, never twice
+
+
+def test_centered_instance_seg_dataset_offset_scale_mask(minimal_instance):
+    """A mask carrying non-identity scale/offset (pseudo-label) places full-frame.
+
+    Regression for the GT-desync bug: a predicted-style mask (output-stride scale
+    + crop offset) must decode + place onto the image grid so its foreground
+    still lands on the centered instance after the crop pipeline.
+    """
+    src = sio.load_slp(minimal_instance.as_posix())
+    video = src.videos[0]
+    sk = src.skeletons[0]
+    h, w = video.shape[1], video.shape[2]
+    cx, cy, r = 150, 192, 20
+    pts = np.tile([cx, cy], (len(sk.nodes), 1)).astype("float32")
+    pts += np.linspace(-3, 3, len(sk.nodes))[:, None]
+    inst = sio.Instance.from_numpy(pts, skeleton=sk)
+    # Build the mask at output-stride 2 with a crop offset (like an inference mask).
+    blob = _disk_mask(h, w, cx, cy, r)
+    ys, xs = np.nonzero(blob)
+    oy, ox = int(ys.min()), int(xs.min())
+    sub = blob[oy : ys.max() + 1, ox : xs.max() + 1][::2, ::2]  # stride-2 crop
+    m = sio.PredictedSegmentationMask.from_numpy(
+        sub.astype(bool), score=0.9, scale=(0.5, 0.5), offset=(float(ox), float(oy))
+    )
+    m.instance = inst
+    lf = sio.LabeledFrame(
+        video=video, frame_idx=src[0].frame_idx, instances=[inst], masks=[m]
+    )
+    labels = sio.Labels(videos=[video], skeletons=[sk], labeled_frames=[lf])
+
+    ds = _build_seg_dataset(labels, crop_size=160, output_stride=2)
+    s = ds[0]
+    fg = s["foreground_mask"][0, 0].numpy() > 0.5
+    # Foreground exists and the instance's nodes land on it (placement correct).
+    assert fg.any()
+    on = sum(
+        1
+        for x, y in (s["instance"][0].numpy() / 2.0)
+        if not np.isnan(x)
+        and 0 <= int(round(y)) < fg.shape[0]
+        and 0 <= int(round(x)) < fg.shape[1]
+        and fg[int(round(y)), int(round(x))]
+    )
+    assert on >= 1
+
+
+def test_centered_instance_seg_dataset_keys_and_shapes(minimal_instance):
+    """Dataset yields one sample per instance with a foreground_mask GT."""
+    labels = _two_instance_seg_labels(minimal_instance, [(120, 192), (260, 192)])
+    ds = _build_seg_dataset(labels, crop_size=160, output_stride=2)
+    assert len(ds) == 2
+    s = ds[0]
+    assert "foreground_mask" in s and "confidence_maps" not in s
+    assert s["instance_image"].shape == (1, 1, 160, 160)
+    assert s["foreground_mask"].shape == (1, 1, 80, 80)
+    assert s["foreground_mask"].dtype == torch.float32
+    # Foreground is non-trivial and the centered instance's nodes land on it.
+    fg = s["foreground_mask"][0, 0].numpy() > 0.5
+    assert fg.any()
+    for x, y in s["instance"][0].numpy() / 2.0:
+        if not np.isnan(x):
+            assert fg[int(round(y)), int(round(x))]
+
+
+def test_centered_instance_seg_dataset_centered_only(minimal_instance):
+    """The GT contains ONLY the centered instance, not an overlapping neighbor."""
+    # Two disjoint disks; inst1 sits INSIDE inst0's crop window.
+    centers = [(160, 192), (230, 192)]
+    labels = _two_instance_seg_labels(minimal_instance, centers, radius=18)
+    ds = _build_seg_dataset(labels, crop_size=160, output_stride=2)
+    s = ds[0]  # crop centered on inst0
+    assert float(s["eff_scale"]) == 1.0  # no size-matcher resize (max_hw None)
+    fg = s["foreground_mask"][0, 0].numpy() > 0.5  # (80, 80) at stride 2
+
+    # inst0 is at the crop center; inst1 is offset by +70 px in x.
+    cx0, cy0 = centers[0]
+    half = 160 // 2
+    # inst0 centre -> crop (half, half) -> stride (40, 40): foreground.
+    assert fg[40, 40]
+    # inst1 centre -> crop (half + 70, half) -> stride (55, 40): background.
+    dx = (centers[1][0] - cx0) // 2
+    assert not fg[40, 40 + dx]
 
 
 # ---------------------------------------------------------------------------
@@ -643,6 +913,51 @@ def test_bottomup_segmentation_train_smoke(minimal_instance_seg, tmp_path):
     assert (run_dir / "best.ckpt").exists()
     assert (run_dir / "training_config.yaml").exists()
     # CSV logged the segmentation-specific metrics.
+    csv_text = (run_dir / "training_log.csv").read_text()
+    assert "val/fg_iou" in csv_text
+    assert "train/fg_loss" in csv_text
+
+
+def _topdown_seg_train_config(seg_path, tmp_path):
+    """One-epoch CPU training config for top-down (crop) segmentation."""
+    cfg = _seg_train_config(seg_path, tmp_path)
+    cfg.data_config.preprocessing.crop_size = 160
+    cfg.model_config.head_configs = OmegaConf.create(
+        {
+            "single_instance": None,
+            "centroid": None,
+            "bottomup": None,
+            "centered_instance": None,
+            "multi_class_bottomup": None,
+            "multi_class_topdown": None,
+            "bottomup_segmentation": None,
+            "centered_instance_segmentation": {
+                "segmentation": {
+                    "output_stride": 2,
+                    "loss_weight": 1.0,
+                    "anchor_part": None,
+                },
+            },
+        }
+    )
+    cfg.trainer_config.run_name = "topdown_seg_smoke"
+    # Exercise the crop-flavored visualization callback (a regression guard).
+    cfg.trainer_config.visualize_preds_during_training = True
+    cfg.trainer_config.keep_viz = False
+    return cfg
+
+
+def test_centered_instance_seg_train_smoke(minimal_instance_seg, tmp_path):
+    """ModelTrainer trains a top-down seg model for one epoch (viz on) + ckpt."""
+    from sleap_nn.training.model_trainer import ModelTrainer
+
+    cfg = _topdown_seg_train_config(minimal_instance_seg.as_posix(), tmp_path)
+    trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+    trainer.train()
+
+    run_dir = tmp_path / "topdown_seg_smoke"
+    assert (run_dir / "best.ckpt").exists()
+    assert (run_dir / "training_config.yaml").exists()
     csv_text = (run_dir / "training_log.csv").read_text()
     assert "val/fg_iou" in csv_text
     assert "train/fg_loss" in csv_text


### PR DESCRIPTION
**Stacked series for top-down (crop-centered) instance segmentation (#622) — PR 2 of 4.** Stacked on #637 (base = `seg-td/1-deps-offset-decode`).

## What
The training stack for a **top-down (crop-centered)** segmentation model — a lone `SegmentationHead` on a centroid crop that predicts the **centered** instance's binary mask (the segmentation analog of `centered_instance`). New model type / head-config key: **`centered_instance_segmentation`**.

- **Config / head:** `CenteredInstanceSegmentationConfig` (with `anchor_part` *inside* the head leaf, so every per-type head config stays a clean dict of head-leaf configs); `get_head` builds a lone `SegmentationHead`.
- **Dataset:** `CenteredInstanceSegmentationDataset` selects **only the centered instance's** mask (one-to-one `_associate_masks` — identity link first, then bbox-IoU, no mask reused), places it on the full-frame canvas, carries it through the **same** size-match/crop/resize/pad as the image, and downsamples to the head output stride. Geometric aug skipped in v1 (masks aren't co-transformed); intensity aug applies.
- **Training:** `TopDownCenteredInstanceSegmentationLightningModule` (crop I/O + BCE-Dice loss / foreground-IoU metric, single-tensor logits `forward`, crop-flavored viz) + `ModelTrainer` wiring (crop_size guards, CSV keys, OKS-eval skip) + sample config `config_topdown_centered_instance_segmentation_unet.yaml`.

## Validation
Trained on burned-in flies13 masks: `val/fg_iou` 0.00 → **0.67** (monotonic). Unit tests cover config/head dispatch, dataset shapes, the **centered-only** property (an overlapping neighbor is excluded), one-to-one association, offset/scale mask placement, and an end-to-end train smoke (viz on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)