### PR TITLE
feat(seg): mask-based reconciliation + re-tracking for SAM inference

### DIFF
--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -1,10 +1,11 @@
-"""SAM-powered prompted instance segmentation for INFERENCE (PR-A).
+"""SAM-powered prompted instance segmentation for INFERENCE.
 
 The pivot (PLAN / README): SAM is used to *predict* per-instance masks for an
 existing pose/centroid ``.slp`` so a human can review/correct them in the GUI,
 then train — **not** to auto-generate training GT. This package is the SAM1 +
-SAM3 prompted producers + their backend interface; reconciliation and the
-mask-native tracker land in later PRs behind the same surfaces.
+SAM3 prompted producers + their backend interface, plus the torch-less
+reconciliation / re-tracking path (:func:`retrack`); the SAM3 mask-native video
+tracker lands in a later PR behind the same surfaces.
 
 Public surface
 --------------
@@ -17,6 +18,10 @@ Public surface
   ``sio.PredictedSegmentationMask`` (raw score + ``instance=``/``track=``
   populated, PLAN L8) onto each frame, and optionally save an embedded ``.slp``
   + a review overlay PNG.
+* :func:`retrack` (+ :mod:`~sleap_nn.inference.sam.reconciliation` primitives) —
+  the torch-less "refine existing tracks" path: correct an existing
+  pose/centroid tracker's identities from identity-consistent per-frame masks.
+  No SAM / torch / transformers dependency (numpy + scipy only).
 
 Everything heavy (``segment-anything``) is imported lazily inside the backend,
 so importing this package on a default install is cheap and dependency-free.
@@ -30,8 +35,25 @@ from typing import Optional, Sequence
 from sleap_nn.inference.sam.backends import MaskBackend, Sam3Backend, SamBackend
 from sleap_nn.inference.sam.mask_layer import SamSegmentationLayer
 from sleap_nn.inference.sam.prompts import PROMPT_MODES, SamPrompt
