### PR TITLE
feat(seg) 3/4: top-down (crop-centered) segmentation inference (#622)

### DIFF
--- a/sleap_nn/inference/layers/topdown_segmentation.py
+++ b/sleap_nn/inference/layers/topdown_segmentation.py
@@ -1,0 +1,285 @@
+"""Top-down (crop-centered) instance-segmentation inference layers (#622).
+
+Two pieces, mirroring the keypoint top-down stack:
+
+* :class:`CenteredInstanceMaskLayer` — the stage-2 analog of
+  :class:`~sleap_nn.inference.layers.centered_instance.CenteredInstanceLayer`.
+  Runs the trained ``centered_instance_segmentation`` model on per-instance
+  crops and returns one boolean foreground mask per crop (at the head's
+  output-stride resolution) instead of keypoints. The crop-resolution masks +
+  per-crop scores are carried on ``Outputs`` for the composed layer to place.
+
+* :class:`TopDownSegmentationLayer` — subclasses
+  :class:`~sleap_nn.inference.layers.topdown.TopDownLayer` to reuse its
+  stage-1 (centroid) + sizematch + crop machinery verbatim, overriding only
+  the stage-2 emission. Each crop mask is emitted into ``Outputs.pred_masks``
+  with the DQ5 offset/scale contract (see :meth:`_run_stage_2`), so
+  ``decode_mask_to_image_res`` upsamples the crop mask to the crop's
+  image-space size and (offset-aware) top-left pads it to land at the correct
+  full-frame location.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from sleap_nn.data.instance_cropping import make_centered_bboxes
+from sleap_nn.inference.layers.backends.base import ModelBackend
+from sleap_nn.inference.layers.base import InferenceLayer
+from sleap_nn.inference.layers.configs import PostprocessConfig, PreprocessConfig
+from sleap_nn.inference.layers.centroid import CentroidLayer
+from sleap_nn.inference.layers.topdown import TopDownLayer
+from sleap_nn.inference.ops.crops import crop_bboxes
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.preprocess_info import PreprocInfo
+
+
+class CenteredInstanceMaskLayer(InferenceLayer):
+    """Per-crop foreground-mask prediction layer (top-down stage 2).
+
+    Runs a trained ``centered_instance_segmentation`` model on per-instance
+    crops and decodes the ``SegmentationHead`` logits into one boolean
+    foreground mask per crop. The structural twin of
+    :class:`CenteredInstanceLayer`, but returns masks (on ``Outputs.crops`` as
+    a stacked tensor + a per-crop score) rather than keypoints — the composed
+    :class:`TopDownSegmentationLayer` places each crop mask back into the frame.
+
+    Args:
+        backend: Runtime backend wrapping the seg Lightning module. Its
+            ``forward`` returns the ``SegmentationHead`` LOGITS (a single
+            tensor, wrapped as ``{"output": ...}`` by ``TorchBackend``).
+        output_stride: Head map → crop-pixel stride (default 2).
+        max_stride: Backbone max stride; crops are padded to a multiple of it.
+        fg_threshold: Foreground probability threshold for binarization
+            (sigmoid(logits) > fg_threshold). Default 0.5.
+        preprocess_config / postprocess_config: Standard knobs. The crops are
+            already sized (extracted from the sizematched image), so only the
+            model's own ``input_scale`` is applied here.
+    """
+
+    _HEAD_OUTPUT_KEY: str = "SegmentationHead"
+
+    def __init__(
+        self,
+        backend: ModelBackend,
+        output_stride: int,
+        max_stride: int = 1,
+        fg_threshold: float = 0.5,
+        preprocess_config: Optional[PreprocessConfig] = None,
+        postprocess_config: Optional[PostprocessConfig] = None,
+    ) -> None:
+        """Compose the layer with default configs when omitted."""
+        super().__init__(
+            backend=backend,
+            preprocess_config=preprocess_config or PreprocessConfig(),
+            postprocess_config=postprocess_config or PostprocessConfig(),
+            output_stride=output_stride,
+            max_stride=max_stride,
+        )
+        self.fg_threshold = float(fg_threshold)
+        # The parent TopDownLayer.predict inspects this on the stage-2 layer to
+        # decide the GT-keypoint branch; a mask layer never takes that branch.
+        self.use_gt_peaks = False
+
+    @property
+    def warmup_input_shape(self):
+        """Tiny single-channel warmup shape."""
+        return (1, 1, 64, 64)
+
+    def postprocess(self, raw_out: dict, info: PreprocInfo) -> Outputs:
+        """Decode ``SegmentationHead`` logits → one bool mask per crop.
+
+        Args:
+            raw_out: Backend output dict carrying the seg-head logits.
+            info: Preprocessing metadata (unused for placement — the composed
+                layer owns the crop→frame mapping).
+
+        Returns:
+            ``Outputs`` with ``crops`` set to the stacked per-crop boolean
+            masks ``(N, 1, h, w)`` (float) at output-stride resolution and
+            ``instance_scores`` set to the per-crop mean foreground
+            probability ``(N, 1)``. The composed layer reads both.
+        """
+        logits = self._extract_confmaps(raw_out)  # (N, 1, h, w)
+        probs = torch.sigmoid(logits.detach())
+        masks = (probs > self.fg_threshold).float()  # (N, 1, h, w)
+        # Per-crop score: mean foreground probability over the predicted mask
+        # (falls back to the centroid confidence at the composed layer when a
+        # crop is empty). Kept on ``instance_scores`` in the (N, 1) layout the
+        # composed layer's scatter expects.
+        denom = masks.sum(dim=(2, 3)).clamp(min=1.0)
+        score = (probs * masks).sum(dim=(2, 3)) / denom  # (N, 1)
+        return Outputs(crops=masks, instance_scores=score, preprocess_info=info)
+
+
+class TopDownSegmentationLayer(TopDownLayer):
+    """Composed centroid + per-crop-mask two-stage segmentation layer.
+
+    Subclasses :class:`TopDownLayer` to reuse stage 1 (centroid) + sizematch +
+    crop extraction verbatim, overriding only :meth:`_run_stage_2` to emit
+    per-crop masks into ``Outputs.pred_masks`` instead of keypoints.
+
+    Args:
+        centroid_layer: Stage-1 :class:`CentroidLayer` (real model or
+            ``use_gt_centroids=True`` for the GT-centroid fallback).
+        centered_instance_layer: Stage-2 :class:`CenteredInstanceMaskLayer`.
+        crop_size: ``(crop_h, crop_w)`` of the per-instance crop.
+        mask_output: Output representation forwarded to ``Outputs.to_labels`` —
+            ``"mask"`` (default), ``"polygon"``, or ``"both"``.
+        polygon_epsilon: Douglas-Peucker tolerance for polygon/both output.
+        centroid_nms / centroid_nms_threshold: Optional centroid dedup before
+            stage 2 (inherited).
+    """
+
+    def __init__(
+        self,
+        centroid_layer: CentroidLayer,
+        centered_instance_layer: CenteredInstanceMaskLayer,
+        crop_size: Tuple[int, int],
+        mask_output: str = "mask",
+        polygon_epsilon: float = 0.01,
+        centroid_nms: bool = False,
+        centroid_nms_threshold: float = 0.5,
+    ) -> None:
+        """Stash inner layers, crop size, and mask packaging knobs."""
+        super().__init__(
+            centroid_layer=centroid_layer,
+            centered_instance_layer=centered_instance_layer,
+            crop_size=crop_size,
+            centroid_nms=centroid_nms,
+            centroid_nms_threshold=centroid_nms_threshold,
+            return_crops=False,
+        )
+        # Read by Predictor.to_labels / predict_to_file via getattr.
+        self.mask_output = str(mask_output)
+        self.polygon_epsilon = float(polygon_epsilon)
+
+    # ──────────────────────────────────────────────────────────────────
+    # Stage 2: crop → seg model → per-crop mask placement
+    # ──────────────────────────────────────────────────────────────────
+
+    def _run_stage_2(
+        self,
+        image_4d: torch.Tensor,
+        centroids: torch.Tensor,
+        centroid_vals: torch.Tensor,
+        valid_mask: torch.Tensor,
+        eff_scale: Optional[torch.Tensor] = None,
+    ) -> Outputs:
+        """Crop around valid centroids, run the seg model, place per-crop masks.
+
+        ``image_4d`` / ``centroids`` are in **sized** space (after the centroid
+        layer's sizematcher). For each valid crop we emit one ``pred_masks``
+        entry with the DQ5 offset/scale contract::
+
+            offset = (crop_topleft_x / eff, crop_topleft_y / eff)   # image px
+            scale  = (eff / output_stride, eff / output_stride)
+            score  = centroid confidence for that crop
+
+        where ``eff`` is the per-crop sizematcher scale and ``crop_topleft`` is
+        the bbox top-left in sized space (``bboxes[:, 0, :]``). With that scale,
+        ``decode_mask_to_image_res`` upsamples the ``(crop/stride)`` mask to the
+        crop's image-space size (``image_coord = mask_coord / scale + offset``)
+        and then offset-aware top-left pads it, landing the crop at its
+        full-frame location.
+        """
+        B, max_inst, _ = centroids.shape
+        crop_h, crop_w = self.crop_size
+
+        valid_idx = valid_mask.nonzero(as_tuple=False)  # (n_valid, 2) — (b, i)
+        n_valid = valid_idx.shape[0]
+
+        if eff_scale is None:
+            eff_scale = torch.ones(B, dtype=torch.float32, device=centroids.device)
+        else:
+            eff_scale = eff_scale.to(centroids.device)
+
+        # Empty batch: one empty mask list per frame. Masks ONLY (no
+        # pred_centroids) so Outputs.to_labels does not synthesize phantom
+        # keypoint instances — matches the bottom-up SegmentationLayer contract.
+        if n_valid == 0:
+            return Outputs(pred_masks=[[] for _ in range(B)])
+
+        valid_centroids = centroids[valid_idx[:, 0], valid_idx[:, 1]]
+        sample_inds = valid_idx[:, 0]  # (n_valid,)
+        per_crop_eff_scale = eff_scale[sample_inds]  # (n_valid,)
+
+        bboxes = make_centered_bboxes(valid_centroids, crop_h, crop_w)
+        crops = crop_bboxes(image_4d, bboxes, sample_inds)
+
+        # Run the seg model on the crops -> per-crop bool masks (N, 1, h, w).
+        stage2_out = self.centered_instance_layer.predict(crops)
+        crop_masks = stage2_out.crops  # (n_valid, 1, h, w) float {0,1}
+        device = crop_masks.device
+
+        # Normalize metadata onto the model device (GT-centroid path runs
+        # centroids/bboxes on CPU while the model runs on cuda/mps).
+        centroid_vals = centroid_vals.to(device)
+        crop_centroid_vals = centroid_vals[
+            valid_idx[:, 0].to(device), valid_idx[:, 1].to(device)
+        ]  # (n_valid,)
+        # Per-crop score: the inner layer's mean foreground probability (a
+        # mask-quality signal for COCO-style AP ranking), falling back to the
+        # centroid confidence when unavailable.
+        if stage2_out.instance_scores is not None:
+            crop_scores = stage2_out.instance_scores.squeeze(1).to(device)
+        else:
+            crop_scores = crop_centroid_vals
+        per_crop_eff_scale = per_crop_eff_scale.to(device)
+
+        # Use the SAME floored top-left that crop_bboxes extracted content from
+        # (it floors `trunc(top_left + half) - half`), so the baked image offset
+        # lands exactly where the crop pixels came from (removes the up-to-1px
+        # shift from using the raw float bbox top-left).
+        bboxes = bboxes.to(device)
+        half_xy = torch.tensor(
+            [crop_w // 2, crop_h // 2], dtype=bboxes.dtype, device=device
+        )
+        crop_topleft = (bboxes[:, 0, :] + half_xy).to(torch.long) - half_xy.long()
+
+        crop_masks_np = crop_masks.squeeze(1).bool().cpu().numpy()  # (n_valid, h, w)
+        crop_topleft_np = crop_topleft.cpu().numpy()  # (n_valid, 2)
+        eff_np = per_crop_eff_scale.cpu().numpy()  # (n_valid,)
+        scores_np = crop_scores.cpu().numpy()  # (n_valid,)
+        samples_np = sample_inds.cpu().numpy()  # (n_valid,)
+        stride = float(self.centered_instance_layer.output_stride)
+        # The crops are downscaled by the seg model's own input_scale before the
+        # head (InferenceLayer.preprocess), so the head mask is at
+        # crop*input_scale/stride px. Fold input_scale into the emitted scale to
+        # match the bottom-up SegmentationLayer convention (s = eff*input_scale).
+        input_scale = float(
+            getattr(
+                getattr(self.centered_instance_layer, "preprocess_config", None),
+                "scale",
+                1.0,
+            )
+        )
+
+        pred_masks: List[List[dict]] = [[] for _ in range(B)]
+        for k in range(n_valid):
+            b = int(samples_np[k])
+            eff = float(eff_np[k])
+            # Image-space crop origin: floored sized top-left / eff_scale.
+            ox = float(crop_topleft_np[k, 0]) / eff
+            oy = float(crop_topleft_np[k, 1]) / eff
+            # image_coord = mask_coord / scale + offset, with the crop mask at
+            # (crop*input_scale/stride) px over a crop/eff image-px span, so
+            # scale (= mask_px / image_px) = (eff * input_scale) / stride.
+            sx = (eff * input_scale) / stride
+            sy = (eff * input_scale) / stride
+            pred_masks[b].append(
+                {
+                    "mask": np.ascontiguousarray(crop_masks_np[k], dtype=bool),
+                    "score": float(scores_np[k]),
+                    "scale": (sx, sy),
+                    "offset": (ox, oy),
+                }
+            )
+
+        # Masks ONLY (no pred_centroids/pred_keypoints) so Outputs.to_labels does
+        # not synthesize phantom keypoint instances next to the masks (which also
+        # broke mask-tracking auto-detection). Mirrors bottom-up SegmentationLayer.
+        return Outputs(pred_masks=pred_masks)

--- a/sleap_nn/inference/layers/topdown_segmentation.py
+++ b/sleap_nn/inference/layers/topdown_segmentation.py
@@ -106,10 +106,9 @@ class CenteredInstanceMaskLayer(InferenceLayer):
         logits = self._extract_confmaps(raw_out)  # (N, 1, h, w)
         probs = torch.sigmoid(logits.detach())
         masks = (probs > self.fg_threshold).float()  # (N, 1, h, w)
-        # Per-crop score: mean foreground probability over the predicted mask
-        # (falls back to the centroid confidence at the composed layer when a
-        # crop is empty). Kept on ``instance_scores`` in the (N, 1) layout the
-        # composed layer's scatter expects.
+        # Per-crop score: mean foreground probability over the predicted mask.
+        # An empty crop scores 0.0 (and is dropped by ``Outputs.to_masks``). Kept
+        # on ``instance_scores`` in the (N, 1) layout the composed layer expects.
         denom = masks.sum(dim=(2, 3)).clamp(min=1.0)
         score = (probs * masks).sum(dim=(2, 3)) / denom  # (N, 1)
         return Outputs(crops=masks, instance_scores=score, preprocess_info=info)

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -35,7 +35,10 @@ from sleap_nn.inference.topdown import (
 )
 from sleap_nn.inference.utils import get_skeleton_from_config
 from sleap_nn.legacy_models import load_legacy_model
-from sleap_nn.inference.segmentation import BottomUpSegmentationInferenceModel
+from sleap_nn.inference.segmentation import (
+    BottomUpSegmentationInferenceModel,
+    CenteredInstanceMaskInferenceModel,
+)
 from sleap_nn.training.lightning_modules import (
     BottomUpLightningModule,
     BottomUpMultiClassLightningModule,
@@ -44,6 +47,7 @@ from sleap_nn.training.lightning_modules import (
     SingleInstanceLightningModule,
     TopDownCenteredInstanceLightningModule,
     TopDownCenteredInstanceMultiClassLightningModule,
+    TopDownCenteredInstanceSegmentationLightningModule,
 )
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -622,6 +626,152 @@ def _build_topdown(
     )
 
 
+def _build_topdown_segmentation(
+    centroid_ckpt_path: Optional[str],
+    seg_ckpt_path: str,
+    *,
+    device: str,
+    backbone_ckpt_path: Optional[str],
+    head_ckpt_path: Optional[str],
+    peak_threshold: Union[float, List[float]],
+    integral_refinement: str,
+    integral_patch_size: int,
+    max_instances: Optional[int],
+    return_confmaps: bool,
+    preprocess_config: Any,
+    anchor_part: Optional[str],
+    fg_threshold: float = 0.5,
+    mask_output: str = "mask",
+    polygon_epsilon: float = 0.01,
+) -> LoadedAssets:
+    """Load a centroid + ``centered_instance_segmentation`` pair for top-down seg.
+
+    Mirrors :func:`_build_topdown` but the second stage is a per-crop mask model
+    (no keypoint peak finding). When ``centroid_ckpt_path`` is ``None`` the
+    centroid stage falls back to GT user-instance centroids
+    (``CentroidCrop(use_gt_centroids=True)`` — the post-train auto-eval / GT-crop
+    path), exactly like ``_build_topdown(centroid_ckpt_path=None)``.
+
+    The crop size comes from the seg config (a centered-instance property);
+    ``output_stride`` / ``fg_threshold`` / ``mask_output`` / ``polygon_epsilon``
+    drive mask emission and packaging.
+    """
+    if isinstance(peak_threshold, list):
+        centroid_peak_threshold = peak_threshold[0]
+    else:
+        centroid_peak_threshold = peak_threshold
+
+    centroid_config = None
+    centroid_model = None
+    centroid_backbone_type = None
+
+    if centroid_ckpt_path is not None:
+        centroid_model, centroid_config, centroid_backbone_type = (
+            _load_lightning_module(
+                CentroidLightningModule,
+                centroid_ckpt_path,
+                model_type="centroid",
+                device=device,
+                backbone_ckpt_path=backbone_ckpt_path,
+                head_ckpt_path=head_ckpt_path,
+            )
+        )
+
+    seg_model, seg_config, seg_backbone_type = _load_lightning_module(
+        TopDownCenteredInstanceSegmentationLightningModule,
+        seg_ckpt_path,
+        model_type="centered_instance_segmentation",
+        device=device,
+        backbone_ckpt_path=backbone_ckpt_path,
+        head_ckpt_path=head_ckpt_path,
+    )
+    # Seg labels may carry no skeleton; tolerate an empty/missing one.
+    try:
+        skeletons = get_skeleton_from_config(seg_config.data_config.skeletons)
+    except Exception:  # noqa: BLE001 — skeleton is optional for segmentation
+        skeletons = []
+
+    # Resolve preprocess_config: centroid first (sizematcher), then seg (which
+    # carries the crop_size — a centered-instance property), without clobbering an
+    # explicit user crop_size.
+    user_crop_size = preprocess_config.crop_size
+    if centroid_config is not None:
+        preprocess_config = _resolve_preprocess_config(
+            preprocess_config, centroid_config
+        )
+    preprocess_config = _resolve_preprocess_config(preprocess_config, seg_config)
+    seg_crop = seg_config.data_config.preprocessing.crop_size
+    if user_crop_size is None and seg_crop is not None:
+        preprocess_config.crop_size = seg_crop
+
+    # Resolve anchor_ind (only used by the GT-centroid crop path; the real
+    # centroid model supplies crop centers directly).
+    seg_anchor = (
+        seg_config.model_config.head_configs.centered_instance_segmentation.segmentation.anchor_part
+    )
+    anch_pt = anchor_part if anchor_part is not None else seg_anchor
+    anchor_ind = None
+    if anch_pt is not None and skeletons:
+        anchor_ind = skeletons[0].node_names.index(anch_pt)
+
+    output_stride = (
+        seg_config.model_config.head_configs.centered_instance_segmentation.segmentation.output_stride
+    )
+    max_stride_seg = seg_config.model_config.backbone_config[seg_backbone_type][
+        "max_stride"
+    ]
+
+    # Build CentroidCrop (real model OR GT-centroid fallback).
+    if centroid_config is None:
+        centroid_crop = CentroidCrop(
+            use_gt_centroids=True,
+            crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
+            anchor_ind=anchor_ind,
+            return_crops=True,
+        )
+    else:
+        max_stride_centroid = centroid_config.model_config.backbone_config[
+            centroid_backbone_type
+        ]["max_stride"]
+        centroid_crop = CentroidCrop(
+            torch_model=centroid_model,
+            peak_threshold=centroid_peak_threshold,
+            output_stride=centroid_config.model_config.head_configs.centroid.confmaps.output_stride,
+            refinement=integral_refinement,
+            integral_patch_size=integral_patch_size,
+            return_confmaps=return_confmaps,
+            return_crops=True,
+            max_instances=max_instances,
+            max_stride=max_stride_centroid,
+            input_scale=centroid_config.data_config.preprocessing.scale,
+            crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
+            use_gt_centroids=False,
+            anchor_ind=anchor_ind,
+        )
+
+    instance_masks = CenteredInstanceMaskInferenceModel(
+        torch_model=seg_model,
+        output_stride=output_stride,
+        input_scale=seg_config.data_config.preprocessing.scale,
+        max_stride=max_stride_seg,
+        fg_threshold=fg_threshold,
+        mask_output=mask_output,
+        polygon_epsilon=polygon_epsilon,
+    )
+
+    inference_model = TopDownInferenceModel(
+        centroid_crop=centroid_crop, instance_peaks=instance_masks
+    )
+    return LoadedAssets(
+        inference_model=inference_model,
+        preprocess_config=preprocess_config,
+        skeletons=skeletons,
+        centroid_config=centroid_config,
+        confmap_config=seg_config,
+        backbone_type=seg_backbone_type or centroid_backbone_type,
+    )
+
+
 def _build_topdown_multiclass(
     centroid_ckpt_path: Optional[str],
     confmap_ckpt_path: Optional[str],
@@ -894,6 +1044,29 @@ def load_model_assets(
             mask_cleanup=mask_cleanup,
             mask_cleanup_radius=mask_cleanup_radius,
             full_res_masks=full_res_masks,
+            mask_output=mask_output,
+            polygon_epsilon=polygon_epsilon,
+            **common_kwargs,
+        )
+
+    elif "centered_instance_segmentation" in model_types:
+        # Top-down (crop-centered) instance segmentation. MUST be checked BEFORE
+        # the topdown family block below: a centroid + centered_instance_segmentation
+        # pair has "centroid" in model_types, so it would otherwise enter that block
+        # and — finding neither "centered_instance" nor "multi_class_topdown" — fall
+        # to the centroid-only else, SILENTLY DROPPING the seg dir (verify/v2 #1).
+        seg_path = model_paths[model_types.index("centered_instance_segmentation")]
+        centroid_path = (
+            model_paths[model_types.index("centroid")]
+            if "centroid" in model_types
+            else None
+        )
+        assets = _build_topdown_segmentation(
+            centroid_path,
+            seg_path,
+            max_instances=max_instances,
+            anchor_part=anchor_part,
+            fg_threshold=fg_threshold,
             mask_output=mask_output,
             polygon_epsilon=polygon_epsilon,
             **common_kwargs,

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -53,6 +53,10 @@ from sleap_nn.inference.layers.topdown_multiclass import (
     CenteredInstanceMultiClassLayer,
     TopDownMultiClassLayer,
 )
+from sleap_nn.inference.layers.topdown_segmentation import (
+    CenteredInstanceMaskLayer,
+    TopDownSegmentationLayer,
+)
 from sleap_nn.inference.outputs import Outputs
 from sleap_nn.inference.providers import Provider
 from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
@@ -399,6 +403,46 @@ def _build_topdown_multiclass_layer(
     )
 
 
+def _build_centered_instance_mask_layer(
+    mask_model: Any, device: str
+) -> CenteredInstanceMaskLayer:
+    """Wrap a ``CenteredInstanceMaskInferenceModel`` in a mask layer (stage 2)."""
+    return CenteredInstanceMaskLayer(
+        backend=TorchBackend(model=mask_model.torch_model, device=device),
+        output_stride=mask_model.output_stride,
+        max_stride=mask_model.max_stride,
+        fg_threshold=getattr(mask_model, "fg_threshold", 0.5),
+        preprocess_config=PreprocessConfig(scale=mask_model.input_scale),
+        postprocess_config=PostprocessConfig(),
+    )
+
+
+def _build_topdown_segmentation_layer(
+    predictor: Any, device: str
+) -> TopDownSegmentationLayer:
+    """Compose centroid + per-crop-mask stages into a ``TopDownSegmentationLayer``."""
+    inf = predictor.inference_model
+    centroid_model = inf.centroid_crop
+    mask_model = inf.instance_peaks
+    # GT-centroid fallback (seg dir only, no centroid model): the CentroidCrop was
+    # built with ``use_gt_centroids=True`` and carries no torch_model, so build a
+    # GT-only centroid layer (mirrors the centered-instance-only branch below).
+    if getattr(centroid_model, "use_gt_centroids", False):
+        mask_layer = _build_centered_instance_mask_layer(mask_model, device)
+        centroid_layer = _build_centroid_layer_gt_only(predictor, mask_layer.backend)
+    else:
+        centroid_layer = _build_centroid_layer(centroid_model, device, assets=predictor)
+        mask_layer = _build_centered_instance_mask_layer(mask_model, device)
+    crop_h, crop_w = centroid_model.crop_hw
+    return TopDownSegmentationLayer(
+        centroid_layer=centroid_layer,
+        centered_instance_layer=mask_layer,
+        crop_size=(crop_h, crop_w),
+        mask_output=getattr(mask_model, "mask_output", "mask"),
+        polygon_epsilon=getattr(mask_model, "polygon_epsilon", 0.01),
+    )
+
+
 def _select_layer(assets: Any, model_types: List[str], device: str):
     """Dispatch on detected model types and build the appropriate layer composition."""
     if "single_instance" in model_types:
@@ -409,6 +453,11 @@ def _select_layer(assets: Any, model_types: List[str], device: str):
         return _build_bottomup_multiclass_layer(assets, device)
     if "bottomup_segmentation" in model_types:
         return _build_bottomup_segmentation_layer(assets, device)
+    # Top-down (crop-centered) segmentation: a centroid + centered_instance_segmentation
+    # pair, OR a seg dir alone (GT-centroid fallback). Checked BEFORE the bare
+    # ``has_centroid`` branch so a centroid+seg pair isn't routed to centroid-only.
+    if "centered_instance_segmentation" in model_types:
+        return _build_topdown_segmentation_layer(assets, device)
     has_centroid = "centroid" in model_types
     has_centered = "centered_instance" in model_types
     has_multi_centered = "multi_class_topdown" in model_types
@@ -827,6 +876,9 @@ class Predictor:
             spec.append(f"fg_threshold={fg_threshold}")
             spec.append(f"min_mask_area={min_mask_area}")
             spec.append(f"full_res_masks={full_res_masks}")
+            spec.append(f"mask_output={mask_output}")
+        if "centered_instance_segmentation" in model_types:
+            spec.append(f"fg_threshold={fg_threshold}")
             spec.append(f"mask_output={mask_output}")
         logger.info("Loaded inference model | " + " | ".join(spec))
 
@@ -1741,8 +1793,13 @@ class Predictor:
         return isinstance(self.layer, (CentroidLayer, ExportedCentroidLayer))
 
     def _is_segmentation_layer(self) -> bool:
-        """``True`` iff ``layer`` is a bottom-up instance-segmentation layer."""
-        return isinstance(self.layer, SegmentationLayer)
+        """``True`` iff ``layer`` is a mask-producing instance-segmentation layer.
+
+        Covers both bottom-up (:class:`SegmentationLayer`) and top-down
+        (:class:`TopDownSegmentationLayer`). Gates tracking/no-skeleton/mask-count
+        behavior — a top-down seg layer emits ``pred_masks`` just like bottom-up.
+        """
+        return isinstance(self.layer, (SegmentationLayer, TopDownSegmentationLayer))
 
     def _resolve_centroid_packaging(self) -> _CentroidPackaging:
         """Resolve the single-source centroid output-packaging decision.

--- a/sleap_nn/inference/segmentation.py
+++ b/sleap_nn/inference/segmentation.py
@@ -221,6 +221,47 @@ def _clean_instance_mask(mask: np.ndarray, radius: int = 0) -> np.ndarray:
     return binary_fill_holes(mask)
 
 
+class CenteredInstanceMaskInferenceModel(L.LightningModule):
+    """Stage-2 holder for top-down (crop-centered) instance segmentation (#622).
+
+    A thin attribute bag (no real ``forward`` — the modern composed
+    :class:`~sleap_nn.inference.layers.topdown_segmentation.TopDownSegmentationLayer`
+    drives the run) carrying the per-crop seg model + the knobs the layer
+    builder reads off it. Mirrors how the legacy ``FindInstancePeaks`` is used
+    purely as an attribute holder by the modern top-down layer builder.
+
+    Attributes:
+        torch_model: Per-crop seg Lightning module; ``forward`` returns the
+            ``SegmentationHead`` logits.
+        output_stride: Head-map → crop-pixel stride.
+        input_scale: Input scale the model was trained with (applied to crops).
+        max_stride: Backbone max stride (crops padded to a multiple of it).
+        fg_threshold: Foreground probability threshold for binarization.
+        mask_output / polygon_epsilon: Output-packaging knobs (read by the
+            layer builder and forwarded to ``Outputs.to_labels``).
+    """
+
+    def __init__(
+        self,
+        torch_model,
+        output_stride: int = 2,
+        input_scale: float = 1.0,
+        max_stride: int = 1,
+        fg_threshold: float = 0.5,
+        mask_output: str = "mask",
+        polygon_epsilon: float = 0.01,
+    ):
+        """Stash the per-crop seg model + knobs."""
+        super().__init__()
+        self.torch_model = torch_model
+        self.output_stride = int(output_stride)
+        self.input_scale = float(input_scale)
+        self.max_stride = int(max_stride)
+        self.fg_threshold = float(fg_threshold)
+        self.mask_output = str(mask_output)
+        self.polygon_epsilon = float(polygon_epsilon)
+
+
 class BottomUpSegmentationInferenceModel(L.LightningModule):
     """Inference model for bottom-up instance segmentation.
 

--- a/sleap_nn/predict.py
+++ b/sleap_nn/predict.py
@@ -618,6 +618,20 @@ def run_inference(
                     "  from sleap_nn.inference.run import predict\n"
                     "  predict(src, model_paths=[centroid_dir], centroid_only=True)"
                 )
+            if "centered_instance_segmentation" in _types:
+                # The legacy Predictor.from_model_paths has no segmentation
+                # branch: a centroid+seg pair silently drops the seg model (emits
+                # centroid keypoints), and a seg-only dir raises a generic error.
+                # Redirect to the new flow, which composes them correctly.
+                raise ValueError(
+                    "Top-down segmentation models are not supported by the legacy "
+                    "`track` / `run_inference` pipeline. Use the new flow:\n"
+                    "  sleap-nn predict --data_path <video|.slp> "
+                    "--model_paths <centroid_dir> --model_paths <seg_dir>\n"
+                    "or, from Python:\n"
+                    "  from sleap_nn.inference.run import predict\n"
+                    "  predict(src, model_paths=[centroid_dir, seg_dir])"
+                )
 
         start_inf_time = time()
         start_datetime = datetime.now()

--- a/tests/inference/test_topdown_segmentation_inference.py
+++ b/tests/inference/test_topdown_segmentation_inference.py
@@ -41,20 +41,24 @@ class _StubMaskLayer:
     the same row order ``_run_stage_2`` builds the crops (sorted by valid (b, i)).
     """
 
-    def __init__(self, crop_masks, output_stride):
+    def __init__(self, crop_masks, output_stride, input_scale=1.0):
         self._crop_masks = crop_masks  # (n_valid, 1, h, w) float
         self.output_stride = output_stride
         self.use_gt_peaks = False
+        # _run_stage_2 reads preprocess_config.scale (the seg model's input_scale).
+        self.preprocess_config = type("_PP", (), {"scale": float(input_scale)})()
 
     def predict(self, crops):
         return Outputs(crops=self._crop_masks)
 
 
-def _make_layer(crop_masks, crop_size, output_stride):
+def _make_layer(crop_masks, crop_size, output_stride, input_scale=1.0):
     """Build a ``TopDownSegmentationLayer`` via ``__new__`` with a stub stage 2."""
     layer = TopDownSegmentationLayer.__new__(TopDownSegmentationLayer)
     layer.centroid_layer = None  # not used by _run_stage_2
-    layer.centered_instance_layer = _StubMaskLayer(crop_masks, output_stride)
+    layer.centered_instance_layer = _StubMaskLayer(
+        crop_masks, output_stride, input_scale
+    )
     layer.crop_size = crop_size
     layer.centroid_nms = False
     layer.centroid_nms_threshold = 0.5
@@ -162,6 +166,47 @@ def test_topdown_seg_two_crops_do_not_collide():
     assert abs(x0 - c0[0]) <= 4 and abs(y0 - c0[1]) <= 4
     assert abs(x1 - c1[0]) <= 4 and abs(y1 - c1[1]) <= 4
     assert (abs(x0 - x1) + abs(y0 - y1)) > 100  # decisively non-colliding
+
+
+def test_topdown_seg_input_scale_folded_into_scale():
+    """A seg model with input_scale != 1 still places masks at the centroid.
+
+    The seg model downscales each crop by its input_scale before the head, so the
+    head mask is at crop*input_scale/stride px; _run_stage_2 must fold input_scale
+    into the emitted scale = (eff*input_scale)/stride for the decode to recover
+    the true crop extent and land the mask at the full-frame centroid.
+    """
+    s = 2
+    isc = 0.5
+    ch = cw = 80
+    cx, cy = 200.0, 150.0  # image-space centroid (eff_scale = 1)
+    # Head mask resolution = crop * input_scale / stride = 80 * 0.5 / 2 = 20.
+    mh = mw = int(ch * isc) // s
+    crop_mask = _disk(mh, mw, mh // 2, mw // 2, 5).astype(np.float32)
+    crop_masks = torch.from_numpy(crop_mask)[None, None]
+
+    layer = _make_layer(
+        crop_masks, crop_size=(ch, cw), output_stride=s, input_scale=isc
+    )
+    out = layer._run_stage_2(
+        torch.zeros(1, 1, 512, 512),
+        torch.tensor([[[cx, cy]]]),
+        torch.tensor([[0.9]]),
+        torch.tensor([[True]]),
+        eff_scale=torch.tensor([1.0]),
+    )
+    inst = out.pred_masks[0][0]
+    # scale = (eff * input_scale) / stride = 0.5 / 2 = 0.25 (NOT eff/stride = 0.5).
+    assert abs(inst["scale"][0] - (isc / s)) < 1e-9
+    assert abs(inst["scale"][1] - (isc / s)) < 1e-9
+    # Decoded mask recovers the true 80px crop extent and lands at the centroid.
+    m = sio.PredictedSegmentationMask.from_numpy(
+        inst["mask"], score=inst["score"], scale=inst["scale"], offset=inst["offset"]
+    )
+    decoded = decode_mask_to_image_res(m)
+    ys, xs = np.nonzero(decoded)
+    assert xs.size > 0
+    assert abs(xs.mean() - cx) <= 4 and abs(ys.mean() - cy) <= 4
 
 
 def test_topdown_seg_empty_batch_emits_empty_frames():

--- a/tests/inference/test_topdown_segmentation_inference.py
+++ b/tests/inference/test_topdown_segmentation_inference.py
@@ -1,0 +1,296 @@
+"""Inference tests for TOP-DOWN (crop-centered) instance segmentation (#622).
+
+Two layers of testing:
+
+* A *deterministic offset-placement unit test*: build the composed
+  ``TopDownSegmentationLayer`` with a stubbed stage-2 backend returning a known
+  crop mask at a known centroid, then assert the emitted ``sio`` mask — decoded
+  through :func:`decode_mask_to_image_res` exactly as eval does — lands at the
+  correct FULL-FRAME location, and that two crops at different centroids do not
+  collide. This validates the DQ5 offset/scale contract end-to-end through the
+  decode path (not just that the dict has the right numbers).
+
+* A full ``train -> predict`` e2e exercising the
+  ``loaders -> TopDownSegmentationLayer -> Predictor -> sio.Labels`` plumbing via
+  the GT-centroid fallback path.
+"""
+
+import numpy as np
+import torch
+
+import sleap_io as sio
+
+from sleap_nn.inference.layers.topdown_segmentation import (
+    CenteredInstanceMaskLayer,
+    TopDownSegmentationLayer,
+)
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+class _StubMaskLayer:
+    """Stand-in for :class:`CenteredInstanceMaskLayer` that returns fixed masks.
+
+    ``predict(crops)`` returns ``Outputs(crops=...)`` where ``crops`` is a
+    pre-set ``(n_valid, 1, h, w)`` boolean-as-float tensor — one per crop, in
+    the same row order ``_run_stage_2`` builds the crops (sorted by valid (b, i)).
+    """
+
+    def __init__(self, crop_masks, output_stride):
+        self._crop_masks = crop_masks  # (n_valid, 1, h, w) float
+        self.output_stride = output_stride
+        self.use_gt_peaks = False
+
+    def predict(self, crops):
+        return Outputs(crops=self._crop_masks)
+
+
+def _make_layer(crop_masks, crop_size, output_stride):
+    """Build a ``TopDownSegmentationLayer`` via ``__new__`` with a stub stage 2."""
+    layer = TopDownSegmentationLayer.__new__(TopDownSegmentationLayer)
+    layer.centroid_layer = None  # not used by _run_stage_2
+    layer.centered_instance_layer = _StubMaskLayer(crop_masks, output_stride)
+    layer.crop_size = crop_size
+    layer.centroid_nms = False
+    layer.centroid_nms_threshold = 0.5
+    layer.return_crops = False
+    layer.mask_output = "mask"
+    layer.polygon_epsilon = 0.01
+    return layer
+
+
+def test_topdown_seg_offset_placement_through_decode():
+    """A crop mask at a known centroid decodes to the correct full-frame location.
+
+    Builds a single 1-instance "frame": a centroid at image (cx, cy), a crop of
+    size (ch, cw), and a known foreground disk drawn in the crop at output
+    stride. The emitted sio mask, decoded via ``decode_mask_to_image_res`` (the
+    eval path), must have its foreground centered at (cx, cy) in full-frame
+    coordinates — NOT at the origin.
+    """
+    s = 2
+    ch = cw = 64
+    cx, cy = 200.0, 150.0  # image-space centroid (eff_scale = 1)
+
+    # Crop-stride mask: a disk centered in the crop (the model "found" the
+    # centered instance). Crop center at crop px (cw/2, ch/2) -> stride
+    # (cw/2/s, ch/2/s).
+    mh, mw = ch // s, cw // s
+    crop_mask = _disk(mh, mw, mh // 2, mw // 2, 6).astype(np.float32)
+    crop_masks = torch.from_numpy(crop_mask)[None, None]  # (1, 1, mh, mw)
+
+    layer = _make_layer(crop_masks, crop_size=(ch, cw), output_stride=s)
+
+    image = torch.zeros(1, 1, 512, 512)  # sized-space frame (eff_scale = 1)
+    centroids = torch.tensor([[[cx, cy]]])  # (B=1, max_inst=1, 2)
+    centroid_vals = torch.tensor([[0.77]])
+    valid_mask = torch.tensor([[True]])
+    out = layer._run_stage_2(
+        image, centroids, centroid_vals, valid_mask, eff_scale=torch.tensor([1.0])
+    )
+
+    assert out.pred_masks is not None
+    assert len(out.pred_masks) == 1  # one frame
+    assert len(out.pred_masks[0]) == 1  # one instance
+    inst = out.pred_masks[0][0]
+    # scale = eff/stride per axis; offset = crop_topleft (eff=1).
+    assert inst["scale"] == (1.0 / s, 1.0 / s)
+    assert abs(inst["score"] - 0.77) < 1e-6
+    # crop top-left in image px ~ (cx - cw/2, cy - ch/2).
+    ox, oy = inst["offset"]
+    assert abs(ox - (cx - cw / 2)) <= 1.0
+    assert abs(oy - (cy - ch / 2)) <= 1.0
+
+    # Decode through the eval path and check the foreground center-of-mass lands
+    # at the image-space centroid (NOT at the origin).
+    m = sio.PredictedSegmentationMask.from_numpy(
+        inst["mask"], score=inst["score"], scale=inst["scale"], offset=inst["offset"]
+    )
+    decoded = decode_mask_to_image_res(m)
+    ys, xs = np.nonzero(decoded)
+    assert ys.size > 0
+    com_y, com_x = ys.mean(), xs.mean()
+    # Within a few px of the true centroid (stride/interp rounding).
+    assert abs(com_x - cx) <= 4.0
+    assert abs(com_y - cy) <= 4.0
+    # And decisively NOT at the origin.
+    assert com_x > cw / 4 and com_y > ch / 4
+
+
+def test_topdown_seg_two_crops_do_not_collide():
+    """Two crops at different centroids decode to two distinct full-frame blobs."""
+    s = 2
+    ch = cw = 64
+    mh, mw = ch // s, cw // s
+    # Two centroids far apart in a 512x512 frame.
+    c0 = (120.0, 100.0)
+    c1 = (400.0, 380.0)
+
+    disk = _disk(mh, mw, mh // 2, mw // 2, 6).astype(np.float32)
+    crop_masks = torch.from_numpy(disk)[None, None].repeat(2, 1, 1, 1)  # (2,1,mh,mw)
+
+    layer = _make_layer(crop_masks, crop_size=(ch, cw), output_stride=s)
+
+    image = torch.zeros(1, 1, 512, 512)
+    centroids = torch.tensor([[list(c0), list(c1)]])  # (1, 2, 2)
+    centroid_vals = torch.tensor([[0.9, 0.8]])
+    valid_mask = torch.tensor([[True, True]])
+    out = layer._run_stage_2(
+        image, centroids, centroid_vals, valid_mask, eff_scale=torch.tensor([1.0])
+    )
+
+    assert len(out.pred_masks[0]) == 2
+    coms = []
+    for inst in out.pred_masks[0]:
+        m = sio.PredictedSegmentationMask.from_numpy(
+            inst["mask"],
+            score=inst["score"],
+            scale=inst["scale"],
+            offset=inst["offset"],
+        )
+        decoded = decode_mask_to_image_res(m)
+        ys, xs = np.nonzero(decoded)
+        coms.append((xs.mean(), ys.mean()))
+
+    # The two blobs land near their respective centroids and far from each other.
+    (x0, y0), (x1, y1) = coms
+    assert abs(x0 - c0[0]) <= 4 and abs(y0 - c0[1]) <= 4
+    assert abs(x1 - c1[0]) <= 4 and abs(y1 - c1[1]) <= 4
+    assert (abs(x0 - x1) + abs(y0 - y1)) > 100  # decisively non-colliding
+
+
+def test_topdown_seg_empty_batch_emits_empty_frames():
+    """No valid centroids -> one empty mask list per frame (to_labels-safe)."""
+    layer = _make_layer(torch.zeros(0, 1, 8, 8), crop_size=(64, 64), output_stride=2)
+    centroids = torch.full((2, 1, 2), float("nan"))
+    centroid_vals = torch.zeros(2, 1)
+    valid_mask = torch.zeros(2, 1, dtype=torch.bool)
+    out = layer._run_stage_2(
+        centroids,
+        centroids,
+        centroid_vals,
+        valid_mask,
+        eff_scale=torch.tensor([1.0, 1.0]),
+    )
+    assert out.pred_masks == [[], []]
+
+
+def test_centered_instance_mask_layer_postprocess_thresholds():
+    """The stage-2 mask layer sigmoids + thresholds logits into a bool mask."""
+    from sleap_nn.inference.preprocess_info import PreprocInfo
+
+    layer = CenteredInstanceMaskLayer.__new__(CenteredInstanceMaskLayer)
+    layer.fg_threshold = 0.5
+    layer.output_stride = 2
+    layer._HEAD_OUTPUT_KEY = "SegmentationHead"
+    layer._TORCH_OUTPUT_KEY = "output"
+
+    # Logits: strongly positive in a 4x4 block, strongly negative elsewhere.
+    logits = torch.full((1, 1, 8, 8), -10.0)
+    logits[0, 0, 2:6, 2:6] = 10.0
+    info = PreprocInfo(
+        original_size=(16, 16),
+        processed_size=(16, 16),
+        eff_scale=torch.tensor([1.0]),
+        input_scale=1.0,
+        output_stride=2,
+    )
+    out = layer.postprocess({"output": logits}, info)
+    assert out.crops.shape == (1, 1, 8, 8)
+    mask = out.crops[0, 0].bool().numpy()
+    assert mask[2:6, 2:6].all()
+    assert not mask[0, 0]
+    # Score is the mean foreground probability over the predicted mask (~1.0).
+    assert float(out.instance_scores[0, 0]) > 0.99
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: train a tiny top-down seg model, predict via GT-centroid fallback
+# ---------------------------------------------------------------------------
+
+
+def _topdown_seg_infer_config(seg_path, tmp_path):
+    """One-epoch CPU training config for a top-down (crop) seg model."""
+    from omegaconf import OmegaConf
+
+    # Reuse the bottom-up seg trainer config and swap in the crop-seg head.
+    from tests.inference.test_segmentation_inference import _seg_train_config
+
+    cfg = _seg_train_config(seg_path, tmp_path, max_epochs=1)
+    cfg.data_config.preprocessing.crop_size = 160
+    cfg.model_config.head_configs = OmegaConf.create(
+        {
+            "single_instance": None,
+            "centroid": None,
+            "bottomup": None,
+            "centered_instance": None,
+            "multi_class_bottomup": None,
+            "multi_class_topdown": None,
+            "bottomup_segmentation": None,
+            "centered_instance_segmentation": {
+                "segmentation": {
+                    "output_stride": 2,
+                    "loss_weight": 1.0,
+                    "anchor_part": None,
+                },
+            },
+        }
+    )
+    cfg.trainer_config.run_name = "topdown_seg_infer"
+    return cfg
+
+
+def test_topdown_seg_train_predict_gt_centroid_wiring(minimal_instance_seg, tmp_path):
+    """Full train -> load -> predict via the GT-centroid fallback (seg dir only).
+
+    Exercises ``loaders -> TopDownSegmentationLayer -> Predictor -> sio.Labels``.
+    With only the seg dir, the centroid stage reads GT user-instance centroids.
+    The 1-epoch model is not expected to produce good masks; placement +
+    plumbing are the point.
+    """
+    from sleap_nn.training.model_trainer import ModelTrainer
+    from sleap_nn.inference.predictor import Predictor
+    from sleap_nn.inference.loaders import load_model_assets
+
+    cfg = _topdown_seg_infer_config(minimal_instance_seg.as_posix(), tmp_path)
+    ModelTrainer.get_model_trainer_from_config(cfg).train()
+    run_dir = (tmp_path / "topdown_seg_infer").as_posix()
+
+    # loaders detect the new model type and build a TopDownSegmentationLayer.
+    assets, model_types = load_model_assets([run_dir], device="cpu")
+    assert model_types == ["centered_instance_segmentation"]
+
+    pred = Predictor.from_model_paths(
+        [run_dir], peak_threshold=0.05, fg_threshold=0.3, device="cpu"
+    )
+    assert isinstance(pred.layer, TopDownSegmentationLayer)
+    # The composed layer is recognized as a segmentation layer (gates
+    # tracking / no-skeleton / mask-count).
+    assert pred._is_segmentation_layer()
+    # GT-centroid fallback => predicts only labeled frames.
+    assert pred._needs_gt_instances()
+    # fg_threshold threads through to the stage-2 mask layer.
+    assert abs(pred.layer.centered_instance_layer.fg_threshold - 0.3) < 1e-9
+
+    out = pred.predict(minimal_instance_seg.as_posix(), make_labels=True)
+    assert isinstance(out, sio.Labels)
+    # A segmentation model must emit masks ONLY — no phantom keypoint instances
+    # (those would also break mask-tracking auto-detection). Regression guard.
+    for lf in out:
+        assert len(lf.instances) == 0
+    for m in out.masks:
+        assert isinstance(m, sio.PredictedSegmentationMask)
+        assert np.isfinite(m.score)
+        # Mask is placed in-frame (non-negative origin within the frame).
+        ox, oy = m.offset
+        assert ox >= -1 and oy >= -1
+
+    # The output saves + reloads as a valid .slp.
+    out_path = tmp_path / "topdown_seg_preds.slp"
+    out.save(out_path.as_posix())
+    sio.load_slp(out_path.as_posix())


### PR DESCRIPTION
**Stacked series for top-down (crop-centered) instance segmentation (#622) — PR 3 of 4.** Stacked on #638 (base = `seg-td/2-model-data-training`).

## What
Composes a `centroid` model dir + a `centered_instance_segmentation` model dir (or seg-only via GT centroids) and emits **one binary mask per crop, placed at the correct full-frame offset**.

- **`CenteredInstanceMaskLayer`** (stage 2): runs the seg model on crops → per-crop boolean masks. **`TopDownSegmentationLayer(TopDownLayer)`** reuses the stage-1 centroid + crop machinery and emits `Outputs.pred_masks` with `offset = floored_crop_topleft / eff_scale` and `scale = (eff_scale * input_scale / output_stride)`. Masks **only** (no `pred_centroids`) so `to_labels` does not synthesize phantom keypoint instances (which would also break mask-tracking). Per-mask score = mean foreground probability.
- **Dispatch:** `loaders._build_topdown_segmentation` + a `load_model_assets` branch placed **before** the centroid-family block (so a centroid+seg pair isn't routed to centroid-only with the seg dir dropped); GT-centroid fallback for seg-only / post-train eval. `predictor._select_layer` branch + `_is_segmentation_layer` broadening.
- Legacy `predict.run_inference` now redirects seg models to the new flow with a clear error instead of silently dropping the seg dir.

## Validation
On flies13: composed real centroid + seg → 48 masks at correct offsets, per-mask **IoU vs GT ≈ 0.69**; `sio render` overlays the masks on the animals. Unit tests cover offset placement through `decode_mask_to_image_res`, two-crop non-collision, the phantom-instance regression guard, and an e2e train→predict (GT centroids).

> Most of the bug fixes here came from an adversarial multi-agent review of the stack (phantom instances, `input_scale` in the emitted scale, floored-offset placement, mask-quality score, legacy-path redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)