### PR TITLE
feat(seg): pose->mask pseudomask GT generator with configurable source {skeleton, sam, hybrid}

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,11 @@ tensorrt = [
     "tensorrt>=10.13.0; sys_platform == 'linux' or sys_platform == 'win32'",
     "torch-tensorrt>=2.5.0; sys_platform == 'linux' or sys_platform == 'win32'",
 ]
+# Optional dependency for the SAM-backed pseudomask GT source
+# (`sleap-nn make-masks --source sam/hybrid`). Heavy (ViT-H checkpoint + GPU
+# pass) and only needed for the one-shot offline pseudomask prep step, so it is
+# kept out of the default deps; the skeleton source stays dependency-free.
+sam = ["segment-anything>=1.0"]
 
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv sync`)

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -2418,6 +2418,131 @@ def info(path):
     print_model_info(path)
 
 
+@cli.command("make-masks", context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "--src",
+    "-i",
+    type=str,
+    required=True,
+    help="Source pose .slp / .pkg.slp (with image data).",
+)
+@click.option(
+    "--out",
+    "-o",
+    type=str,
+    required=True,
+    help="Output .pkg.slp path (saved with embedded images).",
+)
+@click.option(
+    "--source",
+    type=click.Choice(["skeleton", "sam", "hybrid"]),
+    default="skeleton",
+    show_default=True,
+    help=(
+        "Pseudomask GT source: 'skeleton' (dilated skeleton burn, no extra "
+        "deps), 'sam' (Segment Anything keypoint-prompted, drops low-quality "
+        "instances), or 'hybrid' (SAM with per-instance skeleton fallback). "
+        "'sam'/'hybrid' require the optional 'sleap-nn[sam]' extra and a "
+        "checkpoint."
+    ),
+)
+@click.option(
+    "--node-radius",
+    type=int,
+    default=4,
+    show_default=True,
+    help="Skeleton node disk radius (px).",
+)
+@click.option(
+    "--edge-thickness",
+    type=int,
+    default=4,
+    show_default=True,
+    help="Skeleton edge line thickness (px).",
+)
+@click.option(
+    "--dilate-frac",
+    type=float,
+    default=0.10,
+    show_default=True,
+    help="Skeleton dilation as a fraction of the keypoint bbox diagonal.",
+)
+@click.option(
+    "--min-dilate",
+    type=int,
+    default=4,
+    show_default=True,
+    help="Minimum skeleton dilation radius (px).",
+)
+@click.option(
+    "--sam-checkpoint",
+    type=str,
+    default=None,
+    help="Path to the SAM checkpoint (required for --source sam/hybrid).",
+)
+@click.option(
+    "--sam-model-type",
+    type=click.Choice(["vit_h", "vit_l", "vit_b"]),
+    default="vit_h",
+    show_default=True,
+    help="SAM model registry key.",
+)
+@click.option(
+    "--device",
+    type=str,
+    default="cuda",
+    show_default=True,
+    help="Torch device for SAM.",
+)
+@click.option(
+    "--overlay",
+    type=str,
+    default=None,
+    help="Optional path to write a colored mask overlay PNG of frame 0.",
+)
+def make_masks(
+    src,
+    out,
+    source,
+    node_radius,
+    edge_thickness,
+    dilate_frac,
+    min_dilate,
+    sam_checkpoint,
+    sam_model_type,
+    device,
+    overlay,
+):
+    """Generate per-instance segmentation pseudomasks from pose keypoints.
+
+    Reads a pose ``.slp`` whose frames carry keypoint instances + image data and
+    writes a new embedded ``.pkg.slp`` whose frames carry both the original
+    poses (retained for eval frame-pairing) and per-instance
+    ``UserSegmentationMask`` ground truth, ready for bottom-up
+    instance-segmentation training.
+
+    Examples:
+        sleap-nn make-masks -i train.pkg.slp -o train_seg.pkg.slp
+
+        sleap-nn make-masks -i train.pkg.slp -o train_seg.pkg.slp --source hybrid --sam-checkpoint sam_vit_h_4b8939.pth
+    """
+    from sleap_nn.data.pseudomasks import make_pseudomasks_cli
+
+    make_pseudomasks_cli(
+        src=src,
+        out=out,
+        source=source,
+        node_radius=node_radius,
+        edge_thickness=edge_thickness,
+        dilate_frac=dilate_frac,
+        min_dilate=min_dilate,
+        sam_checkpoint=sam_checkpoint,
+        sam_model_type=sam_model_type,
+        device=device,
+        overlay=overlay,
+    )
+
+
 def _register_export_commands():
     """Lazily import and register the export command."""
     from sleap_nn.export.cli import export as export_command

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -212,6 +212,12 @@ class DataConfig:
             Values < 1 down-weight negatives; values > 1 up-weight them. Only has effect when
             ``use_negative_frames`` is ``True``. *Default*: `1.0`.
         skeletons: skeleton configuration for the `.slp` file. This will be pulled from the train dataset and saved to the `training_config.yaml`
+        pseudomask_source: (str) Optional provenance string recording how the per-instance segmentation
+            pseudomask GT in the training labels was generated (e.g. ``"skeleton"``, ``"sam"``, ``"hybrid"``),
+            for bottom-up instance-segmentation models whose masks were produced offline by
+            ``sleap-nn make-masks``. This is a record-keeping field only; pseudomask generation is an explicit
+            offline prep step (SAM is far too heavy to run per-epoch) and is NOT run by the training pipeline.
+            *Default*: `None`.
     """
 
     train_labels_path: Optional[List[str]] = None
@@ -237,6 +243,7 @@ class DataConfig:
     use_negative_frames: bool = False
     negative_loss_weight: float = field(default=1.0, validator=validators.gt(0))
     skeletons: Optional[list] = None
+    pseudomask_source: Optional[str] = None
 
 
 def data_mapper(legacy_config: dict) -> DataConfig:

--- a/sleap_nn/data/pseudomasks.py
+++ b/sleap_nn/data/pseudomasks.py
@@ -1,0 +1,607 @@
+"""Pose -> per-instance segmentation pseudomask generation.
+
+Bottom-up instance-segmentation models train on ``.slp`` files whose labeled
+frames already carry per-instance ground-truth
+``sio.UserSegmentationMask`` silhouettes. This module produces that GT from
+pose keypoints in an explicit, offline prep step, writing a new ``.slp`` whose
+frames carry both the original keypoint instances (retained for eval
+frame-pairing) and the generated masks.
+
+Three GT sources are supported, selected per dataset:
+
+* ``"skeleton"`` (default, no extra deps): rasterize each instance's skeleton
+  into a dilated boolean silhouette using only ``cv2`` + ``numpy``. Robust on
+  every body plan; the silhouette is a coarse over-approximation of the animal.
+* ``"sam"`` (optional): prompt Segment Anything (ViT-H by default) with each
+  instance's visible keypoints to produce a tight, true silhouette, then apply
+  a quality filter (predicted-IoU / own-keypoint-containment / area-ratio). SAM
+  masks are truer on compact animals (e.g. mice) but degrade badly on tiny or
+  elongated ones (e.g. flies), so the source must be a per-dataset choice.
+* ``"hybrid"`` (optional): SAM with a per-instance dilated-skeleton fallback
+  whenever the SAM mask fails the quality filter, so every instance still gets
+  GT and the 1:1 instance<->mask pairing is preserved.
+
+The SAM / hybrid paths require the optional ``segment-anything`` dependency
+(``pip install "sleap-nn[sam]"``) plus a SAM checkpoint; both are imported /
+loaded lazily so the default skeleton path stays dependency-free.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+import sleap_io as sio
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Locked SAM recipe constants (module defaults).
+# ---------------------------------------------------------------------------
+#: Minimum SAM predicted-IoU for a SAM mask to be accepted.
+PRED_IOU_MIN = 0.88
+#: Minimum fraction of an instance's visible keypoints that must fall inside
+#: its own SAM mask for the mask to be accepted.
+OWN_CONTAIN_MIN = 0.9
+#: SAM-area / skeleton-area must lie within ``[AREA_RATIO_MIN, AREA_RATIO_MAX]``.
+AREA_RATIO_MIN = 0.2
+AREA_RATIO_MAX = 2.5
+#: SAM keypoint-box margin: ``max(SAM_BOX_MARGIN_MIN, SAM_BOX_MARGIN_FRAC*side)``.
+SAM_BOX_MARGIN_FRAC = 0.6
+SAM_BOX_MARGIN_MIN = 15.0
+#: Reject SAM candidates whose area exceeds ``SAM_MAX_BOX_AREA_FACTOR * box-area``
+#: (kills SAM's over-confident whole-arena candidate).
+SAM_MAX_BOX_AREA_FACTOR = 1.5
+#: CLAHE parameters applied to the grayscale image before prompting SAM.
+CLAHE_CLIP_LIMIT = 3.0
+CLAHE_TILE_GRID = (8, 8)
+
+
+# ---------------------------------------------------------------------------
+# Skeleton rasterizer (dependency-free: cv2 + numpy only).
+# ---------------------------------------------------------------------------
+def rasterize_instance_mask(
+    points: np.ndarray,
+    edge_inds: Iterable[Tuple[int, int]],
+    hw: Tuple[int, int],
+    node_radius: int = 4,
+    edge_thickness: int = 4,
+    dilate_frac: float = 0.10,
+    min_dilate: int = 4,
+) -> np.ndarray:
+    """Rasterize one instance's skeleton into a dilated boolean mask.
+
+    Each visible node is drawn as a filled disk and each visible edge as a thick
+    line; the union is dilated by ``max(min_dilate, round(dilate_frac * diag))``
+    where ``diag`` is the keypoint bounding-box diagonal, so the silhouette gains
+    body proportional to the instance size.
+
+    Args:
+        points: ``(n_nodes, 2)`` xy keypoints (may contain ``NaN`` for missing).
+        edge_inds: Iterable of ``(src_idx, dst_idx)`` node-index pairs.
+        hw: ``(height, width)`` of the target mask.
+        node_radius: Radius (px) of the filled disk drawn at each visible node.
+        edge_thickness: Line thickness (px) for each visible edge.
+        dilate_frac: Dilation radius as a fraction of the instance bbox diagonal.
+        min_dilate: Minimum dilation radius (px).
+
+    Returns:
+        Boolean array of shape ``hw`` -- the dilated skeleton silhouette.
+    """
+    h, w = hw
+    canvas = np.zeros((h, w), dtype=np.uint8)
+
+    # Edges first (so node disks sit on top of the lines).
+    for s, d in edge_inds:
+        ps, pd = points[s], points[d]
+        if np.isnan(ps).any() or np.isnan(pd).any():
+            continue
+        cv2.line(
+            canvas,
+            (int(round(ps[0])), int(round(ps[1]))),
+            (int(round(pd[0])), int(round(pd[1]))),
+            color=1,
+            thickness=edge_thickness,
+            lineType=cv2.LINE_8,
+        )
+
+    # Nodes.
+    for p in points:
+        if np.isnan(p).any():
+            continue
+        cv2.circle(
+            canvas,
+            (int(round(p[0])), int(round(p[1]))),
+            node_radius,
+            color=1,
+            thickness=-1,
+        )
+
+    # Dilate proportionally to the instance size so the silhouette has body.
+    valid = points[~np.isnan(points).any(axis=1)]
+    diag = (
+        float(np.linalg.norm(valid.max(axis=0) - valid.min(axis=0)))
+        if len(valid) >= 2
+        else 0.0
+    )
+    dilate = max(min_dilate, int(round(dilate_frac * diag)))
+    if dilate > 0:
+        k = cv2.getStructuringElement(
+            cv2.MORPH_ELLIPSE, (2 * dilate + 1, 2 * dilate + 1)
+        )
+        canvas = cv2.dilate(canvas, k)
+
+    return canvas.astype(bool)
+
+
+# ---------------------------------------------------------------------------
+# SAM helpers (locked recipe). All dependency-free except _load_sam_predictor.
+# ---------------------------------------------------------------------------
+def _kpt_box(
+    pos: np.ndarray,
+    hw: Tuple[int, int],
+    margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    margin_min: float = SAM_BOX_MARGIN_MIN,
+) -> np.ndarray:
+    """Compute a padded keypoint bounding box ``[x0, y0, x1, y1]`` clamped to ``hw``.
+
+    Args:
+        pos: ``(n, 2)`` visible xy keypoints (no NaNs).
+        hw: ``(height, width)`` of the frame.
+        margin_frac: Box margin as a fraction of the box side length.
+        margin_min: Minimum box margin (px) per axis.
+
+    Returns:
+        ``float32`` array ``[x0, y0, x1, y1]``.
+    """
+    x0, y0 = pos.min(0)
+    x1, y1 = pos.max(0)
+    mx = max(margin_min, margin_frac * (x1 - x0))
+    my = max(margin_min, margin_frac * (y1 - y0))
+    return np.array(
+        [
+            max(0, x0 - mx),
+            max(0, y0 - my),
+            min(hw[1] - 1, x1 + mx),
+            min(hw[0] - 1, y1 + my),
+        ],
+        np.float32,
+    )
+
+
+def _pick(
+    masks: np.ndarray,
+    scores: np.ndarray,
+    box: np.ndarray,
+    max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+) -> int:
+    """Pick the best SAM candidate mask index.
+
+    Rejects candidates whose area exceeds ``max_box_area_factor * box-area``
+    (SAM's over-confident whole-arena candidate), then returns the highest
+    predicted-IoU survivor; if all are rejected returns the smallest candidate.
+
+    Args:
+        masks: ``(n_cands, H, W)`` candidate masks.
+        scores: ``(n_cands,)`` SAM predicted-IoU per candidate.
+        box: ``[x0, y0, x1, y1]`` prompt box.
+        max_box_area_factor: Area-rejection multiplier relative to box area.
+
+    Returns:
+        Index of the chosen candidate.
+    """
+    box_area = max(1.0, (box[2] - box[0]) * (box[3] - box[1]))
+    areas = masks.reshape(len(masks), -1).sum(1).astype(float)
+    ok = areas <= max_box_area_factor * box_area
+    if ok.any():
+        idx = np.where(ok)[0]
+        return int(idx[int(np.argmax(scores[idx]))])
+    return int(np.argmin(areas))
+
+
+def _disjointify(
+    masks: Sequence[np.ndarray], kpts: Sequence[np.ndarray]
+) -> List[np.ndarray]:
+    """Make per-instance masks disjoint via keypoint-Voronoi assignment.
+
+    Any pixel claimed by >=2 masks is assigned to the instance whose nearest
+    visible keypoint is closest, so the result is exactly disjoint and each
+    instance never loses its own keypoints (they are the Voronoi seeds).
+
+    Args:
+        masks: List of ``(H, W)`` boolean masks, one per instance.
+        kpts: List of ``(n_i, 2)`` visible xy keypoints, index-aligned to ``masks``.
+
+    Returns:
+        List of disjoint boolean masks.
+    """
+    from scipy.ndimage import distance_transform_edt
+
+    n = len(masks)
+    h, w = masks[0].shape
+    stack = np.stack(masks).astype(bool)
+    contested = stack.sum(0) >= 2
+    if not contested.any():
+        return [m.copy() for m in masks]
+    dists = np.full((n, h, w), 1e9, np.float32)
+    for i, ks in enumerate(kpts):
+        seed = np.ones((h, w), np.uint8)
+        for x, y in ks:
+            xi, yi = int(round(x)), int(round(y))
+            if 0 <= yi < h and 0 <= xi < w:
+                seed[yi, xi] = 0
+        if seed.min() == 0:
+            dists[i] = distance_transform_edt(seed)
+    owner = np.argmin(dists, 0)
+    return [np.where(contested & (owner != i), False, stack[i]) for i in range(n)]
+
+
+def _sam_instance_masks(
+    predictor,
+    img_gray: np.ndarray,
+    kpts: Sequence[np.ndarray],
+    clahe: bool = True,
+    max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+) -> Tuple[List[np.ndarray], List[float]]:
+    """Run the locked SAM recipe on one frame.
+
+    Per instance: CLAHE-equalize the grayscale image (replicated to 3 channels),
+    prompt SAM with the instance's visible keypoints (positive) plus a padded
+    keypoint box (no negatives), ``multimask_output=True``, pick via
+    :func:`_pick`. Then make all masks disjoint via :func:`_disjointify`.
+
+    Args:
+        predictor: A loaded ``segment_anything.SamPredictor``.
+        img_gray: ``(H, W)`` uint8 grayscale frame.
+        kpts: List of ``(n_i, 2)`` visible xy keypoints per instance.
+        clahe: Whether to CLAHE-equalize before prompting SAM.
+        max_box_area_factor: Passed through to :func:`_pick`.
+
+    Returns:
+        Tuple ``(masks, pred_ious)`` where ``masks`` is a list of disjoint
+        boolean ``(H, W)`` arrays and ``pred_ious`` the per-instance SAM
+        predicted-IoU of the chosen candidate.
+    """
+    if clahe:
+        src = cv2.createCLAHE(CLAHE_CLIP_LIMIT, CLAHE_TILE_GRID).apply(img_gray)
+    else:
+        src = img_gray
+    predictor.set_image(np.stack([src] * 3, -1).astype(np.uint8))
+    h, w = img_gray.shape
+    masks: List[np.ndarray] = []
+    pred_ious: List[float] = []
+    for ks in kpts:
+        if len(ks) == 0:
+            masks.append(np.zeros((h, w), bool))
+            pred_ious.append(0.0)
+            continue
+        box = _kpt_box(ks, img_gray.shape)
+        ms, sc, _ = predictor.predict(
+            point_coords=ks.astype(np.float32),
+            point_labels=np.ones(len(ks), np.int32),
+            box=box,
+            multimask_output=True,
+        )
+        b = _pick(ms, sc, box, max_box_area_factor)
+        masks.append(ms[b].astype(bool))
+        pred_ious.append(float(sc[b]))
+    masks = _disjointify(masks, kpts)
+    return masks, pred_ious
+
+
+def _load_sam_predictor(
+    checkpoint: str, model_type: str = "vit_h", device: str = "cuda"
+):
+    """Lazily load a ``segment_anything.SamPredictor`` from a checkpoint.
+
+    Args:
+        checkpoint: Path to the SAM checkpoint (e.g. ``sam_vit_h_4b8939.pth``).
+        model_type: SAM model registry key (``"vit_h"``, ``"vit_l"``, ``"vit_b"``).
+        device: Torch device to place the model on.
+
+    Returns:
+        A ready ``SamPredictor``.
+
+    Raises:
+        ImportError: If ``segment-anything`` is not installed.
+        ValueError: If ``checkpoint`` is ``None``.
+        FileNotFoundError: If ``checkpoint`` does not exist.
+    """
+    try:
+        from segment_anything import sam_model_registry, SamPredictor
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "The 'sam'/'hybrid' pseudomask source requires the optional "
+            "'segment-anything' dependency. Install it with "
+            '`pip install "sleap-nn[sam]"` and download a SAM checkpoint '
+            "(e.g. sam_vit_h_4b8939.pth), then pass --sam-checkpoint /path/to/ckpt."
+        ) from e
+
+    if checkpoint is None:
+        raise ValueError(
+            "A SAM checkpoint is required for the 'sam'/'hybrid' source. "
+            "Download one (e.g. sam_vit_h_4b8939.pth) and pass "
+            "--sam-checkpoint /path/to/ckpt."
+        )
+    ckpt = Path(checkpoint).expanduser()
+    if not ckpt.is_file():
+        raise FileNotFoundError(f"SAM checkpoint not found: {ckpt}")
+
+    sam = sam_model_registry[model_type](checkpoint=ckpt.as_posix()).to(device)
+    return SamPredictor(sam)
+
+
+def _own_containment(mask: np.ndarray, kpts: np.ndarray, hw: Tuple[int, int]) -> float:
+    """Fraction of an instance's visible keypoints that fall inside ``mask``."""
+    if len(kpts) == 0:
+        return 0.0
+    h, w = hw
+    inside = 0
+    for x, y in kpts:
+        xi, yi = int(round(x)), int(round(y))
+        if 0 <= yi < h and 0 <= xi < w and mask[yi, xi]:
+            inside += 1
+    return inside / len(kpts)
+
+
+# ---------------------------------------------------------------------------
+# Top-level generator.
+# ---------------------------------------------------------------------------
+def generate_pseudomasks(
+    labels: sio.Labels,
+    source: str = "skeleton",
+    *,
+    node_radius: int = 4,
+    edge_thickness: int = 4,
+    dilate_frac: float = 0.10,
+    min_dilate: int = 4,
+    sam_checkpoint: Optional[str] = None,
+    sam_model_type: str = "vit_h",
+    device: str = "cuda",
+    pred_iou_min: float = PRED_IOU_MIN,
+    own_containment_min: float = OWN_CONTAIN_MIN,
+    area_ratio_range: Tuple[float, float] = (AREA_RATIO_MIN, AREA_RATIO_MAX),
+) -> sio.Labels:
+    """Generate per-instance segmentation pseudomasks from pose keypoints.
+
+    For every labeled frame with at least one posed instance, generates a
+    boolean silhouette per instance and attaches it as a
+    ``sio.UserSegmentationMask``. The original keypoint instances are retained
+    (needed for downstream eval frame-pairing) and embedded images are
+    preserved on save.
+
+    Args:
+        labels: Source ``sio.Labels`` carrying keypoint instances + image data.
+        source: GT source, one of ``"skeleton"`` (default), ``"sam"``,
+            ``"hybrid"``. ``"sam"``/``"hybrid"`` require ``segment-anything`` +
+            a checkpoint.
+        node_radius: Skeleton-rasterizer node disk radius (px).
+        edge_thickness: Skeleton-rasterizer edge line thickness (px).
+        dilate_frac: Skeleton-rasterizer dilation as a fraction of bbox diagonal.
+        min_dilate: Skeleton-rasterizer minimum dilation radius (px).
+        sam_checkpoint: Path to the SAM checkpoint (required for sam/hybrid).
+        sam_model_type: SAM model registry key.
+        device: Torch device for SAM.
+        pred_iou_min: SAM quality filter: minimum predicted-IoU.
+        own_containment_min: SAM quality filter: minimum own-keypoint containment.
+        area_ratio_range: SAM quality filter: ``(min, max)`` for SAM/skeleton area.
+
+    Returns:
+        New ``sio.Labels`` with per-frame ``UserSegmentationMask`` objects.
+
+    Raises:
+        ValueError: If ``source`` is not one of the supported values.
+        ImportError: If ``source`` needs SAM but ``segment-anything`` is absent.
+    """
+    if source not in ("skeleton", "sam", "hybrid"):
+        raise ValueError(
+            f"Unknown pseudomask source {source!r}; expected one of "
+            "'skeleton', 'sam', 'hybrid'."
+        )
+
+    skel = labels.skeletons[0]
+    edge_inds = list(skel.edge_inds)
+    skel_kw = dict(
+        node_radius=node_radius,
+        edge_thickness=edge_thickness,
+        dilate_frac=dilate_frac,
+        min_dilate=min_dilate,
+    )
+
+    predictor = None
+    use_sam = source in ("sam", "hybrid")
+    if use_sam:
+        predictor = _load_sam_predictor(
+            sam_checkpoint, model_type=sam_model_type, device=device
+        )
+
+    area_min, area_max = area_ratio_range
+
+    lfs = [lf for lf in labels.labeled_frames if len(lf.instances) > 0]
+    logger.info(
+        f"Generating '{source}' pseudomasks for {len(lfs)} labeled frames "
+        f"(skeleton: {len(skel.nodes)} nodes / {len(edge_inds)} edges)."
+    )
+
+    new_lfs: List[sio.LabeledFrame] = []
+    n_masks = 0
+    n_sam = 0
+    n_fallback = 0
+    n_dropped = 0
+    for lf in lfs:
+        video = lf.video
+        h, w = video.shape[1], video.shape[2]
+
+        # Per-instance skeleton masks + keypoints, index-aligned to kept
+        # instances. Instances with no pose or an empty skeleton mask are
+        # skipped (mirrors offline scratch behavior).
+        kept_instances = []
+        skel_masks: List[np.ndarray] = []
+        kpts_all: List[np.ndarray] = []
+        for inst in lf.instances:
+            pts = inst.numpy()[:, :2]
+            if np.isnan(pts).all():
+                continue
+            sm = rasterize_instance_mask(pts, edge_inds, (h, w), **skel_kw)
+            if not sm.any():
+                continue
+            kept_instances.append(inst)
+            skel_masks.append(sm)
+            kpts_all.append(pts[~np.isnan(pts).any(axis=1)].astype(np.float32))
+
+        if not skel_masks:
+            continue
+
+        if not use_sam:
+            final_masks = skel_masks
+        else:
+            img = np.asarray(lf.image)
+            if img.ndim == 3:
+                img = img[..., 0]
+            sam_masks, pred_ious = _sam_instance_masks(predictor, img, kpts_all)
+            final_masks = []
+            for i in range(len(skel_masks)):
+                sm = skel_masks[i]
+                mm = sam_masks[i]
+                sam_area = int(mm.sum())
+                skel_area = max(1, int(sm.sum()))
+                area_ratio = sam_area / skel_area
+                oc = _own_containment(mm, kpts_all[i], (h, w))
+                keep = (
+                    sam_area > 0
+                    and pred_ious[i] >= pred_iou_min
+                    and oc >= own_containment_min
+                    and area_min <= area_ratio <= area_max
+                )
+                if keep:
+                    final_masks.append(mm)
+                    n_sam += 1
+                elif source == "hybrid":
+                    final_masks.append(sm)  # per-instance skeleton fallback
+                    n_fallback += 1
+                else:  # source == "sam": drop the rejected instance entirely
+                    final_masks.append(None)
+                    n_dropped += 1
+
+        masks_obj = []
+        kept_for_frame = []
+        for inst, m in zip(kept_instances, final_masks):
+            if m is None:
+                continue
+            masks_obj.append(sio.UserSegmentationMask.from_numpy(m.astype(bool)))
+            kept_for_frame.append(inst)
+        if not masks_obj:
+            continue
+        n_masks += len(masks_obj)
+        new_lfs.append(
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=lf.frame_idx,
+                instances=kept_for_frame,  # retain poses for eval frame-pairing
+                masks=masks_obj,
+            )
+        )
+
+    out_labels = sio.Labels(
+        videos=labels.videos, skeletons=[skel], labeled_frames=new_lfs
+    )
+    mpf = n_masks / max(1, len(new_lfs))
+    logger.info(
+        f"Built {len(new_lfs)} frames, {n_masks} masks ({mpf:.2f} masks/frame)."
+    )
+    if use_sam:
+        logger.info(
+            f"SAM masks: {n_sam}; skeleton-fallback: {n_fallback}; "
+            f"dropped: {n_dropped}."
+        )
+    return out_labels
+
+
+def make_pseudomasks_cli(
+    src: str,
+    out: str,
+    source: str = "skeleton",
+    *,
+    node_radius: int = 4,
+    edge_thickness: int = 4,
+    dilate_frac: float = 0.10,
+    min_dilate: int = 4,
+    sam_checkpoint: Optional[str] = None,
+    sam_model_type: str = "vit_h",
+    device: str = "cuda",
+    overlay: Optional[str] = None,
+) -> sio.Labels:
+    """Load ``src``, generate ``source`` pseudomasks, save embedded to ``out``.
+
+    Args:
+        src: Path to a source pose ``.slp`` / ``.pkg.slp`` (with image data).
+        out: Output ``.pkg.slp`` path (saved with embedded images).
+        source: GT source: ``"skeleton"`` (default), ``"sam"``, ``"hybrid"``.
+        node_radius: Skeleton-rasterizer node disk radius (px).
+        edge_thickness: Skeleton-rasterizer edge line thickness (px).
+        dilate_frac: Skeleton-rasterizer dilation as a fraction of bbox diagonal.
+        min_dilate: Skeleton-rasterizer minimum dilation radius (px).
+        sam_checkpoint: Path to the SAM checkpoint (required for sam/hybrid).
+        sam_model_type: SAM model registry key.
+        device: Torch device for SAM.
+        overlay: Optional path to write a colored mask overlay PNG of frame 0.
+
+    Returns:
+        The generated ``sio.Labels`` (also saved to ``out``).
+    """
+    src_path = Path(src).expanduser().as_posix()
+    logger.info(f"Loading {src_path} ...")
+    labels = sio.load_slp(src_path)
+
+    out_labels = generate_pseudomasks(
+        labels,
+        source=source,
+        node_radius=node_radius,
+        edge_thickness=edge_thickness,
+        dilate_frac=dilate_frac,
+        min_dilate=min_dilate,
+        sam_checkpoint=sam_checkpoint,
+        sam_model_type=sam_model_type,
+        device=device,
+    )
+
+    out_path = Path(out).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Saving embedded -> {out_path} ...")
+    out_labels.save(out_path.as_posix(), embed=True)
+
+    if overlay:
+        _save_overlay(out_labels, Path(overlay).expanduser())
+
+    return out_labels
+
+
+def _save_overlay(labels: sio.Labels, path: Path) -> None:
+    """Render image + colored per-instance mask overlay for the first frame."""
+    if not labels.labeled_frames:
+        logger.warning("No labeled frames; skipping overlay.")
+        return
+    lf = labels.labeled_frames[0]
+    img = np.asarray(lf.image)
+    if img.ndim == 3 and img.shape[-1] == 1:
+        img = img[..., 0]
+    if img.ndim == 2:
+        rgb = np.stack([img] * 3, axis=-1).astype(np.float32)
+    else:
+        rgb = img.astype(np.float32)
+    colors = [
+        (255, 80, 80),
+        (80, 255, 80),
+        (80, 80, 255),
+        (255, 255, 80),
+        (255, 80, 255),
+        (80, 255, 255),
+    ]
+    for i, m in enumerate(lf.masks):
+        mm = np.asarray(m.data, dtype=bool)
+        c = np.array(colors[i % len(colors)], dtype=np.float32)
+        rgb[mm] = 0.5 * rgb[mm] + 0.5 * c
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(path.as_posix(), rgb[..., ::-1].astype(np.uint8))  # RGB->BGR
+    logger.info(f"Overlay -> {path} ({len(lf.masks)} masks on frame {lf.frame_idx}).")

--- a/sleap_nn/data/pseudomasks.py
+++ b/sleap_nn/data/pseudomasks.py
@@ -28,6 +28,7 @@ loaded lazily so the default skeleton path stays dependency-free.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
 
@@ -38,6 +39,11 @@ from loguru import logger
 
 # ---------------------------------------------------------------------------
 # Locked SAM recipe constants (module defaults).
+#
+# These remain the single source of truth for the default recipe; the
+# :class:`PseudomaskGenerator` dataclass fields default to these values (so the
+# constants and the dataclass can never drift), and the free helper functions
+# keep them as keyword-argument defaults for back-compat.
 # ---------------------------------------------------------------------------
 #: Minimum SAM predicted-IoU for a SAM mask to be accepted.
 PRED_IOU_MIN = 0.88
@@ -56,6 +62,11 @@ SAM_MAX_BOX_AREA_FACTOR = 1.5
 #: CLAHE parameters applied to the grayscale image before prompting SAM.
 CLAHE_CLIP_LIMIT = 3.0
 CLAHE_TILE_GRID = (8, 8)
+#: Skeleton-rasterizer defaults (shared by the rasterizer + the generator).
+NODE_RADIUS = 4
+EDGE_THICKNESS = 4
+DILATE_FRAC = 0.10
+MIN_DILATE = 4
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +254,10 @@ def _sam_instance_masks(
     kpts: Sequence[np.ndarray],
     clahe: bool = True,
     max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+    box_margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    box_margin_min: float = SAM_BOX_MARGIN_MIN,
+    clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
+    clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
 ) -> Tuple[List[np.ndarray], List[float]]:
     """Run the locked SAM recipe on one frame.
 
@@ -257,6 +272,10 @@ def _sam_instance_masks(
         kpts: List of ``(n_i, 2)`` visible xy keypoints per instance.
         clahe: Whether to CLAHE-equalize before prompting SAM.
         max_box_area_factor: Passed through to :func:`_pick`.
+        box_margin_frac: Keypoint-box margin fraction passed to :func:`_kpt_box`.
+        box_margin_min: Keypoint-box minimum margin passed to :func:`_kpt_box`.
+        clahe_clip_limit: CLAHE clip limit applied when ``clahe`` is true.
+        clahe_tile_grid: CLAHE tile grid applied when ``clahe`` is true.
 
     Returns:
         Tuple ``(masks, pred_ious)`` where ``masks`` is a list of disjoint
@@ -264,7 +283,7 @@ def _sam_instance_masks(
         predicted-IoU of the chosen candidate.
     """
     if clahe:
-        src = cv2.createCLAHE(CLAHE_CLIP_LIMIT, CLAHE_TILE_GRID).apply(img_gray)
+        src = cv2.createCLAHE(clahe_clip_limit, clahe_tile_grid).apply(img_gray)
     else:
         src = img_gray
     predictor.set_image(np.stack([src] * 3, -1).astype(np.uint8))
@@ -276,7 +295,12 @@ def _sam_instance_masks(
             masks.append(np.zeros((h, w), bool))
             pred_ious.append(0.0)
             continue
-        box = _kpt_box(ks, img_gray.shape)
+        box = _kpt_box(
+            ks,
+            img_gray.shape,
+            margin_frac=box_margin_frac,
+            margin_min=box_margin_min,
+        )
         ms, sc, _ = predictor.predict(
             point_coords=ks.astype(np.float32),
             point_labels=np.ones(len(ks), np.int32),
@@ -348,14 +372,219 @@ def _own_containment(mask: np.ndarray, kpts: np.ndarray, hw: Tuple[int, int]) ->
 # ---------------------------------------------------------------------------
 # Top-level generator.
 # ---------------------------------------------------------------------------
+@dataclass
+class PseudomaskGenerator:
+    """Configurable pose -> per-instance pseudomask generator.
+
+    Bundles every tunable of the skeleton/SAM/hybrid recipe as a field with the
+    same defaults as the module-level constants (the single source of truth), so
+    callers can construct one generator and reuse it. The free helper functions
+    (:func:`rasterize_instance_mask`, :func:`_kpt_box`, :func:`_pick`,
+    :func:`_disjointify`, :func:`_sam_instance_masks`, :func:`_own_containment`)
+    remain available and receive the relevant fields when :meth:`run` calls them.
+
+    Attributes:
+        source: GT source, one of ``"skeleton"`` (default), ``"sam"``,
+            ``"hybrid"``. ``"sam"``/``"hybrid"`` require ``segment-anything`` +
+            a checkpoint.
+        node_radius: Skeleton-rasterizer node disk radius (px).
+        edge_thickness: Skeleton-rasterizer edge line thickness (px).
+        dilate_frac: Skeleton-rasterizer dilation as a fraction of bbox diagonal.
+        min_dilate: Skeleton-rasterizer minimum dilation radius (px).
+        sam_checkpoint: Path to the SAM checkpoint (required for sam/hybrid).
+        sam_model_type: SAM model registry key.
+        device: Torch device for SAM.
+        pred_iou_min: SAM quality filter: minimum predicted-IoU.
+        own_containment_min: SAM quality filter: minimum own-keypoint containment.
+        area_ratio_range: SAM quality filter: ``(min, max)`` for SAM/skeleton area.
+        sam_box_margin_frac: SAM keypoint-box margin as a fraction of the side.
+        sam_box_margin_min: SAM keypoint-box minimum margin (px).
+        sam_max_box_area_factor: Reject SAM candidates above this * box-area.
+        clahe_clip_limit: CLAHE clip limit applied before prompting SAM.
+        clahe_tile_grid: CLAHE tile grid applied before prompting SAM.
+    """
+
+    source: str = "skeleton"
+    node_radius: int = NODE_RADIUS
+    edge_thickness: int = EDGE_THICKNESS
+    dilate_frac: float = DILATE_FRAC
+    min_dilate: int = MIN_DILATE
+    sam_checkpoint: Optional[str] = None
+    sam_model_type: str = "vit_h"
+    device: str = "cuda"
+    pred_iou_min: float = PRED_IOU_MIN
+    own_containment_min: float = OWN_CONTAIN_MIN
+    area_ratio_range: Tuple[float, float] = (AREA_RATIO_MIN, AREA_RATIO_MAX)
+    sam_box_margin_frac: float = SAM_BOX_MARGIN_FRAC
+    sam_box_margin_min: float = SAM_BOX_MARGIN_MIN
+    sam_max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR
+    clahe_clip_limit: float = CLAHE_CLIP_LIMIT
+    clahe_tile_grid: Tuple[int, int] = field(default_factory=lambda: CLAHE_TILE_GRID)
+
+    def run(self, labels: sio.Labels) -> sio.Labels:
+        """Generate per-instance segmentation pseudomasks from pose keypoints.
+
+        For every labeled frame with at least one posed instance, generates a
+        boolean silhouette per instance and attaches it as a
+        ``sio.UserSegmentationMask``. The original keypoint instances are
+        retained (needed for downstream eval frame-pairing) and embedded images
+        are preserved on save.
+
+        Args:
+            labels: Source ``sio.Labels`` carrying keypoint instances + images.
+
+        Returns:
+            New ``sio.Labels`` with per-frame ``UserSegmentationMask`` objects.
+
+        Raises:
+            ValueError: If ``source`` is not one of the supported values.
+            ImportError: If ``source`` needs SAM but ``segment-anything`` is
+                absent.
+        """
+        source = self.source
+        if source not in ("skeleton", "sam", "hybrid"):
+            raise ValueError(
+                f"Unknown pseudomask source {source!r}; expected one of "
+                "'skeleton', 'sam', 'hybrid'."
+            )
+
+        skel = labels.skeletons[0]
+        edge_inds = list(skel.edge_inds)
+        skel_kw = dict(
+            node_radius=self.node_radius,
+            edge_thickness=self.edge_thickness,
+            dilate_frac=self.dilate_frac,
+            min_dilate=self.min_dilate,
+        )
+
+        predictor = None
+        use_sam = source in ("sam", "hybrid")
+        if use_sam:
+            predictor = _load_sam_predictor(
+                self.sam_checkpoint,
+                model_type=self.sam_model_type,
+                device=self.device,
+            )
+
+        area_min, area_max = self.area_ratio_range
+
+        lfs = [lf for lf in labels.labeled_frames if len(lf.instances) > 0]
+        logger.info(
+            f"Generating '{source}' pseudomasks for {len(lfs)} labeled frames "
+            f"(skeleton: {len(skel.nodes)} nodes / {len(edge_inds)} edges)."
+        )
+
+        new_lfs: List[sio.LabeledFrame] = []
+        n_masks = 0
+        n_sam = 0
+        n_fallback = 0
+        n_dropped = 0
+        for lf in lfs:
+            video = lf.video
+            h, w = video.shape[1], video.shape[2]
+
+            # Per-instance skeleton masks + keypoints, index-aligned to kept
+            # instances. Instances with no pose or an empty skeleton mask are
+            # skipped (mirrors offline scratch behavior).
+            kept_instances = []
+            skel_masks: List[np.ndarray] = []
+            kpts_all: List[np.ndarray] = []
+            for inst in lf.instances:
+                pts = inst.numpy()[:, :2]
+                if np.isnan(pts).all():
+                    continue
+                sm = rasterize_instance_mask(pts, edge_inds, (h, w), **skel_kw)
+                if not sm.any():
+                    continue
+                kept_instances.append(inst)
+                skel_masks.append(sm)
+                kpts_all.append(pts[~np.isnan(pts).any(axis=1)].astype(np.float32))
+
+            if not skel_masks:
+                continue
+
+            if not use_sam:
+                final_masks = skel_masks
+            else:
+                img = np.asarray(lf.image)
+                if img.ndim == 3:
+                    img = img[..., 0]
+                sam_masks, pred_ious = _sam_instance_masks(
+                    predictor,
+                    img,
+                    kpts_all,
+                    max_box_area_factor=self.sam_max_box_area_factor,
+                    box_margin_frac=self.sam_box_margin_frac,
+                    box_margin_min=self.sam_box_margin_min,
+                    clahe_clip_limit=self.clahe_clip_limit,
+                    clahe_tile_grid=self.clahe_tile_grid,
+                )
+                final_masks = []
+                for i in range(len(skel_masks)):
+                    sm = skel_masks[i]
+                    mm = sam_masks[i]
+                    sam_area = int(mm.sum())
+                    skel_area = max(1, int(sm.sum()))
+                    area_ratio = sam_area / skel_area
+                    oc = _own_containment(mm, kpts_all[i], (h, w))
+                    keep = (
+                        sam_area > 0
+                        and pred_ious[i] >= self.pred_iou_min
+                        and oc >= self.own_containment_min
+                        and area_min <= area_ratio <= area_max
+                    )
+                    if keep:
+                        final_masks.append(mm)
+                        n_sam += 1
+                    elif source == "hybrid":
+                        final_masks.append(sm)  # per-instance skeleton fallback
+                        n_fallback += 1
+                    else:  # source == "sam": drop the rejected instance entirely
+                        final_masks.append(None)
+                        n_dropped += 1
+
+            masks_obj = []
+            kept_for_frame = []
+            for inst, m in zip(kept_instances, final_masks):
+                if m is None:
+                    continue
+                masks_obj.append(sio.UserSegmentationMask.from_numpy(m.astype(bool)))
+                kept_for_frame.append(inst)
+            if not masks_obj:
+                continue
+            n_masks += len(masks_obj)
+            new_lfs.append(
+                sio.LabeledFrame(
+                    video=video,
+                    frame_idx=lf.frame_idx,
+                    instances=kept_for_frame,  # retain poses for eval pairing
+                    masks=masks_obj,
+                )
+            )
+
+        out_labels = sio.Labels(
+            videos=labels.videos, skeletons=[skel], labeled_frames=new_lfs
+        )
+        mpf = n_masks / max(1, len(new_lfs))
+        logger.info(
+            f"Built {len(new_lfs)} frames, {n_masks} masks ({mpf:.2f} masks/frame)."
+        )
+        if use_sam:
+            logger.info(
+                f"SAM masks: {n_sam}; skeleton-fallback: {n_fallback}; "
+                f"dropped: {n_dropped}."
+            )
+        return out_labels
+
+
 def generate_pseudomasks(
     labels: sio.Labels,
     source: str = "skeleton",
     *,
-    node_radius: int = 4,
-    edge_thickness: int = 4,
-    dilate_frac: float = 0.10,
-    min_dilate: int = 4,
+    node_radius: int = NODE_RADIUS,
+    edge_thickness: int = EDGE_THICKNESS,
+    dilate_frac: float = DILATE_FRAC,
+    min_dilate: int = MIN_DILATE,
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
     device: str = "cuda",
@@ -365,11 +594,9 @@ def generate_pseudomasks(
 ) -> sio.Labels:
     """Generate per-instance segmentation pseudomasks from pose keypoints.
 
-    For every labeled frame with at least one posed instance, generates a
-    boolean silhouette per instance and attaches it as a
-    ``sio.UserSegmentationMask``. The original keypoint instances are retained
-    (needed for downstream eval frame-pairing) and embedded images are
-    preserved on save.
+    Thin wrapper that builds a :class:`PseudomaskGenerator` from the given
+    keyword arguments and calls :meth:`PseudomaskGenerator.run`. Preserved as the
+    stable public function entry point.
 
     Args:
         labels: Source ``sio.Labels`` carrying keypoint instances + image data.
@@ -394,128 +621,19 @@ def generate_pseudomasks(
         ValueError: If ``source`` is not one of the supported values.
         ImportError: If ``source`` needs SAM but ``segment-anything`` is absent.
     """
-    if source not in ("skeleton", "sam", "hybrid"):
-        raise ValueError(
-            f"Unknown pseudomask source {source!r}; expected one of "
-            "'skeleton', 'sam', 'hybrid'."
-        )
-
-    skel = labels.skeletons[0]
-    edge_inds = list(skel.edge_inds)
-    skel_kw = dict(
+    return PseudomaskGenerator(
+        source=source,
         node_radius=node_radius,
         edge_thickness=edge_thickness,
         dilate_frac=dilate_frac,
         min_dilate=min_dilate,
-    )
-
-    predictor = None
-    use_sam = source in ("sam", "hybrid")
-    if use_sam:
-        predictor = _load_sam_predictor(
-            sam_checkpoint, model_type=sam_model_type, device=device
-        )
-
-    area_min, area_max = area_ratio_range
-
-    lfs = [lf for lf in labels.labeled_frames if len(lf.instances) > 0]
-    logger.info(
-        f"Generating '{source}' pseudomasks for {len(lfs)} labeled frames "
-        f"(skeleton: {len(skel.nodes)} nodes / {len(edge_inds)} edges)."
-    )
-
-    new_lfs: List[sio.LabeledFrame] = []
-    n_masks = 0
-    n_sam = 0
-    n_fallback = 0
-    n_dropped = 0
-    for lf in lfs:
-        video = lf.video
-        h, w = video.shape[1], video.shape[2]
-
-        # Per-instance skeleton masks + keypoints, index-aligned to kept
-        # instances. Instances with no pose or an empty skeleton mask are
-        # skipped (mirrors offline scratch behavior).
-        kept_instances = []
-        skel_masks: List[np.ndarray] = []
-        kpts_all: List[np.ndarray] = []
-        for inst in lf.instances:
-            pts = inst.numpy()[:, :2]
-            if np.isnan(pts).all():
-                continue
-            sm = rasterize_instance_mask(pts, edge_inds, (h, w), **skel_kw)
-            if not sm.any():
-                continue
-            kept_instances.append(inst)
-            skel_masks.append(sm)
-            kpts_all.append(pts[~np.isnan(pts).any(axis=1)].astype(np.float32))
-
-        if not skel_masks:
-            continue
-
-        if not use_sam:
-            final_masks = skel_masks
-        else:
-            img = np.asarray(lf.image)
-            if img.ndim == 3:
-                img = img[..., 0]
-            sam_masks, pred_ious = _sam_instance_masks(predictor, img, kpts_all)
-            final_masks = []
-            for i in range(len(skel_masks)):
-                sm = skel_masks[i]
-                mm = sam_masks[i]
-                sam_area = int(mm.sum())
-                skel_area = max(1, int(sm.sum()))
-                area_ratio = sam_area / skel_area
-                oc = _own_containment(mm, kpts_all[i], (h, w))
-                keep = (
-                    sam_area > 0
-                    and pred_ious[i] >= pred_iou_min
-                    and oc >= own_containment_min
-                    and area_min <= area_ratio <= area_max
-                )
-                if keep:
-                    final_masks.append(mm)
-                    n_sam += 1
-                elif source == "hybrid":
-                    final_masks.append(sm)  # per-instance skeleton fallback
-                    n_fallback += 1
-                else:  # source == "sam": drop the rejected instance entirely
-                    final_masks.append(None)
-                    n_dropped += 1
-
-        masks_obj = []
-        kept_for_frame = []
-        for inst, m in zip(kept_instances, final_masks):
-            if m is None:
-                continue
-            masks_obj.append(sio.UserSegmentationMask.from_numpy(m.astype(bool)))
-            kept_for_frame.append(inst)
-        if not masks_obj:
-            continue
-        n_masks += len(masks_obj)
-        new_lfs.append(
-            sio.LabeledFrame(
-                video=video,
-                frame_idx=lf.frame_idx,
-                instances=kept_for_frame,  # retain poses for eval frame-pairing
-                masks=masks_obj,
-            )
-        )
-
-    out_labels = sio.Labels(
-        videos=labels.videos, skeletons=[skel], labeled_frames=new_lfs
-    )
-    mpf = n_masks / max(1, len(new_lfs))
-    logger.info(
-        f"Built {len(new_lfs)} frames, {n_masks} masks ({mpf:.2f} masks/frame)."
-    )
-    if use_sam:
-        logger.info(
-            f"SAM masks: {n_sam}; skeleton-fallback: {n_fallback}; "
-            f"dropped: {n_dropped}."
-        )
-    return out_labels
+        sam_checkpoint=sam_checkpoint,
+        sam_model_type=sam_model_type,
+        device=device,
+        pred_iou_min=pred_iou_min,
+        own_containment_min=own_containment_min,
+        area_ratio_range=area_ratio_range,
+    ).run(labels)
 
 
 def make_pseudomasks_cli(
@@ -523,10 +641,10 @@ def make_pseudomasks_cli(
     out: str,
     source: str = "skeleton",
     *,
-    node_radius: int = 4,
-    edge_thickness: int = 4,
-    dilate_frac: float = 0.10,
-    min_dilate: int = 4,
+    node_radius: int = NODE_RADIUS,
+    edge_thickness: int = EDGE_THICKNESS,
+    dilate_frac: float = DILATE_FRAC,
+    min_dilate: int = MIN_DILATE,
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
     device: str = "cuda",
@@ -554,8 +672,7 @@ def make_pseudomasks_cli(
     logger.info(f"Loading {src_path} ...")
     labels = sio.load_slp(src_path)
 
-    out_labels = generate_pseudomasks(
-        labels,
+    out_labels = PseudomaskGenerator(
         source=source,
         node_radius=node_radius,
         edge_thickness=edge_thickness,
@@ -564,7 +681,7 @@ def make_pseudomasks_cli(
         sam_checkpoint=sam_checkpoint,
         sam_model_type=sam_model_type,
         device=device,
-    )
+    ).run(labels)
 
     out_path = Path(out).expanduser()
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/data/test_pseudomasks.py
+++ b/tests/data/test_pseudomasks.py
@@ -1,0 +1,238 @@
+"""Tests for pose -> per-instance segmentation pseudomask generation.
+
+Covers the dependency-free skeleton rasterizer + the ``generate_pseudomasks``
+skeleton path (mask count, type, roundtrip), the unknown-source guard, and the
+SAM-path lazy-import error surface (exercised by faking ``segment-anything``
+absent). The full SAM / hybrid GPU path is gated behind ``segment_anything`` +
+a checkpoint and skipped when unavailable.
+"""
+
+import builtins
+import os
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap_nn.data.pseudomasks import (
+    generate_pseudomasks,
+    make_pseudomasks_cli,
+    rasterize_instance_mask,
+    _kpt_box,
+    _pick,
+    _disjointify,
+    _load_sam_predictor,
+)
+
+
+# ---------------------------------------------------------------------------
+# rasterize_instance_mask
+# ---------------------------------------------------------------------------
+def test_rasterize_instance_mask_non_empty_and_covers_nodes():
+    """A two-node skeleton rasterizes to a non-empty mask covering both nodes."""
+    points = np.array([[20.0, 30.0], [60.0, 80.0]], dtype=np.float32)
+    edge_inds = [(0, 1)]
+    hw = (128, 128)
+
+    mask = rasterize_instance_mask(points, edge_inds, hw)
+
+    assert mask.shape == hw
+    assert mask.dtype == bool
+    assert mask.any()
+    # The node centers must be foreground (filled disk drawn at each node).
+    for x, y in points:
+        assert mask[int(round(y)), int(round(x))]
+    # The edge midpoint should be covered by the thick line too.
+    mx, my = points.mean(axis=0)
+    assert mask[int(round(my)), int(round(mx))]
+
+
+def test_rasterize_instance_mask_skips_nan_nodes():
+    """A NaN node is skipped but a single valid node still yields a disk."""
+    points = np.array([[40.0, 40.0], [np.nan, np.nan]], dtype=np.float32)
+    mask = rasterize_instance_mask(points, [(0, 1)], (96, 96))
+    assert mask.any()
+    assert mask[40, 40]
+
+
+def test_rasterize_instance_mask_all_nan_empty():
+    """All-NaN points produce an all-False mask."""
+    points = np.full((3, 2), np.nan, dtype=np.float32)
+    mask = rasterize_instance_mask(points, [(0, 1), (1, 2)], (64, 64))
+    assert not mask.any()
+
+
+def test_rasterize_dilate_frac_grows_mask():
+    """A larger dilation fraction grows the silhouette area."""
+    points = np.array([[20.0, 20.0], [80.0, 80.0]], dtype=np.float32)
+    small = rasterize_instance_mask(
+        points, [(0, 1)], (128, 128), dilate_frac=0.0, min_dilate=0
+    )
+    big = rasterize_instance_mask(
+        points, [(0, 1)], (128, 128), dilate_frac=0.5, min_dilate=4
+    )
+    assert big.sum() > small.sum()
+
+
+# ---------------------------------------------------------------------------
+# generate_pseudomasks (skeleton path)
+# ---------------------------------------------------------------------------
+def test_generate_pseudomasks_skeleton(minimal_instance):
+    """Skeleton source yields LFs whose masks are UserSegmentationMask, 1:1."""
+    labels = sio.load_slp(str(minimal_instance))
+    n_inst_src = len(labels[0].instances)
+
+    out = generate_pseudomasks(labels, source="skeleton")
+
+    assert len(out.labeled_frames) == 1
+    lf = out.labeled_frames[0]
+    # One mask per posed instance, poses retained for eval frame-pairing.
+    assert len(lf.masks) == n_inst_src
+    assert len(lf.instances) == n_inst_src
+    for m in lf.masks:
+        assert isinstance(m, sio.UserSegmentationMask)
+        assert np.asarray(m.data, dtype=bool).any()
+
+
+def test_generate_pseudomasks_roundtrip(minimal_instance, tmp_path):
+    """A skeleton-pseudomask Labels saves embedded and reloads with masks."""
+    labels = sio.load_slp(str(minimal_instance))
+    out = generate_pseudomasks(labels, source="skeleton")
+
+    out_path = tmp_path / "seg.pkg.slp"
+    out.save(out_path.as_posix(), embed=True)
+
+    reloaded = sio.load_slp(out_path.as_posix())
+    lf = reloaded.labeled_frames[0]
+    assert len(lf.masks) == len(out.labeled_frames[0].masks)
+    assert isinstance(lf.masks[0], sio.UserSegmentationMask)
+    assert np.asarray(lf.masks[0].data, dtype=bool).any()
+
+
+def test_make_pseudomasks_cli_skeleton(minimal_instance, tmp_path):
+    """The CLI impl fn writes a reloadable seg .pkg.slp with masks."""
+    out_path = tmp_path / "cli_seg.pkg.slp"
+    overlay_path = tmp_path / "overlay.png"
+
+    result = make_pseudomasks_cli(
+        src=str(minimal_instance),
+        out=out_path.as_posix(),
+        source="skeleton",
+        overlay=overlay_path.as_posix(),
+    )
+
+    assert out_path.exists()
+    assert overlay_path.exists()
+    assert len(result.labeled_frames) == 1
+    reloaded = sio.load_slp(out_path.as_posix())
+    assert len(reloaded.labeled_frames[0].masks) >= 1
+
+
+def test_generate_pseudomasks_unknown_source(minimal_instance):
+    """An unsupported source raises a clear ValueError before any SAM load."""
+    labels = sio.load_slp(str(minimal_instance))
+    with pytest.raises(ValueError, match="Unknown pseudomask source"):
+        generate_pseudomasks(labels, source="bogus")
+
+
+# ---------------------------------------------------------------------------
+# SAM helpers (dependency-free pieces).
+# ---------------------------------------------------------------------------
+def test_kpt_box_clamped_and_padded():
+    """The keypoint box is padded by the margin and clamped to the frame."""
+    pos = np.array([[10.0, 10.0], [20.0, 30.0]], dtype=np.float32)
+    box = _kpt_box(pos, (100, 120))
+    x0, y0, x1, y1 = box
+    assert x0 >= 0 and y0 >= 0
+    assert x1 <= 119 and y1 <= 99
+    # Box strictly contains the keypoint bbox.
+    assert x0 <= 10 and y0 <= 10 and x1 >= 20 and y1 >= 30
+
+
+def test_pick_rejects_oversized_candidate():
+    """_pick rejects the whole-frame candidate even with the highest score."""
+    h, w = 40, 40
+    big = np.ones((h, w), dtype=bool)
+    small = np.zeros((h, w), dtype=bool)
+    small[5:15, 5:15] = True
+    masks = np.stack([big, small])
+    scores = np.array([0.99, 0.5])  # big has higher score but is oversized
+    box = np.array([4, 4, 16, 16], dtype=np.float32)
+    assert _pick(masks, scores, box) == 1
+
+
+def test_disjointify_resolves_overlap():
+    """Overlapping masks become disjoint, each keeping its own keypoint."""
+    h, w = 50, 50
+    a = np.zeros((h, w), bool)
+    a[10:30, 10:30] = True
+    b = np.zeros((h, w), bool)
+    b[20:40, 20:40] = True  # overlaps a in [20:30, 20:30]
+    kpts = [np.array([[15.0, 15.0]]), np.array([[35.0, 35.0]])]
+    out = _disjointify([a, b], kpts)
+    # No pixel is claimed by both masks.
+    assert not (out[0] & out[1]).any()
+    # Each instance keeps its own seed keypoint.
+    assert out[0][15, 15]
+    assert out[1][35, 35]
+
+
+# ---------------------------------------------------------------------------
+# SAM lazy-import / checkpoint error surface.
+# ---------------------------------------------------------------------------
+def test_load_sam_predictor_missing_dep_raises(monkeypatch):
+    """When segment-anything is absent, a friendly ImportError is raised."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "segment_anything" or name.startswith("segment_anything."):
+            raise ImportError("No module named 'segment_anything'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match=r"sleap-nn\[sam\]"):
+        _load_sam_predictor("/nonexistent/ckpt.pth")
+
+
+def test_generate_pseudomasks_sam_missing_dep_raises(minimal_instance, monkeypatch):
+    """source='sam' surfaces the friendly ImportError when SAM is absent."""
+    labels = sio.load_slp(str(minimal_instance))
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "segment_anything" or name.startswith("segment_anything."):
+            raise ImportError("No module named 'segment_anything'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match=r"sleap-nn\[sam\]"):
+        generate_pseudomasks(
+            labels, source="sam", sam_checkpoint="/nonexistent/ckpt.pth"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full SAM / hybrid GPU path (gated).
+# ---------------------------------------------------------------------------
+_SAM_CKPT = os.environ.get("SLEAP_NN_SAM_CHECKPOINT")
+
+
+@pytest.mark.skipif(
+    _SAM_CKPT is None,
+    reason="SLEAP_NN_SAM_CHECKPOINT not set; SAM checkpoint unavailable.",
+)
+def test_generate_pseudomasks_hybrid_smoke(minimal_instance):
+    """Hybrid source produces one mask per instance (SAM or skeleton fallback)."""
+    pytest.importorskip("segment_anything")
+    import torch
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    labels = sio.load_slp(str(minimal_instance))
+    n_inst = len(labels[0].instances)
+    out = generate_pseudomasks(
+        labels, source="hybrid", sam_checkpoint=_SAM_CKPT, device=device
+    )
+    lf = out.labeled_frames[0]
+    # Hybrid guarantees a mask for every kept instance.
+    assert len(lf.masks) == n_inst
+    assert all(isinstance(m, sio.UserSegmentationMask) for m in lf.masks)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1039,3 +1039,39 @@ def test_eval_command(
     # Run the command and check for errors
     result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     assert Path(f"{tmp_path}/metrics_test.npz").exists()
+
+
+class TestMakeMasksCommand:
+    """Tests for the ``make-masks`` pseudomask-generation subcommand."""
+
+    def test_make_masks_help(self):
+        """make-masks --help lists the source modes and options."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["make-masks", "--help"])
+        assert result.exit_code == 0
+        assert "skeleton" in result.output
+        assert "sam" in result.output
+        assert "hybrid" in result.output
+
+    def test_make_masks_skeleton(self, minimal_instance, tmp_path):
+        """make-masks --source skeleton writes a reloadable seg .pkg.slp."""
+        out_path = tmp_path / "make_masks_seg.pkg.slp"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "make-masks",
+                "--src",
+                str(minimal_instance),
+                "--out",
+                out_path.as_posix(),
+                "--source",
+                "skeleton",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out_path.exists()
+        labels = sio.load_slp(out_path.as_posix())
+        lf = labels.labeled_frames[0]
+        assert len(lf.masks) >= 1
+        assert isinstance(lf.masks[0], sio.UserSegmentationMask)


### PR DESCRIPTION
## Summary

Bottom-up instance-segmentation models in sleap-nn train on `.slp` files whose labeled frames already carry per-instance `sio.UserSegmentationMask` ground truth. That GT is generated *from poses* in an offline prep step — but until now no such generator existed in the repo (it lived only in investigation scratch scripts). This PR makes it first-class and, crucially, exposes the **GT source as a per-dataset choice**.

### Why the GT source must be configurable

The investigation found the right pseudomask source depends on body plan:

- **SAM keypoint-prompting** produces tighter, truer silhouettes on **compact** animals (mice: 97% of instances kept by the quality filter; the trained model reaches mask-IoU **0.78 vs 0.75** for skeleton GT).
- But SAM is **unusable on tiny/elongated** animals (flies: only ~9% of instances survive the filter) — it collapses onto fragments or the whole arena.

So the source cannot be hardcoded. This PR offers three modes and keeps the robust, dependency-free one as the default (no behavior change for anyone).

### The three modes (`--source`)

- **`skeleton`** (default, **no extra deps**): rasterize each instance's skeleton into a dilated boolean silhouette using only `cv2` + `numpy` (nodes as filled disks + edges as thick lines, dilated proportionally to the instance bbox diagonal). Robust on every body plan.
- **`sam`** (optional): prompt Segment Anything (ViT-H by default) with each instance's visible keypoints (CLAHE + keypoint+box prompt, no negatives), reject SAM's whole-arena candidate, keypoint-Voronoi disjointify, then a quality filter (`pred_iou >= 0.88` AND own-keypoint-containment `>= 0.9` AND `0.2 <= SAM/skeleton area-ratio <= 2.5`). Filter-rejected instances are dropped.
- **`hybrid`** (optional): same as `sam`, but a filter-rejected instance falls back to its dilated-skeleton mask, so **every** instance still gets GT and the 1:1 instance↔mask pairing (needed for eval frame-pairing) is preserved.

In all modes the original keypoint instances are **retained** on each frame (eval frame-pairing keys off user pose instances) and embedded images are preserved on save.

## What's added

- **`sleap_nn/data/pseudomasks.py`** — `rasterize_instance_mask`, the SAM helpers (`_kpt_box`, `_pick`, `_disjointify`, `_sam_instance_masks`, `_load_sam_predictor`), `generate_pseudomasks(labels, source=..., ...)`, and `make_pseudomasks_cli(...)`.
- **CLI** — `sleap-nn make-masks -i SRC -o OUT --source {skeleton,sam,hybrid}` plus the rasterization knobs (`--node-radius/--edge-thickness/--dilate-frac/--min-dilate`), SAM options (`--sam-checkpoint/--sam-model-type/--device`), and `--overlay`. Thin wrapper that lazily delegates to the impl module (mirrors `eval`/`info`).
- **Config** — optional `DataConfig.pseudomask_source` *provenance string only*. SAM is far too heavy to run per-epoch, so pseudomask generation is an explicit offline step and is **NOT** wired into the training data pipeline.
- **`pyproject.toml`** — new optional `sam = ["segment-anything>=1.0"]` extra (sibling to `export`/`tensorrt`). `segment-anything` is imported lazily with a friendly `ImportError` (`pip install "sleap-nn[sam]"` + download a checkpoint). The skeleton path stays dependency-free (`cv2`/`scipy` are already deps).

## Tests

- `tests/data/test_pseudomasks.py`: rasterizer (non-empty, covers nodes, NaN handling, dilation grows area); `generate_pseudomasks(source="skeleton")` yields `UserSegmentationMask` objects 1:1 with instances + a roundtrippable `.pkg.slp`; SAM helper unit tests (`_kpt_box`/`_pick`/`_disjointify`); lazy-import `ImportError` surface (segment-anything faked absent); unknown-source guard.
- `tests/test_cli.py::TestMakeMasksCommand`: `make-masks --help` and a `--source skeleton` CliRunner smoke test.
- Full SAM/hybrid GPU path gated behind `segment_anything` + `SLEAP_NN_SAM_CHECKPOINT` (skipped without a checkpoint).

`black sleap_nn tests`, `ruff check sleap_nn/`, and the new + adjacent suites (`tests/data/test_pseudomasks.py`, `tests/test_cli.py::TestMakeMasksCommand`, `tests/test_segmentation.py`, `tests/config/`) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)