### PR TITLE
feat(seg): add mask_source=sam3/hybrid_sam3 pseudomask GT backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,11 @@ tensorrt = [
 # pass) and only needed for the one-shot offline pseudomask prep step, so it is
 # kept out of the default deps; the skeleton source stays dependency-free.
 sam = ["segment-anything>=1.0"]
+# Optional dependency for the SAM3-backed pseudomask GT source
+# (`sleap-nn make-masks --source sam3/hybrid_sam3`). SAM3 ships in transformers
+# (>=5.0) and the gated `facebook/sam3` weights are pulled at runtime
+# (huggingface-cli login). Like `sam`, only needed for the offline prep step.
+sam3 = ["transformers>=5.0"]
 
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv sync`)

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -2435,15 +2435,17 @@ def info(path):
 )
 @click.option(
     "--source",
-    type=click.Choice(["skeleton", "sam", "hybrid"]),
+    type=click.Choice(["skeleton", "sam", "hybrid", "sam3", "hybrid_sam3"]),
     default="skeleton",
     show_default=True,
     help=(
         "Pseudomask GT source: 'skeleton' (dilated skeleton burn, no extra "
-        "deps), 'sam' (Segment Anything keypoint-prompted, drops low-quality "
-        "instances), or 'hybrid' (SAM with per-instance skeleton fallback). "
-        "'sam'/'hybrid' require the optional 'sleap-nn[sam]' extra and a "
-        "checkpoint."
+        "deps), 'sam' (Segment Anything 1 keypoint-prompted, drops low-quality "
+        "instances), 'hybrid' (SAM1 with per-instance skeleton fallback), "
+        "'sam3' (SAM 3 keypoint-prompted), or 'hybrid_sam3' (SAM3 with "
+        "skeleton fallback). 'sam'/'hybrid' need the 'sleap-nn[sam]' extra + a "
+        "checkpoint; 'sam3'/'hybrid_sam3' need 'sleap-nn[sam3]' + access to the "
+        "gated facebook/sam3 model (huggingface-cli login)."
     ),
 )
 @click.option(
@@ -2485,14 +2487,21 @@ def info(path):
     type=click.Choice(["vit_h", "vit_l", "vit_b"]),
     default="vit_h",
     show_default=True,
-    help="SAM model registry key.",
+    help="SAM1 model registry key.",
+)
+@click.option(
+    "--sam3-model-id",
+    type=str,
+    default="facebook/sam3",
+    show_default=True,
+    help="HF model id for --source sam3/hybrid_sam3 (gated; huggingface-cli login).",
 )
 @click.option(
     "--device",
     type=str,
     default="cuda",
     show_default=True,
-    help="Torch device for SAM.",
+    help="Torch device for the segmentation model.",
 )
 @click.option(
     "--overlay",
@@ -2510,6 +2519,7 @@ def make_masks(
     min_dilate,
     sam_checkpoint,
     sam_model_type,
+    sam3_model_id,
     device,
     overlay,
 ):
@@ -2525,6 +2535,8 @@ def make_masks(
         sleap-nn make-masks -i train.pkg.slp -o train_seg.pkg.slp
 
         sleap-nn make-masks -i train.pkg.slp -o train_seg.pkg.slp --source hybrid --sam-checkpoint sam_vit_h_4b8939.pth
+
+        sleap-nn make-masks -i train.pkg.slp -o train_seg.pkg.slp --source sam3
     """
     from sleap_nn.data.pseudomasks import make_pseudomasks_cli
 
@@ -2538,6 +2550,7 @@ def make_masks(
         min_dilate=min_dilate,
         sam_checkpoint=sam_checkpoint,
         sam_model_type=sam_model_type,
+        sam3_model_id=sam3_model_id,
         device=device,
         overlay=overlay,
     )

--- a/sleap_nn/data/pseudomasks.py
+++ b/sleap_nn/data/pseudomasks.py
@@ -7,23 +7,35 @@ pose keypoints in an explicit, offline prep step, writing a new ``.slp`` whose
 frames carry both the original keypoint instances (retained for eval
 frame-pairing) and the generated masks.
 
-Three GT sources are supported, selected per dataset:
+Five GT sources are supported, selected per dataset:
 
 * ``"skeleton"`` (default, no extra deps): rasterize each instance's skeleton
   into a dilated boolean silhouette using only ``cv2`` + ``numpy``. Robust on
   every body plan; the silhouette is a coarse over-approximation of the animal.
-* ``"sam"`` (optional): prompt Segment Anything (ViT-H by default) with each
+* ``"sam"`` (optional): prompt Segment Anything 1 (ViT-H by default) with each
   instance's visible keypoints to produce a tight, true silhouette, then apply
   a quality filter (predicted-IoU / own-keypoint-containment / area-ratio). SAM
   masks are truer on compact animals (e.g. mice) but degrade badly on tiny or
   elongated ones (e.g. flies), so the source must be a per-dataset choice.
-* ``"hybrid"`` (optional): SAM with a per-instance dilated-skeleton fallback
+* ``"hybrid"`` (optional): SAM1 with a per-instance dilated-skeleton fallback
   whenever the SAM mask fails the quality filter, so every instance still gets
   GT and the 1:1 instance<->mask pairing is preserved.
+* ``"sam3"`` (optional): the same keypoint+box recipe via Meta SAM 3's image
+  visual-prompt path (``transformers`` ``Sam3Tracker*``). On mice it matches
+  SAM1 silhouette-for-silhouette (mask IoU ~0.85 vs SAM1) after a speckle
+  cleanup; it is a higher-ceiling but heavier and *gated* opt-in (SAM1 stays
+  the default SAM path). Two SAM3 specifics are handled internally: a
+  recalibrated predicted-IoU floor (SAM3 scores are lower-scaled) and a
+  morphological speckle cleanup of the fragmented raw masks.
+* ``"hybrid_sam3"`` (optional): SAM3 with the per-instance dilated-skeleton
+  fallback, analogous to ``"hybrid"``.
 
-The SAM / hybrid paths require the optional ``segment-anything`` dependency
-(``pip install "sleap-nn[sam]"``) plus a SAM checkpoint; both are imported /
-loaded lazily so the default skeleton path stays dependency-free.
+The ``sam``/``hybrid`` paths require the optional ``segment-anything``
+dependency (``pip install "sleap-nn[sam]"``) plus a SAM checkpoint; the
+``sam3``/``hybrid_sam3`` paths require ``transformers`` with SAM3 support
+(``pip install "sleap-nn[sam3]"``) and access to the gated ``facebook/sam3``
+model (``huggingface-cli login``). All heavy deps are imported / loaded lazily
+so the default skeleton path stays dependency-free.
 """
 
 from __future__ import annotations
@@ -67,6 +79,36 @@ NODE_RADIUS = 4
 EDGE_THICKNESS = 4
 DILATE_FRAC = 0.10
 MIN_DILATE = 4
+
+# ---------------------------------------------------------------------------
+# SAM3 recipe constants (module defaults).
+#
+# As with the SAM1 constants above, these remain the single source of truth for
+# the SAM3 recipe; the :class:`PseudomaskGenerator` dataclass fields
+# (``sam3_model_id``, ``sam3_pred_iou_min``, ``sam3_cleanup_radius``) default to
+# these values (so the two can never drift), and :func:`_sam3_instance_masks`
+# keeps them as keyword-argument defaults for back-compat.
+# ---------------------------------------------------------------------------
+# SAM3 (Meta SAM 3, via the transformers ``Sam3Tracker*`` image visual-prompt
+# path) is an alternative mask backend that uses the IDENTICAL keypoint+box
+# prompt/select/disjointify recipe as SAM1. It differs from SAM1 in two ways
+# that the defaults below account for:
+#   1. ``iou_scores`` (predicted-IoU) are on a LOWER scale than SAM1 (median
+#      ~0.68 vs SAM1's ~0.95). SAM1's ``PRED_IOU_MIN=0.88`` floor applied
+#      verbatim would drop ~100% of SAM3 masks as a pure calibration artifact,
+#      not a quality signal, so the SAM3 floor is recalibrated to 0.5
+#      (~SAM1's 0.88 in percentile terms; keeps ~92% of mice instances).
+#   2. Raw SAM3 masks are speckly/fragmented (median ~14 connected components/
+#      mask vs SAM1's 1), with ~97% of the area in the keypoint-connected
+#      component. The speckle is cosmetic and removed by a morphological
+#      open+close + keep-keypoint-connected-component cleanup (-> median 1
+#      component, ~97% area retained), applied before the quality filter.
+#: Minimum SAM3 predicted-IoU (recalibrated; see note above).
+SAM3_PRED_IOU_MIN = 0.5
+#: Morphological radius (px) for the SAM3 speckle open+close cleanup.
+SAM3_CLEANUP_RADIUS = 3
+#: Default HF model id for the SAM3 image visual-prompt path.
+SAM3_MODEL_ID = "facebook/sam3"
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +356,205 @@ def _sam_instance_masks(
     return masks, pred_ious
 
 
+def _cleanup_speckle(
+    mask: np.ndarray,
+    kpts: np.ndarray,
+    radius: int = SAM3_CLEANUP_RADIUS,
+) -> np.ndarray:
+    """Remove speckle from a (SAM3) mask, keeping the keypoint-connected blob.
+
+    Raw SAM3 masks are fragmented into many tiny connected components. This
+    applies a morphological open (drop specks) + close (fill pinholes), then
+    keeps only the connected component(s) that contain one of the instance's
+    visible keypoints (falling back to the largest component if the cleanup
+    detached every keypoint, or to the untouched mask if opening erased it
+    entirely). The result is a single coherent silhouette that retains ~97% of
+    the original mask area while collapsing the component count to ~1.
+
+    Args:
+        mask: ``(H, W)`` boolean mask for one instance.
+        kpts: ``(n, 2)`` visible xy keypoints for that instance (the seeds whose
+            connected component is kept).
+        radius: Morphological structuring-element radius (px) for open/close.
+
+    Returns:
+        Cleaned ``(H, W)`` boolean mask.
+    """
+    from scipy import ndimage
+
+    if not mask.any():
+        return mask
+    k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * radius + 1, 2 * radius + 1))
+    mm = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_OPEN, k)
+    mm = cv2.morphologyEx(mm, cv2.MORPH_CLOSE, k)
+    labels_arr, n = ndimage.label(mm)
+    if n == 0:
+        # Opening erased everything (very thin mask) -> keep the raw mask.
+        return mask
+    h, w = mm.shape
+    keep = set()
+    for x, y in kpts:
+        xi, yi = int(round(x)), int(round(y))
+        if 0 <= yi < h and 0 <= xi < w and labels_arr[yi, xi] > 0:
+            keep.add(int(labels_arr[yi, xi]))
+    if not keep:
+        # Cleanup detached every keypoint -> keep the largest component.
+        sizes = ndimage.sum(np.ones_like(labels_arr), labels_arr, range(1, n + 1))
+        keep = {int(np.argmax(sizes)) + 1}
+    return np.isin(labels_arr, list(keep))
+
+
+def _load_sam3(model_id: str = SAM3_MODEL_ID, device: str = "cuda"):
+    """Lazily load the SAM3 image visual-prompt model + processor.
+
+    Uses the transformers ``Sam3TrackerModel`` / ``Sam3TrackerProcessor`` image
+    visual-prompt path (NOT the video-tracking or text/PCS classes). The model
+    is loaded in ``bfloat16`` on ``device`` and set to ``.eval()``.
+
+    ``facebook/sam3`` is a GATED Hugging Face model: authentication comes from a
+    cached HF token (``huggingface-cli login`` / ``~/.cache/huggingface/token``)
+    or the ``HF_TOKEN`` env var, handled transparently by ``transformers``.
+
+    Args:
+        model_id: Hugging Face model id.
+        device: Torch device to place the model on.
+
+    Returns:
+        Tuple ``(model, processor)``.
+
+    Raises:
+        ImportError: If ``transformers`` (with SAM3 support) is not installed.
+    """
+    import torch
+
+    try:
+        from transformers import Sam3TrackerModel, Sam3TrackerProcessor
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "The 'sam3'/'hybrid_sam3' pseudomask source requires the optional "
+            "'transformers' dependency with SAM3 support (transformers>=5.0). "
+            'Install it with `pip install "sleap-nn[sam3]"`. Note that '
+            "facebook/sam3 is a gated model: run `huggingface-cli login` "
+            "(or set HF_TOKEN) with an account that has been granted access."
+        ) from e
+
+    model = (
+        Sam3TrackerModel.from_pretrained(model_id)
+        .to(device, dtype=torch.bfloat16)
+        .eval()
+    )
+    processor = Sam3TrackerProcessor.from_pretrained(model_id)
+    return model, processor
+
+
+def _sam3_instance_masks(
+    model,
+    processor,
+    img_gray: np.ndarray,
+    kpts: Sequence[np.ndarray],
+    device: str = "cuda",
+    clahe: bool = True,
+    max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+    box_margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    box_margin_min: float = SAM_BOX_MARGIN_MIN,
+    clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
+    clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
+    cleanup_radius: int = SAM3_CLEANUP_RADIUS,
+) -> Tuple[List[np.ndarray], List[float]]:
+    """Run the SAM3 image visual-prompt recipe on one frame.
+
+    Mirrors :func:`_sam_instance_masks` (same keypoint+box prompt, oversized-
+    candidate rejection via :func:`_pick`, and keypoint-Voronoi
+    :func:`_disjointify`) but uses SAM3's ``Sam3TrackerModel`` image path, which
+    runs ALL instances of the frame in a single batched forward pass, and adds a
+    per-mask speckle :func:`_cleanup_speckle` before disjointify (SAM3 masks are
+    fragmented where SAM1's are solid).
+
+    Args:
+        model: The SAM3 ``Sam3TrackerModel`` from :func:`_load_sam3`.
+        processor: The SAM3 ``Sam3TrackerProcessor`` from :func:`_load_sam3`.
+        img_gray: ``(H, W)`` uint8 grayscale frame.
+        kpts: List of ``(n_i, 2)`` visible xy keypoints per instance.
+        device: Torch device the prompts are moved to.
+        clahe: Whether to CLAHE-equalize before prompting SAM3.
+        max_box_area_factor: Passed through to :func:`_pick`.
+        box_margin_frac: Keypoint-box margin fraction passed to :func:`_kpt_box`.
+        box_margin_min: Keypoint-box minimum margin passed to :func:`_kpt_box`.
+        clahe_clip_limit: CLAHE clip limit applied when ``clahe`` is true.
+        clahe_tile_grid: CLAHE tile grid applied when ``clahe`` is true.
+        cleanup_radius: Speckle-cleanup morphological radius (px).
+
+    Returns:
+        Tuple ``(masks, pred_ious)`` where ``masks`` is a list of disjoint,
+        de-speckled boolean ``(H, W)`` arrays and ``pred_ious`` the per-instance
+        SAM3 predicted-IoU (on SAM3's lower scale; see ``SAM3_PRED_IOU_MIN``).
+    """
+    import torch
+
+    if clahe:
+        src = cv2.createCLAHE(clahe_clip_limit, clahe_tile_grid).apply(img_gray)
+    else:
+        src = img_gray
+    rgb = np.stack([src] * 3, -1).astype(np.uint8)
+    h, w = img_gray.shape
+
+    # Build batched per-object prompts (one image, each instance a separate
+    # object). Instances with no visible keypoints get an empty mask.
+    obj_points: List[List[List[float]]] = []
+    obj_labels: List[List[int]] = []
+    obj_boxes: List[List[float]] = []
+    valid_idx: List[int] = []
+    boxes_by_idx: dict = {}
+    for i, ks in enumerate(kpts):
+        if len(ks) == 0:
+            continue
+        box = _kpt_box(
+            np.asarray(ks, np.float32),
+            (h, w),
+            margin_frac=box_margin_frac,
+            margin_min=box_margin_min,
+        )
+        obj_points.append([[float(x), float(y)] for x, y in ks])
+        obj_labels.append([1] * len(ks))  # all positive, no negatives
+        obj_boxes.append([float(v) for v in box])
+        boxes_by_idx[i] = box
+        valid_idx.append(i)
+
+    masks: List[np.ndarray] = [np.zeros((h, w), bool) for _ in kpts]
+    pred_ious: List[float] = [0.0 for _ in kpts]
+    if not valid_idx:
+        return _disjointify(masks, kpts), pred_ious
+
+    inputs = processor(
+        images=rgb,
+        input_points=[obj_points],
+        input_labels=[obj_labels],
+        input_boxes=[obj_boxes],
+        return_tensors="pt",
+    ).to(device)
+    with torch.no_grad():
+        out = model(**inputs, multimask_output=True)
+    post = processor.post_process_masks(
+        out.pred_masks, original_sizes=inputs["original_sizes"], binarize=True
+    )[
+        0
+    ]  # (n_obj, n_cand, H, W) bool
+    post = post.cpu().numpy().astype(bool)
+    scores = out.iou_scores.float().cpu().numpy()[0]  # (n_obj, n_cand)
+
+    for j, i in enumerate(valid_idx):
+        box = boxes_by_idx[i]
+        b = _pick(post[j], scores[j], box, max_box_area_factor)
+        m = _cleanup_speckle(
+            post[j][b], np.asarray(kpts[i], np.float32), cleanup_radius
+        )
+        masks[i] = m
+        pred_ious[i] = float(scores[j][b])
+
+    masks = _disjointify(masks, kpts)
+    return masks, pred_ious
+
+
 def _load_sam_predictor(
     checkpoint: str, model_type: str = "vit_h", device: str = "cuda"
 ):
@@ -376,32 +617,40 @@ def _own_containment(mask: np.ndarray, kpts: np.ndarray, hw: Tuple[int, int]) ->
 class PseudomaskGenerator:
     """Configurable pose -> per-instance pseudomask generator.
 
-    Bundles every tunable of the skeleton/SAM/hybrid recipe as a field with the
-    same defaults as the module-level constants (the single source of truth), so
-    callers can construct one generator and reuse it. The free helper functions
+    Bundles every tunable of the skeleton/SAM1/SAM3/hybrid recipe as a field with
+    the same defaults as the module-level constants (the single source of truth),
+    so callers can construct one generator and reuse it. The free helper functions
     (:func:`rasterize_instance_mask`, :func:`_kpt_box`, :func:`_pick`,
-    :func:`_disjointify`, :func:`_sam_instance_masks`, :func:`_own_containment`)
-    remain available and receive the relevant fields when :meth:`run` calls them.
+    :func:`_disjointify`, :func:`_sam_instance_masks`, :func:`_sam3_instance_masks`,
+    :func:`_cleanup_speckle`, :func:`_own_containment`) remain available and
+    receive the relevant fields when :meth:`run` calls them.
 
     Attributes:
         source: GT source, one of ``"skeleton"`` (default), ``"sam"``,
-            ``"hybrid"``. ``"sam"``/``"hybrid"`` require ``segment-anything`` +
-            a checkpoint.
+            ``"hybrid"``, ``"sam3"``, ``"hybrid_sam3"``. ``"sam"``/``"hybrid"``
+            require ``segment-anything`` + a checkpoint; ``"sam3"``/
+            ``"hybrid_sam3"`` require ``transformers`` + the gated
+            ``facebook/sam3`` model.
         node_radius: Skeleton-rasterizer node disk radius (px).
         edge_thickness: Skeleton-rasterizer edge line thickness (px).
         dilate_frac: Skeleton-rasterizer dilation as a fraction of bbox diagonal.
         min_dilate: Skeleton-rasterizer minimum dilation radius (px).
-        sam_checkpoint: Path to the SAM checkpoint (required for sam/hybrid).
-        sam_model_type: SAM model registry key.
-        device: Torch device for SAM.
-        pred_iou_min: SAM quality filter: minimum predicted-IoU.
-        own_containment_min: SAM quality filter: minimum own-keypoint containment.
-        area_ratio_range: SAM quality filter: ``(min, max)`` for SAM/skeleton area.
-        sam_box_margin_frac: SAM keypoint-box margin as a fraction of the side.
-        sam_box_margin_min: SAM keypoint-box minimum margin (px).
-        sam_max_box_area_factor: Reject SAM candidates above this * box-area.
-        clahe_clip_limit: CLAHE clip limit applied before prompting SAM.
-        clahe_tile_grid: CLAHE tile grid applied before prompting SAM.
+        sam_checkpoint: Path to the SAM1 checkpoint (required for sam/hybrid).
+        sam_model_type: SAM1 model registry key.
+        sam3_model_id: HF model id for the SAM3 path (sam3/hybrid_sam3).
+        device: Torch device for the segmentation model.
+        pred_iou_min: Quality filter: minimum predicted-IoU. ``None`` (default)
+            selects the source-appropriate floor in :meth:`run`: ``PRED_IOU_MIN``
+            (0.88) for SAM1 and ``sam3_pred_iou_min`` (0.5) for SAM3, whose
+            predicted-IoU is on a lower scale.
+        own_containment_min: Quality filter: minimum own-keypoint containment.
+        area_ratio_range: Quality filter: ``(min, max)`` for model/skeleton area.
+        sam_box_margin_frac: Keypoint-box margin as a fraction of the side.
+        sam_box_margin_min: Keypoint-box minimum margin (px).
+        sam_max_box_area_factor: Reject candidates above this * box-area.
+        clahe_clip_limit: CLAHE clip limit applied before prompting the model.
+        clahe_tile_grid: CLAHE tile grid applied before prompting the model.
+        sam3_cleanup_radius: SAM3 speckle-cleanup morphological radius (px).
     """
 
     source: str = "skeleton"
@@ -411,8 +660,9 @@ class PseudomaskGenerator:
     min_dilate: int = MIN_DILATE
     sam_checkpoint: Optional[str] = None
     sam_model_type: str = "vit_h"
+    sam3_model_id: str = SAM3_MODEL_ID
     device: str = "cuda"
-    pred_iou_min: float = PRED_IOU_MIN
+    pred_iou_min: Optional[float] = None
     own_containment_min: float = OWN_CONTAIN_MIN
     area_ratio_range: Tuple[float, float] = (AREA_RATIO_MIN, AREA_RATIO_MAX)
     sam_box_margin_frac: float = SAM_BOX_MARGIN_FRAC
@@ -420,6 +670,8 @@ class PseudomaskGenerator:
     sam_max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR
     clahe_clip_limit: float = CLAHE_CLIP_LIMIT
     clahe_tile_grid: Tuple[int, int] = field(default_factory=lambda: CLAHE_TILE_GRID)
+    sam3_pred_iou_min: float = SAM3_PRED_IOU_MIN
+    sam3_cleanup_radius: int = SAM3_CLEANUP_RADIUS
 
     def run(self, labels: sio.Labels) -> sio.Labels:
         """Generate per-instance segmentation pseudomasks from pose keypoints.
@@ -438,14 +690,14 @@ class PseudomaskGenerator:
 
         Raises:
             ValueError: If ``source`` is not one of the supported values.
-            ImportError: If ``source`` needs SAM but ``segment-anything`` is
+            ImportError: If ``source`` needs SAM/SAM3 but its dependency is
                 absent.
         """
         source = self.source
-        if source not in ("skeleton", "sam", "hybrid"):
+        if source not in ("skeleton", "sam", "hybrid", "sam3", "hybrid_sam3"):
             raise ValueError(
                 f"Unknown pseudomask source {source!r}; expected one of "
-                "'skeleton', 'sam', 'hybrid'."
+                "'skeleton', 'sam', 'hybrid', 'sam3', 'hybrid_sam3'."
             )
 
         skel = labels.skeletons[0]
@@ -457,13 +709,29 @@ class PseudomaskGenerator:
             min_dilate=self.min_dilate,
         )
 
+        use_sam1 = source in ("sam", "hybrid")
+        use_sam3 = source in ("sam3", "hybrid_sam3")
+        use_sam = use_sam1 or use_sam3
+        is_hybrid = source in ("hybrid", "hybrid_sam3")
+
+        # Source-appropriate predicted-IoU floor (SAM3's scores are
+        # lower-scaled, so SAM1's 0.88 is recalibrated to keep mask quality
+        # comparable).
+        pred_iou_min = self.pred_iou_min
+        if pred_iou_min is None:
+            pred_iou_min = self.sam3_pred_iou_min if use_sam3 else PRED_IOU_MIN
+
         predictor = None
-        use_sam = source in ("sam", "hybrid")
-        if use_sam:
+        sam3_model = sam3_processor = None
+        if use_sam1:
             predictor = _load_sam_predictor(
                 self.sam_checkpoint,
                 model_type=self.sam_model_type,
                 device=self.device,
+            )
+        elif use_sam3:
+            sam3_model, sam3_processor = _load_sam3(
+                model_id=self.sam3_model_id, device=self.device
             )
 
         area_min, area_max = self.area_ratio_range
@@ -509,16 +777,31 @@ class PseudomaskGenerator:
                 img = np.asarray(lf.image)
                 if img.ndim == 3:
                     img = img[..., 0]
-                sam_masks, pred_ious = _sam_instance_masks(
-                    predictor,
-                    img,
-                    kpts_all,
-                    max_box_area_factor=self.sam_max_box_area_factor,
-                    box_margin_frac=self.sam_box_margin_frac,
-                    box_margin_min=self.sam_box_margin_min,
-                    clahe_clip_limit=self.clahe_clip_limit,
-                    clahe_tile_grid=self.clahe_tile_grid,
-                )
+                if use_sam3:
+                    sam_masks, pred_ious = _sam3_instance_masks(
+                        sam3_model,
+                        sam3_processor,
+                        img,
+                        kpts_all,
+                        device=self.device,
+                        max_box_area_factor=self.sam_max_box_area_factor,
+                        box_margin_frac=self.sam_box_margin_frac,
+                        box_margin_min=self.sam_box_margin_min,
+                        clahe_clip_limit=self.clahe_clip_limit,
+                        clahe_tile_grid=self.clahe_tile_grid,
+                        cleanup_radius=self.sam3_cleanup_radius,
+                    )
+                else:
+                    sam_masks, pred_ious = _sam_instance_masks(
+                        predictor,
+                        img,
+                        kpts_all,
+                        max_box_area_factor=self.sam_max_box_area_factor,
+                        box_margin_frac=self.sam_box_margin_frac,
+                        box_margin_min=self.sam_box_margin_min,
+                        clahe_clip_limit=self.clahe_clip_limit,
+                        clahe_tile_grid=self.clahe_tile_grid,
+                    )
                 final_masks = []
                 for i in range(len(skel_masks)):
                     sm = skel_masks[i]
@@ -529,17 +812,17 @@ class PseudomaskGenerator:
                     oc = _own_containment(mm, kpts_all[i], (h, w))
                     keep = (
                         sam_area > 0
-                        and pred_ious[i] >= self.pred_iou_min
+                        and pred_ious[i] >= pred_iou_min
                         and oc >= self.own_containment_min
                         and area_min <= area_ratio <= area_max
                     )
                     if keep:
                         final_masks.append(mm)
                         n_sam += 1
-                    elif source == "hybrid":
+                    elif is_hybrid:
                         final_masks.append(sm)  # per-instance skeleton fallback
                         n_fallback += 1
-                    else:  # source == "sam": drop the rejected instance entirely
+                    else:  # plain sam/sam3: drop the rejected instance entirely
                         final_masks.append(None)
                         n_dropped += 1
 
@@ -570,8 +853,9 @@ class PseudomaskGenerator:
             f"Built {len(new_lfs)} frames, {n_masks} masks ({mpf:.2f} masks/frame)."
         )
         if use_sam:
+            model_name = "SAM3" if use_sam3 else "SAM"
             logger.info(
-                f"SAM masks: {n_sam}; skeleton-fallback: {n_fallback}; "
+                f"{model_name} masks: {n_sam}; skeleton-fallback: {n_fallback}; "
                 f"dropped: {n_dropped}."
             )
         return out_labels
@@ -587,8 +871,9 @@ def generate_pseudomasks(
     min_dilate: int = MIN_DILATE,
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
+    sam3_model_id: str = SAM3_MODEL_ID,
     device: str = "cuda",
-    pred_iou_min: float = PRED_IOU_MIN,
+    pred_iou_min: Optional[float] = None,
     own_containment_min: float = OWN_CONTAIN_MIN,
     area_ratio_range: Tuple[float, float] = (AREA_RATIO_MIN, AREA_RATIO_MAX),
 ) -> sio.Labels:
@@ -601,25 +886,37 @@ def generate_pseudomasks(
     Args:
         labels: Source ``sio.Labels`` carrying keypoint instances + image data.
         source: GT source, one of ``"skeleton"`` (default), ``"sam"``,
-            ``"hybrid"``. ``"sam"``/``"hybrid"`` require ``segment-anything`` +
-            a checkpoint.
+            ``"hybrid"``, ``"sam3"``, ``"hybrid_sam3"``. The ``sam*`` sources
+            prompt a foundation segmentation model with each instance's visible
+            keypoints + a keypoint box, then quality-filter the result; the
+            ``hybrid*`` variants fall back to the dilated-skeleton mask per
+            instance whenever the model mask is rejected (so every instance
+            keeps GT), while the plain ``sam``/``sam3`` variants drop rejected
+            instances. ``sam``/``hybrid`` use SAM1 (``segment-anything`` +
+            checkpoint); ``sam3``/``hybrid_sam3`` use SAM3 (``transformers``,
+            gated ``facebook/sam3``).
         node_radius: Skeleton-rasterizer node disk radius (px).
         edge_thickness: Skeleton-rasterizer edge line thickness (px).
         dilate_frac: Skeleton-rasterizer dilation as a fraction of bbox diagonal.
         min_dilate: Skeleton-rasterizer minimum dilation radius (px).
-        sam_checkpoint: Path to the SAM checkpoint (required for sam/hybrid).
-        sam_model_type: SAM model registry key.
-        device: Torch device for SAM.
-        pred_iou_min: SAM quality filter: minimum predicted-IoU.
-        own_containment_min: SAM quality filter: minimum own-keypoint containment.
-        area_ratio_range: SAM quality filter: ``(min, max)`` for SAM/skeleton area.
+        sam_checkpoint: Path to the SAM1 checkpoint (required for sam/hybrid).
+        sam_model_type: SAM1 model registry key.
+        sam3_model_id: HF model id for the SAM3 path (sam3/hybrid_sam3).
+        device: Torch device for the segmentation model.
+        pred_iou_min: Quality filter minimum predicted-IoU. ``None`` (default)
+            selects the source-appropriate floor: ``PRED_IOU_MIN`` (0.88) for
+            SAM1 and ``SAM3_PRED_IOU_MIN`` (0.5) for SAM3 -- SAM3's predicted-IoU
+            is on a lower scale, so SAM1's 0.88 is recalibrated to keep mask
+            quality comparable (see ``SAM3_PRED_IOU_MIN``).
+        own_containment_min: Quality filter: minimum own-keypoint containment.
+        area_ratio_range: Quality filter: ``(min, max)`` for model/skeleton area.
 
     Returns:
         New ``sio.Labels`` with per-frame ``UserSegmentationMask`` objects.
 
     Raises:
         ValueError: If ``source`` is not one of the supported values.
-        ImportError: If ``source`` needs SAM but ``segment-anything`` is absent.
+        ImportError: If ``source`` needs SAM/SAM3 but its dependency is absent.
     """
     return PseudomaskGenerator(
         source=source,
@@ -629,6 +926,7 @@ def generate_pseudomasks(
         min_dilate=min_dilate,
         sam_checkpoint=sam_checkpoint,
         sam_model_type=sam_model_type,
+        sam3_model_id=sam3_model_id,
         device=device,
         pred_iou_min=pred_iou_min,
         own_containment_min=own_containment_min,
@@ -647,6 +945,7 @@ def make_pseudomasks_cli(
     min_dilate: int = MIN_DILATE,
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
+    sam3_model_id: str = SAM3_MODEL_ID,
     device: str = "cuda",
     overlay: Optional[str] = None,
 ) -> sio.Labels:
@@ -655,14 +954,16 @@ def make_pseudomasks_cli(
     Args:
         src: Path to a source pose ``.slp`` / ``.pkg.slp`` (with image data).
         out: Output ``.pkg.slp`` path (saved with embedded images).
-        source: GT source: ``"skeleton"`` (default), ``"sam"``, ``"hybrid"``.
+        source: GT source: ``"skeleton"`` (default), ``"sam"``, ``"hybrid"``,
+            ``"sam3"``, ``"hybrid_sam3"``.
         node_radius: Skeleton-rasterizer node disk radius (px).
         edge_thickness: Skeleton-rasterizer edge line thickness (px).
         dilate_frac: Skeleton-rasterizer dilation as a fraction of bbox diagonal.
         min_dilate: Skeleton-rasterizer minimum dilation radius (px).
-        sam_checkpoint: Path to the SAM checkpoint (required for sam/hybrid).
-        sam_model_type: SAM model registry key.
-        device: Torch device for SAM.
+        sam_checkpoint: Path to the SAM1 checkpoint (required for sam/hybrid).
+        sam_model_type: SAM1 model registry key.
+        sam3_model_id: HF model id for the SAM3 path (sam3/hybrid_sam3).
+        device: Torch device for the segmentation model.
         overlay: Optional path to write a colored mask overlay PNG of frame 0.
 
     Returns:
@@ -680,6 +981,7 @@ def make_pseudomasks_cli(
         min_dilate=min_dilate,
         sam_checkpoint=sam_checkpoint,
         sam_model_type=sam_model_type,
+        sam3_model_id=sam3_model_id,
         device=device,
     ).run(labels)
 

--- a/tests/data/test_pseudomasks.py
+++ b/tests/data/test_pseudomasks.py
@@ -1,10 +1,11 @@
 """Tests for pose -> per-instance segmentation pseudomask generation.
 
 Covers the dependency-free skeleton rasterizer + the ``generate_pseudomasks``
-skeleton path (mask count, type, roundtrip), the unknown-source guard, and the
+skeleton path (mask count, type, roundtrip), the unknown-source guard, the
 SAM-path lazy-import error surface (exercised by faking ``segment-anything``
-absent). The full SAM / hybrid GPU path is gated behind ``segment_anything`` +
-a checkpoint and skipped when unavailable.
+absent), and the SAM3 speckle cleanup + lazy-import surface (faking
+``transformers`` absent). The full SAM / SAM3 GPU paths are gated behind their
+deps + a checkpoint / gated model and skipped when unavailable.
 """
 
 import builtins
@@ -21,7 +22,9 @@ from sleap_nn.data.pseudomasks import (
     _kpt_box,
     _pick,
     _disjointify,
+    _cleanup_speckle,
     _load_sam_predictor,
+    _load_sam3,
 )
 
 
@@ -236,3 +239,223 @@ def test_generate_pseudomasks_hybrid_smoke(minimal_instance):
     # Hybrid guarantees a mask for every kept instance.
     assert len(lf.masks) == n_inst
     assert all(isinstance(m, sio.UserSegmentationMask) for m in lf.masks)
+
+
+# ---------------------------------------------------------------------------
+# SAM3 speckle cleanup (dependency-free).
+# ---------------------------------------------------------------------------
+def test_cleanup_speckle_keeps_keypoint_blob_drops_specks():
+    """Cleanup keeps the keypoint-connected blob and removes detached specks."""
+    h, w = 80, 80
+    m = np.zeros((h, w), bool)
+    m[20:50, 20:50] = True  # main body (contains the keypoint)
+    m[5, 5] = True  # isolated single-pixel speck (removed by opening)
+    m[70:73, 70:73] = True  # small detached speck far from any keypoint
+    kpts = np.array([[35.0, 35.0]], np.float32)
+
+    out = _cleanup_speckle(m, kpts, radius=2)
+
+    # The keypoint stays inside the cleaned mask; the far speck is gone.
+    assert out[35, 35]
+    assert not out[71, 71]
+    assert not out[5, 5]
+    # Result is a single connected component.
+    from scipy import ndimage
+
+    _, n = ndimage.label(out)
+    assert n == 1
+
+
+def test_cleanup_speckle_empty_mask_is_noop():
+    """An all-False mask is returned unchanged (no components to keep)."""
+    m = np.zeros((30, 30), bool)
+    out = _cleanup_speckle(m, np.array([[10.0, 10.0]], np.float32))
+    assert not out.any()
+
+
+def test_cleanup_speckle_no_keypoint_hit_keeps_largest():
+    """If no keypoint lands on a component, the largest one is kept."""
+    h, w = 80, 80
+    m = np.zeros((h, w), bool)
+    m[10:40, 10:40] = True  # large blob
+    m[60:65, 60:65] = True  # smaller blob
+    # Keypoint in empty space -> falls back to largest component.
+    out = _cleanup_speckle(m, np.array([[1.0, 1.0]], np.float32), radius=2)
+    assert out[25, 25]  # large blob kept
+    assert not out[62, 62]  # smaller blob dropped
+
+
+# ---------------------------------------------------------------------------
+# SAM3 lazy-import error surface (transformers faked absent).
+# ---------------------------------------------------------------------------
+def test_load_sam3_missing_dep_raises(monkeypatch):
+    """When transformers (SAM3) is absent, a friendly ImportError is raised."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "transformers" or name.startswith("transformers."):
+            raise ImportError("No module named 'transformers'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match=r"sleap-nn\[sam3\]"):
+        _load_sam3()
+
+
+def test_generate_pseudomasks_sam3_missing_dep_raises(minimal_instance, monkeypatch):
+    """source='sam3' surfaces the friendly ImportError when SAM3 is absent."""
+    labels = sio.load_slp(str(minimal_instance))
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "transformers" or name.startswith("transformers."):
+            raise ImportError("No module named 'transformers'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match=r"sleap-nn\[sam3\]"):
+        generate_pseudomasks(labels, source="sam3")
+
+
+# ---------------------------------------------------------------------------
+# SAM3 frame-loop wiring (transformers FAKED, no GPU / no weights).
+# ---------------------------------------------------------------------------
+class _FakeTorchTensor:
+    """Minimal stand-in exposing the ``.cpu().numpy()`` / ``.float()`` chain."""
+
+    def __init__(self, arr):
+        self._a = arr
+
+    def float(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._a
+
+
+class _FakeInputs(dict):
+    def to(self, *_a, **_k):
+        return self
+
+
+class _FakeSam3Processor:
+    """Builds a fake batched input + returns plausible per-object candidates.
+
+    For each prompted object it emits 3 candidates: a tight box around the
+    keypoint bbox plus a couple of detached single-pixel specks (so the real
+    ``_cleanup_speckle`` has something to remove), and a deliberately oversized
+    whole-frame candidate (so ``_pick`` must reject it).
+    """
+
+    def __init__(self, hw, n_obj_ref):
+        self._hw = hw
+        self._n_obj_ref = n_obj_ref
+
+    def __call__(self, images, input_points, input_boxes, **_k):
+        self._boxes = input_boxes[0]  # [obj][xyxy]
+        self._points = input_points[0]  # [obj][pt][xy]
+        self._n_obj = len(self._boxes)
+        self._n_obj_ref[0] = self._n_obj
+        return _FakeInputs(original_sizes=[self._hw])
+
+    def post_process_masks(self, pred_masks, original_sizes, binarize):
+        h, w = self._hw
+        n_cand = 3
+        out = np.zeros((self._n_obj, n_cand, h, w), bool)
+        for j in range(self._n_obj):
+            pts = np.asarray(self._points[j], float)
+            x0 = int(np.floor(pts[:, 0].min())) - 6
+            y0 = int(np.floor(pts[:, 1].min())) - 6
+            x1 = int(np.ceil(pts[:, 0].max())) + 6
+            y1 = int(np.ceil(pts[:, 1].max())) + 6
+            x0, y0 = max(0, x0), max(0, y0)
+            x1, y1 = min(w, x1), min(h, y1)
+            # candidate 0: a tight body covering the keypoints (own-containment
+            # ok, area comparable to the dilated skeleton so the area-ratio
+            # filter accepts it) + 2 detached single-pixel specks for
+            # _cleanup_speckle to remove.
+            out[j, 0, y0:y1, x0:x1] = True
+            out[j, 0, 1, 1] = True
+            out[j, 0, h - 2, w - 2] = True
+            # candidate 1: slightly smaller body covering the keypoints.
+            out[j, 1, y0 + 2 : max(y0 + 3, y1 - 2), x0 + 2 : max(x0 + 3, x1 - 2)] = True
+            # candidate 2: oversized whole-frame (must be rejected by _pick).
+            out[j, 2, :, :] = True
+        return [_FakeTensor4D(out)]
+
+
+class _FakeTensor4D:
+    def __init__(self, arr):
+        self._a = arr
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._a
+
+
+class _FakeSam3Model:
+    """Returns synthetic ``pred_masks`` + ``iou_scores`` for the frame batch."""
+
+    def __init__(self, n_obj_ref):
+        self._n_obj_ref = n_obj_ref
+
+    def __call__(self, original_sizes=None, **_k):
+        n_obj = self._n_obj_ref[0]
+        # candidate 0 (tight body) gets the highest score among survivors.
+        scores = np.tile(np.array([0.8, 0.6, 0.95]), (n_obj, 1))[None]
+        return type(
+            "Out",
+            (),
+            {"pred_masks": None, "iou_scores": _FakeTorchTensor(scores)},
+        )()
+
+
+@pytest.mark.parametrize("source", ["sam3", "hybrid_sam3"])
+def test_generate_pseudomasks_sam3_frame_loop_faked(
+    minimal_instance, monkeypatch, source
+):
+    """The full sam3/hybrid_sam3 frame loop runs end-to-end with a faked model.
+
+    Exercises prompt building, candidate selection (``_pick`` rejecting the
+    oversized whole-frame candidate), speckle cleanup, disjointify, the
+    recalibrated quality filter, and assembly into ``UserSegmentationMask`` --
+    all without ``transformers`` / GPU / weights.
+    """
+    import sleap_nn.data.pseudomasks as pm
+
+    labels = sio.load_slp(str(minimal_instance))
+    n_inst = len(labels[0].instances)
+    h, w = labels.videos[0].shape[1], labels.videos[0].shape[2]
+
+    n_obj_ref = [0]
+
+    def fake_load_sam3(model_id=pm.SAM3_MODEL_ID, device="cuda"):
+        proc = _FakeSam3Processor((h, w), n_obj_ref)
+        return _FakeSam3Model(n_obj_ref), proc
+
+    monkeypatch.setattr(pm, "_load_sam3", fake_load_sam3)
+
+    out = generate_pseudomasks(labels, source=source, device="cpu")
+
+    assert len(out.labeled_frames) == 1
+    lf = out.labeled_frames[0]
+    # Both instances keep GT (tight candidate passes the filter / hybrid falls back).
+    assert len(lf.masks) == n_inst
+    assert len(lf.instances) == n_inst
+    for m, inst in zip(lf.masks, lf.instances):
+        mm = np.asarray(m.data, dtype=bool)
+        assert isinstance(m, sio.UserSegmentationMask)
+        assert mm.any()
+        # The oversized whole-frame candidate must NOT have been selected.
+        assert mm.mean() < 0.9
+        # Speckle in the far corner must be gone (cleanup kept the keypoint blob).
+        assert not mm[h - 2, w - 2]
+    # Disjoint: no pixel claimed by both instance masks.
+    a = np.asarray(lf.masks[0].data, bool)
+    b = np.asarray(lf.masks[1].data, bool)
+    assert not (a & b).any()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1052,6 +1052,8 @@ class TestMakeMasksCommand:
         assert "skeleton" in result.output
         assert "sam" in result.output
         assert "hybrid" in result.output
+        assert "sam3" in result.output
+        assert "hybrid_sam3" in result.output
 
     def test_make_masks_skeleton(self, minimal_instance, tmp_path):
         """make-masks --source skeleton writes a reloadable seg .pkg.slp."""


### PR DESCRIPTION
## Summary

Adds **SAM3** as a new optional pose→mask pseudomask GT backend, stacked on
#642 (the `{skeleton, sam, hybrid}` generator). SAM3 is offered as a
**higher-ceiling but gated + heavy** option; **SAM1 (`sam`/`hybrid`, Apache,
light, ungated) remains the default SAM path**, and **`skeleton` stays the
overall default** (no behavior change for existing users).

Two new sources are added to `generate_pseudomasks(...)` and
`sleap-nn make-masks --source ...`:

- **`sam3`** — Meta SAM 3 image visual-prompt path (`transformers`
  `Sam3TrackerModel` / `Sam3TrackerProcessor`), run with the *identical*
  exp-07 SAM1 recipe: visible keypoints as positive points + a keypoint-bbox
  box (`margin = max(15px, 0.6·side)`), no negatives, `multimask_output`,
  reject candidates with `area > 1.5·box_area` (kills SAM's whole-arena
  candidate), best `iou_scores` among survivors, then keypoint-Voronoi
  disjointify. Drops instances that fail the quality filter.
- **`hybrid_sam3`** — SAM3 with the per-instance dilated-skeleton fallback
  (every instance keeps GT; the 1:1 instance↔mask pairing is preserved),
  analogous to the existing `hybrid`.

## Mice probe result (scratch, `mice_of` val: 100 frames / 293 instances)

SAM3 run with the same keypoint+box recipe is **COMPARABLE to SAM1 on
silhouette quality — not better, noisier raw, equal after a trivial cleanup**:

| metric | SAM3 | SAM1 (exp-07) | dilated-skeleton |
|---|---|---|---|
| area ratio vs skeleton (median) | 0.47 | 0.42 | 1.0 |
| inter-instance overlap (mean, post-disjointify) | 0.000 | 0.001 | 0.047 |
| own-keypoint containment (mean) | 0.99 | 0.997 | — |
| **mask IoU vs SAM1 (median / mean)** | **0.84 / 0.78** | — | — |
| area ratio vs SAM1 (median) | 1.09× | — | — |

Both SAM models hug the true silhouette (~0.42–0.47× the inflated skeleton)
and split the touching mice the dilated-skeleton GT merges into one fat blob;
the skeleton GT over-covers by ~2.4×. **SAM1 is cleaner raw**; SAM3 has two
quirks handled internally:

1. **Lower-scaled predicted-IoU** (calibration, not quality): SAM3 `iou_scores`
   median ~0.68 vs SAM1's ~0.95. Exp-07's `pred_iou >= 0.88` floor applied
   verbatim drops ~100% of SAM3, so the SAM3 floor is recalibrated to
   `SAM3_PRED_IOU_MIN = 0.5` (~SAM1's 0.88 in percentile terms; keeps ~92–95%).
2. **Fragmented raw masks** (median ~14 connected components): a morphological
   open+close + keep-keypoint-connected-component cleanup (`_cleanup_speckle`)
   collapses to ~1 component while retaining ~97% of the area, and *raises*
   SAM1 agreement (mask IoU 0.82 → 0.84).

**Verdict:** prefer **SAM1** as the default SAM GT for mice (lighter, ungated,
identical quality); offer **SAM3 (`sam3`/`hybrid_sam3`)** as a first-class
opt-in. Like SAM1, do not use SAM (1 or 3) GT for tiny/elongated body plans
(e.g. flies) without a per-dataset probe.

## Packaging / deps

SAM3 deps are **lazy-imported behind a new optional `sleap-nn[sam3]` extra**
(`transformers>=5.0`); `facebook/sam3` is a **gated** Hugging Face model
(`huggingface-cli login` / `HF_TOKEN` with granted access). The lazy import
raises a clear, actionable `ImportError` (pointing at `sleap-nn[sam3]` + HF
login) when the dep or access is missing. The default `skeleton` path stays
**dependency-free**, and `sam`/`hybrid` (SAM1) are **unchanged**. SAM3 needs a
cu13x `transformers` env — the [`sam-track`](https://github.com/talmolab/sam-track)
venv is a working reference.

## Tests (green)

- enum/config + CLI help accept `sam3` / `hybrid_sam3`; `skeleton` / `sam` /
  `hybrid` paths unaffected.
- `sam3` path raises the friendly `sleap-nn[sam3]` `ImportError` when
  `transformers` is monkeypatched absent.
- `_cleanup_speckle`: keeps the keypoint-connected blob / empty no-op /
  largest-component fallback.
- a faked-model end-to-end frame loop for both `sam3` and `hybrid_sam3`
  (prompt build, oversized-candidate rejection, cleanup, disjointify,
  recalibrated filter, skeleton fallback, `UserSegmentationMask` assembly) —
  all CPU, no weights.

`black` + `ruff` clean; pseudomask + make-masks suites **22 passed, 1 gated-skip**.

## Follow-up (out of scope)

A full SAM3-GT retrain + downstream seg eval is a documented follow-up. Both
SAM3-GT mice splits are already burned in scratch and cross-eval-ready.

## Stacking

Based on `feat/seg-pseudomask-gt-source` (#642). Review/merge #642 first; the
diff here is the SAM3-only delta. Retarget to `main` once #642 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