+from sleap_nn.inference.sam.reconciliation import (
+    IDReconciler,
+    MaskAssignment,
+    MaskReconciler,
+    MatchContext,
+    MatchPredicate,
+    SwapEvent,
+    TrackAssignment,
+    TrackNameResolver,
+    default_match_predicate,
+    require_centroid_proximity,
+    require_min_fraction_inside,
+    require_min_keypoints_inside,
+    require_reasonable_mask_area,
+)
+from sleap_nn.inference.sam.retrack import RetrackResult, retrack
 
 __all__ = [
+    # SAM mask producers + backend interface.
     "MaskBackend",
     "SamBackend",
     "Sam3Backend",
@@ -41,6 +63,22 @@ __all__ = [
     "MASK_BACKENDS",
     "get_mask_backend",
     "run_sam_segmentation",
+    # Torch-less reconciliation / re-tracking.
+    "IDReconciler",
+    "MaskAssignment",
+    "MaskReconciler",
+    "MatchContext",
+    "MatchPredicate",
+    "SwapEvent",
+    "TrackAssignment",
+    "TrackNameResolver",
+    "default_match_predicate",
+    "require_centroid_proximity",
+    "require_min_fraction_inside",
+    "require_min_keypoints_inside",
+    "require_reasonable_mask_area",
+    "RetrackResult",
+    "retrack",
 ]
 
 #: Registered explicit ``mask_backend`` names (PLAN L2 — no default).

--- a/sleap_nn/inference/sam/reconciliation.py
+++ b/sleap_nn/inference/sam/reconciliation.py
@@ -1,0 +1,975 @@
+"""ID reconciliation for matching SAM3 masks to poses or input masks.
+
+Lifted **verbatim** from ``talmolab/sam-track`` (BSD-3-Clause) at commit
+``7b2531d92b5035f5f83016b12350f7c394b92522``:
+
+    https://github.com/talmolab/sam-track/blob/7b2531d92b5035f5f83016b12350f7c394b92522/src/sam_track/reconciliation.py
+
+Only this attribution header was added; the implementation below is unchanged.
+
+BSD 3-Clause License
+
+Copyright (c) 2025, Talmo Lab
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----
+
+This module provides tools for:
+- Matching SAM3 segmentation masks to pose instances using Hungarian algorithm
+- Matching SAM3 segmentation masks to input masks using IoU
+- Detecting identity swaps across frames
+- Building frame-to-ID mappings for output reconciliation
+
+The key insight from experimentation is that SAM3 mid-propagation re-prompting
+works for adding NEW objects, but NOT for correcting existing tracks. Therefore,
+identity correction must be done via post-processing with mask-to-pose matching
+or mask-to-mask matching (IoU-based).
+"""
+
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+if TYPE_CHECKING:
+    import sleap_io as sio
+
+
+@dataclass
+class MatchContext:
+    """Context for match predicate evaluation.
+
+    Attributes:
+        frame_idx: Frame index where the match was made.
+        sam3_obj_id: SAM3 object ID of the matched mask.
+        cost: Raw cost from the cost matrix (negative keypoints inside).
+        keypoints_inside: Number of visible keypoints inside the mask.
+        keypoints_visible: Total number of visible keypoints in the pose.
+        mask_area: Area of the mask in pixels.
+        mask_centroid: Centroid of the mask as (x, y).
+    """
+
+    frame_idx: int
+    sam3_obj_id: int
+    cost: float
+    keypoints_inside: int
+    keypoints_visible: int
+    mask_area: int
+    mask_centroid: tuple[float, float]
+
+
+# Type alias for match predicates
+MatchPredicate = Callable[["sio.Instance", np.ndarray, MatchContext], bool]
+
+
+@dataclass
+class TrackAssignment:
+    """A single track assignment at a frame.
+
+    Attributes:
+        frame_idx: Frame index where assignment was made.
+        pose_track_name: Name of the pose's track (None if untracked).
+        pose_idx: Index of the pose in the frame's instance list.
+        sam3_obj_id: SAM3 object ID that was matched.
+        confidence: Match quality score (0-1, higher is better).
+        sam3_score: SAM3 mask detection confidence score.
+    """
+
+    frame_idx: int
+    pose_track_name: str | None
+    pose_idx: int
+    sam3_obj_id: int
+    confidence: float
+    sam3_score: float = 1.0
+
+
+@dataclass
+class SwapEvent:
+    """Detected identity swap.
+
+    Attributes:
+        frame_idx: Frame where the swap was detected.
+        track_name: Name of the track that swapped.
+        old_sam3_id: Previous SAM3 object ID.
+        new_sam3_id: New SAM3 object ID after swap.
+    """
+
+    frame_idx: int
+    track_name: str
+    old_sam3_id: int
+    new_sam3_id: int
+
+
+@dataclass
+class MaskAssignment:
+    """A single mask-to-mask assignment at a frame.
+
+    Used for matching input (anchor) masks to SAM3 output masks.
+
+    Attributes:
+        frame_idx: Frame index where assignment was made.
+        input_track_id: Track ID from the input/anchor mask.
+        input_track_name: Track name from the input/anchor mask.
+        sam3_obj_id: SAM3 object ID that was matched.
+        iou: Intersection over Union score for the match.
+        sam3_score: SAM3 mask detection confidence score.
+    """
+
+    frame_idx: int
+    input_track_id: int
+    input_track_name: str | None
+    sam3_obj_id: int
+    iou: float
+    sam3_score: float = 1.0
+
+
+def default_match_predicate(
+    pose: "sio.Instance", mask: np.ndarray, ctx: MatchContext
+) -> bool:
+    """Default match predicate: require at least 1 keypoint inside mask."""
+    return ctx.keypoints_inside >= 1
+
+
+@dataclass
+class IDReconciler:
+    """Matches SAM3 masks to poses and reconciles track IDs.
+
+    This class implements Hungarian algorithm matching between pose instances
+    and SAM3 segmentation masks, using keypoints-inside-mask as the cost metric.
+
+    Attributes:
+        skeleton: The SLEAP skeleton for node name lookups.
+        exclude_nodes: Set of node names to exclude from matching.
+        match_predicates: List of predicates that must all pass for a valid match.
+
+    Example:
+        >>> reconciler = IDReconciler(
+        ...     skeleton=handler.skeleton,
+        ...     exclude_nodes={"tail0", "tail1"},
+        ... )
+        >>> for frame_idx in gt_frame_indices:
+        ...     assignments = reconciler.match_frame(
+        ...         frame_idx=frame_idx,
+        ...         poses=lf.instances,
+        ...         masks=result.masks,
+        ...         object_ids=result.object_ids,
+        ...     )
+        >>> swaps = reconciler.detect_swaps()
+        >>> id_map = reconciler.build_id_map()
+    """
+
+    skeleton: "sio.Skeleton"
+    exclude_nodes: set[str] = field(default_factory=set)
+    match_predicates: list[MatchPredicate] = field(default_factory=list)
+    ignore_gt_tracks: bool = False
+    _assignments: list[TrackAssignment] = field(default_factory=list, repr=False)
+
+    def __post_init__(self):
+        """Add default predicate if none provided."""
+        if not self.match_predicates:
+            self.match_predicates = [default_match_predicate]
+
+    def compute_cost_matrix(
+        self,
+        poses: list["sio.Instance"],
+        masks: np.ndarray,
+    ) -> np.ndarray:
+        """Compute cost matrix for Hungarian matching.
+
+        The cost is the negative number of visible keypoints inside each mask.
+        Lower cost = better match (more keypoints inside).
+
+        Args:
+            poses: List of pose instances to match.
+            masks: Array of masks with shape (N, H, W).
+
+        Returns:
+            Cost matrix with shape (n_poses, n_masks).
+        """
+        n_poses = len(poses)
+        n_masks = len(masks)
+
+        if n_poses == 0 or n_masks == 0:
+            return np.zeros((n_poses, n_masks))
+
+        cost = np.zeros((n_poses, n_masks))
+
+        # Get node names for filtering
+        node_names = [n.name for n in self.skeleton.nodes]
+
+        for i, pose in enumerate(poses):
+            coords = pose.numpy()
+            visible_mask = ~np.isnan(coords[:, 0])
+
+            # Apply node exclusion filter
+            if self.exclude_nodes:
+                for j, name in enumerate(node_names):
+                    if name in self.exclude_nodes:
+                        visible_mask[j] = False
+
+            visible_coords = coords[visible_mask].astype(int)
+
+            for j, mask in enumerate(masks):
+                inside_count = 0
+                for x, y in visible_coords:
+                    if 0 <= y < mask.shape[0] and 0 <= x < mask.shape[1]:
+                        if mask[y, x]:
+                            inside_count += 1
+
+                # Negative because Hungarian minimizes cost
+                cost[i, j] = -inside_count
+
+        return cost
+
+    def match_frame(
+        self,
+        frame_idx: int,
+        poses: list["sio.Instance"],
+        masks: np.ndarray,
+        object_ids: np.ndarray,
+        scores: np.ndarray | None = None,
+    ) -> list[TrackAssignment]:
+        """Match poses to masks for a single frame.
+
+        Uses Hungarian algorithm for optimal assignment, then filters
+        matches through predicates.
+
+        Args:
+            frame_idx: Frame index for this match.
+            poses: List of pose instances to match.
+            masks: Array of masks with shape (N, H, W) or (N, 1, H, W).
+            object_ids: Array of SAM3 object IDs corresponding to masks.
+            scores: Optional SAM3 mask detection confidence scores, shape (N,).
+
+        Returns:
+            List of valid TrackAssignment objects.
+        """
+        if len(poses) == 0 or len(masks) == 0:
+            return []
+
+        # Default scores to 1.0 if not provided
+        if scores is None:
+            scores = np.ones(len(object_ids))
+
+        # Handle (N, 1, H, W) mask format from SAM3
+        if masks.ndim == 4 and masks.shape[1] == 1:
+            masks = masks.squeeze(axis=1)
+
+        # Compute cost matrix and solve assignment
+        cost = self.compute_cost_matrix(poses, masks)
+        row_ind, col_ind = linear_sum_assignment(cost)
+
+        # Get node names for visibility calculation
+        node_names = [n.name for n in self.skeleton.nodes]
+
+        assignments = []
+        for pose_idx, mask_idx in zip(row_ind, col_ind):
+            pose = poses[pose_idx]
+            mask = masks[mask_idx]
+
+            # Calculate visibility (excluding filtered nodes)
+            coords = pose.numpy()
+            visible_mask = ~np.isnan(coords[:, 0])
+            if self.exclude_nodes:
+                for j, name in enumerate(node_names):
+                    if name in self.exclude_nodes:
+                        visible_mask[j] = False
+            visible_count = int(visible_mask.sum())
+
+            # Calculate mask statistics
+            ys, xs = np.where(mask)
+            if len(xs) > 0:
+                centroid = (float(xs.mean()), float(ys.mean()))
+                mask_area = int(mask.sum())
+            else:
+                centroid = (0.0, 0.0)
+                mask_area = 0
+
+            # Build context for predicate evaluation
+            keypoints_inside = int(-cost[pose_idx, mask_idx])
+            ctx = MatchContext(
+                frame_idx=frame_idx,
+                sam3_obj_id=int(object_ids[mask_idx]),
+                cost=float(cost[pose_idx, mask_idx]),
+                keypoints_inside=keypoints_inside,
+                keypoints_visible=visible_count,
+                mask_area=mask_area,
+                mask_centroid=centroid,
+            )
+
+            # Apply match predicates
+            if all(pred(pose, mask, ctx) for pred in self.match_predicates):
+                # Use None for track_name when ignoring GT tracks
+                if self.ignore_gt_tracks:
+                    track_name = None
+                else:
+                    track_name = pose.track.name if pose.track else None
+                confidence = (
+                    keypoints_inside / visible_count if visible_count > 0 else 0.0
+                )
+                assignment = TrackAssignment(
+                    frame_idx=frame_idx,
+                    pose_track_name=track_name,
+                    pose_idx=pose_idx,
+                    sam3_obj_id=ctx.sam3_obj_id,
+                    confidence=confidence,
+                    sam3_score=float(scores[mask_idx]),
+                )
+                assignments.append(assignment)
+
+        self._assignments.extend(assignments)
+        return assignments
+
+    def detect_swaps(self) -> list[SwapEvent]:
+        """Detect identity swaps from accumulated assignments.
+
+        A swap occurs when a track name is matched to different SAM3 object IDs
+        across frames.
+
+        Returns:
+            List of SwapEvent objects describing detected swaps.
+        """
+        swaps = []
+        by_track: dict[str, list[TrackAssignment]] = defaultdict(list)
+
+        for a in self._assignments:
+            if a.pose_track_name:
+                by_track[a.pose_track_name].append(a)
+
+        for track_name, track_assignments in by_track.items():
+            track_assignments.sort(key=lambda a: a.frame_idx)
+
+            for i in range(1, len(track_assignments)):
+                prev = track_assignments[i - 1]
+                curr = track_assignments[i]
+
+                if prev.sam3_obj_id != curr.sam3_obj_id:
+                    swaps.append(
+                        SwapEvent(
+                            frame_idx=curr.frame_idx,
+                            track_name=track_name,
+                            old_sam3_id=prev.sam3_obj_id,
+                            new_sam3_id=curr.sam3_obj_id,
+                        )
+                    )
+
+        return swaps
+
+    def build_id_map(self) -> dict[int, dict[int, str]]:
+        """Build frame -> {sam3_id -> track_name} mapping.
+
+        This can be used to remap SAM3 object IDs to consistent track names
+        in output files.
+
+        Returns:
+            Dictionary mapping frame_idx to {sam3_obj_id: track_name}.
+        """
+        by_frame: dict[int, dict[int, str]] = defaultdict(dict)
+        for a in self._assignments:
+            if a.pose_track_name:
+                by_frame[a.frame_idx][a.sam3_obj_id] = a.pose_track_name
+        return dict(by_frame)
+
+    def get_assignments(self) -> list[TrackAssignment]:
+        """Get all accumulated assignments.
+
+        Returns:
+            List of all TrackAssignment objects from match_frame() calls.
+        """
+        return list(self._assignments)
+
+    def clear(self) -> None:
+        """Clear accumulated assignments."""
+        self._assignments.clear()
+
+
+@dataclass
+class MaskReconciler:
+    """Matches SAM3 masks to input masks using IoU and reconciles track IDs.
+
+    This class implements Hungarian algorithm matching between input/anchor masks
+    and SAM3 segmentation masks, using IoU (Intersection over Union) as the cost
+    metric. This enables post-hoc identity correction using sparse ground truth
+    mask annotations.
+
+    Unlike IDReconciler (which uses keypoints-in-mask for pose matching), this
+    reconciler works purely with mask overlap, making it suitable for workflows
+    where users have corrected masks at specific frames that should be used as
+    identity anchors.
+
+    Attributes:
+        min_iou: Minimum IoU threshold for a valid match. Matches below this
+            threshold are rejected.
+        track_names: Optional mapping of input track_id -> name for naming.
+
+    Example:
+        >>> reconciler = MaskReconciler(min_iou=0.3)
+        >>> for frame_idx in anchor_frames:
+        ...     assignments = reconciler.match_frame(
+        ...         frame_idx=frame_idx,
+        ...         input_masks=reader.get_masks(frame_idx),
+        ...         input_track_ids=reader.get_track_ids(frame_idx),
+        ...         sam3_masks=result.masks,
+        ...         sam3_obj_ids=result.object_ids,
+        ...     )
+        >>> swaps = reconciler.detect_swaps()
+        >>> id_map = reconciler.build_id_map()
+    """
+
+    min_iou: float = 0.3
+    track_names: dict[int, str] = field(default_factory=dict)
+    _assignments: list[MaskAssignment] = field(default_factory=list, repr=False)
+
+    @staticmethod
+    def compute_iou(mask1: np.ndarray, mask2: np.ndarray) -> float:
+        """Compute Intersection over Union between two binary masks.
+
+        Args:
+            mask1: First binary mask as (H, W) array.
+            mask2: Second binary mask as (H, W) array.
+
+        Returns:
+            IoU score between 0 and 1.
+        """
+        # Convert to boolean for logical operations
+        m1 = mask1.astype(bool)
+        m2 = mask2.astype(bool)
+
+        intersection = np.logical_and(m1, m2).sum()
+        union = np.logical_or(m1, m2).sum()
+
+        if union == 0:
+            return 0.0
+        return float(intersection / union)
+
+    def compute_cost_matrix(
+        self,
+        input_masks: np.ndarray,
+        sam3_masks: np.ndarray,
+    ) -> np.ndarray:
+        """Compute cost matrix for Hungarian matching.
+
+        The cost is the negative IoU (because Hungarian minimizes cost).
+        Lower cost = better match (higher IoU).
+
+        Args:
+            input_masks: Input/anchor masks with shape (N, H, W).
+            sam3_masks: SAM3 output masks with shape (M, H, W) or (M, 1, H, W).
+
+        Returns:
+            Cost matrix with shape (n_input, n_sam3).
+        """
+        # Handle (M, 1, H, W) mask format from SAM3
+        if sam3_masks.ndim == 4 and sam3_masks.shape[1] == 1:
+            sam3_masks = sam3_masks.squeeze(axis=1)
+
+        n_input = len(input_masks)
+        n_sam3 = len(sam3_masks)
+
+        if n_input == 0 or n_sam3 == 0:
+            return np.zeros((n_input, n_sam3))
+
+        cost = np.zeros((n_input, n_sam3))
+
+        for i, input_mask in enumerate(input_masks):
+            for j, sam3_mask in enumerate(sam3_masks):
+                iou = self.compute_iou(input_mask, sam3_mask)
+                # Negative because Hungarian minimizes cost
+                cost[i, j] = -iou
+
+        return cost
+
+    def match_frame(
+        self,
+        frame_idx: int,
+        input_masks: np.ndarray,
+        input_track_ids: np.ndarray,
+        sam3_masks: np.ndarray,
+        sam3_obj_ids: np.ndarray,
+        scores: np.ndarray | None = None,
+    ) -> list[MaskAssignment]:
+        """Match input masks to SAM3 masks for a single frame.
+
+        Uses Hungarian algorithm for optimal assignment, then filters
+        matches by IoU threshold.
+
+        Args:
+            frame_idx: Frame index for this match.
+            input_masks: Input/anchor masks with shape (N, H, W).
+            input_track_ids: Track IDs corresponding to input masks.
+            sam3_masks: SAM3 output masks with shape (M, H, W) or (M, 1, H, W).
+            sam3_obj_ids: SAM3 object IDs corresponding to SAM3 masks.
+            scores: Optional SAM3 mask detection confidence scores, shape (M,).
+
+        Returns:
+            List of valid MaskAssignment objects.
+        """
+        if len(input_masks) == 0 or len(sam3_masks) == 0:
+            return []
+
+        # Default scores to 1.0 if not provided
+        if scores is None:
+            scores = np.ones(len(sam3_obj_ids))
+
+        # Compute cost matrix and solve assignment
+        cost = self.compute_cost_matrix(input_masks, sam3_masks)
+        row_ind, col_ind = linear_sum_assignment(cost)
+
+        assignments = []
+        for input_idx, sam3_idx in zip(row_ind, col_ind):
+            iou = -cost[input_idx, sam3_idx]  # Convert back from negative
+
+            # Apply IoU threshold
+            if iou < self.min_iou:
+                continue
+
+            input_track_id = int(input_track_ids[input_idx])
+            track_name = self.track_names.get(input_track_id)
+
+            assignment = MaskAssignment(
+                frame_idx=frame_idx,
+                input_track_id=input_track_id,
+                input_track_name=track_name,
+                sam3_obj_id=int(sam3_obj_ids[sam3_idx]),
+                iou=iou,
+                sam3_score=float(scores[sam3_idx]),
+            )
+            assignments.append(assignment)
+
+        self._assignments.extend(assignments)
+        return assignments
+
+    def detect_swaps(self) -> list[SwapEvent]:
+        """Detect identity swaps from accumulated assignments.
+
+        A swap occurs when an input track is matched to different SAM3 object IDs
+        across frames.
+
+        Returns:
+            List of SwapEvent objects describing detected swaps.
+        """
+        swaps = []
+        by_track: dict[int, list[MaskAssignment]] = defaultdict(list)
+
+        for a in self._assignments:
+            by_track[a.input_track_id].append(a)
+
+        for input_track_id, track_assignments in by_track.items():
+            track_assignments.sort(key=lambda a: a.frame_idx)
+
+            for i in range(1, len(track_assignments)):
+                prev = track_assignments[i - 1]
+                curr = track_assignments[i]
+
+                if prev.sam3_obj_id != curr.sam3_obj_id:
+                    # Use track name if available, otherwise use "track_{id}"
+                    track_name = (
+                        curr.input_track_name
+                        or self.track_names.get(input_track_id)
+                        or f"track_{input_track_id}"
+                    )
+                    swaps.append(
+                        SwapEvent(
+                            frame_idx=curr.frame_idx,
+                            track_name=track_name,
+                            old_sam3_id=prev.sam3_obj_id,
+                            new_sam3_id=curr.sam3_obj_id,
+                        )
+                    )
+
+        return swaps
+
+    def build_id_map(self) -> dict[int, dict[int, str]]:
+        """Build frame -> {sam3_id -> track_name} mapping.
+
+        This can be used to remap SAM3 object IDs to consistent track names
+        in output files.
+
+        Returns:
+            Dictionary mapping frame_idx to {sam3_obj_id: track_name}.
+        """
+        by_frame: dict[int, dict[int, str]] = defaultdict(dict)
+        for a in self._assignments:
+            name = (
+                a.input_track_name
+                or self.track_names.get(a.input_track_id)
+                or f"track_{a.input_track_id}"
+            )
+            by_frame[a.frame_idx][a.sam3_obj_id] = name
+        return dict(by_frame)
+
+    def get_assignments(self) -> list[MaskAssignment]:
+        """Get all accumulated assignments.
+
+        Returns:
+            List of all MaskAssignment objects from match_frame() calls.
+        """
+        return list(self._assignments)
+
+    def get_iou_stats(self) -> dict[str, float]:
+        """Get IoU statistics from accumulated assignments.
+
+        Returns:
+            Dictionary with 'min', 'max', 'mean', 'median' IoU values.
+        """
+        if not self._assignments:
+            return {"min": 0.0, "max": 0.0, "mean": 0.0, "median": 0.0}
+
+        ious = [a.iou for a in self._assignments]
+        return {
+            "min": float(min(ious)),
+            "max": float(max(ious)),
+            "mean": float(np.mean(ious)),
+            "median": float(np.median(ious)),
+        }
+
+    def clear(self) -> None:
+        """Clear accumulated assignments."""
+        self._assignments.clear()
+
+
+# Predefined match predicates for common use cases
+
+
+def require_min_keypoints_inside(min_count: int = 3) -> MatchPredicate:
+    """Create predicate requiring minimum keypoints inside mask.
+
+    Args:
+        min_count: Minimum number of keypoints required inside mask.
+
+    Returns:
+        A MatchPredicate function.
+    """
+
+    def predicate(pose: "sio.Instance", mask: np.ndarray, ctx: MatchContext) -> bool:
+        return ctx.keypoints_inside >= min_count
+
+    return predicate
+
+
+def require_min_fraction_inside(min_frac: float = 0.5) -> MatchPredicate:
+    """Create predicate requiring minimum fraction of keypoints inside mask.
+
+    Args:
+        min_frac: Minimum fraction (0-1) of visible keypoints inside mask.
+
+    Returns:
+        A MatchPredicate function.
+    """
+
+    def predicate(pose: "sio.Instance", mask: np.ndarray, ctx: MatchContext) -> bool:
+        if ctx.keypoints_visible == 0:
+            return False
+        return ctx.keypoints_inside / ctx.keypoints_visible >= min_frac
+
+    return predicate
+
+
+def require_centroid_proximity(max_dist: float = 100.0) -> MatchPredicate:
+    """Create predicate requiring pose centroid near mask centroid.
+
+    Args:
+        max_dist: Maximum allowed distance between centroids in pixels.
+
+    Returns:
+        A MatchPredicate function.
+    """
+
+    def predicate(pose: "sio.Instance", mask: np.ndarray, ctx: MatchContext) -> bool:
+        coords = pose.numpy()
+        pose_centroid = np.nanmean(coords, axis=0)
+        if np.any(np.isnan(pose_centroid)):
+            return False
+        dist = np.linalg.norm(pose_centroid - np.array(ctx.mask_centroid))
+        return float(dist) <= max_dist
+
+    return predicate
+
+
+def require_reasonable_mask_area(
+    min_area: int = 1000, max_area: int = 500000
+) -> MatchPredicate:
+    """Create predicate requiring mask area within bounds.
+
+    Args:
+        min_area: Minimum mask area in pixels.
+        max_area: Maximum mask area in pixels.
+
+    Returns:
+        A MatchPredicate function.
+    """
+
+    def predicate(pose: "sio.Instance", mask: np.ndarray, ctx: MatchContext) -> bool:
+        return min_area <= ctx.mask_area <= max_area
+
+    return predicate
+
+
+@dataclass
+class TrackNameResolver:
+    """Resolves SAM3 obj_ids to GT track names via nearest-anchor flood fill.
+
+    This class takes the sparse ID mappings from GT anchor frames and propagates
+    them to all frames using a nearest-anchor approach. Each frame uses the
+    mapping from its closest GT anchor frame.
+
+    Attributes:
+        gt_anchors: Mapping of frame_idx -> {sam3_obj_id: track_name} at GT frames.
+        fallback_names: Optional mapping of sam3_obj_id -> name for objects without
+            GT matches (e.g., from initial prompt).
+
+    Example:
+        >>> resolver = TrackNameResolver.from_reconciler(reconciler)
+        >>> # Get track name for a specific frame and object
+        >>> name = resolver.get_track_name(frame_idx=150, sam3_obj_id=1)
+        >>> # Get all mappings for batch processing
+        >>> all_mappings = resolver.resolve_all_frames(total_frames=1000)
+    """
+
+    gt_anchors: dict[int, dict[int, str]] = field(default_factory=dict)
+    fallback_names: dict[int, str] = field(default_factory=dict)
+    _anchor_frames: list[int] = field(default_factory=list, repr=False)
+
+    def __post_init__(self):
+        """Cache sorted anchor frames for efficient lookup."""
+        self._anchor_frames = sorted(self.gt_anchors.keys())
+
+    @classmethod
+    def from_reconciler(
+        cls,
+        reconciler: IDReconciler,
+        fallback_names: dict[int, str] | None = None,
+    ) -> "TrackNameResolver":
+        """Create resolver from an IDReconciler with accumulated assignments.
+
+        Args:
+            reconciler: IDReconciler that has processed GT frames.
+            fallback_names: Optional mapping for objects without GT matches.
+
+        Returns:
+            TrackNameResolver initialized with the reconciler's ID map.
+        """
+        return cls(
+            gt_anchors=reconciler.build_id_map(),
+            fallback_names=fallback_names or {},
+        )
+
+    @classmethod
+    def from_id_map(
+        cls,
+        id_map: dict[int, dict[int, str]],
+        fallback_names: dict[int, str] | None = None,
+    ) -> "TrackNameResolver":
+        """Create resolver from an existing ID map.
+
+        Args:
+            id_map: Mapping of frame_idx -> {sam3_obj_id: track_name}.
+            fallback_names: Optional mapping for objects without GT matches.
+
+        Returns:
+            TrackNameResolver initialized with the ID map.
+        """
+        return cls(
+            gt_anchors=id_map,
+            fallback_names=fallback_names or {},
+        )
+
+    def _find_nearest_anchor(self, frame_idx: int) -> int | None:
+        """Find the nearest GT anchor frame to a given frame.
+
+        Args:
+            frame_idx: The frame index to find nearest anchor for.
+
+        Returns:
+            The frame index of the nearest anchor, or None if no anchors exist.
+        """
+        if not self._anchor_frames:
+            return None
+
+        # Binary search would be faster for large anchor lists,
+        # but linear is fine for typical use cases (< 100 anchors)
+        return min(self._anchor_frames, key=lambda a: abs(frame_idx - a))
+
+    def get_mapping_at_frame(self, frame_idx: int) -> dict[int, str]:
+        """Get the sam3_obj_id -> track_name mapping for a frame.
+
+        Uses the mapping from the nearest GT anchor frame.
+
+        Args:
+            frame_idx: The frame index to get mapping for.
+
+        Returns:
+            Dictionary mapping sam3_obj_id to track_name.
+            Returns empty dict if no GT anchors exist.
+        """
+        nearest = self._find_nearest_anchor(frame_idx)
+        if nearest is None:
+            return {}
+        return self.gt_anchors[nearest]
+
+    def get_track_name(
+        self,
+        frame_idx: int,
+        sam3_obj_id: int,
+        default: str | None = None,
+    ) -> str:
+        """Get track name for a SAM3 obj_id at a given frame.
+
+        Uses the mapping from the nearest GT anchor frame. Falls back to
+        fallback_names, then to a generated name.
+
+        Args:
+            frame_idx: The frame index.
+            sam3_obj_id: The SAM3 object ID.
+            default: Optional default name if not found. If None, generates
+                a name like "track_{sam3_obj_id}".
+
+        Returns:
+            The resolved track name.
+        """
+        mapping = self.get_mapping_at_frame(frame_idx)
+
+        if sam3_obj_id in mapping:
+            return mapping[sam3_obj_id]
+
+        if sam3_obj_id in self.fallback_names:
+            return self.fallback_names[sam3_obj_id]
+
+        if default is not None:
+            return default
+
+        return f"track_{sam3_obj_id}"
+
+    def resolve_all_frames(
+        self,
+        total_frames: int,
+    ) -> dict[int, dict[int, str]]:
+        """Get resolved mappings for all frames.
+
+        Args:
+            total_frames: Total number of frames in the video.
+
+        Returns:
+            Dictionary mapping frame_idx -> {sam3_obj_id: track_name}.
+            Empty frames (no mapping) are not included in the result.
+        """
+        if not self._anchor_frames:
+            return {}
+
+        result: dict[int, dict[int, str]] = {}
+        for frame_idx in range(total_frames):
+            nearest = self._find_nearest_anchor(frame_idx)
+            if nearest is not None:
+                result[frame_idx] = self.gt_anchors[nearest]
+
+        return result
+
+    def get_anchor_frames(self) -> list[int]:
+        """Get sorted list of GT anchor frame indices.
+
+        Returns:
+            List of frame indices where GT anchors exist.
+        """
+        return list(self._anchor_frames)
+
+    def get_all_track_names(self) -> set[str]:
+        """Get all unique track names from GT anchors.
+
+        Returns:
+            Set of all track names found in GT mappings.
+        """
+        names: set[str] = set()
+        for mapping in self.gt_anchors.values():
+            names.update(mapping.values())
+        return names
+
+    def get_all_sam3_obj_ids(self) -> set[int]:
+        """Get all unique SAM3 object IDs from GT anchors.
+
+        Returns:
+            Set of all SAM3 object IDs found in GT mappings.
+        """
+        obj_ids: set[int] = set()
+        for mapping in self.gt_anchors.values():
+            obj_ids.update(mapping.keys())
+        return obj_ids
+
+    def get_canonical_mapping(self) -> dict[int, str]:
+        """Get a canonical sam3_obj_id -> track_name mapping.
+
+        Returns a single global mapping from SAM3 object IDs to track names.
+        For objects that appear in multiple anchors, uses the name from the
+        first anchor frame.
+
+        This is useful for writers that need a single consistent mapping
+        (like BBoxWriter and SegmentationWriter) rather than per-frame mappings.
+
+        Returns:
+            Dictionary mapping sam3_obj_id to track_name.
+        """
+        canonical: dict[int, str] = {}
+
+        # Iterate anchors in frame order to get consistent "first seen" names
+        for frame_idx in self._anchor_frames:
+            mapping = self.gt_anchors[frame_idx]
+            for obj_id, name in mapping.items():
+                if obj_id not in canonical:
+                    canonical[obj_id] = name
+
+        return canonical
+
+    def get_anchor_source(self, frame_idx: int) -> tuple[int | None, str]:
+        """Get the anchor frame and propagation direction for a frame.
+
+        Useful for debugging and visualization.
+
+        Args:
+            frame_idx: The frame index to check.
+
+        Returns:
+            Tuple of (anchor_frame_idx, direction) where direction is one of:
+            - "anchor": frame_idx is a GT anchor
+            - "forward": propagated forward from an earlier anchor
+            - "backward": propagated backward from a later anchor
+            - "none": no anchors exist
+        """
+        if not self._anchor_frames:
+            return (None, "none")
+
+        nearest = self._find_nearest_anchor(frame_idx)
+        if nearest is None:
+            return (None, "none")
+
+        if frame_idx == nearest:
+            return (nearest, "anchor")
+        elif frame_idx > nearest:
+            return (nearest, "forward")
+        else:
+            return (nearest, "backward")

--- a/sleap_nn/inference/sam/retrack.py
+++ b/sleap_nn/inference/sam/retrack.py
@@ -1,0 +1,372 @@
+"""Mask-based re-tracking: refine existing pose/centroid track identities.
+
+This module provides :func:`retrack`, a thin orchestration over the lifted
+:mod:`sleap_nn.inference.sam.reconciliation` primitives. It implements the
+**"refine existing tracks"** path of the SAM segmentation stack: given a set of
+labeled frames whose instances already carry (possibly *wrong*) track labels,
+plus identity-consistent per-frame masks (e.g. from a SAM3 video tracker), it
+re-derives a clean, swap-free track assignment for every instance.
+
+The recipe (re-derived from ``talmolab/sam-track``'s CLI glue and validated by
+prototype P3) is:
+
+1. **Match.** At each frame, Hungarian-match poses to masks by keypoints-inside
+   (:class:`~sleap_nn.inference.sam.reconciliation.IDReconciler`), gated by a
+   match predicate (the default requires >=1 keypoint inside; a stricter
+   ``require_min_keypoints_inside(3)`` is recommended for re-tracking).
+2. **Build anchors.** Treat *trusted* frames (by default the frames whose
+   instances carry GT/user track labels, else all frames) as identity anchors,
+   yielding a sparse ``frame -> {mask_obj_id: track_name}`` map.
+3. **Canonical remap.** Collapse the per-frame anchors to a single canonical
+   ``mask_obj_id -> track_name`` map (first-seen wins;
+   :meth:`~sleap_nn.inference.sam.reconciliation.TrackNameResolver.get_canonical_mapping`),
+   with a per-frame nearest-anchor fallback for obj_ids that change identity
+   across anchors.
+4. **Relabel all frames.** For every frame, reassign each matched instance's
+   ``track`` to the resolved name (creating :class:`sio.Track` objects as
+   needed). Instances with no mask match keep their original track.
+
+This is the *post-processing* identity-correction path. Per the experimental
+finding baked into the reconciliation module's docstring, SAM3 mid-propagation
+re-prompting adds *new* objects but does not fix *existing* tracks, so identity
+correction must happen here, after tracking, via mask<->pose matching.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from sleap_nn.inference.sam.reconciliation import (
+    IDReconciler,
+    MatchPredicate,
+    TrackAssignment,
+    TrackNameResolver,
+)
+
+if TYPE_CHECKING:
+    import sleap_io as sio
+
+
+@dataclass
+class RetrackResult:
+    """Result of a :func:`retrack` run.
+
+    Attributes:
+        labeled_frames: The relabeled frames. Same objects as the input when
+            ``in_place=True``; the corrected deep copies when ``in_place=False``.
+        assignments: All :class:`TrackAssignment` objects produced across frames
+            (pose<->mask Hungarian matches, after predicate filtering).
+        id_map: Sparse anchor map ``frame_idx -> {mask_obj_id: track_name}``
+            built from trusted (anchor) frames only.
+        canonical_map: The global ``mask_obj_id -> track_name`` map used to
+            relabel instances. Each obj_id is named by majority vote across
+            anchor frames; obj_ids with no clear majority (an exact tie) are
+            omitted here and resolved per-frame via the nearest anchor.
+        resolver: The :class:`TrackNameResolver` used for nearest-anchor
+            fallback, exposed for inspection / debugging.
+        num_relabeled: Number of instances whose ``track`` was changed.
+        num_matched: Number of instances that received a mask match.
+        anchor_frames: Sorted frame indices used as identity anchors.
+    """
+
+    labeled_frames: list["sio.LabeledFrame"] = field(default_factory=list)
+    assignments: list[TrackAssignment] = field(default_factory=list)
+    id_map: dict[int, dict[int, str]] = field(default_factory=dict)
+    canonical_map: dict[int, str] = field(default_factory=dict)
+    resolver: TrackNameResolver | None = None
+    num_relabeled: int = 0
+    num_matched: int = 0
+    anchor_frames: list[int] = field(default_factory=list)
+
+
+def _is_anchor_instance(inst: "sio.Instance") -> bool:
+    """Return ``True`` if an instance is a trusted (GT/user) identity anchor.
+
+    Uses the GT-precedence rule from the SAM stack: a *user* instance is exactly
+    ``sio.Instance`` (predicted instances are the ``sio.PredictedInstance``
+    subclass), so ``type(inst) is sio.Instance`` distinguishes hand-labeled
+    anchors from model predictions. An anchor must additionally carry a track.
+
+    Args:
+        inst: The instance to test.
+
+    Returns:
+        ``True`` if the instance is a user-labeled, tracked anchor.
+    """
+    import sleap_io as sio
+
+    return type(inst) is sio.Instance and inst.track is not None
+
+
+def _frame_has_anchor(frame: "sio.LabeledFrame") -> bool:
+    """Return ``True`` if a frame contains at least one anchor instance."""
+    return any(_is_anchor_instance(inst) for inst in frame.instances)
+
+
+def _masks_for_frame(
+    masks: np.ndarray,
+    object_ids: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Drop padded entries and squeeze ``(N, 1, H, W)`` to ``(N, H, W)``.
+
+    SAM3 batches commonly pad per-frame mask/obj_id arrays to a fixed ``N`` with
+    a sentinel ``object_id < 0``. This strips those padded rows and normalizes
+    the mask rank.
+
+    Args:
+        masks: Masks for one frame, shape ``(N, H, W)`` or ``(N, 1, H, W)``.
+        object_ids: Object IDs for one frame, shape ``(N,)``; entries ``< 0``
+            are treated as padding and removed.
+
+    Returns:
+        Tuple ``(masks, object_ids)`` with padding removed and masks squeezed.
+    """
+    object_ids = np.asarray(object_ids)
+    masks = np.asarray(masks)
+
+    if masks.ndim == 4 and masks.shape[1] == 1:
+        masks = masks.squeeze(axis=1)
+
+    if object_ids.size and np.any(object_ids < 0):
+        keep = object_ids >= 0
+        masks = masks[keep]
+        object_ids = object_ids[keep]
+
+    return masks, object_ids
+
+
+def retrack(
+    labeled_frames: Sequence["sio.LabeledFrame"],
+    masks: Sequence[np.ndarray],
+    object_ids: Sequence[np.ndarray],
+    skeleton: "sio.Skeleton",
+    *,
+    scores: Sequence[np.ndarray] | None = None,
+    match_predicates: list[MatchPredicate] | None = None,
+    exclude_nodes: set[str] | None = None,
+    anchor_frame_indices: Sequence[int] | None = None,
+    fallback_names: dict[int, str] | None = None,
+    in_place: bool = True,
+) -> RetrackResult:
+    """Refine instance track identities from per-frame masks.
+
+    Re-derives track assignments for ``labeled_frames`` by matching each frame's
+    pose instances to its masks (Hungarian on keypoints-inside), anchoring the
+    ``mask_obj_id -> track_name`` mapping on trusted frames, and relabeling every
+    instance to the canonical / nearest-anchor name implied by its matched mask.
+
+    The mask sequences are aligned to ``labeled_frames`` **by position**:
+    ``masks[i]`` / ``object_ids[i]`` describe the same frame as
+    ``labeled_frames[i]``. Frames whose instances carry GT/user tracks act as
+    identity anchors by default (override via ``anchor_frame_indices``).
+
+    Args:
+        labeled_frames: Frames to re-track, in the same order as ``masks``. Each
+            instance's ``.track`` may be wrong; it will be corrected in place
+            (unless ``in_place=False``, in which case a deep copy is corrected
+            and the originals are left untouched).
+        masks: Per-frame masks; ``masks[i]`` has shape ``(N_i, H, W)`` or
+            ``(N_i, 1, H, W)``. Entries are paired with ``object_ids[i]``.
+        object_ids: Per-frame object IDs; ``object_ids[i]`` has shape ``(N_i,)``.
+            Entries ``< 0`` are treated as padding and dropped.
+        skeleton: Skeleton for node-name lookups during pose<->mask matching.
+        scores: Optional per-frame mask confidence scores, ``scores[i]`` shape
+            ``(N_i,)``. Defaults to all-ones when omitted.
+        match_predicates: Predicates (all must pass) gating a valid match. When
+            ``None``, :class:`IDReconciler`'s default (>=1 keypoint inside) is
+            used. ``require_min_keypoints_inside(3)`` is recommended.
+        exclude_nodes: Node names to ignore when counting keypoints-inside
+            (e.g. unreliable tail nodes).
+        anchor_frame_indices: Explicit positions into ``labeled_frames`` to use
+            as identity anchors. When ``None``, frames containing a GT/user
+            tracked instance are used; if there are none, every frame is an
+            anchor.
+        fallback_names: Optional ``mask_obj_id -> track_name`` map used for
+            obj_ids that never appear in any anchor frame.
+        in_place: When ``True`` (default), mutate the instances of
+            ``labeled_frames`` directly. When ``False``, deep copy the frames,
+            correct the copies, and leave the inputs untouched. Either way the
+            (corrected) frames are returned on ``RetrackResult.labeled_frames``.
+
+    Returns:
+        A :class:`RetrackResult` with the assignments, the sparse and canonical
+        ID maps, the resolver, and relabel/match counts.
+
+    Example:
+        >>> from sleap_nn.inference.sam.reconciliation import (
+        ...     require_min_keypoints_inside,
+        ... )
+        >>> result = retrack(
+        ...     labeled_frames=lfs,
+        ...     masks=[m for m in per_frame_masks],
+        ...     object_ids=[o for o in per_frame_obj_ids],
+        ...     skeleton=labels.skeleton,
+        ...     match_predicates=[require_min_keypoints_inside(3)],
+        ... )
+        >>> result.num_relabeled
+        12
+    """
+    import sleap_io as sio
+
+    n_frames = len(labeled_frames)
+    if len(masks) != n_frames or len(object_ids) != n_frames:
+        raise ValueError(
+            "labeled_frames, masks, and object_ids must be the same length "
+            f"(got {n_frames}, {len(masks)}, {len(object_ids)})."
+        )
+    if scores is not None and len(scores) != n_frames:
+        raise ValueError(
+            "scores, when provided, must match labeled_frames in length "
+            f"(got {len(scores)} vs {n_frames})."
+        )
+
+    frames: list["sio.LabeledFrame"] = list(labeled_frames)
+    if not in_place:
+        from copy import deepcopy
+
+        # Copy the whole list in one deepcopy so shared references (e.g. the
+        # same ``Track`` object across frames) stay shared in the copy.
+        frames = deepcopy(frames)
+
+    # --- 1. determine anchor frames ---------------------------------------
+    if anchor_frame_indices is not None:
+        anchor_set = {int(i) for i in anchor_frame_indices}
+    else:
+        anchor_set = {i for i, lf in enumerate(frames) if _frame_has_anchor(lf)}
+        if not anchor_set:
+            # No trusted tracks anywhere: every frame anchors itself.
+            anchor_set = set(range(n_frames))
+
+    # --- 2. Hungarian match poses<->masks at every frame ------------------
+    reconciler = IDReconciler(
+        skeleton=skeleton,
+        exclude_nodes=set(exclude_nodes) if exclude_nodes else set(),
+        match_predicates=list(match_predicates) if match_predicates else [],
+    )
+
+    # frame position -> {pose_idx: mask_obj_id} for relabeling.
+    per_frame_pose_to_obj: list[dict[int, int]] = []
+    for i, lf in enumerate(frames):
+        m_i, o_i = _masks_for_frame(masks[i], object_ids[i])
+        s_i = None
+        if scores is not None:
+            s_i = np.asarray(scores[i])
+            if s_i.size and o_i.size and len(s_i) != len(o_i):
+                # Re-derive the keep mask to align scores with dropped padding.
+                raw_ids = np.asarray(object_ids[i])
+                if raw_ids.size and np.any(raw_ids < 0):
+                    s_i = s_i[raw_ids >= 0]
+        assignments = reconciler.match_frame(
+            frame_idx=i,
+            poses=list(lf.instances),
+            masks=m_i,
+            object_ids=o_i,
+            scores=s_i,
+        )
+        per_frame_pose_to_obj.append({a.pose_idx: a.sam3_obj_id for a in assignments})
+
+    # --- 3. build the sparse anchor id map + canonical / fallback resolver -
+    # Re-run the matcher's id-map logic but restricted to anchor frames: only
+    # trusted frames define the obj_id -> track_name identity.
+    id_map: dict[int, dict[int, str]] = {}
+    for a in reconciler.get_assignments():
+        if a.frame_idx not in anchor_set:
+            continue
+        if a.pose_track_name:
+            id_map.setdefault(a.frame_idx, {})[a.sam3_obj_id] = a.pose_track_name
+
+    resolver = TrackNameResolver.from_id_map(
+        id_map, fallback_names=fallback_names or {}
+    )
+
+    # The mask obj_id is the trustworthy identity signal; the anchor map only
+    # *names* it. Name each obj_id by MAJORITY VOTE across anchor frames, so a
+    # minority of wrong/swapped anchor frames cannot flip a stable identity
+    # (this is what self-corrects the common "every frame labeled, a few
+    # swapped" case). Ties / no-clear-majority obj_ids are genuine cross-anchor
+    # reassignments (the sparse-GT SAM3 case) and are routed per-frame via the
+    # nearest anchor instead.
+    from collections import Counter
+
+    votes_per_obj: dict[int, Counter] = {}
+    for mapping in id_map.values():
+        for obj_id, name in mapping.items():
+            votes_per_obj.setdefault(obj_id, Counter())[name] += 1
+
+    canonical_map: dict[int, str] = {}
+    ambiguous_obj_ids: set[int] = set()
+    for obj_id, counter in votes_per_obj.items():
+        ranked = counter.most_common()
+        top_name, top_count = ranked[0]
+        # A clear majority (strictly more votes than the runner-up) names the
+        # obj_id globally; an exact tie is ambiguous -> nearest-anchor per frame.
+        if len(ranked) == 1 or top_count > ranked[1][1]:
+            canonical_map[obj_id] = top_name
+        else:
+            ambiguous_obj_ids.add(obj_id)
+
+    # --- 4. relabel every instance to its resolved track name -------------
+    track_by_name: dict[str, "sio.Track"] = {}
+    # Seed with existing track objects so we reuse identities where possible.
+    for lf in frames:
+        for inst in lf.instances:
+            if inst.track is not None:
+                track_by_name.setdefault(inst.track.name, inst.track)
+
+    def _resolve_name(frame_idx: int, obj_id: int) -> str | None:
+        # Genuine cross-anchor identity changes route through the nearest anchor
+        # (so a real SAM3 swap between two sparse GT frames flips at the
+        # midpoint). Stable obj_ids take the canonical first-seen name globally,
+        # immune to a single swapped/wrong anchor frame. Fallback last.
+        if obj_id in ambiguous_obj_ids:
+            mapping = resolver.get_mapping_at_frame(frame_idx)
+            if obj_id in mapping:
+                return mapping[obj_id]
+        if obj_id in canonical_map:
+            return canonical_map[obj_id]
+        if fallback_names and obj_id in fallback_names:
+            return fallback_names[obj_id]
+        return None
+
+    num_relabeled = 0
+    num_matched = 0
+    for i, lf in enumerate(frames):
+        pose_to_obj = per_frame_pose_to_obj[i]
+        for pose_idx, inst in enumerate(lf.instances):
+            obj_id = pose_to_obj.get(pose_idx)
+            if obj_id is None:
+                continue
+            num_matched += 1
+            name = _resolve_name(i, obj_id)
+            if name is None:
+                continue
+            track = track_by_name.get(name)
+            if track is None:
+                track = sio.Track(name=name)
+                track_by_name[name] = track
+            if inst.track is not track:
+                inst.track = track
+                num_relabeled += 1
+
+    return RetrackResult(
+        labeled_frames=frames,
+        assignments=reconciler.get_assignments(),
+        id_map=id_map,
+        canonical_map=canonical_map,
+        resolver=resolver,
+        num_relabeled=num_relabeled,
+        num_matched=num_matched,
+        anchor_frames=sorted(anchor_set),
+    )
+
+
+# Re-export the predicate factories so callers can build a stricter
+# re-tracking predicate without importing the lifted module directly.
+__all__: list[str] = [
+    "RetrackResult",
+    "retrack",
+]

--- a/sleap_nn/inference/sam/retrack.py
+++ b/sleap_nn/inference/sam/retrack.py
@@ -17,11 +17,10 @@ prototype P3) is:
 2. **Build anchors.** Treat *trusted* frames (by default the frames whose
    instances carry GT/user track labels, else all frames) as identity anchors,
    yielding a sparse ``frame -> {mask_obj_id: track_name}`` map.
