### PR TITLE
feat: symmetry-aware flip augmentation

### DIFF
--- a/docs/configuration/data.md
+++ b/docs/configuration/data.md
@@ -157,7 +157,17 @@ augmentation_config:
     mixup_p: 0.0
     mixup_lambda_min: 0.01
     mixup_lambda_max: 0.05
+
+    # Flip (mirror image + keypoints, swapping symmetric node pairs)
+    flip_p: 0.0           # 0 disables; >0 enables (uses skeleton symmetries)
+    flip_horizontal: true # true = left/right, false = up/down
 ```
+
+> **Flip & skeleton symmetries:** when `flip_p > 0`, left/right symmetric body
+> parts (e.g. `left_paw` ↔ `right_paw`) are swapped after mirroring so labels stay
+> correct. Symmetry pairs are read from the skeleton. If the skeleton has **no**
+> symmetries, flipping is only correct when the animal is truly left/right
+> symmetric in labeling — a warning is logged otherwise.
 
 ---
 
@@ -288,3 +298,5 @@ data_config:
 | `mixup_lambda_min` | float | `0.01` | Minimum mixup strength |
 | `mixup_lambda_max` | float | `0.05` | Maximum mixup strength |
 | `mixup_p` | float | `0.0` | Probability of applying mixup |
+| `flip_p` | float | `0.0` | Probability of mirroring image + keypoints (swaps symmetric node pairs) |
+| `flip_horizontal` | bool | `true` | `true` = left/right flip, `false` = up/down flip |

--- a/docs/configuration/data.md
+++ b/docs/configuration/data.md
@@ -158,16 +158,15 @@ augmentation_config:
     mixup_lambda_min: 0.01
     mixup_lambda_max: 0.05
 
-    # Flip (mirror image + keypoints, swapping symmetric node pairs)
-    flip_p: 0.0           # 0 disables; >0 enables (uses skeleton symmetries)
-    flip_horizontal: true # true = left/right, false = up/down
+    # Flip (mirror image + keypoints left/right, swapping symmetric node pairs)
+    flip_p: 0.0  # 0 disables; >0 enables left/right flip (uses skeleton symmetries)
 ```
 
-> **Flip & skeleton symmetries:** when `flip_p > 0`, left/right symmetric body
-> parts (e.g. `left_paw` ↔ `right_paw`) are swapped after mirroring so labels stay
-> correct. Symmetry pairs are read from the skeleton. If the skeleton has **no**
-> symmetries, flipping is only correct when the animal is truly left/right
-> symmetric in labeling — a warning is logged otherwise.
+> **Flip & skeleton symmetries:** when `flip_p > 0`, the image and keypoints are
+> mirrored left/right and left/right symmetric body parts (e.g. `left_paw` ↔
+> `right_paw`) are swapped so labels stay correct. Symmetry pairs are read from the
+> skeleton. If the skeleton has **no** symmetries, flipping is only correct when the
+> animal is truly left/right symmetric in labeling — a warning is logged otherwise.
 
 ---
 
@@ -298,5 +297,4 @@ data_config:
 | `mixup_lambda_min` | float | `0.01` | Minimum mixup strength |
 | `mixup_lambda_max` | float | `0.05` | Maximum mixup strength |
 | `mixup_p` | float | `0.0` | Probability of applying mixup |
-| `flip_p` | float | `0.0` | Probability of mirroring image + keypoints (swaps symmetric node pairs) |
-| `flip_horizontal` | bool | `true` | `true` = left/right flip, `false` = up/down flip |
+| `flip_p` | float | `0.0` | Probability of mirroring image + keypoints left/right (swaps symmetric node pairs) |

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -125,8 +125,7 @@ class GeometricConfig:
         mixup_lambda_min: (float) Minimum mixup strength value. *Default*: `0.01`.
         mixup_lambda_max: (float) Maximum mixup strength value. *Default*: `0.05`.
         mixup_p: (float) Probability of applying random mixup v2. *Default*: `0.0`.
-        flip_p: (float) Probability of mirroring the image and keypoints. When applied, left/right (or top/bottom) symmetric body parts are swapped using the skeleton's symmetries so labels stay correct. *Correctness note*: if the skeleton has no symmetries, flipping is only valid when the animal is truly left/right symmetric in labeling; a warning is emitted otherwise. *Default*: `0.0` (disabled).
-        flip_horizontal: (bool) If `True`, mirror left/right (`x' = (W-1) - x`); if `False`, mirror up/down (`y' = (H-1) - y`). *Default*: `True`.
+        flip_p: (float) Probability of mirroring the image and keypoints left/right (`x' = (W-1) - x`). When applied, left/right symmetric body parts are swapped using the skeleton's symmetries so labels stay correct. *Correctness note*: if the skeleton has no symmetries, flipping is only valid when the animal is truly left/right symmetric in labeling; a warning is emitted otherwise. *Default*: `0.0` (disabled).
     """
 
     rotation_min: float = field(default=-15.0, validator=validators.ge(-180))
@@ -148,7 +147,6 @@ class GeometricConfig:
     mixup_lambda_max: float = field(default=0.05, validator=validators.le(1))
     mixup_p: float = field(default=0.0, validator=validate_proportion)
     flip_p: float = field(default=0.0, validator=validate_proportion)
-    flip_horizontal: bool = True
 
 
 @define

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -125,6 +125,8 @@ class GeometricConfig:
         mixup_lambda_min: (float) Minimum mixup strength value. *Default*: `0.01`.
         mixup_lambda_max: (float) Maximum mixup strength value. *Default*: `0.05`.
         mixup_p: (float) Probability of applying random mixup v2. *Default*: `0.0`.
+        flip_p: (float) Probability of mirroring the image and keypoints. When applied, left/right (or top/bottom) symmetric body parts are swapped using the skeleton's symmetries so labels stay correct. *Correctness note*: if the skeleton has no symmetries, flipping is only valid when the animal is truly left/right symmetric in labeling; a warning is emitted otherwise. *Default*: `0.0` (disabled).
+        flip_horizontal: (bool) If `True`, mirror left/right (`x' = (W-1) - x`); if `False`, mirror up/down (`y' = (H-1) - y`). *Default*: `True`.
     """
 
     rotation_min: float = field(default=-15.0, validator=validators.ge(-180))