-3. **Canonical remap.** Collapse the per-frame anchors to a single canonical
-   ``mask_obj_id -> track_name`` map (first-seen wins;
-   :meth:`~sleap_nn.inference.sam.reconciliation.TrackNameResolver.get_canonical_mapping`),
-   with a per-frame nearest-anchor fallback for obj_ids that change identity
-   across anchors.
+3. **Canonical remap.** Name each ``mask_obj_id`` by majority vote across anchor
+   frames (strict majority wins); obj_ids with no clear majority (an exact tie)
+   are omitted from the canonical map and resolved per-frame via the nearest
+   anchor.
 4. **Relabel all frames.** For every frame, reassign each matched instance's
    ``track`` to the resolved name (creating :class:`sio.Track` objects as
    needed). Instances with no mask match keep their original track.
@@ -320,7 +319,7 @@ def retrack(
     def _resolve_name(frame_idx: int, obj_id: int) -> str | None:
         # Genuine cross-anchor identity changes route through the nearest anchor
         # (so a real SAM3 swap between two sparse GT frames flips at the
-        # midpoint). Stable obj_ids take the canonical first-seen name globally,
+        # midpoint). Stable obj_ids take the canonical majority-vote name globally,
         # immune to a single swapped/wrong anchor frame. Fallback last.
         if obj_id in ambiguous_obj_ids:
             mapping = resolver.get_mapping_at_frame(frame_idx)
@@ -364,8 +363,7 @@ def retrack(
     )
 
 
-# Re-export the predicate factories so callers can build a stricter
-# re-tracking predicate without importing the lifted module directly.
+# Public API of this module.
 __all__: list[str] = [
     "RetrackResult",
     "retrack",

--- a/tests/inference/sam/__init__.py
+++ b/tests/inference/sam/__init__.py
@@ -1,0 +1,1 @@
+"""Test functions for the SAM inference segmentation modules."""

--- a/tests/inference/sam/test_reconciliation.py
+++ b/tests/inference/sam/test_reconciliation.py
@@ -1,0 +1,1191 @@
+"""Tests for ID reconciliation module.
+
+Lifted from ``talmolab/sam-track`` @ ``7b2531d92b5035f5f83016b12350f7c394b92522``
+(``tests/test_reconciliation.py``); only the import path was swapped to
+``sleap_nn.inference.sam.reconciliation``.
+"""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap_nn.inference.sam.reconciliation import (
+    IDReconciler,
+    MaskAssignment,
+    MaskReconciler,
+    MatchContext,
+    SwapEvent,
+    TrackAssignment,
+    TrackNameResolver,
+    default_match_predicate,
+    require_min_fraction_inside,
+    require_min_keypoints_inside,
+    require_reasonable_mask_area,
+)
+
+
+@pytest.fixture
+def simple_skeleton():
+    """Create a simple 3-node skeleton for testing."""
+    return sio.Skeleton(
+        nodes=[
+            sio.Node(name="head"),
+            sio.Node(name="body"),
+            sio.Node(name="tail"),
+        ]
+    )
+
+
+@pytest.fixture
+def reconciler(simple_skeleton):
+    """Create a basic reconciler."""
+    return IDReconciler(skeleton=simple_skeleton)
+
+
+@pytest.fixture
+def sample_poses(simple_skeleton):
+    """Create sample pose instances."""
+    # Instance 1: all nodes visible at (10, 10), (50, 50), (90, 90)
+    coords1 = np.array([[10, 10], [50, 50], [90, 90]], dtype=np.float64)
+    inst1 = sio.Instance.from_numpy(coords1, skeleton=simple_skeleton)
+
+    # Instance 2: all nodes visible at (200, 200), (250, 250), (300, 300)
+    coords2 = np.array([[200, 200], [250, 250], [300, 300]], dtype=np.float64)
+    inst2 = sio.Instance.from_numpy(coords2, skeleton=simple_skeleton)
+
+    return [inst1, inst2]
+
+
+@pytest.fixture
+def sample_masks():
+    """Create sample masks that match the poses."""
+    # Mask 1: covers area around (10-90, 10-90)
+    mask1 = np.zeros((400, 400), dtype=bool)
+    mask1[5:95, 5:95] = True
+
+    # Mask 2: covers area around (200-300, 200-300)
+    mask2 = np.zeros((400, 400), dtype=bool)
+    mask2[195:305, 195:305] = True
+
+    return np.stack([mask1, mask2])
+
+
+class TestIDReconciler:
+    """Tests for IDReconciler class."""
+
+    def test_init(self, simple_skeleton):
+        """Test reconciler initialization."""
+        reconciler = IDReconciler(skeleton=simple_skeleton)
+        assert reconciler.skeleton == simple_skeleton
+        assert reconciler.exclude_nodes == set()
+        assert len(reconciler.match_predicates) == 1  # Default predicate
+
+    def test_init_with_exclude_nodes(self, simple_skeleton):
+        """Test initialization with excluded nodes."""
+        reconciler = IDReconciler(
+            skeleton=simple_skeleton,
+            exclude_nodes={"tail"},
+        )
+        assert "tail" in reconciler.exclude_nodes
+
+    def test_compute_cost_matrix(self, reconciler, sample_poses, sample_masks):
+        """Test cost matrix computation."""
+        cost = reconciler.compute_cost_matrix(sample_poses, sample_masks)
+
+        assert cost.shape == (2, 2)
+        # Pose 1 should match mask 1 better (negative cost = more keypoints inside)
+        assert cost[0, 0] < cost[0, 1]
+        # Pose 2 should match mask 2 better
+        assert cost[1, 1] < cost[1, 0]
+
+    def test_compute_cost_matrix_empty_poses(self, reconciler, sample_masks):
+        """Test cost matrix with empty poses."""
+        cost = reconciler.compute_cost_matrix([], sample_masks)
+        assert cost.shape == (0, 2)
+
+    def test_compute_cost_matrix_empty_masks(self, reconciler, sample_poses):
+        """Test cost matrix with empty masks."""
+        cost = reconciler.compute_cost_matrix(sample_poses, np.array([]))
+        assert cost.shape == (2, 0)
+
+    def test_match_frame(self, reconciler, sample_poses, sample_masks):
+        """Test frame matching."""
+        object_ids = np.array([0, 1])
+        assignments = reconciler.match_frame(
+            frame_idx=0,
+            poses=sample_poses,
+            masks=sample_masks,
+            object_ids=object_ids,
+        )
+
+        assert len(assignments) == 2
+        # Pose 0 should match mask 0
+        assert assignments[0].pose_idx == 0
+        assert assignments[0].sam3_obj_id == 0
+        # Pose 1 should match mask 1
+        assert assignments[1].pose_idx == 1
+        assert assignments[1].sam3_obj_id == 1
+
+    def test_match_frame_accumulates(self, reconciler, sample_poses, sample_masks):
+        """Test that match_frame accumulates assignments."""
+        object_ids = np.array([0, 1])
+
+        # First frame
+        reconciler.match_frame(0, sample_poses, sample_masks, object_ids)
+        assert len(reconciler.get_assignments()) == 2
+
+        # Second frame
+        reconciler.match_frame(10, sample_poses, sample_masks, object_ids)
+        assert len(reconciler.get_assignments()) == 4
+
+    def test_detect_swaps_no_swaps(self, simple_skeleton):
+        """Test swap detection with consistent assignments."""
+        reconciler = IDReconciler(skeleton=simple_skeleton)
+
+        # Add consistent assignments
+        reconciler._assignments = [
+            TrackAssignment(
+                frame_idx=0,
+                pose_track_name="mouse1",
+                pose_idx=0,
+                sam3_obj_id=0,
+                confidence=1.0,
+            ),
+            TrackAssignment(
+                frame_idx=10,
+                pose_track_name="mouse1",
+                pose_idx=0,
+                sam3_obj_id=0,
+                confidence=1.0,
+            ),
+        ]
+
+        swaps = reconciler.detect_swaps()
+        assert len(swaps) == 0
+
+    def test_detect_swaps_with_swap(self, simple_skeleton):
+        """Test swap detection when identity changes."""
+        reconciler = IDReconciler(skeleton=simple_skeleton)
+
+        # mouse1 is assigned to obj 0 at frame 0, but obj 1 at frame 10
+        reconciler._assignments = [
+            TrackAssignment(
+                frame_idx=0,
+                pose_track_name="mouse1",
+                pose_idx=0,
+                sam3_obj_id=0,
+                confidence=1.0,
+            ),
+            TrackAssignment(
+                frame_idx=10,
+                pose_track_name="mouse1",
+                pose_idx=0,
+                sam3_obj_id=1,
+                confidence=1.0,
+            ),
+        ]
+
+        swaps = reconciler.detect_swaps()
+        assert len(swaps) == 1
+        assert swaps[0].track_name == "mouse1"
+        assert swaps[0].old_sam3_id == 0
+        assert swaps[0].new_sam3_id == 1
+
+    def test_build_id_map(self, simple_skeleton):
+        """Test building frame-to-ID mapping."""
+        reconciler = IDReconciler(skeleton=simple_skeleton)
+
+        reconciler._assignments = [
+            TrackAssignment(
+                frame_idx=0,
+                pose_track_name="mouse1",
+                pose_idx=0,
+                sam3_obj_id=0,
+                confidence=1.0,
+            ),
+            TrackAssignment(
+                frame_idx=0,
+                pose_track_name="mouse2",
+                pose_idx=1,
+                sam3_obj_id=1,
+                confidence=1.0,
+            ),
+            TrackAssignment(
+                frame_idx=10,
+                pose_track_name="mouse1",
+                pose_idx=0,
+                sam3_obj_id=0,
+                confidence=1.0,
+            ),
+        ]
+
+        id_map = reconciler.build_id_map()
+        assert 0 in id_map
+        assert 10 in id_map
+        assert id_map[0][0] == "mouse1"
+        assert id_map[0][1] == "mouse2"
+        assert id_map[10][0] == "mouse1"
+
+    def test_clear(self, reconciler, sample_poses, sample_masks):
+        """Test clearing assignments."""
+        reconciler.match_frame(0, sample_poses, sample_masks, np.array([0, 1]))
+        assert len(reconciler.get_assignments()) > 0
+
+        reconciler.clear()
+        assert len(reconciler.get_assignments()) == 0
+
+    def test_node_exclusion(self, simple_skeleton, sample_masks):
+        """Test that excluded nodes are not counted."""
+        reconciler = IDReconciler(
+            skeleton=simple_skeleton,
+            exclude_nodes={"head", "body"},  # Only tail counts
+        )
+
+        # Create pose with all nodes: head (10,10), body (50,50), tail (90,90)
+        coords = np.array([[10, 10], [50, 50], [90, 90]], dtype=np.float64)
+        inst = sio.Instance.from_numpy(coords, skeleton=simple_skeleton)
+
+        cost = reconciler.compute_cost_matrix([inst], sample_masks)
+        # Only tail (90, 90) should be counted, which is in mask 0 (covers 5:95, 5:95)
+        assert cost[0, 0] == -1  # 1 keypoint inside
+
+
+class TestMatchPredicates:
+    """Tests for match predicate functions."""
+
+    def test_default_predicate_passes(self):
+        """Test default predicate passes with keypoints inside."""
+        ctx = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=-3.0,
+            keypoints_inside=3,
+            keypoints_visible=5,
+            mask_area=1000,
+            mask_centroid=(50.0, 50.0),
+        )
+        assert default_match_predicate(None, None, ctx)
+
+    def test_default_predicate_fails(self):
+        """Test default predicate fails with no keypoints inside."""
+        ctx = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0.0,
+            keypoints_inside=0,
+            keypoints_visible=5,
+            mask_area=1000,
+            mask_centroid=(50.0, 50.0),
+        )
+        assert not default_match_predicate(None, None, ctx)
+
+    def test_require_min_keypoints_inside(self):
+        """Test minimum keypoints predicate."""
+        predicate = require_min_keypoints_inside(min_count=3)
+
+        ctx_pass = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0,
+            keypoints_inside=3,
+            keypoints_visible=5,
+            mask_area=1000,
+            mask_centroid=(0, 0),
+        )
+        ctx_fail = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0,
+            keypoints_inside=2,
+            keypoints_visible=5,
+            mask_area=1000,
+            mask_centroid=(0, 0),
+        )
+
+        assert predicate(None, None, ctx_pass)
+        assert not predicate(None, None, ctx_fail)
+
+    def test_require_min_fraction_inside(self):
+        """Test minimum fraction predicate."""
+        predicate = require_min_fraction_inside(min_frac=0.5)
+
+        ctx_pass = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0,
+            keypoints_inside=3,
+            keypoints_visible=5,
+            mask_area=1000,
+            mask_centroid=(0, 0),
+        )  # 3/5 = 0.6 >= 0.5
+        ctx_fail = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0,
+            keypoints_inside=1,
+            keypoints_visible=5,
+            mask_area=1000,
+            mask_centroid=(0, 0),
+        )  # 1/5 = 0.2 < 0.5
+
+        assert predicate(None, None, ctx_pass)
+        assert not predicate(None, None, ctx_fail)
+
+    def test_require_reasonable_mask_area(self):
+        """Test mask area bounds predicate."""
+        predicate = require_reasonable_mask_area(min_area=100, max_area=10000)
+
+        ctx_pass = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0,
+            keypoints_inside=3,
+            keypoints_visible=5,
+            mask_area=5000,
+            mask_centroid=(0, 0),
+        )
+        ctx_too_small = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0,
+            keypoints_inside=3,
+            keypoints_visible=5,
+            mask_area=50,
+            mask_centroid=(0, 0),
+        )
+        ctx_too_large = MatchContext(
+            frame_idx=0,
+            sam3_obj_id=0,
+            cost=0,
+            keypoints_inside=3,
+            keypoints_visible=5,
+            mask_area=50000,
+            mask_centroid=(0, 0),
+        )
+
+        assert predicate(None, None, ctx_pass)
+        assert not predicate(None, None, ctx_too_small)
+        assert not predicate(None, None, ctx_too_large)
+
+
+class TestTrackAssignment:
+    """Tests for TrackAssignment dataclass."""
+
+    def test_creation(self):
+        """Test creating a track assignment."""
+        assignment = TrackAssignment(
+            frame_idx=10,
+            pose_track_name="mouse1",
+            pose_idx=0,
+            sam3_obj_id=5,
+            confidence=0.95,
+        )
+        assert assignment.frame_idx == 10
+        assert assignment.pose_track_name == "mouse1"
+        assert assignment.pose_idx == 0
+        assert assignment.sam3_obj_id == 5
+        assert assignment.confidence == 0.95
+
+    def test_none_track_name(self):
+        """Test assignment with no track name."""
+        assignment = TrackAssignment(
+            frame_idx=0,
+            pose_track_name=None,
+            pose_idx=0,
+            sam3_obj_id=0,
+            confidence=0.5,
+        )
+        assert assignment.pose_track_name is None
+
+
+class TestSwapEvent:
+    """Tests for SwapEvent dataclass."""
+
+    def test_creation(self):
+        """Test creating a swap event."""
+        swap = SwapEvent(
+            frame_idx=50,
+            track_name="mouse1",
+            old_sam3_id=0,
+            new_sam3_id=1,
+        )
+        assert swap.frame_idx == 50
+        assert swap.track_name == "mouse1"
+        assert swap.old_sam3_id == 0
+        assert swap.new_sam3_id == 1
+
+
+class TestTrackNameResolver:
+    """Tests for TrackNameResolver class."""
+
+    def test_init_empty(self):
+        """Test initialization with no anchors."""
+        resolver = TrackNameResolver()
+        assert resolver.gt_anchors == {}
+        assert resolver.fallback_names == {}
+        assert resolver.get_anchor_frames() == []
+
+    def test_init_with_anchors(self):
+        """Test initialization with anchor mappings."""
+        anchors = {
+            0: {0: "mouse1", 1: "mouse2"},
+            100: {0: "mouse1", 1: "mouse2"},
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+        assert resolver.get_anchor_frames() == [0, 100]
+
+    def test_from_id_map(self):
+        """Test creating resolver from ID map."""
+        id_map = {
+            0: {0: "mouse1", 1: "mouse2"},
+            50: {1: "mouse1", 0: "mouse2"},  # Swap!
+        }
+        resolver = TrackNameResolver.from_id_map(id_map)
+        assert resolver.get_anchor_frames() == [0, 50]
+
+    def test_from_reconciler(self, simple_skeleton):
+        """Test creating resolver from IDReconciler."""
+        reconciler = IDReconciler(skeleton=simple_skeleton)
+        reconciler._assignments = [
+            TrackAssignment(
+                frame_idx=0,
+                pose_track_name="mouse1",
+                pose_idx=0,
+                sam3_obj_id=0,
+                confidence=1.0,
+            ),
+            TrackAssignment(
+                frame_idx=0,
+                pose_track_name="mouse2",
+                pose_idx=1,
+                sam3_obj_id=1,
+                confidence=1.0,
+            ),
+        ]
+
+        resolver = TrackNameResolver.from_reconciler(reconciler)
+        assert resolver.get_anchor_frames() == [0]
+        assert resolver.get_track_name(0, 0) == "mouse1"
+        assert resolver.get_track_name(0, 1) == "mouse2"
+
+    def test_get_track_name_at_anchor(self):
+        """Test getting track name at an anchor frame."""
+        anchors = {0: {0: "mouse1", 1: "mouse2"}}
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        assert resolver.get_track_name(0, 0) == "mouse1"
+        assert resolver.get_track_name(0, 1) == "mouse2"
+
+    def test_get_track_name_forward_propagation(self):
+        """Test track names propagate forward from anchor."""
+        anchors = {0: {0: "mouse1", 1: "mouse2"}}
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        # Frames after anchor 0 should use anchor 0's mapping
+        assert resolver.get_track_name(50, 0) == "mouse1"
+        assert resolver.get_track_name(100, 1) == "mouse2"
+
+    def test_get_track_name_backward_propagation(self):
+        """Test track names propagate backward from anchor."""
+        anchors = {100: {0: "mouse1", 1: "mouse2"}}
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        # Frames before anchor 100 should use anchor 100's mapping
+        assert resolver.get_track_name(0, 0) == "mouse1"
+        assert resolver.get_track_name(50, 1) == "mouse2"
+
+    def test_get_track_name_nearest_anchor(self):
+        """Test that nearest anchor is used for mapping."""
+        # Anchors at 0 and 100, with different mappings (swap)
+        anchors = {
+            0: {0: "mouse1", 1: "mouse2"},
+            100: {0: "mouse2", 1: "mouse1"},  # Swapped IDs
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        # Frame 25: closer to anchor 0
+        assert resolver.get_track_name(25, 0) == "mouse1"
+        assert resolver.get_track_name(25, 1) == "mouse2"
+
+        # Frame 75: closer to anchor 100
+        assert resolver.get_track_name(75, 0) == "mouse2"
+        assert resolver.get_track_name(75, 1) == "mouse1"
+
+        # Frame 50: equidistant, should pick one (min picks first, which is 0)
+        assert resolver.get_track_name(50, 0) == "mouse1"
+
+    def test_get_track_name_fallback(self):
+        """Test fallback names for unknown obj_ids."""
+        anchors = {0: {0: "mouse1"}}
+        fallback = {2: "extra_mouse"}
+        resolver = TrackNameResolver(gt_anchors=anchors, fallback_names=fallback)
+
+        # obj_id 2 not in anchor, should use fallback
+        assert resolver.get_track_name(0, 2) == "extra_mouse"
+
+    def test_get_track_name_generated_fallback(self):
+        """Test generated fallback names when not in anchors or fallback."""
+        anchors = {0: {0: "mouse1"}}
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        # obj_id 5 not anywhere, should generate name
+        assert resolver.get_track_name(0, 5) == "track_5"
+
+    def test_get_track_name_custom_default(self):
+        """Test custom default name."""
+        anchors = {0: {0: "mouse1"}}
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        assert resolver.get_track_name(0, 5, default="unknown") == "unknown"
+
+    def test_get_track_name_no_anchors(self):
+        """Test behavior with no anchors."""
+        resolver = TrackNameResolver()
+
+        # Should generate name since no anchors exist
+        assert resolver.get_track_name(0, 0) == "track_0"
+
+    def test_get_mapping_at_frame(self):
+        """Test getting full mapping at a frame."""
+        anchors = {
+            0: {0: "mouse1", 1: "mouse2"},
+            100: {0: "mouse2", 1: "mouse1"},
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        # At anchor
+        assert resolver.get_mapping_at_frame(0) == {0: "mouse1", 1: "mouse2"}
+
+        # Between anchors (closer to 0)
+        assert resolver.get_mapping_at_frame(25) == {0: "mouse1", 1: "mouse2"}
+
+        # Between anchors (closer to 100)
+        assert resolver.get_mapping_at_frame(75) == {0: "mouse2", 1: "mouse1"}
+
+    def test_get_mapping_at_frame_no_anchors(self):
+        """Test mapping returns empty dict when no anchors."""
+        resolver = TrackNameResolver()
+        assert resolver.get_mapping_at_frame(50) == {}
+
+    def test_resolve_all_frames(self):
+        """Test resolving mappings for all frames."""
+        anchors = {
+            0: {0: "mouse1", 1: "mouse2"},
+            10: {0: "mouse2", 1: "mouse1"},  # Swap at frame 10
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        all_mappings = resolver.resolve_all_frames(total_frames=15)
+
+        # Should have mappings for all 15 frames
+        assert len(all_mappings) == 15
+
+        # Frames 0-5 use anchor 0 (closer to 0, or equidistant at frame 5)
+        # Note: frame 5 is equidistant (dist 5 to both), min() picks first (anchor 0)
+        for f in range(6):
+            assert all_mappings[f][0] == "mouse1"
+
+        # Frames 6-14 use anchor 10 (strictly closer to 10)
+        for f in range(6, 15):
+            assert all_mappings[f][0] == "mouse2"
+
+    def test_resolve_all_frames_no_anchors(self):
+        """Test resolve_all_frames with no anchors returns empty."""
+        resolver = TrackNameResolver()
+        assert resolver.resolve_all_frames(total_frames=100) == {}
+
+    def test_get_all_track_names(self):
+        """Test getting all unique track names."""
+        anchors = {
+            0: {0: "mouse1", 1: "mouse2"},
+            100: {0: "mouse2", 1: "mouse1", 2: "mouse3"},
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        names = resolver.get_all_track_names()
+        assert names == {"mouse1", "mouse2", "mouse3"}
+
+    def test_get_all_sam3_obj_ids(self):
+        """Test getting all unique SAM3 obj_ids."""
+        anchors = {
+            0: {0: "mouse1", 1: "mouse2"},
+            100: {0: "mouse2", 2: "mouse3"},
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        obj_ids = resolver.get_all_sam3_obj_ids()
+        assert obj_ids == {0, 1, 2}
+
+    def test_get_anchor_source(self):
+        """Test getting anchor source info for frames."""
+        anchors = {
+            10: {0: "mouse1"},
+            50: {0: "mouse2"},
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        # At anchor
+        assert resolver.get_anchor_source(10) == (10, "anchor")
+        assert resolver.get_anchor_source(50) == (50, "anchor")
+
+        # Before first anchor (backward from 10)
+        assert resolver.get_anchor_source(5) == (10, "backward")
+
+        # After anchor 10, before 50 (forward from 10)
+        assert resolver.get_anchor_source(20) == (10, "forward")
+
+        # After anchor 50 (forward from 50)
+        assert resolver.get_anchor_source(60) == (50, "forward")
+
+    def test_get_anchor_source_no_anchors(self):
+        """Test anchor source with no anchors."""
+        resolver = TrackNameResolver()
+        assert resolver.get_anchor_source(0) == (None, "none")
+
+    def test_get_canonical_mapping(self):
+        """Test getting canonical global mapping."""
+        anchors = {
+            0: {0: "mouse1", 1: "mouse2"},
+            100: {0: "mouse2", 1: "mouse1", 2: "mouse3"},
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        canonical = resolver.get_canonical_mapping()
+
+        # Should have all obj_ids
+        assert 0 in canonical
+        assert 1 in canonical
+        assert 2 in canonical
+
+        # obj_ids 0 and 1 use first anchor's names
+        assert canonical[0] == "mouse1"
+        assert canonical[1] == "mouse2"
+
+        # obj_id 2 only appears in second anchor
+        assert canonical[2] == "mouse3"
+
+    def test_get_canonical_mapping_empty(self):
+        """Test canonical mapping with no anchors."""
+        resolver = TrackNameResolver()
+        assert resolver.get_canonical_mapping() == {}
+
+    def test_flood_fill_scenario_from_readme(self):
+        """Test the flood fill scenario described in the README.
+
+        GT frames at 2 and 7, SAM swap occurs at frame 4.
+        Frames 1-4 should use frame 2's mapping.
+        Frames 5-8 should use frame 7's mapping.
+        """
+        anchors = {
+            2: {1: "mouse1", 2: "mouse2"},  # Before swap
+            7: {2: "mouse1", 1: "mouse2"},  # After swap (IDs swapped)
+        }
+        resolver = TrackNameResolver(gt_anchors=anchors)
+
+        # Frames 1-4: closer to anchor 2
+        # Frame 1: dist to 2 is 1, dist to 7 is 6 -> use anchor 2
+        assert resolver.get_track_name(1, 1) == "mouse1"
+        assert resolver.get_track_name(1, 2) == "mouse2"
+
+        # Frame 4: dist to 2 is 2, dist to 7 is 3 -> use anchor 2
+        assert resolver.get_track_name(4, 1) == "mouse1"
+        assert resolver.get_track_name(4, 2) == "mouse2"
+
+        # Frames 5-8: closer to anchor 7
+        # Frame 5: dist to 2 is 3, dist to 7 is 2 -> use anchor 7
+        assert resolver.get_track_name(5, 1) == "mouse2"  # Note: swapped!
+        assert resolver.get_track_name(5, 2) == "mouse1"
+
+        # Frame 8: dist to 2 is 6, dist to 7 is 1 -> use anchor 7
+        assert resolver.get_track_name(8, 1) == "mouse2"
+        assert resolver.get_track_name(8, 2) == "mouse1"
+
+
+class TestMaskAssignment:
+    """Tests for MaskAssignment dataclass."""
+
+    def test_creation(self):
+        """Test creating a mask assignment."""
+        assignment = MaskAssignment(
+            frame_idx=10,
+            input_track_id=1,
+            input_track_name="mouse1",
+            sam3_obj_id=5,
+            iou=0.85,
+        )
+        assert assignment.frame_idx == 10
+        assert assignment.input_track_id == 1
+        assert assignment.input_track_name == "mouse1"
+        assert assignment.sam3_obj_id == 5
+        assert assignment.iou == 0.85
+        assert assignment.sam3_score == 1.0  # Default
+
+    def test_with_score(self):
+        """Test assignment with custom score."""
+        assignment = MaskAssignment(
+            frame_idx=0,
+            input_track_id=0,
+            input_track_name=None,
+            sam3_obj_id=0,
+            iou=0.5,
+            sam3_score=0.9,
+        )
+        assert assignment.sam3_score == 0.9
+
+    def test_none_track_name(self):
+        """Test assignment with no track name."""
+        assignment = MaskAssignment(
+            frame_idx=0,
+            input_track_id=0,
+            input_track_name=None,
+            sam3_obj_id=0,
+            iou=0.5,
+        )
+        assert assignment.input_track_name is None
+
+
+class TestMaskReconciler:
+    """Tests for MaskReconciler class."""
+
+    @pytest.fixture
+    def sample_masks_overlapping(self):
+        """Create two pairs of overlapping masks for testing."""
+        # Input mask 1: top-left quadrant
+        input1 = np.zeros((100, 100), dtype=np.uint8)
+        input1[:50, :50] = 1
+
+        # Input mask 2: bottom-right quadrant
+        input2 = np.zeros((100, 100), dtype=np.uint8)
+        input2[50:, 50:] = 1
+
+        # SAM3 mask 1: overlaps with input1 (shifted slightly)
+        sam3_1 = np.zeros((100, 100), dtype=np.uint8)
+        sam3_1[10:60, 10:60] = 1  # 40x40 overlap with input1
+
+        # SAM3 mask 2: overlaps with input2 (shifted slightly)
+        sam3_2 = np.zeros((100, 100), dtype=np.uint8)
+        sam3_2[40:90, 40:90] = 1  # 40x40 overlap with input2
+
+        return (
+            np.stack([input1, input2]),  # input_masks
+            np.stack([sam3_1, sam3_2]),  # sam3_masks
+        )
+
+    def test_init_default(self):
+        """Test reconciler initialization with defaults."""
+        reconciler = MaskReconciler()
+        assert reconciler.min_iou == 0.3
+        assert reconciler.track_names == {}
+        assert reconciler.get_assignments() == []
+
+    def test_init_custom(self):
+        """Test reconciler initialization with custom values."""
+        reconciler = MaskReconciler(
+            min_iou=0.5,
+            track_names={0: "mouse1", 1: "mouse2"},
+        )
+        assert reconciler.min_iou == 0.5
+        assert reconciler.track_names == {0: "mouse1", 1: "mouse2"}
+
+    def test_compute_iou_perfect_overlap(self):
+        """Test IoU computation with perfect overlap."""
+        mask = np.ones((50, 50), dtype=np.uint8)
+        iou = MaskReconciler.compute_iou(mask, mask)
+        assert iou == 1.0
+
+    def test_compute_iou_no_overlap(self):
+        """Test IoU computation with no overlap."""
+        mask1 = np.zeros((100, 100), dtype=np.uint8)
+        mask1[:50, :] = 1
+
+        mask2 = np.zeros((100, 100), dtype=np.uint8)
+        mask2[50:, :] = 1
+
+        iou = MaskReconciler.compute_iou(mask1, mask2)
+        assert iou == 0.0
+
+    def test_compute_iou_partial_overlap(self):
+        """Test IoU computation with partial overlap."""
+        mask1 = np.zeros((100, 100), dtype=np.uint8)
+        mask1[:60, :60] = 1  # 3600 pixels
+
+        mask2 = np.zeros((100, 100), dtype=np.uint8)
+        mask2[30:90, 30:90] = 1  # 3600 pixels
+
+        # Intersection: 30:60, 30:60 = 30x30 = 900 pixels
+        # Union: 3600 + 3600 - 900 = 6300 pixels
+        # IoU = 900 / 6300 ≈ 0.143
+        iou = MaskReconciler.compute_iou(mask1, mask2)
+        assert 0.14 < iou < 0.15
+
+    def test_compute_iou_empty_masks(self):
+        """Test IoU computation with empty masks."""
+        empty = np.zeros((50, 50), dtype=np.uint8)
+        iou = MaskReconciler.compute_iou(empty, empty)
+        assert iou == 0.0
+
+    def test_compute_cost_matrix(self, sample_masks_overlapping):
+        """Test cost matrix computation."""
+        input_masks, sam3_masks = sample_masks_overlapping
+        reconciler = MaskReconciler()
+
+        cost = reconciler.compute_cost_matrix(input_masks, sam3_masks)
+
+        assert cost.shape == (2, 2)
+        # Input mask 0 should have higher IoU with SAM3 mask 0
+        assert cost[0, 0] < cost[0, 1]
+        # Input mask 1 should have higher IoU with SAM3 mask 1
+        assert cost[1, 1] < cost[1, 0]
+
+    def test_compute_cost_matrix_empty_input(self):
+        """Test cost matrix with empty input masks."""
+        reconciler = MaskReconciler()
+        sam3_masks = np.ones((2, 50, 50), dtype=np.uint8)
+
+        cost = reconciler.compute_cost_matrix(np.array([]), sam3_masks)
+        assert cost.shape == (0, 2)
+
+    def test_compute_cost_matrix_empty_sam3(self):
+        """Test cost matrix with empty SAM3 masks."""
+        reconciler = MaskReconciler()
+        input_masks = np.ones((2, 50, 50), dtype=np.uint8)
+
+        cost = reconciler.compute_cost_matrix(input_masks, np.array([]))
+        assert cost.shape == (2, 0)
+
+    def test_compute_cost_matrix_4d_sam3(self):
+        """Test cost matrix handles (N, 1, H, W) SAM3 format."""
+        reconciler = MaskReconciler()
+        input_masks = np.ones((2, 50, 50), dtype=np.uint8)
+        sam3_masks = np.ones((2, 1, 50, 50), dtype=np.uint8)  # 4D format
+
+        cost = reconciler.compute_cost_matrix(input_masks, sam3_masks)
+        assert cost.shape == (2, 2)
+
+    def test_match_frame(self, sample_masks_overlapping):
+        """Test frame matching."""
+        input_masks, sam3_masks = sample_masks_overlapping
+        reconciler = MaskReconciler(min_iou=0.1)
+
+        input_track_ids = np.array([1, 2])
+        sam3_obj_ids = np.array([0, 1])
+
+        assignments = reconciler.match_frame(
+            frame_idx=0,
+            input_masks=input_masks,
+            input_track_ids=input_track_ids,
+            sam3_masks=sam3_masks,
+            sam3_obj_ids=sam3_obj_ids,
+        )
+
+        # Both should match (with low threshold)
+        assert len(assignments) == 2
+
+        # Verify correct pairing
+        assignment_map = {a.input_track_id: a.sam3_obj_id for a in assignments}
+        assert assignment_map[1] == 0  # Input track 1 -> SAM3 obj 0
+        assert assignment_map[2] == 1  # Input track 2 -> SAM3 obj 1
+
+    def test_match_frame_with_track_names(self, sample_masks_overlapping):
+        """Test matching with track name resolution."""
+        input_masks, sam3_masks = sample_masks_overlapping
+        reconciler = MaskReconciler(
+            min_iou=0.1,
+            track_names={1: "mouse1", 2: "mouse2"},
+        )
+
+        assignments = reconciler.match_frame(
+            frame_idx=0,
+            input_masks=input_masks,
+            input_track_ids=np.array([1, 2]),
+            sam3_masks=sam3_masks,
+            sam3_obj_ids=np.array([0, 1]),
+        )
+
+        # Verify track names are populated
+        name_map = {a.input_track_id: a.input_track_name for a in assignments}
+        assert name_map[1] == "mouse1"
+        assert name_map[2] == "mouse2"
+
+    def test_match_frame_iou_threshold(self):
+        """Test that IoU threshold filters matches."""
+        # Create masks with low overlap
+        input_mask = np.zeros((100, 100), dtype=np.uint8)
+        input_mask[:30, :30] = 1
+
+        sam3_mask = np.zeros((100, 100), dtype=np.uint8)
+        sam3_mask[20:50, 20:50] = 1  # Small overlap
+
+        reconciler = MaskReconciler(min_iou=0.5)  # High threshold
+
+        assignments = reconciler.match_frame(
+            frame_idx=0,
+            input_masks=np.array([input_mask]),
+            input_track_ids=np.array([1]),
+            sam3_masks=np.array([sam3_mask]),
+            sam3_obj_ids=np.array([0]),
+        )
+
+        # Should be filtered out by IoU threshold
+        assert len(assignments) == 0
+
+    def test_match_frame_accumulates(self, sample_masks_overlapping):
+        """Test that match_frame accumulates assignments."""
+        input_masks, sam3_masks = sample_masks_overlapping
+        reconciler = MaskReconciler(min_iou=0.1)
+
+        # First frame
+        reconciler.match_frame(
+            frame_idx=0,
+            input_masks=input_masks,
+            input_track_ids=np.array([1, 2]),
+            sam3_masks=sam3_masks,
+            sam3_obj_ids=np.array([0, 1]),
+        )
+        assert len(reconciler.get_assignments()) == 2
+
+        # Second frame
+        reconciler.match_frame(
+            frame_idx=10,
+            input_masks=input_masks,
+            input_track_ids=np.array([1, 2]),
+            sam3_masks=sam3_masks,
+            sam3_obj_ids=np.array([0, 1]),
+        )
+        assert len(reconciler.get_assignments()) == 4
+
+    def test_match_frame_empty_input(self):
+        """Test matching with empty input masks."""
+        reconciler = MaskReconciler()
+        sam3_masks = np.ones((2, 50, 50), dtype=np.uint8)
+
+        assignments = reconciler.match_frame(
+            frame_idx=0,
+            input_masks=np.array([]),
+            input_track_ids=np.array([]),
+            sam3_masks=sam3_masks,
+            sam3_obj_ids=np.array([0, 1]),
+        )
+
+        assert len(assignments) == 0
+
+    def test_detect_swaps_no_swaps(self):
+        """Test swap detection with consistent assignments."""
+        reconciler = MaskReconciler(track_names={1: "mouse1"})
+        reconciler._assignments = [
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=1,
+                input_track_name="mouse1",
+                sam3_obj_id=0,
+                iou=0.9,
+            ),
+            MaskAssignment(
+                frame_idx=10,
+                input_track_id=1,
+                input_track_name="mouse1",
+                sam3_obj_id=0,
+                iou=0.85,
+            ),
+        ]
+
+        swaps = reconciler.detect_swaps()
+        assert len(swaps) == 0
+
+    def test_detect_swaps_with_swap(self):
+        """Test swap detection when identity changes."""
+        reconciler = MaskReconciler(track_names={1: "mouse1"})
+        reconciler._assignments = [
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=1,
+                input_track_name="mouse1",
+                sam3_obj_id=0,
+                iou=0.9,
+            ),
+            MaskAssignment(
+                frame_idx=10,
+                input_track_id=1,
+                input_track_name="mouse1",
+                sam3_obj_id=1,  # Changed!
+                iou=0.85,
+            ),
+        ]
+
+        swaps = reconciler.detect_swaps()
+        assert len(swaps) == 1
+        assert swaps[0].track_name == "mouse1"
+        assert swaps[0].old_sam3_id == 0
+        assert swaps[0].new_sam3_id == 1
+        assert swaps[0].frame_idx == 10
+
+    def test_detect_swaps_multiple_tracks(self):
+        """Test swap detection with multiple tracks."""
+        reconciler = MaskReconciler()
+        reconciler._assignments = [
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=1,
+                input_track_name=None,
+                sam3_obj_id=0,
+                iou=0.9,
+            ),
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=2,
+                input_track_name=None,
+                sam3_obj_id=1,
+                iou=0.9,
+            ),
+            MaskAssignment(
+                frame_idx=10,
+                input_track_id=1,
+                input_track_name=None,
+                sam3_obj_id=1,
+                iou=0.85,  # Track 1 swapped to obj 1
+            ),
+            MaskAssignment(
+                frame_idx=10,
+                input_track_id=2,
+                input_track_name=None,
+                sam3_obj_id=0,
+                iou=0.85,  # Track 2 swapped to obj 0
+            ),
+        ]
+
+        swaps = reconciler.detect_swaps()
+        assert len(swaps) == 2
+
+    def test_build_id_map(self):
+        """Test building frame-to-ID mapping."""
+        reconciler = MaskReconciler(track_names={1: "mouse1", 2: "mouse2"})
+        reconciler._assignments = [
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=1,
+                input_track_name="mouse1",
+                sam3_obj_id=0,
+                iou=0.9,
+            ),
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=2,
+                input_track_name="mouse2",
+                sam3_obj_id=1,
+                iou=0.85,
+            ),
+            MaskAssignment(
+                frame_idx=10,
+                input_track_id=1,
+                input_track_name="mouse1",
+                sam3_obj_id=0,
+                iou=0.8,
+            ),
+        ]
+
+        id_map = reconciler.build_id_map()
+        assert 0 in id_map
+        assert 10 in id_map
+        assert id_map[0][0] == "mouse1"
+        assert id_map[0][1] == "mouse2"
+        assert id_map[10][0] == "mouse1"
+
+    def test_build_id_map_fallback_names(self):
+        """Test ID map uses generated names when track_name is None."""
+        reconciler = MaskReconciler()
+        reconciler._assignments = [
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=42,
+                input_track_name=None,
+                sam3_obj_id=0,
+                iou=0.9,
+            ),
+        ]
+
+        id_map = reconciler.build_id_map()
+        assert id_map[0][0] == "track_42"
+
+    def test_get_iou_stats(self):
+        """Test IoU statistics computation."""
+        reconciler = MaskReconciler()
+        reconciler._assignments = [
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=1,
+                input_track_name=None,
+                sam3_obj_id=0,
+                iou=0.5,
+            ),
+            MaskAssignment(
+                frame_idx=0,
+                input_track_id=2,
+                input_track_name=None,
+                sam3_obj_id=1,
+                iou=0.7,
+            ),
+            MaskAssignment(
+                frame_idx=10,
+                input_track_id=1,
+                input_track_name=None,
+                sam3_obj_id=0,
+                iou=0.9,
+            ),
+        ]
+
+        stats = reconciler.get_iou_stats()
+        assert stats["min"] == 0.5
+        assert stats["max"] == 0.9
+        assert stats["mean"] == pytest.approx(0.7, abs=0.01)
+        assert stats["median"] == 0.7
+
+    def test_get_iou_stats_empty(self):
+        """Test IoU statistics with no assignments."""
+        reconciler = MaskReconciler()
+        stats = reconciler.get_iou_stats()
+        assert stats == {"min": 0.0, "max": 0.0, "mean": 0.0, "median": 0.0}
+
+    def test_clear(self, sample_masks_overlapping):
+        """Test clearing assignments."""
+        input_masks, sam3_masks = sample_masks_overlapping
+        reconciler = MaskReconciler(min_iou=0.1)
+
+        reconciler.match_frame(
+            frame_idx=0,
+            input_masks=input_masks,
+            input_track_ids=np.array([1, 2]),
+            sam3_masks=sam3_masks,
+            sam3_obj_ids=np.array([0, 1]),
+        )
+        assert len(reconciler.get_assignments()) > 0
+
+        reconciler.clear()
+        assert len(reconciler.get_assignments()) == 0
+
+    def test_integration_with_track_name_resolver(self, sample_masks_overlapping):
+        """Test that MaskReconciler output works with TrackNameResolver."""
+        input_masks, sam3_masks = sample_masks_overlapping
+        reconciler = MaskReconciler(
+            min_iou=0.1,
+            track_names={1: "mouse1", 2: "mouse2"},
+        )
+
+        # Match at frame 0
+        reconciler.match_frame(
+            frame_idx=0,
+            input_masks=input_masks,
+            input_track_ids=np.array([1, 2]),
+            sam3_masks=sam3_masks,
+            sam3_obj_ids=np.array([0, 1]),
+        )
+
+        # Build ID map and create resolver
+        id_map = reconciler.build_id_map()
+        resolver = TrackNameResolver.from_id_map(id_map)
+
+        # Verify resolver works
+        assert resolver.get_track_name(0, 0) == "mouse1"
+        assert resolver.get_track_name(0, 1) == "mouse2"
+        # Propagation to other frames
+        assert resolver.get_track_name(50, 0) == "mouse1"
+        assert resolver.get_track_name(50, 1) == "mouse2"

--- a/tests/inference/sam/test_retrack.py
+++ b/tests/inference/sam/test_retrack.py
@@ -1,0 +1,378 @@
+"""Tests for mask-based re-tracking (`sleap_nn.inference.sam.retrack`).
+
+The end-to-end test mirrors prototype P3: a (simulated) pose tracker produced
+track labels with an identity SWAP over a window of frames; identity-consistent
+per-frame masks are used to detect and correct the swap purely from
+mask<->pose overlap.
+"""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap_nn.inference.sam.reconciliation import require_min_keypoints_inside
+from sleap_nn.inference.sam.retrack import RetrackResult, retrack
+
+
+@pytest.fixture
+def skeleton():
+    """A simple 3-node skeleton."""
+    return sio.Skeleton(nodes=[sio.Node("a"), sio.Node("b"), sio.Node("c")])
+
+
+def _make_instance(cx, cy, skeleton, track=None, predicted=False):
+    """Build a 3-node instance centered near (cx, cy)."""
+    coords = np.array([[cx, cy], [cx + 5, cy + 5], [cx - 5, cy - 5]], dtype=float)
+    if predicted:
+        return sio.PredictedInstance.from_numpy(
+            coords,
+            skeleton=skeleton,
+            point_scores=np.ones(3),
+            score=1.0,
+            track=track,
+        )
+    return sio.Instance.from_numpy(coords, skeleton=skeleton, track=track)
+
+
+def _make_mask(cx, cy, size=12, shape=(100, 100)):
+    """Build a square binary mask centered at (cx, cy)."""
+    m = np.zeros(shape, dtype=bool)
+    m[cy - size : cy + size, cx - size : cx + size] = True
+    return m
+
+
+def _build_swap_clip(skeleton, n_frames=6, swap_window=(2, 4), predicted=False):
+    """Two-mouse clip with a track-label swap injected over ``swap_window``.
+
+    Returns (labeled_frames, masks, object_ids, tracks). obj_id 0 always covers
+    mouse at (20, 20); obj_id 1 always covers mouse at (70, 70) (masks are the
+    *correct* identity signal).
+    """
+    t0 = sio.Track("mouse0")
+    t1 = sio.Track("mouse1")
+    lo, hi = swap_window
+    frames, masks, obj_ids = [], [], []
+    for f in range(n_frames):
+        i0 = _make_instance(20, 20, skeleton, track=t0, predicted=predicted)
+        i1 = _make_instance(70, 70, skeleton, track=t1, predicted=predicted)
+        if lo <= f < hi:  # injected swap
+            i0.track, i1.track = t1, t0
+        frames.append(sio.LabeledFrame(video=None, frame_idx=f, instances=[i0, i1]))
+        masks.append(np.stack([_make_mask(20, 20), _make_mask(70, 70)]))
+        obj_ids.append(np.array([0, 1]))
+    return frames, masks, obj_ids, (t0, t1)
+
+
+def _names(frames):
+    return [
+        [inst.track.name if inst.track else None for inst in lf.instances]
+        for lf in frames
+    ]
+
+
+class TestRetrackEndToEnd:
+    """End-to-end re-tracking on a simulated identity swap (P3 scenario)."""
+
+    def test_corrects_minority_swap(self, skeleton):
+        """A minority-window swap is fully corrected by majority-vote naming."""
+        frames, masks, obj_ids, _ = _build_swap_clip(skeleton)
+
+        # Pre-condition: frames 2 and 3 are swapped.
+        before = _names(frames)
+        assert before[2] == ["mouse1", "mouse0"]
+        assert before[3] == ["mouse1", "mouse0"]
+
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+
+        assert isinstance(result, RetrackResult)
+        assert result.canonical_map == {0: "mouse0", 1: "mouse1"}
+        assert result.num_matched == 12  # 2 instances x 6 frames
+        assert result.num_relabeled == 4  # 2 instances x 2 swapped frames
+
+        after = _names(frames)
+        for f in range(6):
+            assert after[f] == ["mouse0", "mouse1"], f"frame {f} not corrected"
+
+    def test_accuracy_before_after(self, skeleton):
+        """Track-name accuracy goes from <1.0 to 1.0 after re-tracking."""
+        frames, masks, obj_ids, _ = _build_swap_clip(skeleton)
+        truth = {0: "mouse0", 1: "mouse1"}  # pose order -> true name
+
+        def accuracy(names):
+            correct = total = 0
+            for frame_names in names:
+                for j, got in enumerate(frame_names):
+                    total += 1
+                    correct += int(got == truth[j])
+            return correct / total
+
+        acc_before = accuracy(_names(frames))
+        retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        acc_after = accuracy(_names(frames))
+
+        assert acc_before < 1.0
+        assert acc_after == 1.0
+
+    def test_works_on_predicted_instances(self, skeleton):
+        """Re-tracking operates on `PredictedInstance`s (the inference case)."""
+        frames, masks, obj_ids, _ = _build_swap_clip(skeleton, predicted=True)
+        assert all(
+            isinstance(inst, sio.PredictedInstance)
+            for lf in frames
+            for inst in lf.instances
+        )
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        assert result.num_relabeled == 4
+        assert _names(frames) == [["mouse0", "mouse1"]] * 6
+
+
+class TestRetrackBehavior:
+    """Targeted behavior / option tests."""
+
+    def test_no_swap_is_noop(self, skeleton):
+        """A clean clip is left untouched (zero relabels)."""
+        frames, masks, obj_ids, _ = _build_swap_clip(skeleton, swap_window=(0, 0))
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        assert result.num_relabeled == 0
+        assert _names(frames) == [["mouse0", "mouse1"]] * 6
+
+    def test_in_place_false_preserves_input(self, skeleton):
+        """``in_place=False`` leaves the caller's frames untouched."""
+        frames, masks, obj_ids, _ = _build_swap_clip(skeleton)
+        before = _names(frames)
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+            in_place=False,
+        )
+        # Original frames unchanged...
+        assert _names(frames) == before
+        # ...but the correction is returned on the result's frames.
+        assert result.num_relabeled == 4
+        assert result.canonical_map == {0: "mouse0", 1: "mouse1"}
+        assert result.labeled_frames is not frames
+        assert _names(result.labeled_frames) == [["mouse0", "mouse1"]] * 6
+
+    def test_in_place_true_returns_same_frames(self, skeleton):
+        """``in_place=True`` returns the caller's own frame objects."""
+        frames, masks, obj_ids, _ = _build_swap_clip(skeleton)
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        assert all(a is b for a, b in zip(result.labeled_frames, frames))
+
+    def test_explicit_anchor_frames(self, skeleton):
+        """Explicit (clean) anchor frames define identity for all frames."""
+        frames, masks, obj_ids, _ = _build_swap_clip(skeleton)
+        # Anchor only on clean frames 0 and 5.
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+            anchor_frame_indices=[0, 5],
+        )
+        assert result.anchor_frames == [0, 5]
+        assert result.canonical_map == {0: "mouse0", 1: "mouse1"}
+        assert _names(frames) == [["mouse0", "mouse1"]] * 6
+
+    def test_cross_anchor_reassignment_routes_per_frame(self, skeleton):
+        """A genuine cross-anchor identity change flips at the nearest anchor.
+
+        Two sparse anchors (frames 0 and 10) disagree on what obj_id 0 is
+        (mouse0 vs mouse1) -> obj_id is ambiguous (tie) and must resolve via the
+        nearest anchor, not a global canonical name.
+        """
+        t0 = sio.Track("mouse0")
+        t1 = sio.Track("mouse1")
+        frames, masks, obj_ids = [], [], []
+        for f in range(11):
+            # Anchor frames carry GT (user) tracks; others are predicted/untracked.
+            if f == 0:
+                tracks = (t0, t1)  # obj0 -> mouse0
+                pred = False
+            elif f == 10:
+                tracks = (t1, t0)  # obj0 -> mouse1 (real reassignment)
+                pred = False
+            else:
+                tracks = (None, None)
+                pred = True
+            i0 = _make_instance(20, 20, skeleton, track=tracks[0], predicted=pred)
+            i1 = _make_instance(70, 70, skeleton, track=tracks[1], predicted=pred)
+            frames.append(sio.LabeledFrame(video=None, frame_idx=f, instances=[i0, i1]))
+            masks.append(np.stack([_make_mask(20, 20), _make_mask(70, 70)]))
+            obj_ids.append(np.array([0, 1]))
+
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        # Only the two GT frames anchor (predicted frames are not anchors).
+        assert result.anchor_frames == [0, 10]
+        # obj_id 0 is ambiguous across anchors -> not in the canonical map.
+        assert 0 not in result.canonical_map
+        names = _names(frames)
+        # Frames nearer anchor 0 -> obj0 is mouse0; nearer anchor 10 -> mouse1.
+        assert names[1][0] == "mouse0"
+        assert names[9][0] == "mouse1"
+
+    def test_exclude_nodes(self, skeleton):
+        """Excluded nodes do not contribute to keypoints-inside matching."""
+        frames, masks, obj_ids, _ = _build_swap_clip(
+            skeleton, n_frames=2, swap_window=(0, 0)
+        )
+        # Excluding all nodes makes every match fail the >=1 predicate.
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            exclude_nodes={"a", "b", "c"},
+        )
+        assert result.num_matched == 0
+        assert result.num_relabeled == 0
+
+
+class TestRetrackInputHandling:
+    """Input normalization and validation."""
+
+    def test_squeezes_4d_masks(self, skeleton):
+        """`(N, 1, H, W)` SAM3 mask format is squeezed transparently."""
+        frames, masks2d, obj_ids, _ = _build_swap_clip(
+            skeleton, n_frames=2, swap_window=(0, 0)
+        )
+        masks4d = [m[:, None, :, :] for m in masks2d]  # (N, 1, H, W)
+        result = retrack(
+            frames,
+            masks4d,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        assert result.num_matched == 4  # 2 instances x 2 frames
+
+    def test_drops_padded_object_ids(self, skeleton):
+        """Padded entries (object_id < 0) are dropped before matching."""
+        frames, masks, obj_ids, _ = _build_swap_clip(
+            skeleton, n_frames=2, swap_window=(0, 0)
+        )
+        # Pad each frame with a third sentinel mask/obj_id.
+        padded_masks = [
+            np.concatenate([m, np.zeros((1,) + m.shape[1:], dtype=bool)], axis=0)
+            for m in masks
+        ]
+        padded_ids = [np.array([0, 1, -1]) for _ in obj_ids]
+        result = retrack(
+            frames,
+            padded_masks,
+            padded_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        # Padding ignored: still a clean 2-mouse match, no spurious obj_id.
+        assert -1 not in result.canonical_map
+        assert result.canonical_map == {0: "mouse0", 1: "mouse1"}
+
+    def test_aligns_scores_after_padding_drop(self, skeleton):
+        """Per-frame scores are realigned when padding is dropped."""
+        frames, masks, obj_ids, _ = _build_swap_clip(
+            skeleton, n_frames=2, swap_window=(0, 0)
+        )
+        padded_masks = [
+            np.concatenate([m, np.zeros((1,) + m.shape[1:], dtype=bool)], axis=0)
+            for m in masks
+        ]
+        padded_ids = [np.array([0, 1, -1]) for _ in obj_ids]
+        scores = [np.array([0.9, 0.8, 0.0]) for _ in obj_ids]
+        result = retrack(
+            frames,
+            padded_masks,
+            padded_ids,
+            skeleton,
+            scores=scores,
+            match_predicates=[require_min_keypoints_inside(1)],
+        )
+        kept_scores = sorted(a.sam3_score for a in result.assignments)
+        assert kept_scores == pytest.approx([0.8, 0.8, 0.9, 0.9])
+
+    def test_empty_frame_is_handled(self, skeleton):
+        """A frame with no instances/masks contributes nothing."""
+        empty = sio.LabeledFrame(video=None, frame_idx=0, instances=[])
+        result = retrack(
+            [empty],
+            [np.zeros((0, 100, 100), dtype=bool)],
+            [np.zeros((0,), dtype=int)],
+            skeleton,
+        )
+        assert result.num_matched == 0
+        assert result.num_relabeled == 0
+        assert result.canonical_map == {}
+
+    def test_length_mismatch_raises(self, skeleton):
+        """Mismatched masks/object_ids/frames lengths raise ValueError."""
+        frames, masks, obj_ids, _ = _build_swap_clip(
+            skeleton, n_frames=2, swap_window=(0, 0)
+        )
+        with pytest.raises(ValueError, match="same length"):
+            retrack(frames, masks[:1], obj_ids, skeleton)
+
+    def test_scores_length_mismatch_raises(self, skeleton):
+        """Mismatched scores length raises ValueError."""
+        frames, masks, obj_ids, _ = _build_swap_clip(
+            skeleton, n_frames=2, swap_window=(0, 0)
+        )
+        with pytest.raises(ValueError, match="scores"):
+            retrack(frames, masks, obj_ids, skeleton, scores=[np.ones(2)])
+
+    def test_fallback_names_for_unmatched_objects(self, skeleton):
+        """obj_ids never anchored fall back to provided names."""
+        # Single untracked predicted instance -> no anchor name for its obj_id.
+        inst = _make_instance(20, 20, skeleton, track=None, predicted=True)
+        frames = [sio.LabeledFrame(video=None, frame_idx=0, instances=[inst])]
+        masks = [np.stack([_make_mask(20, 20)])]
+        obj_ids = [np.array([7])]
+        result = retrack(
+            frames,
+            masks,
+            obj_ids,
+            skeleton,
+            match_predicates=[require_min_keypoints_inside(1)],
+            fallback_names={7: "extra"},
+        )
+        assert result.num_matched == 1
+        assert frames[0].instances[0].track.name == "extra"


### PR DESCRIPTION
> **Status:** Deferred building block (PLAN PR-C). This PR is torch-less, CI-green, and additive; it ships **no end-to-end user-facing capability on its own** — user-facing mask inference arrives via #647 (PR-A). `retrack()`'s only mask producer is the deferred SAM3 video tracker (PR-D). Landed now, ahead of its producer, as the sanctioned PLAN-ordered, de-risking building block.

## What

PR-C of the SAM-powered **inference** segmentation stack: the **torch-less reconciliation / mask-based re-tracking** path. New code lives under `sleap_nn/inference/sam/`. Independent of the SAM mask producers (PR-A/PR-B) — **no torch, SAM, or transformers** — so it can land first / in parallel. Dependencies: numpy + scipy only; `sleap_io` is referenced under `TYPE_CHECKING` (reconciliation) or lazily inside functions (retrack).

## Contents

### `reconciliation.py` — lifted **verbatim**
Lifted byte-for-byte from `talmolab/sam-track` (BSD-3-Clause) at commit `7b2531d92b5035f5f83016b12350f7c394b92522`:

> https://github.com/talmolab/sam-track/blob/7b2531d92b5035f5f83016b12350f7c394b92522/src/sam_track/reconciliation.py

The only change is a BSD-3 attribution + permalink header prepended to the module docstring; the implementation is unchanged. Provides:
- `IDReconciler` — mask↔pose Hungarian matching on keypoints-inside-mask
- `MaskReconciler` — mask↔mask IoU Hungarian matching
- swap detection (`detect_swaps`), id maps (`build_id_map`)
- predicate factories (`require_min_keypoints_inside`, `require_min_fraction_inside`, `require_centroid_proximity`, `require_reasonable_mask_area`)
- `TrackNameResolver` — nearest-anchor track-name flood fill (sparse GT anchors → all frames)

### `retrack.py` — new `retrack()` orchestration (public, documented)
Implements the **"refine existing tracks"** path. Given labeled frames whose instances already carry (possibly **wrong**) track labels, plus identity-consistent per-frame masks (e.g. from a SAM3 video tracker), `retrack()`:

1. Hungarian-matches poses → masks per frame (`IDReconciler`), gated by a match predicate (default ≥1 keypoint inside; `require_min_keypoints_inside(3)` recommended).
2. Anchors the `mask_obj_id → track_name` identity on **trusted** frames (default: frames carrying GT/user tracks, via the `type(i) is sio.Instance` GT-precedence rule; else all frames; or an explicit `anchor_frame_indices`).
3. Names each obj_id by **majority vote** across anchors (so a minority of swapped/wrong anchor frames can't flip a stable identity), with **nearest-anchor per-frame** fallback for genuine cross-anchor reassignments (the sparse-GT SAM3 case).
4. Relabels every matched instance; unmatched instances keep their original track.

Defensive handling: squeezes `(N,1,H,W)` SAM3 masks, drops `object_id < 0` padding (and realigns scores), validates lengths. `in_place` toggle; corrected frames are always returned on `RetrackResult.labeled_frames`.

This is the post-processing identity-correction path: per the experimental finding baked into `reconciliation.py`, SAM3 mid-propagation re-prompting adds *new* objects but does not fix *existing* tracks, so correction happens here, after tracking.

## Tests — `tests/inference/sam/`
- `test_reconciliation.py`: the ~70 CPU-only reconciliation tests brought over from sam-track (import path swapped to `sleap_nn.inference.sam.reconciliation`).
- `test_retrack.py`: new suite for `retrack()` — the P3 simulated swap (track-name accuracy **<1.0 → 1.0**), `PredictedInstance` inputs (the inference case), no-swap no-op, `in_place` semantics, explicit/sparse anchors, genuine cross-anchor reassignment routing per-frame, `(N,1,H,W)` squeeze, padding drop + score realignment, empty frames, length validation, and fallback names.

**86 tests pass; `black --check` and `ruff check sleap_nn/` clean.**

## Scope / non-goals
- No SAM/torch/transformers; no changes to shared inference code (purely additive new package).
- The SAM3 mask *producer* (PR-B) and mask-native video *tracker* (PR-D) are separate PRs; this PR only consumes masks for re-tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