@@ -145,6 +147,8 @@ class GeometricConfig:
     mixup_lambda_min: float = field(default=0.01, validator=validators.ge(0))
     mixup_lambda_max: float = field(default=0.05, validator=validators.le(1))
     mixup_p: float = field(default=0.0, validator=validate_proportion)
+    flip_p: float = field(default=0.0, validator=validate_proportion)
+    flip_horizontal: bool = True
 
 
 @define

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -73,7 +73,7 @@ def get_aug_config(
             - Dictionary: Custom configuration matching `IntensityConfig` structure
             - None: No intensity augmentation applied
         geometric_aug: Geometric augmentation configuration. Can be:
-            - String: One of ["rotation", "scale", "translate", "erase_scale", "mixup"]
+            - String: One of ["rotation", "scale", "translate", "erase_scale", "mixup", "flip"]
             - List of strings: Multiple geometric augmentations from the allowed values
             - Dictionary: Custom configuration matching `GeometricConfig` structure
             - None: No geometric augmentation applied
@@ -151,9 +151,11 @@ def get_aug_config(
                 aug_config.geometric.erase_p = 1.0
             elif g == "mixup":
                 aug_config.geometric.mixup_p = 1.0
+            elif g == "flip":
+                aug_config.geometric.flip_p = 1.0
             else:
                 raise ValueError(
-                    f"`{geometric_aug}` is not a valid geometric augmentation option. Please use one of ['rotation', 'scale', 'translate', 'erase_scale', 'mixup']"
+                    f"`{geometric_aug}` is not a valid geometric augmentation option. Please use one of ['rotation', 'scale', 'translate', 'erase_scale', 'mixup', 'flip']"
                 )
 
     elif isinstance(geometric_aug, dict):

--- a/sleap_nn/data/augmentation.py
+++ b/sleap_nn/data/augmentation.py
@@ -3,13 +3,49 @@
 Uses Skia (skia-python) for ~1.5x faster augmentation compared to Kornia.
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 import torch
 
 from sleap_nn.data.skia_augmentation import (
     apply_intensity_augmentation_skia,
     apply_geometric_augmentation_skia,
+    apply_flip_augmentation_skia,
 )
+
+
+def apply_flip_augmentation(
+    image: torch.Tensor,
+    instances: torch.Tensor,
+    symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
+    horizontal: bool = True,
+    flip_p: float = 0.0,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Randomly mirror an image and keypoints, swapping symmetric node pairs.
+
+    When an image is mirrored, left/right (or top/bottom) symmetric body parts
+    physically exchange sides, so their node slots must be swapped to keep semantic
+    labels correct. Ported from SLEAP v1.4's ``RandomFlipper``.
+
+    Args:
+        image: Input image. Shape: (n_samples, C, H, W)
+        instances: Input keypoints. (n_samples, n_instances, n_nodes, 2) or (n_samples, n_nodes, 2)
+        symmetric_inds: Iterable of ``(i, j)`` node-index pairs to swap after mirroring.
+            ``None``/empty means no swap (correct only for truly symmetric labeling,
+            e.g. centroids).
+        horizontal: If ``True``, flip left/right; if ``False``, flip up/down.
+        flip_p: Probability of applying the flip. ``0`` disables (no-op).
+
+    Returns:
+        Returns tuple: (image, instances) with the flip applied (or unchanged inputs
+        when not applied). NaN keypoints are preserved.
+    """
+    return apply_flip_augmentation_skia(
+        image=image,
+        instances=instances,
+        symmetric_inds=symmetric_inds,
+        horizontal=horizontal,
+        flip_p=flip_p,
+    )
 
 
 def apply_intensity_augmentation(
@@ -88,6 +124,9 @@ def apply_geometric_augmentation(
     mixup_lambda_min: Optional[float] = 0.01,
     mixup_lambda_max: Optional[float] = 0.05,
     mixup_p: float = 0.0,
+    flip_p: float = 0.0,
+    flip_horizontal: bool = True,
+    symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Apply geometric augmentation on image and instances.
 
@@ -116,6 +155,12 @@ def apply_geometric_augmentation(
         mixup_lambda_min: Minimum mixup strength value. Default: 0.01.
         mixup_lambda_max: Maximum mixup strength value. Default: 0.05.
         mixup_p: Probability of applying random mixup v2. Default: 0.0.
+        flip_p: Probability of mirroring the sample (with symmetric-node swap).
+            Default: 0.0 (disabled).
+        flip_horizontal: If True, flip left/right; if False, flip up/down. Default: True.
+        symmetric_inds: Node-index pairs to swap after mirroring. Passed separately
+            from the config scalars because it is runtime skeleton data. None/empty
+            means no swap. Default: None.
 
     Returns:
         Returns tuple: (image, instances) with augmentation applied.
@@ -141,4 +186,7 @@ def apply_geometric_augmentation(
         mixup_lambda_min=mixup_lambda_min,
         mixup_lambda_max=mixup_lambda_max,
         mixup_p=mixup_p,
+        flip_p=flip_p,
+        flip_horizontal=flip_horizontal,
+        symmetric_inds=symmetric_inds,
     )

--- a/sleap_nn/data/augmentation.py
+++ b/sleap_nn/data/augmentation.py
@@ -17,14 +17,13 @@ def apply_flip_augmentation(
     image: torch.Tensor,
     instances: torch.Tensor,
     symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
-    horizontal: bool = True,
     flip_p: float = 0.0,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Randomly mirror an image and keypoints, swapping symmetric node pairs.
+    """Randomly mirror an image and keypoints left/right, swapping symmetric pairs.
 
-    When an image is mirrored, left/right (or top/bottom) symmetric body parts
-    physically exchange sides, so their node slots must be swapped to keep semantic
-    labels correct. Ported from SLEAP v1.4's ``RandomFlipper``.
+    When an image is mirrored left/right, left/right symmetric body parts physically
+    exchange sides, so their node slots must be swapped to keep semantic labels
+    correct. Ported from SLEAP v1.4's ``RandomFlipper`` (horizontal flip).
 
     Args:
         image: Input image. Shape: (n_samples, C, H, W)
@@ -32,7 +31,6 @@ def apply_flip_augmentation(
         symmetric_inds: Iterable of ``(i, j)`` node-index pairs to swap after mirroring.
             ``None``/empty means no swap (correct only for truly symmetric labeling,
             e.g. centroids).
-        horizontal: If ``True``, flip left/right; if ``False``, flip up/down.
         flip_p: Probability of applying the flip. ``0`` disables (no-op).
 
     Returns:
@@ -43,7 +41,6 @@ def apply_flip_augmentation(
         image=image,
         instances=instances,
         symmetric_inds=symmetric_inds,
-        horizontal=horizontal,
         flip_p=flip_p,
     )
 
@@ -125,7 +122,6 @@ def apply_geometric_augmentation(
     mixup_lambda_max: Optional[float] = 0.05,
     mixup_p: float = 0.0,
     flip_p: float = 0.0,
-    flip_horizontal: bool = True,
     symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Apply geometric augmentation on image and instances.
@@ -155,9 +151,8 @@ def apply_geometric_augmentation(
         mixup_lambda_min: Minimum mixup strength value. Default: 0.01.
         mixup_lambda_max: Maximum mixup strength value. Default: 0.05.
         mixup_p: Probability of applying random mixup v2. Default: 0.0.
-        flip_p: Probability of mirroring the sample (with symmetric-node swap).
-            Default: 0.0 (disabled).
-        flip_horizontal: If True, flip left/right; if False, flip up/down. Default: True.
+        flip_p: Probability of mirroring the sample left/right (with symmetric-node
+            swap). Default: 0.0 (disabled).
         symmetric_inds: Node-index pairs to swap after mirroring. Passed separately
             from the config scalars because it is runtime skeleton data. None/empty
             means no swap. Default: None.
@@ -187,6 +182,5 @@ def apply_geometric_augmentation(
         mixup_lambda_max=mixup_lambda_max,
         mixup_p=mixup_p,
         flip_p=flip_p,
-        flip_horizontal=flip_horizontal,
         symmetric_inds=symmetric_inds,
     )

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -46,6 +46,7 @@ from sleap_nn.data.augmentation import (
     apply_geometric_augmentation,
     apply_intensity_augmentation,
 )
+from sleap_nn.data.utils import get_symmetric_inds
 from sleap_nn.data.confidence_maps import generate_confmaps, generate_multiconfmaps
 from sleap_nn.data.edge_maps import generate_pafs
 from sleap_nn.data.segmentation_maps import (
@@ -344,6 +345,30 @@ class BaseDataset(Dataset):
         self.num_nodes = (
             len(labels[0].skeletons[0].nodes) if labels and labels[0].skeletons else 0
         )
+
+        # Resolve symmetric node-index pairs once for flip augmentation. After
+        # mirroring an image, left/right symmetric parts must be swapped to keep
+        # labels correct. Read from the raw skeleton (version-proof; see
+        # `get_symmetric_inds`).
+        self.symmetric_inds = (
+            get_symmetric_inds(labels[0].skeletons[0])
+            if labels and labels[0].skeletons
+            else []
+        )
+        # Warn about the silent correctness footgun: flipping a left/right
+        # asymmetric skeleton without symmetries teaches the model wrong labels.
+        flip_p = (
+            self.geometric_aug.get("flip_p", 0.0)
+            if self.geometric_aug is not None
+            else 0.0
+        )
+        if self.apply_aug and flip_p and flip_p > 0 and not self.symmetric_inds:
+            logger.warning(
+                "Flip augmentation is enabled (flip_p > 0) but the skeleton has no "
+                "symmetries. Flipping will not swap any nodes, which is only correct "
+                "if the labeled animal is truly left/right symmetric. Add symmetry "
+                "pairs to the skeleton to fix this."
+            )
 
         self.cache_img = cache_img
         self.cache_img_path = cache_img_path
@@ -701,6 +726,7 @@ class BaseDataset(Dataset):
                 sample["image"], sample["instances"] = apply_geometric_augmentation(
                     sample["image"],
                     sample["instances"],
+                    symmetric_inds=self.symmetric_inds,
                     **self.geometric_aug,
                 )
 
@@ -1331,6 +1357,7 @@ class CenteredInstanceDataset(BaseDataset):
                 ) = apply_geometric_augmentation(
                     sample["instance_image"],
                     sample["instance"],
+                    symmetric_inds=self.symmetric_inds,
                     **self.geometric_aug,
                 )
 
@@ -1593,6 +1620,7 @@ class TopDownCenteredInstanceMultiClassDataset(CenteredInstanceDataset):
                 ) = apply_geometric_augmentation(
                     sample["instance_image"],
                     sample["instance"],
+                    symmetric_inds=self.symmetric_inds,
                     **self.geometric_aug,
                 )
 
@@ -1815,6 +1843,9 @@ class CentroidDataset(BaseDataset):
                 sample["image"], sample["centroids"] = apply_geometric_augmentation(
                     sample["image"],
                     sample["centroids"],
+                    # Centroids are one point per instance (no node axis), so no
+                    # symmetric swap applies — just mirror the coordinates.
+                    symmetric_inds=[],
                     **self.geometric_aug,
                 )
 

--- a/sleap_nn/data/skia_augmentation.py
+++ b/sleap_nn/data/skia_augmentation.py
@@ -21,10 +21,66 @@ Usage:
     image, instances = apply_geometric_augmentation_skia(image, instances, **config)
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 import numpy as np
 import torch
 import skia
+
+
+def apply_flip_augmentation_skia(
+    image: torch.Tensor,
+    instances: torch.Tensor,
+    symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
+    horizontal: bool = True,
+    flip_p: float = 0.0,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Randomly mirror an image and its keypoints, swapping symmetric node pairs.
+
+    When an image is mirrored, left/right (or top/bottom) symmetric body parts
+    physically exchange sides, so their slots in the instance array must be swapped
+    to keep semantic labels correct (e.g. ``left_paw`` must remain ``left_paw``).
+    This mirrors the behavior of SLEAP v1.4's ``RandomFlipper``.
+
+    The flip is applied to the whole sample with probability ``flip_p`` (sampled once
+    per call). Mirroring is exact and lossless (a tensor reverse, no interpolation).
+
+    Args:
+        image: Input tensor of shape ``(1, C, H, W)`` with dtype uint8 or float32.
+        instances: Keypoints tensor of shape ``(1, n_instances, n_nodes, 2)`` or
+            ``(1, n_nodes, 2)``. The node axis is the second-to-last (``-2``).
+        symmetric_inds: Iterable of ``(i, j)`` node-index pairs to swap after
+            mirroring. ``None`` or empty means no swap (correct only if the skeleton
+            is truly left/right symmetric in labeling, e.g. centroids).
+        horizontal: If ``True``, mirror left/right (``x' = (W - 1) - x``). If
+            ``False``, mirror up/down (``y' = (H - 1) - y``).
+        flip_p: Probability of applying the flip. ``0`` disables (no-op).
+
+    Returns:
+        Tuple of ``(image, instances)``. When the flip is not applied, the inputs
+        are returned unchanged. NaN keypoints are preserved (``(W - 1) - NaN`` is
+        ``NaN``).
+    """
+    if flip_p <= 0 or np.random.random() >= flip_p:
+        return image, instances
+
+    instances = instances.clone()
+    if horizontal:
+        width = image.shape[-1]
+        image = torch.flip(image, dims=[-1])
+        instances[..., 0] = (width - 1) - instances[..., 0]
+    else:
+        height = image.shape[-2]
+        image = torch.flip(image, dims=[-2])
+        instances[..., 1] = (height - 1) - instances[..., 1]
+
+    # Swap symmetric node pairs on the node axis (-2) so labels stay correct.
+    if symmetric_inds is not None:
+        for a, b in symmetric_inds:
+            swap = instances[..., a, :].clone()
+            instances[..., a, :] = instances[..., b, :]
+            instances[..., b, :] = swap
+
+    return image, instances
 
 
 def apply_intensity_augmentation_skia(
@@ -135,6 +191,9 @@ def apply_geometric_augmentation_skia(
     mixup_lambda_min: float = 0.01,
     mixup_lambda_max: float = 0.05,
     mixup_p: float = 0.0,
+    flip_p: float = 0.0,
+    flip_horizontal: bool = True,
+    symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Apply geometric augmentations using Skia.
 
@@ -161,10 +220,24 @@ def apply_geometric_augmentation_skia(
         mixup_lambda_min: Min mixup strength (not implemented).
         mixup_lambda_max: Max mixup strength (not implemented).
         mixup_p: Probability of mixup (not implemented).
+        flip_p: Probability of mirroring the sample (with symmetric-node swap).
+        flip_horizontal: If True, flip left/right; if False, flip up/down.
+        symmetric_inds: Node-index pairs to swap after mirroring (see
+            ``apply_flip_augmentation_skia``). None/empty means no swap.
 
     Returns:
         Tuple of (augmented_image, augmented_instances). Image dtype matches input.
     """
+    # Apply flip first (matches SLEAP v1.4 ordering: flip before affine).
+    if flip_p > 0:
+        image, instances = apply_flip_augmentation_skia(
+            image,
+            instances,
+            symmetric_inds=symmetric_inds,
+            horizontal=flip_horizontal,
+            flip_p=flip_p,
+        )
+
     # Convert to numpy for Skia processing
     is_float = image.dtype == torch.float32
     if is_float:

--- a/sleap_nn/data/skia_augmentation.py
+++ b/sleap_nn/data/skia_augmentation.py
@@ -31,15 +31,14 @@ def apply_flip_augmentation_skia(
     image: torch.Tensor,
     instances: torch.Tensor,
     symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
-    horizontal: bool = True,
     flip_p: float = 0.0,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Randomly mirror an image and its keypoints, swapping symmetric node pairs.
+    """Randomly mirror an image and its keypoints left/right, swapping symmetries.
 
-    When an image is mirrored, left/right (or top/bottom) symmetric body parts
-    physically exchange sides, so their slots in the instance array must be swapped
-    to keep semantic labels correct (e.g. ``left_paw`` must remain ``left_paw``).
-    This mirrors the behavior of SLEAP v1.4's ``RandomFlipper``.
+    When an image is mirrored left/right, left/right symmetric body parts physically
+    exchange sides, so their slots in the instance array must be swapped to keep
+    semantic labels correct (e.g. ``left_paw`` must remain ``left_paw``). This
+    mirrors the behavior of SLEAP v1.4's ``RandomFlipper`` (horizontal flip).
 
     The flip is applied to the whole sample with probability ``flip_p`` (sampled once
     per call). Mirroring is exact and lossless (a tensor reverse, no interpolation).
@@ -51,8 +50,6 @@ def apply_flip_augmentation_skia(
         symmetric_inds: Iterable of ``(i, j)`` node-index pairs to swap after
             mirroring. ``None`` or empty means no swap (correct only if the skeleton
             is truly left/right symmetric in labeling, e.g. centroids).
-        horizontal: If ``True``, mirror left/right (``x' = (W - 1) - x``). If
-            ``False``, mirror up/down (``y' = (H - 1) - y``).
         flip_p: Probability of applying the flip. ``0`` disables (no-op).
 
     Returns:
@@ -64,14 +61,9 @@ def apply_flip_augmentation_skia(
         return image, instances
 
     instances = instances.clone()
-    if horizontal:
-        width = image.shape[-1]
-        image = torch.flip(image, dims=[-1])
-        instances[..., 0] = (width - 1) - instances[..., 0]
-    else:
-        height = image.shape[-2]
-        image = torch.flip(image, dims=[-2])
-        instances[..., 1] = (height - 1) - instances[..., 1]
+    width = image.shape[-1]
+    image = torch.flip(image, dims=[-1])
+    instances[..., 0] = (width - 1) - instances[..., 0]
 
     # Swap symmetric node pairs on the node axis (-2) so labels stay correct.
     if symmetric_inds is not None:
@@ -192,7 +184,6 @@ def apply_geometric_augmentation_skia(
     mixup_lambda_max: float = 0.05,
     mixup_p: float = 0.0,
     flip_p: float = 0.0,
-    flip_horizontal: bool = True,
     symmetric_inds: Optional[Sequence[Tuple[int, int]]] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Apply geometric augmentations using Skia.
@@ -220,8 +211,8 @@ def apply_geometric_augmentation_skia(
         mixup_lambda_min: Min mixup strength (not implemented).
         mixup_lambda_max: Max mixup strength (not implemented).
         mixup_p: Probability of mixup (not implemented).
-        flip_p: Probability of mirroring the sample (with symmetric-node swap).
-        flip_horizontal: If True, flip left/right; if False, flip up/down.
+        flip_p: Probability of mirroring the sample left/right (with symmetric-node
+            swap).
         symmetric_inds: Node-index pairs to swap after mirroring (see
             ``apply_flip_augmentation_skia``). None/empty means no swap.
 
@@ -234,7 +225,6 @@ def apply_geometric_augmentation_skia(
             image,
             instances,
             symmetric_inds=symmetric_inds,
-            horizontal=flip_horizontal,
             flip_p=flip_p,
         )
 

--- a/sleap_nn/data/utils.py
+++ b/sleap_nn/data/utils.py
@@ -19,6 +19,39 @@ def ensure_list(x: Any) -> List[Any]:
     return x
 
 
+def get_symmetric_inds(skeleton: "sio.Skeleton") -> List[Tuple[int, int]]:
+    """Resolve symmetric node-index pairs from a skeleton's raw symmetries.
+
+    Used by flip augmentation to swap left/right (or top/bottom) symmetric body
+    parts after mirroring, so semantic labels stay correct.
+
+    This intentionally reads only the stable ``skeleton.symmetries`` field (each
+    ``Symmetry`` iterates to its two ``Node``s) and resolves indices via the node
+    ordering ourselves, rather than relying on newer sleap-io convenience
+    properties (``symmetry_inds``, ``symmetry_names``, ``flipped_node_inds``) that
+    are absent in older sleap-io versions.
+
+    Args:
+        skeleton: A ``sleap_io.Skeleton``. May be ``None`` or lack symmetries.
+
+    Returns:
+        A list of ``(i, j)`` node-index pairs (possibly empty). Within-pair order is
+        irrelevant since the swap is symmetric (``a<->b == b<->a``).
+    """
+    if skeleton is None:
+        return []
+    try:
+        names = [node.name for node in skeleton.nodes]
+        pairs = []
+        for symmetry in getattr(skeleton, "symmetries", []) or []:
+            node_a, node_b = list(symmetry)
+            pairs.append((names.index(node_a.name), names.index(node_b.name)))
+        return pairs
+    except Exception as e:  # pragma: no cover - defensive against API drift
+        logger.warning(f"Could not resolve skeleton symmetries for flip aug: {e}")
+        return []
+
+
 def make_grid_vectors(
     image_height: int, image_width: int, output_stride: int = 1
 ) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/tests/config/test_data_config.py
+++ b/tests/config/test_data_config.py
@@ -117,15 +117,13 @@ def test_geometric_config_initialization():
     assert config.scale_max == 1.2
 
 
-def test_geometric_config_flip_fields():
-    """Flip fields default to disabled and validate flip_p as a proportion."""
+def test_geometric_config_flip_field():
+    """flip_p defaults to disabled and is validated as a proportion."""
     config = GeometricConfig()
     assert config.flip_p == 0.0
-    assert config.flip_horizontal is True
 
-    config = GeometricConfig(flip_p=1.0, flip_horizontal=False)
+    config = GeometricConfig(flip_p=1.0)
     assert config.flip_p == 1.0
-    assert config.flip_horizontal is False
 
     with pytest.raises(ValueError):
         GeometricConfig(flip_p=1.5)
@@ -137,7 +135,6 @@ def test_get_aug_config_flip_preset():
 
     aug = get_aug_config(geometric_aug="flip")
     assert aug.geometric.flip_p == 1.0
-    assert aug.geometric.flip_horizontal is True
 
 
 def test_validate_proportion(caplog):

--- a/tests/config/test_data_config.py
+++ b/tests/config/test_data_config.py
@@ -117,6 +117,29 @@ def test_geometric_config_initialization():
     assert config.scale_max == 1.2
 
 
+def test_geometric_config_flip_fields():
+    """Flip fields default to disabled and validate flip_p as a proportion."""
+    config = GeometricConfig()
+    assert config.flip_p == 0.0
+    assert config.flip_horizontal is True
+
+    config = GeometricConfig(flip_p=1.0, flip_horizontal=False)
+    assert config.flip_p == 1.0
+    assert config.flip_horizontal is False
+
+    with pytest.raises(ValueError):
+        GeometricConfig(flip_p=1.5)
+
+
+def test_get_aug_config_flip_preset():
+    """The 'flip' string preset enables flip_p in the geometric config."""
+    from sleap_nn.config.get_config import get_aug_config
+
+    aug = get_aug_config(geometric_aug="flip")
+    assert aug.geometric.flip_p == 1.0
+    assert aug.geometric.flip_horizontal is True
+
+
 def test_validate_proportion(caplog):
     """Test the validate_proportion helper function."""
     with pytest.raises(ValueError):

--- a/tests/data/test_augmentation.py
+++ b/tests/data/test_augmentation.py
@@ -8,12 +8,14 @@ import sleap_io as sio
 from sleap_nn.data.augmentation import (
     apply_intensity_augmentation,
     apply_geometric_augmentation,
+    apply_flip_augmentation,
 )
 from sleap_nn.data.skia_augmentation import (
     _transform_image_skia,
     crop_and_resize_skia,
     apply_geometric_augmentation_skia,
 )
+from sleap_nn.data.utils import get_symmetric_inds
 from sleap_nn.data.normalization import apply_normalization
 from sleap_nn.data.providers import process_lf
 
@@ -164,3 +166,138 @@ class TestSkiaChannelOrdering:
         assert (
             result[0, 0, 25, 10] > result[0, 2, 25, 10]
         ), "Left half should be red, not blue (channels may be swapped)"
+
+
+class TestFlipAugmentation:
+    """Tests for symmetry-aware horizontal/vertical flip augmentation."""
+
+    def _img_and_instances(self):
+        """Return a small (1,1,2,3) image and (1,1,2,2) two-node instance."""
+        # Pixels are distinct so mirroring is detectable.
+        img = torch.arange(6, dtype=torch.uint8).reshape(1, 1, 2, 3)
+        # node0 at (x=0, y=0); node1 at (x=2, y=1)
+        instances = torch.tensor([[[[0.0, 0.0], [2.0, 1.0]]]])
+        return img, instances
+
+    def test_horizontal_flip_coords_and_image(self):
+        """H-flip mirrors x (x' = W-1-x) and reverses image columns."""
+        img, instances = self._img_and_instances()
+        out_img, out_inst = apply_flip_augmentation(
+            img, instances, symmetric_inds=None, horizontal=True, flip_p=1.0
+        )
+        # W=3 -> columns reversed.
+        assert torch.equal(
+            out_img[0, 0], torch.tensor([[2, 1, 0], [5, 4, 3]], dtype=torch.uint8)
+        )
+        # x mirrored: node0 (0,0)->(2,0); node1 (2,1)->(0,1). No swap.
+        assert torch.allclose(out_inst[0, 0], torch.tensor([[2.0, 0.0], [0.0, 1.0]]))
+        assert out_img.dtype == torch.uint8
+
+    def test_vertical_flip_coords_and_image(self):
+        """V-flip mirrors y (y' = H-1-y) and reverses image rows."""
+        img, instances = self._img_and_instances()
+        out_img, out_inst = apply_flip_augmentation(
+            img, instances, symmetric_inds=None, horizontal=False, flip_p=1.0
+        )
+        # H=2 -> rows reversed.
+        assert torch.equal(
+            out_img[0, 0], torch.tensor([[3, 4, 5], [0, 1, 2]], dtype=torch.uint8)
+        )
+        # y mirrored: node0 (0,0)->(0,1); node1 (2,1)->(2,0).
+        assert torch.allclose(out_inst[0, 0], torch.tensor([[0.0, 1.0], [2.0, 0.0]]))
+
+    def test_symmetry_swap(self):
+        """Symmetric node pairs are swapped after mirroring."""
+        img, instances = self._img_and_instances()
+        _, out_inst = apply_flip_augmentation(
+            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+        )
+        # node1 mirrored (0,1) lands in slot 0; node0 mirrored (2,0) in slot 1.
+        assert torch.allclose(out_inst[0, 0], torch.tensor([[0.0, 1.0], [2.0, 0.0]]))
+
+    def test_flip_p_zero_is_noop(self):
+        """flip_p=0 returns inputs unchanged."""
+        img, instances = self._img_and_instances()
+        out_img, out_inst = apply_flip_augmentation(
+            img, instances, symmetric_inds=[(0, 1)], flip_p=0.0
+        )
+        assert torch.equal(out_img, img)
+        assert torch.equal(out_inst, instances)
+
+    def test_flip_p_one_always_flips(self):
+        """flip_p=1 always applies the flip (image actually changes)."""
+        img, instances = self._img_and_instances()
+        for _ in range(5):
+            out_img, _ = apply_flip_augmentation(img, instances, flip_p=1.0)
+            assert not torch.equal(out_img, img)
+
+    def test_nan_keypoints_preserved(self):
+        """NaN keypoints stay NaN through mirroring and swap."""
+        img, _ = self._img_and_instances()
+        instances = torch.tensor([[[[float("nan"), float("nan")], [2.0, 1.0]]]])
+        _, out_inst = apply_flip_augmentation(
+            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+        )
+        # NaN node swapped into slot 1, still NaN.
+        assert torch.isnan(out_inst[0, 0, 1, 0])
+        assert torch.isnan(out_inst[0, 0, 1, 1])
+
+    def test_topdown_shape_no_node_swap(self):
+        """Works on top-down crop shape (1, n_nodes, 2)."""
+        img = torch.arange(6, dtype=torch.uint8).reshape(1, 1, 2, 3)
+        instances = torch.tensor([[[0.0, 0.0], [2.0, 1.0]]])  # (1, 2, 2)
+        _, out_inst = apply_flip_augmentation(
+            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+        )
+        assert out_inst.shape == (1, 2, 2)
+        assert torch.allclose(out_inst[0], torch.tensor([[0.0, 1.0], [2.0, 0.0]]))
+
+    def test_double_flip_is_identity(self):
+        """Flipping twice (with the same swap) restores the original."""
+        img, instances = self._img_and_instances()
+        once_img, once_inst = apply_flip_augmentation(
+            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+        )
+        twice_img, twice_inst = apply_flip_augmentation(
+            once_img, once_inst, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+        )
+        assert torch.equal(twice_img, img)
+        assert torch.allclose(twice_inst, instances)
+
+    def test_flip_via_geometric_wrapper(self):
+        """flip_p threads through apply_geometric_augmentation."""
+        img, instances = self._img_and_instances()
+        np.random.seed(0)
+        out_img, out_inst = apply_geometric_augmentation(
+            img,
+            instances,
+            rotation_p=0.0,
+            scale_p=0.0,
+            translate_p=0.0,
+            flip_p=1.0,
+            flip_horizontal=True,
+            symmetric_inds=[(0, 1)],
+        )
+        assert torch.equal(
+            out_img[0, 0], torch.tensor([[2, 1, 0], [5, 4, 3]], dtype=torch.uint8)
+        )
+        assert torch.allclose(out_inst[0, 0], torch.tensor([[0.0, 1.0], [2.0, 0.0]]))
+
+
+class TestGetSymmetricInds:
+    """Tests for resolving symmetric node-index pairs from a skeleton."""
+
+    def test_resolves_pairs_from_raw_symmetries(self):
+        skel = sio.Skeleton(["nose", "left_eye", "right_eye", "left_ear", "right_ear"])
+        skel.add_symmetry("left_eye", "right_eye")
+        skel.add_symmetry("left_ear", "right_ear")
+        pairs = get_symmetric_inds(skel)
+        # Within-pair order is set-derived; normalize before comparing.
+        assert sorted(tuple(sorted(p)) for p in pairs) == [(1, 2), (3, 4)]
+
+    def test_no_symmetries_returns_empty(self):
+        skel = sio.Skeleton(["a", "b", "c"])
+        assert get_symmetric_inds(skel) == []
+
+    def test_none_skeleton_returns_empty(self):
+        assert get_symmetric_inds(None) == []

--- a/tests/data/test_augmentation.py
+++ b/tests/data/test_augmentation.py
@@ -169,7 +169,7 @@ class TestSkiaChannelOrdering:
 
 
 class TestFlipAugmentation:
-    """Tests for symmetry-aware horizontal/vertical flip augmentation."""
+    """Tests for symmetry-aware horizontal (left/right) flip augmentation."""
 
     def _img_and_instances(self):
         """Return a small (1,1,2,3) image and (1,1,2,2) two-node instance."""
@@ -183,7 +183,7 @@ class TestFlipAugmentation:
         """H-flip mirrors x (x' = W-1-x) and reverses image columns."""
         img, instances = self._img_and_instances()
         out_img, out_inst = apply_flip_augmentation(
-            img, instances, symmetric_inds=None, horizontal=True, flip_p=1.0
+            img, instances, symmetric_inds=None, flip_p=1.0
         )
         # W=3 -> columns reversed.
         assert torch.equal(
@@ -193,24 +193,11 @@ class TestFlipAugmentation:
         assert torch.allclose(out_inst[0, 0], torch.tensor([[2.0, 0.0], [0.0, 1.0]]))
         assert out_img.dtype == torch.uint8
 
-    def test_vertical_flip_coords_and_image(self):
-        """V-flip mirrors y (y' = H-1-y) and reverses image rows."""
-        img, instances = self._img_and_instances()
-        out_img, out_inst = apply_flip_augmentation(
-            img, instances, symmetric_inds=None, horizontal=False, flip_p=1.0
-        )
-        # H=2 -> rows reversed.
-        assert torch.equal(
-            out_img[0, 0], torch.tensor([[3, 4, 5], [0, 1, 2]], dtype=torch.uint8)
-        )
-        # y mirrored: node0 (0,0)->(0,1); node1 (2,1)->(2,0).
-        assert torch.allclose(out_inst[0, 0], torch.tensor([[0.0, 1.0], [2.0, 0.0]]))
-
     def test_symmetry_swap(self):
         """Symmetric node pairs are swapped after mirroring."""
         img, instances = self._img_and_instances()
         _, out_inst = apply_flip_augmentation(
-            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+            img, instances, symmetric_inds=[(0, 1)], flip_p=1.0
         )
         # node1 mirrored (0,1) lands in slot 0; node0 mirrored (2,0) in slot 1.
         assert torch.allclose(out_inst[0, 0], torch.tensor([[0.0, 1.0], [2.0, 0.0]]))
@@ -236,7 +223,7 @@ class TestFlipAugmentation:
         img, _ = self._img_and_instances()
         instances = torch.tensor([[[[float("nan"), float("nan")], [2.0, 1.0]]]])
         _, out_inst = apply_flip_augmentation(
-            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+            img, instances, symmetric_inds=[(0, 1)], flip_p=1.0
         )
         # NaN node swapped into slot 1, still NaN.
         assert torch.isnan(out_inst[0, 0, 1, 0])
@@ -247,7 +234,7 @@ class TestFlipAugmentation:
         img = torch.arange(6, dtype=torch.uint8).reshape(1, 1, 2, 3)
         instances = torch.tensor([[[0.0, 0.0], [2.0, 1.0]]])  # (1, 2, 2)
         _, out_inst = apply_flip_augmentation(
-            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+            img, instances, symmetric_inds=[(0, 1)], flip_p=1.0
         )
         assert out_inst.shape == (1, 2, 2)
         assert torch.allclose(out_inst[0], torch.tensor([[0.0, 1.0], [2.0, 0.0]]))
@@ -256,10 +243,10 @@ class TestFlipAugmentation:
         """Flipping twice (with the same swap) restores the original."""
         img, instances = self._img_and_instances()
         once_img, once_inst = apply_flip_augmentation(
-            img, instances, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+            img, instances, symmetric_inds=[(0, 1)], flip_p=1.0
         )
         twice_img, twice_inst = apply_flip_augmentation(
-            once_img, once_inst, symmetric_inds=[(0, 1)], horizontal=True, flip_p=1.0
+            once_img, once_inst, symmetric_inds=[(0, 1)], flip_p=1.0
         )
         assert torch.equal(twice_img, img)
         assert torch.allclose(twice_inst, instances)
@@ -275,7 +262,6 @@ class TestFlipAugmentation:
             scale_p=0.0,
             translate_p=0.0,
             flip_p=1.0,
-            flip_horizontal=True,
             symmetric_inds=[(0, 1)],
         )
         assert torch.equal(

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -1359,3 +1359,60 @@ def test_uint8_pipeline_centered_instance(minimal_instance):
     assert (
         sample["instance_image"].dtype == torch.uint8
     ), f"Expected uint8 image for GPU normalization, got {sample["instance_image"].dtype}"
+
+
+def test_flip_augmentation_resolves_symmetries(minimal_instance):
+    """BottomUpDataset resolves symmetric_inds and applies flip end-to-end."""
+    labels = sio.load_slp(minimal_instance)
+    # Add a symmetry between the two nodes of the minimal skeleton.
+    skel = labels.skeletons[0]
+    node_names = [n.name for n in skel.nodes]
+    skel.add_symmetry(node_names[0], node_names[1])
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+
+    dataset = BottomUpDataset(
+        max_stride=32,
+        scale=1.0,
+        confmap_head_config=confmap_head,
+        pafs_head_config=pafs_head,
+        labels=[labels],
+        geometric_aug=DictConfig(
+            {"flip_p": 1.0, "flip_horizontal": True, "affine_p": 0.0}
+        ),
+        apply_aug=True,
+    )
+
+    # Symmetric pair resolved from the raw skeleton.
+    assert sorted(tuple(sorted(p)) for p in dataset.symmetric_inds) == [(0, 1)]
+
+    # Sample is produced without error and image is the expected shape.
+    sample = next(iter(dataset))
+    assert sample["image"].shape == (1, 1, 384, 384)
+
+
+def test_flip_augmentation_warns_without_symmetries(minimal_instance):
+    """A warning is emitted when flip is enabled but skeleton has no symmetries."""
+    from loguru import logger
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+
+    messages = []
+    sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        dataset = BottomUpDataset(
+            max_stride=32,
+            scale=1.0,
+            confmap_head_config=confmap_head,
+            pafs_head_config=pafs_head,
+            labels=[sio.load_slp(minimal_instance)],
+            geometric_aug=DictConfig({"flip_p": 1.0, "affine_p": 0.0}),
+            apply_aug=True,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert dataset.symmetric_inds == []
+    assert any("no symmetries" in m for m in messages)

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -1378,9 +1378,7 @@ def test_flip_augmentation_resolves_symmetries(minimal_instance):
         confmap_head_config=confmap_head,
         pafs_head_config=pafs_head,
         labels=[labels],
-        geometric_aug=DictConfig(
-            {"flip_p": 1.0, "flip_horizontal": True, "affine_p": 0.0}
-        ),
+        geometric_aug=DictConfig({"flip_p": 1.0, "affine_p": 0.0}),
         apply_aug=True,
     )
 


### PR DESCRIPTION
## Summary
- Adds **horizontal (left/right) flip augmentation** to the training data pipeline, ported from SLEAP v1.4.
- When an image is mirrored left/right, **symmetric body parts are swapped** in the instance array so semantic labels stay correct (e.g. `left_paw` stays `left_paw`).
- Symmetry pairs are read from the skeleton's raw `.symmetries` field — **version-proof**, intentionally avoiding newer sleap-io convenience APIs (`symmetry_inds`, etc.) that are absent in older versions.
- Scope: **horizontal only** (no vertical/up-down flip).

## Changes Made
- **`sleap_nn/data/skia_augmentation.py`** — standalone `apply_flip_augmentation_skia(image, instances, symmetric_inds, flip_p)`: mirrors the image left/right (exact, lossless tensor reverse), remaps coords (`x' = (W-1)-x`, NaN-safe), and swaps symmetric node pairs on the node axis. Invoked at the top of `apply_geometric_augmentation_skia` (before the affine matrix, matching v1.4 ordering).
- **`sleap_nn/data/augmentation.py`** — `apply_flip_augmentation` wrapper + `flip_p` / `symmetric_inds` params on `apply_geometric_augmentation`.
- **`sleap_nn/config/data_config.py`** — `flip_p` (proportion-validated) on `GeometricConfig` (kept scalar-only so it stays `**dict`-unpackable).
- **`sleap_nn/config/get_config.py`** — `"flip"` string preset.
- **`sleap_nn/data/utils.py`** — `get_symmetric_inds(skeleton)` resolves name pairs → index pairs from the raw skeleton (defensive, returns `[]` on absence/error).
- **`sleap_nn/data/custom_datasets.py`** — `BaseDataset.__init__` resolves `self.symmetric_inds` once and warns if flip is enabled but the skeleton has no symmetries; threads `symmetric_inds` into the geometric call sites (`[]` for centroids, which have no node axis). Segmentation already disables the whole geometric path, so flip is correctly skipped there.
- **`docs/configuration/data.md`** — documents `flip_p` + the symmetry requirement.

## Example Usage
```yaml
augmentation_config:
  geometric:
    flip_p: 0.5  # 50% chance to mirror each sample left/right (uses skeleton symmetries)
```
```python
from sleap_nn.data.augmentation import apply_flip_augmentation
img, pts = apply_flip_augmentation(img, pts, symmetric_inds=[(1, 2), (3, 4)], flip_p=1.0)
```

## API Changes
- New public function `apply_flip_augmentation` (and `_skia` impl).
- `apply_geometric_augmentation[_skia]` gain `flip_p`, `symmetric_inds` (both default to a no-op).
- `GeometricConfig` gains `flip_p=0.0`. New helper `get_symmetric_inds`. No breaking changes — flip is disabled by default.

## Design Decisions
- **Horizontal only** per maintainer decision; no `flip_horizontal` field.
- **`flip_p` folded into `GeometricConfig`; `symmetric_inds` passed separately.** Avoids threading a new constructor arg through 8 dataset classes + 16 instantiation sites, while keeping the config scalar-only and the runtime skeleton data out of the `**dict`. The flip itself is a standalone, independently-tested function.
- **Read raw `.symmetries`, resolve indices ourselves** — works on older sleap-io.
- **Warn (don't error) when flip is on but no symmetries exist** — flipping is still valid for truly L/R-symmetric labeling; silent mislabeling is the real footgun.

## Testing
- Unit: coord formula, symmetry swap, NaN preservation, `flip_p=0` no-op / `flip_p=1` always flips, top-down crop shape, double-flip identity, threading via the geometric wrapper.
- Helper: `get_symmetric_inds` resolves correct pairs / empty / `None`.
- Config: `flip_p` default + validation, `"flip"` preset.
- End-to-end: `BottomUpDataset` resolves `symmetric_inds` and produces a sample; warning fires without symmetries.
- `tests/data/` + `tests/config/` (176) all green; `black` + `ruff` clean.

## Visual verification
Before/after renders (H-flip **with** swap, and H-flip **without** swap as a contrast) were generated on a synthetic critter with real `left_*`/`right_*` nodes + declared symmetries and reviewed locally. The script lives in the investigation scratch folder (gitignored) and is not part of this PR.

## Future Considerations
- Optional manual `symmetric_nodes` config override for flipping without editing the `.slp`.
- Bottom-up PAF edge direction after flip is computed from the (already swapped) instances downstream, so it should follow automatically — worth a dedicated check if PAF training shows asymmetry.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)