### PR TITLE
feat(seg): SAM1 prompted inference segmentation core

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -13,6 +13,7 @@ Task-oriented guides for common workflows.
 | &nbsp;&nbsp;&nbsp;&nbsp;[Python API](inference-api.md) | `Predictor` / `predict` / `Outputs` for embedding inference in code |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Centroid-Only](centroid-only-inference.md) | Run a centroid model standalone |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Top-Down Segmentation](topdown-segmentation.md) | Per-instance masks via centroid + crop-mask |
+| &nbsp;&nbsp;&nbsp;&nbsp;[SAM-Prompted Segmentation](sam-inference-segmentation.md) | Per-instance masks from poses via Segment Anything |
 | [Evaluation](evaluation.md) | Assess model performance with metrics |
 | [Tracking](tracking.md) | Assign consistent IDs across frames |
 | [Export](export.md) | ONNX/TensorRT for production inference |

--- a/docs/guides/sam-inference-segmentation.md
+++ b/docs/guides/sam-inference-segmentation.md
@@ -12,10 +12,10 @@ from a trained `centered_instance_segmentation` head; here it comes from SAM,
 prompted by poses you already have. Use it to bootstrap masks from a pose model
 without training a mask model.
 
-> **v1 is prompted-only.** Four prompt modes — pose, centroid, box, and the
-> top-down crop-center-pixel seam. Unprompted ("everything") mask generation is
-> deferred. The GUI correction round-trip is gated on upstream frontend work; v1
-> ships the masks plus a review-overlay PNG.
+> **v1 is prompted-only.** Three prompt modes — pose, centroid, and box.
+> Unprompted ("everything") mask generation is deferred. The GUI correction
+> round-trip is gated on upstream frontend work; v1 ships the masks plus a
+> review-overlay PNG.
 
 ## Install
 
@@ -78,7 +78,6 @@ labels = run_sam_segmentation(
 | **pose** | every visible keypoint as a positive point **+** the padded keypoint box | a pose | cleanest; the product rule below |
 | **centroid** | a single positive point (anchor node or the mean keypoint) | a centroid | under-covers; box kept only for candidate rejection |
 | **box** | the padded pose box, no points | a pose | leaks between adjacent animals; secondary |
-| **crop-center-pixel** | the crop center `(w/2, h/2)` of an instance-centered crop | a centroid | the top-down seam (`FindInstanceMaskSAM`); needs no pose |
 
 **Product rule:** in `"pose"` mode, an instance with no visible keypoints falls
 back to its centroid as a single point. No negative points are used for
@@ -93,22 +92,10 @@ Each instance produces one `sio.PredictedSegmentationMask` on
   scores are surfaced, not dropped).
 - `instance` / `track` / `tracking_score` — populated from the source pose when
   present, so a correction is referential (which instance) not positional.
-- full-frame masks use identity `scale`/`offset`; crop-center-pixel masks pack a
-  crop-local mask at `offset=floored_top_left`, byte-identical to the trained
-  top-down segmentation layer's output.
+- full-frame masks use identity `scale`/`offset`.
 
 The original pose instances are retained alongside the masks (correction needs
 the pose).
-
-## The top-down crop-center seam
-
-`FindInstanceMaskSAM` is a drop-in twin of the trained `CenteredInstanceMaskLayer`:
-it honors the same `.predict(crops) -> Outputs(crops, instance_scores)` contract,
-so it slots straight into `TopDownSegmentationLayer._run_stage_2` and inherits the
-entire offset/scale/`to_masks`/`save` path. Each crop is prompted at its center
-pixel (the centroid the crop was centered on); because the mask comes back at
-crop-pixel resolution, `output_stride=1` and `input_scale=1`, giving
-`scale=(eff, eff)` and `offset=floored_top_left/eff`.
 
 ## Limitations
 

--- a/docs/guides/sam-inference-segmentation.md
+++ b/docs/guides/sam-inference-segmentation.md
@@ -1,0 +1,120 @@
+# SAM-prompted instance segmentation (inference)
+
+Predict a **per-instance mask** for every animal in an existing pose `.slp` by
+prompting [Segment Anything](https://github.com/facebookresearch/segment-anything)
+(SAM) with the predicted keypoints / centroids. The masks are written as
+`sio.PredictedSegmentationMask` so they import into the SLEAP GUI for review and
+correction; you do **not** train a segmentation model.
+
+This is the inference complement to
+[top-down (trained) segmentation](topdown-segmentation.md): there the mask comes
+from a trained `centered_instance_segmentation` head; here it comes from SAM,
+prompted by poses you already have. Use it to bootstrap masks from a pose model
+without training a mask model.
+
+> **v1 is prompted-only.** Four prompt modes — pose, centroid, box, and the
+> top-down crop-center-pixel seam. Unprompted ("everything") mask generation is
+> deferred. The GUI correction round-trip is gated on upstream frontend work; v1
+> ships the masks plus a review-overlay PNG.
+
+## Install
+
+SAM1 (ViT-H, Apache-2.0, ungated) is an **optional, lazily imported** extra so
+the default install never needs it:
+
+```bash
+pip install "sleap-nn[sam]"
+```
+
+Download a SAM checkpoint (e.g.
+[`sam_vit_h_4b8939.pth`](https://github.com/facebookresearch/segment-anything#model-checkpoints))
+and pass its path via `sam_checkpoint=`.
+
+## The backend is explicit — there is no default
+
+`mask_backend` is **required** when you ask for SAM masks; nothing is selected
+silently. `"sam"` is SAM1 (this PR); `"sam3"` (the gated SAM3 image path) lands
+in a follow-up behind the `sleap_nn[sam3]` extra. Each backend stores its own
+**raw** per-model score in `PredictedSegmentationMask.score`.
+
+## Predict masks for a pose `.slp`
+
+```python
+from sleap_nn.inference.run import predict
+
+labels = predict(
+    "poses.pkg.slp",            # a .slp with predicted poses + image data
+    mask_backend="sam",         # explicit, required
+    sam_checkpoint="/path/to/sam_vit_h_4b8939.pth",
+    sam_prompt_mode="pose",     # "pose" | "centroid" | "box"
+    device="cuda",
+    output_path="poses_with_masks.pkg.slp",
+    overlay_path="review_frame0.png",   # optional review overlay (PLAN L4)
+)
+```
+
+When `mask_backend` is set, `source` is treated as a pose `.slp` and masks are
+produced from its existing instances — **no trained seg model**, so you must not
+also pass `model_paths` / `export_dir`.
+
+Or call the producer directly:
+
+```python
+from sleap_nn.inference.sam import run_sam_segmentation
+
+labels = run_sam_segmentation(
+    "poses.pkg.slp",
+    mask_backend="sam",
+    prompt_mode="pose",
+    sam_checkpoint="/path/to/sam_vit_h_4b8939.pth",
+    device="cuda",
+)
+```
+
+## Prompt modes
+
+| Mode | Prompt | Needs | Notes |
+|------|--------|-------|-------|
+| **pose** | every visible keypoint as a positive point **+** the padded keypoint box | a pose | cleanest; the product rule below |
+| **centroid** | a single positive point (anchor node or the mean keypoint) | a centroid | under-covers; box kept only for candidate rejection |
+| **box** | the padded pose box, no points | a pose | leaks between adjacent animals; secondary |
+| **crop-center-pixel** | the crop center `(w/2, h/2)` of an instance-centered crop | a centroid | the top-down seam (`FindInstanceMaskSAM`); needs no pose |
+
+**Product rule:** in `"pose"` mode, an instance with no visible keypoints falls
+back to its centroid as a single point. No negative points are used for
+automatic prompting.
+
+## What gets written
+
+Each instance produces one `sio.PredictedSegmentationMask` on
+`LabeledFrame.masks`:
+
+- `score` — the raw SAM predicted-IoU of the chosen candidate (no drop-gate; low
+  scores are surfaced, not dropped).
+- `instance` / `track` / `tracking_score` — populated from the source pose when
+  present, so a correction is referential (which instance) not positional.
+- full-frame masks use identity `scale`/`offset`; crop-center-pixel masks pack a
+  crop-local mask at `offset=floored_top_left`, byte-identical to the trained
+  top-down segmentation layer's output.
+
+The original pose instances are retained alongside the masks (correction needs
+the pose).
+
+## The top-down crop-center seam
+
+`FindInstanceMaskSAM` is a drop-in twin of the trained `CenteredInstanceMaskLayer`:
+it honors the same `.predict(crops) -> Outputs(crops, instance_scores)` contract,
+so it slots straight into `TopDownSegmentationLayer._run_stage_2` and inherits the
+entire offset/scale/`to_masks`/`save` path. Each crop is prompted at its center
+pixel (the centroid the crop was centered on); because the mask comes back at
+crop-pixel resolution, `output_stride=1` and `input_scale=1`, giving
+`scale=(eff, eff)` and `offset=floored_top_left/eff`.
+
+## Limitations
+
+- SAM works best on compact animals (e.g. mice); it degrades on tiny / elongated
+  ones (e.g. flies) — choose the mode per dataset, or skip SAM there.
+- On extreme-low-light data a lone center point can under-segment; prefer the
+  pose prompt when a pose exists.
+- The GUI correction round-trip (predicted→user mask transition, mask editing) is
+  upstream work; v1 is review-only.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Python API: guides/inference-api.md
       - Centroid-Only: guides/centroid-only-inference.md
       - Top-Down Segmentation: guides/topdown-segmentation.md
+      - SAM-Prompted Segmentation: guides/sam-inference-segmentation.md
       - Performance: guides/inference-performance.md
     - Evaluation: guides/evaluation.md
     - Tracking: guides/tracking.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,14 @@ tensorrt = [
     "tensorrt>=10.13.0; sys_platform == 'linux' or sys_platform == 'win32'",
     "torch-tensorrt>=2.5.0; sys_platform == 'linux' or sys_platform == 'win32'",
 ]
+# SAM1 prompted-mask inference (`mask_backend="sam"`). Lazy: imported only inside
+# the SAM backend, so the default install never needs it. ViT-H is Apache-2.0 and
+# ungated; download a checkpoint (e.g. sam_vit_h_4b8939.pth) separately and pass
+# it via `sam_checkpoint=`.
+sam = [
+    "segment-anything>=1.0",
+    "opencv-python-headless>=4.5",
+]
 
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv sync`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,10 @@ tensorrt = [
 # SAM1 prompted-mask inference (`mask_backend="sam"`). Lazy: imported only inside
 # the SAM backend, so the default install never needs it. ViT-H is Apache-2.0 and
 # ungated; download a checkpoint (e.g. sam_vit_h_4b8939.pth) separately and pass
-# it via `sam_checkpoint=`.
+# it via `sam_checkpoint=`. cv2 (CLAHE / overlay) comes from the base
+# `opencv-python` dependency, so no OpenCV is pinned here.
 sam = [
     "segment-anything>=1.0",
-    "opencv-python-headless>=4.5",
 ]
 
 [dependency-groups]

--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -547,9 +547,13 @@ class Outputs:
         offset``). By default ``mask`` is at output-stride resolution; with
         ``full_res_masks`` it is at original-image resolution with identity
         ``scale``/``offset``. ``scale``/``offset`` are read with identity
-        defaults for back-compat callers that build this dict directly. Each
-        entry becomes a ``sio.PredictedSegmentationMask`` (stored in
-        ``LabeledFrame.masks``). Returns ``[]`` when there are no masks.
+        defaults for back-compat callers that build this dict directly. An entry
+        may also carry optional ``"instance"``/``"track"``/``"tracking_score"``
+        provenance (set by the SAM mask layer per PLAN L8 when the mask was
+        produced from a paired pose/centroid/track); these default to absent so
+        the model-driven seg layers are unchanged. Each entry becomes a
+        ``sio.PredictedSegmentationMask`` (stored in ``LabeledFrame.masks``).
+        Returns ``[]`` when there are no masks.
 
         Args:
             batch_index: Which sample in the batch to convert.
@@ -571,6 +575,9 @@ class Outputs:
                     float(inst.get("score", 0.0)),
                     scale=inst.get("scale", (1.0, 1.0)),
                     offset=inst.get("offset", (0.0, 0.0)),
+                    instance=inst.get("instance"),
+                    track=inst.get("track"),
+                    tracking_score=inst.get("tracking_score"),
                 )
             )
         return out

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -443,6 +443,63 @@ def _build_topdown_segmentation_layer(
     )
 
 
+def _build_sam_segmentation_layer(
+    predictor: Any,
+    device: str,
+    mask_backend: str,
+    *,
+    sam_checkpoint: Optional[str] = None,
+    sam_model_type: str = "vit_h",
+    prompt_mode: str = "crop_center",
+) -> TopDownSegmentationLayer:
+    """Compose a centroid stage + a SAM crop-center stage-2 (the top-down seam).
+
+    Reuses :class:`TopDownSegmentationLayer` verbatim — only the stage-2 layer is
+    swapped from the trained ``CenteredInstanceMaskLayer`` to
+    :class:`~sleap_nn.inference.sam.mask_layer.FindInstanceMaskSAM`, which prompts
+    each crop at its center pixel (PLAN §2.1, P2). The whole offset/scale/
+    ``to_masks``/``save`` path is inherited. ``mask_backend`` is **explicit /
+    required** (PLAN L2); the SAM import is lazy (inside the backend).
+
+    Args:
+        predictor: The :class:`Predictor` carrying the inference model (a centroid
+            stage; the seg/instance stage is replaced by SAM and may be absent
+            via the GT-centroid fallback).
+        device: Torch device for the SAM backend.
+        mask_backend: Explicit backend name (``"sam"`` / ``"sam3"``).
+        sam_checkpoint: SAM1 checkpoint path (required for ``"sam"``).
+        sam_model_type: SAM1 model registry key.
+        prompt_mode: The per-crop prompt mode; ``"crop_center"`` (the seam) is the
+            default and only mode wired here in PR-A.
+
+    Returns:
+        A composed :class:`TopDownSegmentationLayer` with a SAM stage-2.
+    """
+    from sleap_nn.inference.sam import get_mask_backend
+    from sleap_nn.inference.sam.mask_layer import FindInstanceMaskSAM
+
+    inf = predictor.inference_model
+    centroid_model = inf.centroid_crop
+    backend = get_mask_backend(
+        mask_backend,
+        sam_checkpoint=sam_checkpoint,
+        sam_model_type=sam_model_type,
+        device=device,
+    )
+    mask_layer = FindInstanceMaskSAM(backend)
+    if getattr(centroid_model, "use_gt_centroids", False):
+        centroid_layer = _build_centroid_layer_gt_only(predictor, None)
+    else:
+        centroid_layer = _build_centroid_layer(centroid_model, device, assets=predictor)
+    crop_h, crop_w = centroid_model.crop_hw
+    return TopDownSegmentationLayer(
+        centroid_layer=centroid_layer,
+        centered_instance_layer=mask_layer,
+        crop_size=(crop_h, crop_w),
+        mask_output="mask",
+    )
+
+
 def _select_layer(assets: Any, model_types: List[str], device: str):
     """Dispatch on detected model types and build the appropriate layer composition."""
     if "single_instance" in model_types:

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -443,63 +443,6 @@ def _build_topdown_segmentation_layer(
     )
 
 
-def _build_sam_segmentation_layer(
-    predictor: Any,
-    device: str,
-    mask_backend: str,
-    *,
-    sam_checkpoint: Optional[str] = None,
-    sam_model_type: str = "vit_h",
-    prompt_mode: str = "crop_center",
-) -> TopDownSegmentationLayer:
-    """Compose a centroid stage + a SAM crop-center stage-2 (the top-down seam).
-
-    Reuses :class:`TopDownSegmentationLayer` verbatim — only the stage-2 layer is
-    swapped from the trained ``CenteredInstanceMaskLayer`` to
-    :class:`~sleap_nn.inference.sam.mask_layer.FindInstanceMaskSAM`, which prompts
-    each crop at its center pixel (PLAN §2.1, P2). The whole offset/scale/
-    ``to_masks``/``save`` path is inherited. ``mask_backend`` is **explicit /
-    required** (PLAN L2); the SAM import is lazy (inside the backend).
-
-    Args:
-        predictor: The :class:`Predictor` carrying the inference model (a centroid
-            stage; the seg/instance stage is replaced by SAM and may be absent
-            via the GT-centroid fallback).
-        device: Torch device for the SAM backend.
-        mask_backend: Explicit backend name (``"sam"`` / ``"sam3"``).
-        sam_checkpoint: SAM1 checkpoint path (required for ``"sam"``).
-        sam_model_type: SAM1 model registry key.
-        prompt_mode: The per-crop prompt mode; ``"crop_center"`` (the seam) is the
-            default and only mode wired here in PR-A.
-
-    Returns:
-        A composed :class:`TopDownSegmentationLayer` with a SAM stage-2.
-    """
-    from sleap_nn.inference.sam import get_mask_backend
-    from sleap_nn.inference.sam.mask_layer import FindInstanceMaskSAM
-
-    inf = predictor.inference_model
-    centroid_model = inf.centroid_crop
-    backend = get_mask_backend(
-        mask_backend,
-        sam_checkpoint=sam_checkpoint,
-        sam_model_type=sam_model_type,
-        device=device,
-    )
-    mask_layer = FindInstanceMaskSAM(backend)
-    if getattr(centroid_model, "use_gt_centroids", False):
-        centroid_layer = _build_centroid_layer_gt_only(predictor, None)
-    else:
-        centroid_layer = _build_centroid_layer(centroid_model, device, assets=predictor)
-    crop_h, crop_w = centroid_model.crop_hw
-    return TopDownSegmentationLayer(
-        centroid_layer=centroid_layer,
-        centered_instance_layer=mask_layer,
-        crop_size=(crop_h, crop_w),
-        mask_output="mask",
-    )
-
-
 def _select_layer(assets: Any, model_types: List[str], device: str):
     """Dispatch on detected model types and build the appropriate layer composition."""
     if "single_instance" in model_types:

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -297,8 +297,7 @@ def predict(
             (the default) leaves the model-driven path untouched.
         sam_checkpoint: SAM1 checkpoint path (required for ``mask_backend="sam"``).
         sam_model_type: SAM1 model registry key.
-        sam_prompt_mode: ``"pose"`` / ``"centroid"`` / ``"box"`` (PLAN §2.2; the
-            top-down crop-center seam is handled in the model-driven path).
+        sam_prompt_mode: ``"pose"`` / ``"centroid"`` / ``"box"`` (PLAN §2.2).
         sam_anchor_ind: Centroid anchor node index for ``sam_prompt_mode="centroid"``.
         sam_disjointify_masks: Make per-frame masks disjoint when >=2 instances.
         overlay_path: Optional review-overlay PNG path (PLAN L4; SAM path only).
@@ -369,6 +368,7 @@ def predict(
             anchor_ind=sam_anchor_ind,
             disjointify_masks=sam_disjointify_masks,
             overlay_path=overlay_path,
+            frames=frames,
         )
         if output_path is not None:
             save_predictions(labels, output_path, output_format=output_format)

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -203,6 +203,15 @@ def predict(
     full_res_masks: bool = False,
     mask_output: str = "mask",
     polygon_epsilon: float = 0.01,
+    # SAM prompted-mask producer (explicit, no default; PLAN L2). When set, masks
+    # are produced from the existing poses in ``source`` (no trained seg model).
+    mask_backend: Optional[str] = None,
+    sam_checkpoint: Optional[str] = None,
+    sam_model_type: str = "vit_h",
+    sam_prompt_mode: str = "pose",
+    sam_anchor_ind: Optional[int] = None,
+    sam_disjointify_masks: bool = False,
+    overlay_path: Optional[str] = None,
     # Prediction-time (can vary per call)
     frames: Optional[List[int]] = None,
     peak_threshold: Optional[float] = None,
@@ -281,6 +290,18 @@ def predict(
             segmentation only).
         polygon_epsilon: Douglas-Peucker tolerance (fraction of perimeter) for
             ``mask_output`` polygon/both (bottom-up segmentation only).
+        mask_backend: **Explicit** SAM mask backend (PLAN L2): ``"sam"`` (SAM1) /
+            ``"sam3"`` (PR-B). When set, ``source`` is treated as a pose ``.slp``
+            and masks are predicted from its existing instances (no trained seg
+            model, so ``model_paths`` / ``export_dir`` are not required). ``None``
+            (the default) leaves the model-driven path untouched.
+        sam_checkpoint: SAM1 checkpoint path (required for ``mask_backend="sam"``).
+        sam_model_type: SAM1 model registry key.
+        sam_prompt_mode: ``"pose"`` / ``"centroid"`` / ``"box"`` (PLAN §2.2; the
+            top-down crop-center seam is handled in the model-driven path).
+        sam_anchor_ind: Centroid anchor node index for ``sam_prompt_mode="centroid"``.
+        sam_disjointify_masks: Make per-frame masks disjoint when >=2 instances.
+        overlay_path: Optional review-overlay PNG path (PLAN L4; SAM path only).
         frames: Frame indices to predict. ``None`` = all.
         peak_threshold: Override peak threshold for all stages.
         centroid_threshold: Override centroid-stage threshold (top-down).
@@ -318,17 +339,45 @@ def predict(
 
     from sleap_nn.inference.predictor import Predictor
 
-    if model_paths and export_dir:
-        raise ValueError("Provide model_paths or export_dir, not both.")
-    if not model_paths and not export_dir:
-        raise ValueError("Either model_paths or export_dir is required.")
-
     if device == "auto":
         device = (
             "cuda"
             if torch.cuda.is_available()
             else "mps" if torch.backends.mps.is_available() else "cpu"
         )
+
+    # SAM prompted-mask producer (PLAN L2/L8): masks come from the existing poses
+    # in ``source`` — there is no trained seg model, so this short-circuits the
+    # model-driven path entirely. ``mask_backend`` is explicit / required to opt
+    # in; ``None`` (the default) leaves everything below unchanged.
+    if mask_backend is not None:
+        if model_paths or export_dir:
+            raise ValueError(
+                "mask_backend produces masks from the poses in `source` and does "
+                "not use a trained seg model; do not also pass model_paths / "
+                "export_dir."
+            )
+        from sleap_nn.inference.sam import run_sam_segmentation
+
+        labels = run_sam_segmentation(
+            source,
+            mask_backend,
+            prompt_mode=sam_prompt_mode,
+            sam_checkpoint=sam_checkpoint,
+            sam_model_type=sam_model_type,
+            device=device,
+            anchor_ind=sam_anchor_ind,
+            disjointify_masks=sam_disjointify_masks,
+            overlay_path=overlay_path,
+        )
+        if output_path is not None:
+            save_predictions(labels, output_path, output_format=output_format)
+        return labels
+
+    if model_paths and export_dir:
+        raise ValueError("Provide model_paths or export_dir, not both.")
+    if not model_paths and not export_dir:
+        raise ValueError("Either model_paths or export_dir is required.")
 
     if tracker_config is not None and emit_centroid != "instance":
         raise ValueError(

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -25,20 +25,16 @@ so importing this package on a default install is cheap and dependency-free.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 from sleap_nn.inference.sam.backends import MaskBackend, SamBackend
-from sleap_nn.inference.sam.mask_layer import (
-    FindInstanceMaskSAM,
-    SamSegmentationLayer,
-)
+from sleap_nn.inference.sam.mask_layer import SamSegmentationLayer
 from sleap_nn.inference.sam.prompts import PROMPT_MODES, SamPrompt
 
 __all__ = [
     "MaskBackend",
     "SamBackend",
     "SamSegmentationLayer",
-    "FindInstanceMaskSAM",
     "SamPrompt",
     "PROMPT_MODES",
     "MASK_BACKENDS",
@@ -51,7 +47,7 @@ MASK_BACKENDS = ("sam", "sam3")
 
 
 def get_mask_backend(
-    mask_backend: str,
+    mask_backend: Optional[str],
     *,
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
@@ -112,6 +108,7 @@ def run_sam_segmentation(
     backend: Optional[MaskBackend] = None,
     output_path: Optional[str] = None,
     overlay_path: Optional[str] = None,
+    frames: Optional[Sequence[int]] = None,
 ):
     """Predict per-instance masks for a pose ``.slp`` with a SAM backend.
 
@@ -125,9 +122,7 @@ def run_sam_segmentation(
         source: A path to a pose ``.slp``/``.pkg.slp`` (with image data) or an
             in-memory ``sio.Labels``.
         mask_backend: **Explicit** backend name (PLAN L2): ``"sam"`` / ``"sam3"``.
-        prompt_mode: ``"pose"`` / ``"centroid"`` / ``"box"`` (full-frame). The
-            crop-center-pixel mode is the top-down seam
-            (:class:`~.mask_layer.FindInstanceMaskSAM`), not this entry point.
+        prompt_mode: ``"pose"`` / ``"centroid"`` / ``"box"`` (full-frame).
         sam_checkpoint: SAM1 checkpoint path (required for ``"sam"`` unless a
             pre-built ``backend`` is passed).
         sam_model_type: SAM1 model registry key.
@@ -140,6 +135,9 @@ def run_sam_segmentation(
         output_path: Optional path to save the result embedded (``.slp``).
         overlay_path: Optional path to write a review overlay PNG of the first
             frame.
+        frames: Optional frame indices (matched against ``lf.frame_idx``) to
+            restrict masking to; ``None`` masks every labeled frame. SAM encoding
+            is the slow step, so subsetting here avoids unrequested compute.
 
     Returns:
         A new ``sio.Labels`` with per-frame ``PredictedSegmentationMask`` (and the
@@ -174,8 +172,14 @@ def run_sam_segmentation(
         disjointify_masks=disjointify_masks,
     )
 
+    if frames is not None:
+        wanted = {int(f) for f in frames}
+        source_lfs = [lf for lf in labels.labeled_frames if int(lf.frame_idx) in wanted]
+    else:
+        source_lfs = list(labels.labeled_frames)
+
     new_lfs = []
-    for lf in labels.labeled_frames:
+    for lf in source_lfs:
         frame_masks = layer.masks_for_frame(lf.image, lf.instances)
         if not frame_masks:
             continue

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -1,0 +1,206 @@
+"""SAM-powered prompted instance segmentation for INFERENCE (PR-A).
+
+The pivot (PLAN / README): SAM is used to *predict* per-instance masks for an
+existing pose/centroid ``.slp`` so a human can review/correct them in the GUI,
+then train — **not** to auto-generate training GT. This package is the SAM1
+prompted producer + its backend interface; SAM3, reconciliation, and the
+mask-native tracker land in later PRs behind the same surfaces.
+
+Public surface
+--------------
+* :func:`get_mask_backend` — **explicit, no-default** backend selection
+  (PLAN L2). ``"sam"`` builds a SAM1 :class:`~.backends.SamBackend`; an unknown
+  or omitted name raises. ``"sam3"`` is reserved for PR-B and currently errors
+  with a pointer.
+* :func:`run_sam_segmentation` — end-to-end orchestration: load a pose ``.slp``,
+  run the chosen backend with the chosen prompt mode, emit
+  ``sio.PredictedSegmentationMask`` (raw score + ``instance=``/``track=``
+  populated, PLAN L8) onto each frame, and optionally save an embedded ``.slp``
+  + a review overlay PNG.
+
+Everything heavy (``segment-anything``) is imported lazily inside the backend,
+so importing this package on a default install is cheap and dependency-free.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from sleap_nn.inference.sam.backends import MaskBackend, SamBackend
+from sleap_nn.inference.sam.mask_layer import (
+    FindInstanceMaskSAM,
+    SamSegmentationLayer,
+)
+from sleap_nn.inference.sam.prompts import PROMPT_MODES, SamPrompt
+
+__all__ = [
+    "MaskBackend",
+    "SamBackend",
+    "SamSegmentationLayer",
+    "FindInstanceMaskSAM",
+    "SamPrompt",
+    "PROMPT_MODES",
+    "MASK_BACKENDS",
+    "get_mask_backend",
+    "run_sam_segmentation",
+]
+
+#: Registered explicit ``mask_backend`` names (PLAN L2 — no default).
+MASK_BACKENDS = ("sam", "sam3")
+
+
+def get_mask_backend(
+    mask_backend: str,
+    *,
+    sam_checkpoint: Optional[str] = None,
+    sam_model_type: str = "vit_h",
+    device: str = "cuda",
+    **kwargs,
+) -> MaskBackend:
+    """Build a mask backend by **explicit** name (no default; PLAN L2).
+
+    Args:
+        mask_backend: The backend name. ``"sam"`` builds a SAM1
+            :class:`~.backends.SamBackend`; ``"sam3"`` is reserved for PR-B.
+            There is no default — the caller must name one.
+        sam_checkpoint: Path to the SAM1 checkpoint (required for ``"sam"``).
+        sam_model_type: SAM1 model registry key.
+        device: Torch device for the model.
+        **kwargs: Forwarded to the backend constructor (e.g. ``clahe``).
+
+    Returns:
+        A ready :class:`~.backends.MaskBackend`.
+
+    Raises:
+        ValueError: If ``mask_backend`` is not a registered name.
+        NotImplementedError: If ``mask_backend == "sam3"`` (lands in PR-B).
+    """
+    if mask_backend is None:
+        raise ValueError(
+            "mask_backend is required and has no default; pass one of "
+            f"{MASK_BACKENDS} (PLAN L2)."
+        )
+    name = str(mask_backend).lower()
+    if name == "sam":
+        return SamBackend.from_checkpoint(
+            sam_checkpoint,
+            model_type=sam_model_type,
+            device=device,
+            **kwargs,
+        )
+    if name == "sam3":
+        raise NotImplementedError(
+            "mask_backend='sam3' is added in PR-B (the SAM3 backend behind the "
+            "'sam3' extra). Use mask_backend='sam' for SAM1."
+        )
+    raise ValueError(
+        f"Unknown mask_backend {mask_backend!r}; expected one of {MASK_BACKENDS}."
+    )
+
+
+def run_sam_segmentation(
+    source,
+    mask_backend: str,
+    *,
+    prompt_mode: str = "pose",
+    sam_checkpoint: Optional[str] = None,
+    sam_model_type: str = "vit_h",
+    device: str = "cuda",
+    anchor_ind: Optional[int] = None,
+    disjointify_masks: bool = False,
+    backend: Optional[MaskBackend] = None,
+    output_path: Optional[str] = None,
+    overlay_path: Optional[str] = None,
+):
+    """Predict per-instance masks for a pose ``.slp`` with a SAM backend.
+
+    Loads (or accepts) a ``sio.Labels`` whose frames carry pose/centroid
+    instances, runs the chosen backend with the chosen prompt mode, attaches one
+    ``sio.PredictedSegmentationMask`` per instance (raw score + ``instance=`` /
+    ``track=`` populated, PLAN L8), and returns a new ``sio.Labels``. The
+    instances are retained alongside the masks (correction needs the pose).
+
+    Args:
+        source: A path to a pose ``.slp``/``.pkg.slp`` (with image data) or an
+            in-memory ``sio.Labels``.
+        mask_backend: **Explicit** backend name (PLAN L2): ``"sam"`` / ``"sam3"``.
+        prompt_mode: ``"pose"`` / ``"centroid"`` / ``"box"`` (full-frame). The
+            crop-center-pixel mode is the top-down seam
+            (:class:`~.mask_layer.FindInstanceMaskSAM`), not this entry point.
+        sam_checkpoint: SAM1 checkpoint path (required for ``"sam"`` unless a
+            pre-built ``backend`` is passed).
+        sam_model_type: SAM1 model registry key.
+        device: Torch device for the model.
+        anchor_ind: Optional centroid anchor node index for ``"centroid"``.
+        disjointify_masks: Make per-frame masks disjoint when >=2 instances.
+        backend: A pre-built :class:`~.backends.MaskBackend` to use directly
+            (skips loading); when given, ``mask_backend`` is still validated for
+            the name but the checkpoint/device args are ignored.
+        output_path: Optional path to save the result embedded (``.slp``).
+        overlay_path: Optional path to write a review overlay PNG of the first
+            frame.
+
+    Returns:
+        A new ``sio.Labels`` with per-frame ``PredictedSegmentationMask`` (and the
+        original pose instances retained).
+    """
+    import sleap_io as sio
+
+    from sleap_nn.inference.outputs import Outputs
+    from sleap_nn.inference.sam.overlay import save_mask_overlay
+
+    if isinstance(source, sio.Labels):
+        labels = source
+    else:
+        labels = sio.load_slp(Path(source).expanduser().as_posix())
+
+    if backend is None:
+        backend = get_mask_backend(
+            mask_backend,
+            sam_checkpoint=sam_checkpoint,
+            sam_model_type=sam_model_type,
+            device=device,
+        )
+    elif mask_backend not in MASK_BACKENDS:
+        raise ValueError(
+            f"Unknown mask_backend {mask_backend!r}; expected one of {MASK_BACKENDS}."
+        )
+
+    layer = SamSegmentationLayer(
+        backend,
+        prompt_mode=prompt_mode,
+        anchor_ind=anchor_ind,
+        disjointify_masks=disjointify_masks,
+    )
+
+    new_lfs = []
+    for lf in labels.labeled_frames:
+        frame_masks = layer.masks_for_frame(lf.image, lf.instances)
+        if not frame_masks:
+            continue
+        # Reuse the standard packaging path (build_predicted_segmentation_mask).
+        masks = Outputs(pred_masks=[frame_masks]).to_masks(0)
+        new_lfs.append(
+            sio.LabeledFrame(
+                video=lf.video,
+                frame_idx=lf.frame_idx,
+                instances=list(lf.instances),  # retain poses for correction
+                masks=masks,
+            )
+        )
+
+    out = sio.Labels(
+        videos=list(labels.videos),
+        skeletons=list(labels.skeletons),
+        labeled_frames=new_lfs,
+    )
+
+    if output_path is not None:
+        out_path = Path(output_path).expanduser()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out.save(out_path.as_posix(), embed=True)
+    if overlay_path is not None:
+        save_mask_overlay(out, overlay_path)
+
+    return out

--- a/sleap_nn/inference/sam/backends.py
+++ b/sleap_nn/inference/sam/backends.py
@@ -1,0 +1,359 @@
+"""SAM mask backends for prompted instance segmentation (PR-A).
+
+A *backend* owns the model-specific half of mask production: loading the model,
+preprocessing an image (grayscale -> CLAHE -> 3-channel), encoding it once, and
+turning a list of :class:`~sleap_nn.inference.sam.prompts.SamPrompt` into one
+boolean mask + a raw per-model score per prompt.
+
+PR-A ships :class:`SamBackend` (SAM1, ViT-H, Apache-2.0, ungated; the
+``sleap_nn[sam]`` extra). The model-specific recipe constants
+(:data:`SamBackend.pred_iou_min`, the candidate-rejection factor, the keypoint
+box margins, CLAHE) and the candidate-selection / score helpers
+(:func:`_pick`, :func:`own_containment`, :func:`disjointify`) are harvested from
+the closed #642 (``sleap_nn/data/pseudomasks.py``) and the exp-07 locked recipe,
+repurposed to emit a *raw score* rather than to drive a drop-gate (PLAN §1).
+
+Backend selection is **explicit / required** (PLAN L2): there is no default
+``mask_backend``; the caller names ``"sam"`` (this backend) and a later PR adds
+``"sam3"`` behind the same :class:`MaskBackend` interface. The SAM import is
+lazy so the default sleap-nn install never needs ``segment-anything``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from sleap_nn.inference.sam.prompts import SamPrompt
+
+# ---------------------------------------------------------------------------
+# Locked SAM1 recipe constants (harvested from #642 / exp-07; PLAN §1).
+# ---------------------------------------------------------------------------
+#: SAM1 candidate rejection: drop candidates whose area exceeds this * box-area
+#: (kills SAM's over-confident whole-arena candidate).
+SAM_MAX_BOX_AREA_FACTOR: float = 1.5
+#: CLAHE parameters applied to the grayscale image before encoding (SAM1).
+CLAHE_CLIP_LIMIT: float = 3.0
+CLAHE_TILE_GRID: Tuple[int, int] = (8, 8)
+#: SAM1's nominal predicted-IoU floor. Carried as a per-model attribute so a
+#: future SAM3 backend can override it (SAM3 uses a recalibrated 0.5, PLAN §2.3);
+#: SAM1's raw predicted-IoU is reported as the mask score, not used as a gate.
+SAM_PRED_IOU_MIN: float = 0.88
+
+
+def _to_3ch_clahe(
+    img_gray: np.ndarray,
+    clahe: bool = True,
+    clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
+    clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
+) -> np.ndarray:
+    """Grayscale ``(H, W)`` -> optional CLAHE -> 3-channel uint8 (SAM's input).
+
+    Harvested from #642 ``_sam_instance_masks`` / the prototype ``to_3ch_clahe``.
+
+    Args:
+        img_gray: ``(H, W)`` uint8 grayscale frame (or crop).
+        clahe: Whether to CLAHE-equalize before replicating to 3 channels.
+        clahe_clip_limit: CLAHE clip limit (when ``clahe``).
+        clahe_tile_grid: CLAHE tile grid (when ``clahe``).
+
+    Returns:
+        ``(H, W, 3)`` uint8 RGB array.
+    """
+    import cv2
+
+    src = img_gray
+    if src.ndim == 3:
+        src = src[..., 0]
+    src = np.ascontiguousarray(src).astype(np.uint8)
+    if clahe:
+        src = cv2.createCLAHE(clahe_clip_limit, clahe_tile_grid).apply(src)
+    return np.stack([src] * 3, axis=-1).astype(np.uint8)
+
+
+def _pick(
+    masks: np.ndarray,
+    scores: np.ndarray,
+    box: np.ndarray,
+    max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+) -> int:
+    """Pick the best SAM candidate-mask index (harvested verbatim from #642).
+
+    Rejects candidates whose area exceeds ``max_box_area_factor * box-area``
+    (SAM's over-confident whole-arena candidate), then returns the highest
+    predicted-IoU survivor; if all are rejected returns the smallest candidate.
+
+    Args:
+        masks: ``(n_cands, H, W)`` candidate masks.
+        scores: ``(n_cands,)`` SAM predicted-IoU per candidate.
+        box: ``[x0, y0, x1, y1]`` reject box.
+        max_box_area_factor: Area-rejection multiplier relative to box area.
+
+    Returns:
+        Index of the chosen candidate.
+    """
+    box_area = max(1.0, (box[2] - box[0]) * (box[3] - box[1]))
+    areas = masks.reshape(len(masks), -1).sum(1).astype(float)
+    ok = areas <= max_box_area_factor * box_area
+    if ok.any():
+        idx = np.where(ok)[0]
+        return int(idx[int(np.argmax(scores[idx]))])
+    return int(np.argmin(areas))
+
+
+def own_containment(mask: np.ndarray, kpts: np.ndarray, hw: Tuple[int, int]) -> float:
+    """Fraction of an instance's visible keypoints that fall inside ``mask``.
+
+    Harvested from #642 ``_own_containment``. In the inference stack this is a
+    *score* (a mask-quality signal surfaced for review), never a drop-gate.
+
+    Args:
+        mask: ``(H, W)`` boolean mask.
+        kpts: ``(n, 2)`` visible xy keypoints.
+        hw: ``(height, width)`` of ``mask``.
+
+    Returns:
+        Containment in ``[0, 1]`` (``0.0`` for an empty keypoint set).
+    """
+    kpts = np.asarray(kpts, dtype=np.float32).reshape(-1, 2)
+    if len(kpts) == 0:
+        return 0.0
+    h, w = hw
+    inside = 0
+    for x, y in kpts:
+        xi, yi = int(round(float(x))), int(round(float(y)))
+        if 0 <= yi < h and 0 <= xi < w and mask[yi, xi]:
+            inside += 1
+    return inside / len(kpts)
+
+
+def disjointify(
+    masks: Sequence[np.ndarray], kpts: Sequence[np.ndarray]
+) -> List[np.ndarray]:
+    """Make per-instance masks disjoint via keypoint-Voronoi assignment.
+
+    Harvested verbatim from #642 ``_disjointify`` (multi-instance only). Any
+    pixel claimed by >=2 masks is assigned to the instance whose nearest visible
+    keypoint is closest, so the result is exactly disjoint and each instance
+    keeps its own keypoints (they are the Voronoi seeds).
+
+    Args:
+        masks: List of ``(H, W)`` boolean masks, one per instance.
+        kpts: List of ``(n_i, 2)`` visible xy keypoints, index-aligned to
+            ``masks``.
+
+    Returns:
+        List of disjoint boolean masks (a shallow copy when uncontested).
+    """
+    from scipy.ndimage import distance_transform_edt
+
+    n = len(masks)
+    if n == 0:
+        return []
+    h, w = masks[0].shape
+    stack = np.stack(masks).astype(bool)
+    contested = stack.sum(0) >= 2
+    if not contested.any():
+        return [m.copy() for m in masks]
+    dists = np.full((n, h, w), 1e9, np.float32)
+    for i, ks in enumerate(kpts):
+        seed = np.ones((h, w), np.uint8)
+        for x, y in np.asarray(ks, dtype=np.float32).reshape(-1, 2):
+            xi, yi = int(round(float(x))), int(round(float(y)))
+            if 0 <= yi < h and 0 <= xi < w:
+                seed[yi, xi] = 0
+        if seed.min() == 0:
+            dists[i] = distance_transform_edt(seed)
+    owner = np.argmin(dists, 0)
+    return [np.where(contested & (owner != i), False, stack[i]) for i in range(n)]
+
+
+def _load_sam_predictor(
+    checkpoint: str, model_type: str = "vit_h", device: str = "cuda"
+):
+    """Lazily load a ``segment_anything.SamPredictor`` (harvested from #642).
+
+    Args:
+        checkpoint: Path to the SAM checkpoint (e.g. ``sam_vit_h_4b8939.pth``).
+        model_type: SAM model registry key (``"vit_h"``, ``"vit_l"``, ``"vit_b"``).
+        device: Torch device to place the model on.
+
+    Returns:
+        A ready ``SamPredictor``.
+
+    Raises:
+        ImportError: If ``segment-anything`` is not installed.
+        ValueError: If ``checkpoint`` is ``None``.
+        FileNotFoundError: If ``checkpoint`` does not exist.
+    """
+    try:
+        from segment_anything import SamPredictor, sam_model_registry
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "mask_backend='sam' requires the optional 'segment-anything' "
+            'dependency. Install it with `pip install "sleap-nn[sam]"` and '
+            "download a SAM checkpoint (e.g. sam_vit_h_4b8939.pth), then pass "
+            "sam_checkpoint=/path/to/ckpt."
+        ) from e
+
+    if checkpoint is None:
+        raise ValueError(
+            "mask_backend='sam' requires a SAM checkpoint. Download one "
+            "(e.g. sam_vit_h_4b8939.pth) and pass sam_checkpoint=/path/to/ckpt."
+        )
+    ckpt = Path(checkpoint).expanduser()
+    if not ckpt.is_file():
+        raise FileNotFoundError(f"SAM checkpoint not found: {ckpt}")
+
+    sam = sam_model_registry[model_type](checkpoint=ckpt.as_posix()).to(device)
+    return SamPredictor(sam)
+
+
+class MaskBackend(ABC):
+    """Abstract prompted-mask backend (the :class:`SamBackend` / SAM3 interface).
+
+    A backend encodes one image and answers a batch of prompts on it. The
+    composed inference layer (:mod:`sleap_nn.inference.sam.mask_layer`) owns the
+    crop/frame geometry; the backend owns only the model call. Selection is
+    explicit (PLAN L2) — see :func:`sleap_nn.inference.sam.get_mask_backend`.
+    """
+
+    #: Per-model nominal predicted-IoU floor (SAM1: 0.88; SAM3 recalibrates).
+    pred_iou_min: float = SAM_PRED_IOU_MIN
+
+    @abstractmethod
+    def masks(
+        self, image: np.ndarray, prompts: Sequence[SamPrompt]
+    ) -> Tuple[List[np.ndarray], List[float]]:
+        """Encode ``image`` once and answer each prompt with a mask + raw score.
+
+        Args:
+            image: ``(H, W)`` grayscale (or ``(H, W, C)``) image to encode.
+            prompts: Per-instance prompts in image space.
+
+        Returns:
+            ``(masks, scores)``: a list of ``(H, W)`` boolean masks (one per
+            prompt) and the list of raw per-model scores.
+        """
+        raise NotImplementedError
+
+
+class SamBackend(MaskBackend):
+    """SAM1 (ViT-H) prompted-mask backend (the ``sleap_nn[sam]`` extra).
+
+    Wraps a lazily loaded ``segment_anything.SamPredictor``. For one frame:
+    CLAHE-equalize + 3-channel replicate, ``set_image`` once, then per prompt
+    call ``predict(..., multimask_output=True)`` and select via :func:`_pick`.
+    The raw SAM predicted-IoU of the chosen candidate is the mask score (PLAN
+    §2.3 — store the raw per-model score; no drop-gate).
+
+    Args:
+        predictor: A ready ``SamPredictor`` (e.g. from :func:`_load_sam_predictor`
+            or injected for testing). When ``None``, :meth:`from_checkpoint`
+            builds one.
+        clahe: Whether to CLAHE-equalize before encoding.
+        max_box_area_factor: Candidate-rejection factor (:func:`_pick`).
+        clahe_clip_limit: CLAHE clip limit.
+        clahe_tile_grid: CLAHE tile grid.
+        pred_iou_min: Nominal predicted-IoU floor carried for parity with SAM3;
+            SAM1 reports the raw score and does not gate on it.
+    """
+
+    def __init__(
+        self,
+        predictor,
+        clahe: bool = True,
+        max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+        clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
+        clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
+        pred_iou_min: float = SAM_PRED_IOU_MIN,
+    ) -> None:
+        """Stash the predictor and the (model-specific) recipe knobs."""
+        self.predictor = predictor
+        self.clahe = bool(clahe)
+        self.max_box_area_factor = float(max_box_area_factor)
+        self.clahe_clip_limit = float(clahe_clip_limit)
+        self.clahe_tile_grid = tuple(clahe_tile_grid)
+        self.pred_iou_min = float(pred_iou_min)
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        checkpoint: str,
+        model_type: str = "vit_h",
+        device: str = "cuda",
+        **kwargs,
+    ) -> "SamBackend":
+        """Build a backend by lazily loading a SAM checkpoint.
+
+        Args:
+            checkpoint: Path to the SAM checkpoint.
+            model_type: SAM model registry key.
+            device: Torch device for the model.
+            **kwargs: Forwarded to :class:`SamBackend` (e.g. ``clahe``).
+
+        Returns:
+            A ready :class:`SamBackend`.
+        """
+        predictor = _load_sam_predictor(
+            checkpoint, model_type=model_type, device=device
+        )
+        return cls(predictor, **kwargs)
+
+    def masks(
+        self, image: np.ndarray, prompts: Sequence[SamPrompt]
+    ) -> Tuple[List[np.ndarray], List[float]]:
+        """Encode ``image`` once, run each prompt, return masks + raw scores.
+
+        Args:
+            image: ``(H, W)`` grayscale (or ``(H, W, C)``) image / crop.
+            prompts: Per-instance :class:`SamPrompt` in ``image`` pixel space.
+
+        Returns:
+            ``(masks, scores)`` with one ``(H, W)`` boolean mask + raw
+            predicted-IoU per prompt. An empty prompt list returns ``([], [])``.
+        """
+        img = np.asarray(image)
+        if img.ndim == 3:
+            img = img[..., 0]
+        h, w = img.shape[:2]
+        rgb = _to_3ch_clahe(
+            img,
+            clahe=self.clahe,
+            clahe_clip_limit=self.clahe_clip_limit,
+            clahe_tile_grid=self.clahe_tile_grid,
+        )
+        self.predictor.set_image(rgb)
+
+        out_masks: List[np.ndarray] = []
+        out_scores: List[float] = []
+        for prompt in prompts:
+            point_coords = (
+                prompt.point_coords.astype(np.float32)
+                if prompt.point_coords is not None
+                else None
+            )
+            point_labels = (
+                prompt.point_labels.astype(np.int32)
+                if prompt.point_labels is not None
+                else None
+            )
+            box = prompt.box.astype(np.float32) if prompt.box is not None else None
+            ms, sc, _ = self.predictor.predict(
+                point_coords=point_coords,
+                point_labels=point_labels,
+                box=box,
+                multimask_output=True,
+            )
+            b = _pick(ms, sc, prompt.reject_box, self.max_box_area_factor)
+            out_masks.append(ms[b].astype(bool))
+            out_scores.append(float(sc[b]))
+        # Defensive: a degenerate single-px prompt could yield a (h, w) mismatch
+        # only if SAM is given a wrong-size image; guard the contract here.
+        for m in out_masks:
+            if m.shape[:2] != (h, w):
+                raise ValueError(f"SAM returned a {m.shape} mask for a {(h, w)} image.")
+        return out_masks, out_scores

--- a/sleap_nn/inference/sam/mask_layer.py
+++ b/sleap_nn/inference/sam/mask_layer.py
@@ -1,0 +1,347 @@
+"""SAM mask inference layers — the producers that emit ``PredictedSegmentationMask``.
+
+Two layers, mirroring the two seams the prototypes validated:
+
+* :class:`SamSegmentationLayer` — the full-frame producer. Given a backend, a
+  prompt mode, and the per-frame poses/centroids, it encodes each frame once,
+  builds one :class:`~sleap_nn.inference.sam.prompts.SamPrompt` per instance,
+  asks the backend for masks, and emits ``Outputs.pred_masks`` dicts at the
+  correct full-frame offset/scale with ``instance=``/``track=`` populated
+  (PLAN L8). Output collection / SLP packaging is **free** — it reuses
+  ``Outputs.to_masks`` -> ``build_predicted_segmentation_mask`` ->
+  ``labels.save`` exactly like every other seg layer (PLAN §2.5).
+
+* :class:`FindInstanceMaskSAM` — the top-down crop-center-pixel seam. A drop-in
+  twin of :class:`~sleap_nn.inference.layers.topdown_segmentation.CenteredInstanceMaskLayer`
+  honoring the ``.predict(crops) -> Outputs(crops=(N,1,h,w), instance_scores=(N,1))``
+  contract, so it slots straight into ``TopDownSegmentationLayer._run_stage_2``
+  and the whole offset/scale/``to_masks`` path is inherited (PLAN §2.1; P2
+  validated byte-identical packaging).
+
+Both are torch-light: they shell out to a :class:`MaskBackend` (SAM1 here, SAM3
+later) and do numpy mask placement. The heavy SAM import lives in the backend.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.sam.backends import MaskBackend
+from sleap_nn.inference.sam.prompts import (
+    SamPrompt,
+    prompt_for_instance,
+    visible_keypoints,
+)
+
+
+def _frame_gray(image) -> np.ndarray:
+    """Coerce a frame/crop to a 2-D ``(H, W)`` uint8 grayscale array.
+
+    Accepts ``(H, W)``, ``(H, W, C)``, or ``(C, H, W)`` numpy/torch input and
+    returns the first channel as ``uint8``.
+
+    Args:
+        image: A frame or crop in any of the accepted layouts.
+
+    Returns:
+        ``(H, W)`` uint8 array.
+    """
+    arr = image
+    if isinstance(arr, torch.Tensor):
+        arr = arr.detach().cpu().numpy()
+    arr = np.asarray(arr)
+    if arr.ndim == 3:
+        # Channels-first (C, H, W) with a small leading dim, else (H, W, C).
+        if arr.shape[0] in (1, 3) and arr.shape[0] < arr.shape[-1]:
+            arr = arr[0]
+        else:
+            arr = arr[..., 0]
+    if arr.dtype != np.uint8:
+        arr = np.clip(arr, 0, 255).astype(np.uint8)
+    return np.ascontiguousarray(arr)
+
+
+def place_full(
+    mask_crop: np.ndarray, tl: Tuple[int, int], full_hw: Tuple[int, int]
+) -> np.ndarray:
+    """Place a crop-space bool mask into a full-frame array at floored top-left.
+
+    Harvested from the P2 prototype ``place_full``; the inverse of the crop
+    extraction. Pixels of the crop that fall outside the frame are dropped.
+
+    Args:
+        mask_crop: ``(h, w)`` boolean crop mask.
+        tl: ``(x0, y0)`` floored top-left of the crop in full-frame px.
+        full_hw: ``(H, W)`` of the full frame.
+
+    Returns:
+        ``(H, W)`` boolean full-frame mask.
+    """
+    H, W = full_hw
+    out = np.zeros((H, W), bool)
+    h, w = mask_crop.shape
+    x0, y0 = int(tl[0]), int(tl[1])
+    xs0, ys0 = max(0, x0), max(0, y0)
+    xs1, ys1 = min(W, x0 + w), min(H, y0 + h)
+    if xs1 <= xs0 or ys1 <= ys0:
+        return out
+    out[ys0:ys1, xs0:xs1] = mask_crop[ys0 - y0 : ys1 - y0, xs0 - x0 : xs1 - x0]
+    return out
+
+
+class SamSegmentationLayer:
+    """Full-frame SAM mask producer (pose / centroid / box prompts).
+
+    Operates on in-memory ``sio.LabeledFrame`` content (image + pose/centroid
+    instances), not on a torch model — there is no trained net here. For each
+    frame it encodes the image once via the backend, builds one prompt per
+    instance, and emits per-frame ``Outputs.pred_masks`` dicts that the standard
+    ``Outputs.to_masks`` path packages into ``sio.PredictedSegmentationMask``.
+    Full-frame masks use identity ``scale``/``offset`` (the whole-frame
+    representation the P1 prototype produced); the crop-center-pixel seam is
+    :class:`FindInstanceMaskSAM` instead.
+
+    Args:
+        backend: A :class:`MaskBackend` (SAM1 here; SAM3 later).
+        prompt_mode: One of ``"pose"`` / ``"centroid"`` / ``"box"``. ``"pose"``
+            applies the L3 product rule (pose-if-visible-else-centroid-point).
+        anchor_ind: Optional skeleton node index used as the centroid anchor for
+            ``prompt_mode="centroid"``; ``None`` uses the mean of visible
+            keypoints.
+        disjointify_masks: When ``True`` and a frame has >=2 instances, make the
+            per-frame masks disjoint via keypoint-Voronoi (harvested #642).
+            Default ``False`` (single-instance is the common case; disjointify is
+            a multi-instance refinement).
+    """
+
+    def __init__(
+        self,
+        backend: MaskBackend,
+        prompt_mode: str = "pose",
+        anchor_ind: Optional[int] = None,
+        disjointify_masks: bool = False,
+    ) -> None:
+        """Stash the backend and prompt knobs."""
+        if prompt_mode not in ("pose", "centroid", "box"):
+            raise ValueError(
+                f"SamSegmentationLayer prompt_mode must be 'pose'/'centroid'/'box', "
+                f"got {prompt_mode!r}. The crop-center-pixel mode is "
+                "FindInstanceMaskSAM (the top-down seam)."
+            )
+        self.backend = backend
+        self.prompt_mode = prompt_mode
+        self.anchor_ind = anchor_ind
+        self.disjointify_masks = bool(disjointify_masks)
+
+    def _instance_centroid(self, kpts_vis: np.ndarray, inst) -> Optional[np.ndarray]:
+        """Anchor point for an instance: anchor node if set/visible, else mean."""
+        if self.anchor_ind is not None:
+            pts = np.asarray(inst.numpy()[:, :2], dtype=np.float32)
+            if 0 <= self.anchor_ind < len(pts):
+                a = pts[self.anchor_ind]
+                if np.isfinite(a).all():
+                    return a.astype(np.float32)
+        if len(kpts_vis) > 0:
+            return kpts_vis.mean(0).astype(np.float32)
+        return None
+
+    def masks_for_frame(self, image, instances: Sequence) -> List[dict]:
+        """Produce one ``pred_masks`` dict per posed instance for a frame.
+
+        Args:
+            image: The frame image (``(H, W)`` / ``(H, W, C)`` / ``(C, H, W)``).
+            instances: The frame's ``sio.PredictedInstance`` (or ``sio.Instance``)
+                pose/centroid instances. Instances with no visible keypoints (and
+                no usable centroid) are skipped.
+
+        Returns:
+            A list of ``pred_masks`` dicts ``{"mask", "score", "scale",
+            "offset", "instance", "track", "tracking_score"}`` — full-frame masks
+            with identity scale/offset and ``instance``/``track`` populated when
+            the source instance carries them (PLAN L8).
+        """
+        gray = _frame_gray(image)
+        h, w = gray.shape
+        prompts: List[SamPrompt] = []
+        kept = []  # (instance, kpts_vis)
+        for inst in instances:
+            kpts = np.asarray(inst.numpy()[:, :2], dtype=np.float32)
+            kpts_vis = visible_keypoints(kpts)
+            centroid = self._instance_centroid(kpts_vis, inst)
+            try:
+                prompt = prompt_for_instance(
+                    self.prompt_mode,
+                    (h, w),
+                    keypoints=kpts_vis if len(kpts_vis) else None,
+                    centroid=centroid,
+                )
+            except ValueError:
+                # No usable prompt source for this instance — skip it.
+                continue
+            prompts.append(prompt)
+            kept.append((inst, kpts_vis))
+
+        if not prompts:
+            return []
+
+        masks, scores = self.backend.masks(gray, prompts)
+
+        if self.disjointify_masks and len(masks) >= 2:
+            from sleap_nn.inference.sam.backends import disjointify
+
+            masks = disjointify(masks, [kv[1] for kv in kept])
+
+        out: List[dict] = []
+        for (inst, _kpts), mask, score in zip(kept, masks, scores):
+            if mask is None or not mask.any():
+                continue
+            out.append(
+                {
+                    "mask": np.ascontiguousarray(mask, dtype=bool),
+                    "score": float(score),
+                    "scale": (1.0, 1.0),
+                    "offset": (0.0, 0.0),
+                    "instance": inst if _is_predicted(inst) else None,
+                    "track": getattr(inst, "track", None),
+                    "tracking_score": _tracking_score(inst),
+                }
+            )
+        return out
+
+    def predict_labels(self, labels) -> "List[List[dict]]":
+        """Build ``pred_masks`` for every labeled frame of a ``sio.Labels``.
+
+        Args:
+            labels: The source ``sio.Labels`` with pose/centroid instances + image
+                data (used as the prompt source).
+
+        Returns:
+            A list (one entry per labeled frame) of the frame's ``pred_masks``
+            dicts; frames are index-aligned to ``labels.labeled_frames``.
+        """
+        return [
+            self.masks_for_frame(lf.image, lf.instances) for lf in labels.labeled_frames
+        ]
+
+
+class FindInstanceMaskSAM:
+    """Top-down crop-center-pixel SAM mask layer (the ``CenteredInstanceMaskLayer`` twin).
+
+    Honors the exact stage-2 contract of
+    :class:`~sleap_nn.inference.layers.topdown_segmentation.CenteredInstanceMaskLayer`::
+
+        predict(crops: (N, C, h, w)) -> Outputs(crops=(N, 1, h, w) float {0,1},
+                                                 instance_scores=(N, 1))
+
+    so it drops straight into ``TopDownSegmentationLayer._run_stage_2`` and the
+    entire offset/scale/``to_masks``/``save`` path is inherited (PLAN §2.1). Each
+    crop is prompted at its **center pixel** ``(w/2, h/2)`` (the centroid the crop
+    was centered on; P2). Because the mask comes back at crop-pixel resolution,
+    ``output_stride=1`` and ``input_scale=1`` so the inherited
+    ``scale=(eff, eff)`` / ``offset=floored_TL/eff`` contract holds.
+
+    Args:
+        backend: A :class:`MaskBackend` (SAM1 here; SAM3 later).
+        output_stride: Reported head->crop stride. SAM emits at crop-pixel res,
+            so this is ``1`` (the parent layer divides by it).
+        input_scale: Reported crop input_scale; ``1.0`` (crops are not rescaled
+            before SAM).
+        fg_threshold: Unused (SAM emits a binary mask); accepted for surface
+            parity with ``CenteredInstanceMaskLayer``.
+    """
+
+    def __init__(
+        self,
+        backend: MaskBackend,
+        output_stride: int = 1,
+        input_scale: float = 1.0,
+        fg_threshold: float = 0.5,
+    ) -> None:
+        """Stash the backend and the stride/scale parity knobs."""
+        self.backend = backend
+        self.output_stride = int(output_stride)
+        self.fg_threshold = float(fg_threshold)
+        # _run_stage_2 reads preprocess_config.scale (the seg model's input_scale).
+        self.preprocess_config = type("_PP", (), {"scale": float(input_scale)})()
+        # The parent TopDownLayer.predict inspects this; a mask layer never takes
+        # the GT-keypoint branch.
+        self.use_gt_peaks = False
+
+    @property
+    def warmup_input_shape(self):
+        """Tiny single-channel warmup shape (surface parity)."""
+        return (1, 1, 64, 64)
+
+    def predict(self, crops) -> Outputs:
+        """Prompt each crop at its center pixel; return masks at crop resolution.
+
+        Args:
+            crops: ``(N, C, h, w)`` per-instance crops (torch tensor or ndarray),
+                already centered on each instance's centroid by the parent layer.
+
+        Returns:
+            ``Outputs`` with ``crops`` set to the stacked per-crop boolean masks
+            ``(N, 1, h, w)`` (float) and ``instance_scores`` set to the per-crop
+            raw SAM score ``(N, 1)`` — the exact shape ``_run_stage_2`` consumes.
+        """
+        if isinstance(crops, torch.Tensor):
+            crops_np = crops.detach().cpu().numpy()
+        else:
+            crops_np = np.asarray(crops)
+        if crops_np.ndim != 4:
+            raise ValueError(
+                f"FindInstanceMaskSAM.predict expects (N, C, h, w) crops, got "
+                f"shape {crops_np.shape}."
+            )
+        n, _c, h, w = crops_np.shape
+        if n == 0:
+            return Outputs(
+                crops=torch.zeros(0, 1, h, w, dtype=torch.float32),
+                instance_scores=torch.zeros(0, 1, dtype=torch.float32),
+            )
+
+        from sleap_nn.inference.sam.prompts import crop_center_prompt
+
+        masks: List[np.ndarray] = []
+        scores: List[float] = []
+        # SAM encodes one image at a time; each crop is its own image here.
+        for k in range(n):
+            gray = _frame_gray(crops_np[k])
+            prompt = crop_center_prompt((h, w))
+            m, s = self.backend.masks(gray, [prompt])
+            masks.append(m[0])
+            scores.append(s[0])
+
+        mask_stack = np.stack(masks).astype(np.float32)[:, None]  # (N, 1, h, w)
+        score_arr = np.asarray(scores, dtype=np.float32)[:, None]  # (N, 1)
+        return Outputs(
+            crops=torch.from_numpy(mask_stack),
+            instance_scores=torch.from_numpy(score_arr),
+        )
+
+
+def _is_predicted(inst) -> bool:
+    """``True`` iff ``inst`` is a ``sio.PredictedInstance`` (vs GT ``Instance``).
+
+    Only predicted instances are set on ``mask.instance`` — a GT instance is a
+    user annotation, not a prediction, and pairing a predicted mask to it would
+    be misleading provenance.
+    """
+    import sleap_io as sio
+
+    return isinstance(inst, sio.PredictedInstance)
+
+
+def _tracking_score(inst) -> Optional[float]:
+    """Best-effort tracking score off an instance (``None`` when absent)."""
+    ts = getattr(inst, "tracking_score", None)
+    if ts is None:
+        return None
+    try:
+        return float(ts)
+    except (TypeError, ValueError):
+        return None

--- a/sleap_nn/inference/sam/mask_layer.py
+++ b/sleap_nn/inference/sam/mask_layer.py
@@ -1,30 +1,21 @@
-"""SAM mask inference layers — the producers that emit ``PredictedSegmentationMask``.
+"""SAM mask inference layer — the producer that emits ``PredictedSegmentationMask``.
 
-Two layers, mirroring the two seams the prototypes validated:
+:class:`SamSegmentationLayer` is the full-frame producer. Given a backend, a
+prompt mode, and the per-frame poses/centroids, it encodes each frame once,
+builds one :class:`~sleap_nn.inference.sam.prompts.SamPrompt` per instance,
+asks the backend for masks, and emits ``Outputs.pred_masks`` dicts at the
+correct full-frame offset/scale with ``instance=``/``track=`` populated
+(PLAN L8). Output collection / SLP packaging is **free** — it reuses
+``Outputs.to_masks`` -> ``build_predicted_segmentation_mask`` ->
+``labels.save`` exactly like every other seg layer (PLAN §2.5).
 
-* :class:`SamSegmentationLayer` — the full-frame producer. Given a backend, a
-  prompt mode, and the per-frame poses/centroids, it encodes each frame once,
-  builds one :class:`~sleap_nn.inference.sam.prompts.SamPrompt` per instance,
-  asks the backend for masks, and emits ``Outputs.pred_masks`` dicts at the
-  correct full-frame offset/scale with ``instance=``/``track=`` populated
-  (PLAN L8). Output collection / SLP packaging is **free** — it reuses
-  ``Outputs.to_masks`` -> ``build_predicted_segmentation_mask`` ->
-  ``labels.save`` exactly like every other seg layer (PLAN §2.5).
-
-* :class:`FindInstanceMaskSAM` — the top-down crop-center-pixel seam. A drop-in
-  twin of :class:`~sleap_nn.inference.layers.topdown_segmentation.CenteredInstanceMaskLayer`
-  honoring the ``.predict(crops) -> Outputs(crops=(N,1,h,w), instance_scores=(N,1))``
-  contract, so it slots straight into ``TopDownSegmentationLayer._run_stage_2``
-  and the whole offset/scale/``to_masks`` path is inherited (PLAN §2.1; P2
-  validated byte-identical packaging).
-
-Both are torch-light: they shell out to a :class:`MaskBackend` (SAM1 here, SAM3
-later) and do numpy mask placement. The heavy SAM import lives in the backend.
+It is torch-light: it shells out to a :class:`MaskBackend` (SAM1 here, SAM3
+later). The heavy SAM import lives in the backend.
 """
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence
 
 import numpy as np
 import torch
@@ -65,34 +56,6 @@ def _frame_gray(image) -> np.ndarray:
     return np.ascontiguousarray(arr)
 
 
-def place_full(
-    mask_crop: np.ndarray, tl: Tuple[int, int], full_hw: Tuple[int, int]
-) -> np.ndarray:
-    """Place a crop-space bool mask into a full-frame array at floored top-left.
-
-    Harvested from the P2 prototype ``place_full``; the inverse of the crop
-    extraction. Pixels of the crop that fall outside the frame are dropped.
-
-    Args:
-        mask_crop: ``(h, w)`` boolean crop mask.
-        tl: ``(x0, y0)`` floored top-left of the crop in full-frame px.
-        full_hw: ``(H, W)`` of the full frame.
-
-    Returns:
-        ``(H, W)`` boolean full-frame mask.
-    """
-    H, W = full_hw
-    out = np.zeros((H, W), bool)
-    h, w = mask_crop.shape
-    x0, y0 = int(tl[0]), int(tl[1])
-    xs0, ys0 = max(0, x0), max(0, y0)
-    xs1, ys1 = min(W, x0 + w), min(H, y0 + h)
-    if xs1 <= xs0 or ys1 <= ys0:
-        return out
-    out[ys0:ys1, xs0:xs1] = mask_crop[ys0 - y0 : ys1 - y0, xs0 - x0 : xs1 - x0]
-    return out
-
-
 class SamSegmentationLayer:
     """Full-frame SAM mask producer (pose / centroid / box prompts).
 
@@ -102,8 +65,7 @@ class SamSegmentationLayer:
     instance, and emits per-frame ``Outputs.pred_masks`` dicts that the standard
     ``Outputs.to_masks`` path packages into ``sio.PredictedSegmentationMask``.
     Full-frame masks use identity ``scale``/``offset`` (the whole-frame
-    representation the P1 prototype produced); the crop-center-pixel seam is
-    :class:`FindInstanceMaskSAM` instead.
+    representation the P1 prototype produced).
 
     Args:
         backend: A :class:`MaskBackend` (SAM1 here; SAM3 later).
@@ -129,8 +91,7 @@ class SamSegmentationLayer:
         if prompt_mode not in ("pose", "centroid", "box"):
             raise ValueError(
                 f"SamSegmentationLayer prompt_mode must be 'pose'/'centroid'/'box', "
-                f"got {prompt_mode!r}. The crop-center-pixel mode is "
-                "FindInstanceMaskSAM (the top-down seam)."
+                f"got {prompt_mode!r}."
             )
         self.backend = backend
         self.prompt_mode = prompt_mode
@@ -226,102 +187,6 @@ class SamSegmentationLayer:
         return [
             self.masks_for_frame(lf.image, lf.instances) for lf in labels.labeled_frames
         ]
-
-
-class FindInstanceMaskSAM:
-    """Top-down crop-center-pixel SAM mask layer (the ``CenteredInstanceMaskLayer`` twin).
-
-    Honors the exact stage-2 contract of
-    :class:`~sleap_nn.inference.layers.topdown_segmentation.CenteredInstanceMaskLayer`::
-
-        predict(crops: (N, C, h, w)) -> Outputs(crops=(N, 1, h, w) float {0,1},
-                                                 instance_scores=(N, 1))
-
-    so it drops straight into ``TopDownSegmentationLayer._run_stage_2`` and the
-    entire offset/scale/``to_masks``/``save`` path is inherited (PLAN §2.1). Each
-    crop is prompted at its **center pixel** ``(w/2, h/2)`` (the centroid the crop
-    was centered on; P2). Because the mask comes back at crop-pixel resolution,
-    ``output_stride=1`` and ``input_scale=1`` so the inherited
-    ``scale=(eff, eff)`` / ``offset=floored_TL/eff`` contract holds.
-
-    Args:
-        backend: A :class:`MaskBackend` (SAM1 here; SAM3 later).
-        output_stride: Reported head->crop stride. SAM emits at crop-pixel res,
-            so this is ``1`` (the parent layer divides by it).
-        input_scale: Reported crop input_scale; ``1.0`` (crops are not rescaled
-            before SAM).
-        fg_threshold: Unused (SAM emits a binary mask); accepted for surface
-            parity with ``CenteredInstanceMaskLayer``.
-    """
-
-    def __init__(
-        self,
-        backend: MaskBackend,
-        output_stride: int = 1,
-        input_scale: float = 1.0,
-        fg_threshold: float = 0.5,
-    ) -> None:
-        """Stash the backend and the stride/scale parity knobs."""
-        self.backend = backend
-        self.output_stride = int(output_stride)
-        self.fg_threshold = float(fg_threshold)
-        # _run_stage_2 reads preprocess_config.scale (the seg model's input_scale).
-        self.preprocess_config = type("_PP", (), {"scale": float(input_scale)})()
-        # The parent TopDownLayer.predict inspects this; a mask layer never takes
-        # the GT-keypoint branch.
-        self.use_gt_peaks = False
-
-    @property
-    def warmup_input_shape(self):
-        """Tiny single-channel warmup shape (surface parity)."""
-        return (1, 1, 64, 64)
-
-    def predict(self, crops) -> Outputs:
-        """Prompt each crop at its center pixel; return masks at crop resolution.
-
-        Args:
-            crops: ``(N, C, h, w)`` per-instance crops (torch tensor or ndarray),
-                already centered on each instance's centroid by the parent layer.
-
-        Returns:
-            ``Outputs`` with ``crops`` set to the stacked per-crop boolean masks
-            ``(N, 1, h, w)`` (float) and ``instance_scores`` set to the per-crop
-            raw SAM score ``(N, 1)`` — the exact shape ``_run_stage_2`` consumes.
-        """
-        if isinstance(crops, torch.Tensor):
-            crops_np = crops.detach().cpu().numpy()
-        else:
-            crops_np = np.asarray(crops)
-        if crops_np.ndim != 4:
-            raise ValueError(
-                f"FindInstanceMaskSAM.predict expects (N, C, h, w) crops, got "
-                f"shape {crops_np.shape}."
-            )
-        n, _c, h, w = crops_np.shape
-        if n == 0:
-            return Outputs(
-                crops=torch.zeros(0, 1, h, w, dtype=torch.float32),
-                instance_scores=torch.zeros(0, 1, dtype=torch.float32),
-            )
-
-        from sleap_nn.inference.sam.prompts import crop_center_prompt
-
-        masks: List[np.ndarray] = []
-        scores: List[float] = []
-        # SAM encodes one image at a time; each crop is its own image here.
-        for k in range(n):
-            gray = _frame_gray(crops_np[k])
-            prompt = crop_center_prompt((h, w))
-            m, s = self.backend.masks(gray, [prompt])
-            masks.append(m[0])
-            scores.append(s[0])
-
-        mask_stack = np.stack(masks).astype(np.float32)[:, None]  # (N, 1, h, w)
-        score_arr = np.asarray(scores, dtype=np.float32)[:, None]  # (N, 1)
-        return Outputs(
-            crops=torch.from_numpy(mask_stack),
-            instance_scores=torch.from_numpy(score_arr),
-        )
 
 
 def _is_predicted(inst) -> bool:

--- a/sleap_nn/inference/sam/overlay.py
+++ b/sleap_nn/inference/sam/overlay.py
@@ -1,0 +1,86 @@
+"""Review/debug overlay rendering for predicted segmentation masks.
+
+A v1 deliverable is *review-style* overlays (PLAN L4): masks are produced now;
+the GUI correction round-trip is gated on upstream frontend work. This module
+renders a colored per-instance mask overlay PNG so a human can eyeball the
+predictions before importing the ``.slp``. Harvested from #642 ``_save_overlay``
+and repurposed for ``PredictedSegmentationMask`` (which carries scale/offset, so
+masks are decoded to the image grid first).
+
+``cv2`` is imported lazily inside the function so importing this module never
+pulls OpenCV.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+#: Distinct per-instance overlay colors (RGB), cycled by instance index.
+_COLORS = [
+    (255, 80, 80),
+    (80, 255, 80),
+    (80, 80, 255),
+    (255, 255, 80),
+    (255, 80, 255),
+    (80, 255, 255),
+    (255, 160, 80),
+    (160, 80, 255),
+]
+
+
+def save_mask_overlay(labels, path, frame_index: int = 0) -> Optional[Path]:
+    """Render image + colored per-instance mask overlay for one labeled frame.
+
+    Args:
+        labels: A ``sio.Labels`` whose frames carry
+            ``sio.PredictedSegmentationMask`` objects.
+        path: Output PNG path.
+        frame_index: Which labeled frame to render (default the first).
+
+    Returns:
+        The written ``Path`` on success, or ``None`` if there were no frames /
+        masks to render.
+    """
+    import cv2
+
+    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+    frames = list(labels.labeled_frames)
+    if not frames or frame_index >= len(frames):
+        return None
+    lf = frames[frame_index]
+
+    img = np.asarray(lf.image)
+    if img.ndim == 3 and img.shape[-1] == 1:
+        img = img[..., 0]
+    if img.ndim == 2:
+        rgb = np.stack([img] * 3, axis=-1).astype(np.float32)
+    else:
+        rgb = img.astype(np.float32)
+    H, W = rgb.shape[:2]
+
+    masks = list(getattr(lf, "masks", []) or [])
+    if not masks:
+        return None
+
+    for i, m in enumerate(masks):
+        decoded = decode_mask_to_image_res(m)
+        # decode_mask_to_image_res can return a +/-1 px or differently-sized
+        # canvas (offset padding / scale rounding); clamp to the frame extent.
+        mm = np.zeros((H, W), bool)
+        hh, ww = min(H, decoded.shape[0]), min(W, decoded.shape[1])
+        mm[:hh, :ww] = decoded[:hh, :ww]
+        c = np.array(_COLORS[i % len(_COLORS)], dtype=np.float32)
+        rgb[mm] = 0.5 * rgb[mm] + 0.5 * c
+        cnts, _ = cv2.findContours(
+            mm.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
+        cv2.drawContours(rgb, cnts, -1, tuple(int(x) for x in c), 2)
+
+    out_path = Path(path).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(out_path.as_posix(), rgb[..., ::-1].astype(np.uint8))  # RGB->BGR
+    return out_path

--- a/sleap_nn/inference/sam/prompts.py
+++ b/sleap_nn/inference/sam/prompts.py
@@ -4,25 +4,20 @@ A *prompt* is the geometric hint handed to a SAM backend
 (:mod:`sleap_nn.inference.sam.backends`) for one instance: positive point
 coordinates, an optional box, and the keypoint-box used by the candidate
 rejection heuristic (:func:`sleap_nn.inference.sam.backends._pick`). All
-coordinates are in the pixel space of the image the backend will encode (the
-full frame for the pose/centroid/box modes, the crop for the top-down
-crop-center-pixel mode).
+coordinates are in the pixel space of the full frame the backend will encode.
 
-Four prompt modes (v1 = prompted-only, PLAN L3), each validated by a prototype:
+Three prompt modes (v1 = prompted-only, PLAN L3), each validated by a prototype:
 
 * :func:`pose_prompt` — every visible keypoint as a positive point **plus** the
   padded keypoint box (the locked exp-07 recipe; cleanest — P1).
 * :func:`centroid_prompt` — a single positive point (the predicted centroid /
   anchor, or the mean of the visible keypoints); ``multimask_output`` is
   essential and the keypoint box is kept only for candidate rejection (P1/P2).
-* :func:`box_prompt` — the padded pose/crop box as the only prompt, no points
+* :func:`box_prompt` — the padded pose box as the only prompt, no points
   (leaks between adjacent animals; secondary — P1/P2).
-* :func:`crop_center_prompt` — the naive crop center ``(w/2, h/2)`` of an
-  instance-centered crop; needs only a centroid, no pose (the top-down seam,
-  byte-identical packaging — P2).
 
 The product rule (PLAN L3 / P2): use the pose prompt when an instance has
-visible keypoints, else fall back to the centroid/crop-center point.
+visible keypoints, else fall back to the centroid point.
 :func:`prompt_for_instance` implements exactly that dispatch.
 """
 
@@ -43,7 +38,7 @@ SAM_BOX_MARGIN_MIN: float = 15.0
 
 #: Available prompt modes (v1; PLAN L3). ``"pose"`` falls back to a center point
 #: per-instance when no keypoints are visible (the product rule).
-PROMPT_MODES: Tuple[str, ...] = ("pose", "centroid", "box", "crop_center")
+PROMPT_MODES: Tuple[str, ...] = ("pose", "centroid", "box")
 
 
 @dataclass
@@ -62,8 +57,8 @@ class SamPrompt:
             candidate-rejection heuristic (:func:`backends._pick`) — never passed
             to SAM. Always populated so :func:`backends._pick` can size-reject the
             whole-arena candidate even in point-only modes.
-        mode: The originating mode tag (``"pose"`` / ``"centroid"`` / ``"box"`` /
-            ``"crop_center"``), carried for diagnostics / overlays.
+        mode: The originating mode tag (``"pose"`` / ``"centroid"`` / ``"box"``),
+            carried for diagnostics / overlays.
     """
 
     point_coords: Optional[np.ndarray]
@@ -252,32 +247,6 @@ def box_prompt(
     )
 
 
-def crop_center_prompt(crop_hw: Tuple[int, int]) -> SamPrompt:
-    """Top-down crop-center-pixel prompt: the naive crop center ``(w/2, h/2)``.
-
-    For an instance-centered crop, the crop center *is* the centroid (the crop
-    math centers it there). Needs only a centroid — no pose (P2). The reject box
-    is the full crop extent.
-
-    Args:
-        crop_hw: ``(crop_h, crop_w)`` of the crop being prompted.
-
-    Returns:
-        A :class:`SamPrompt` with a single center ``point_coords`` and the full
-        crop as the reject box.
-    """
-    ch, cw = int(crop_hw[0]), int(crop_hw[1])
-    center = np.array([[cw / 2.0, ch / 2.0]], np.float32)
-    reject = np.array([0.0, 0.0, cw - 1.0, ch - 1.0], np.float32)
-    return SamPrompt(
-        point_coords=center,
-        point_labels=np.ones(1, np.int32),
-        box=None,
-        reject_box=reject,
-        mode="crop_center",
-    )
-
-
 def prompt_for_instance(
     mode: str,
     hw: Tuple[int, int],
@@ -290,16 +259,14 @@ def prompt_for_instance(
 
     The product rule (PLAN L3 / P2): for ``mode="pose"`` use the pose prompt when
     the instance has visible keypoints, else fall back to a center point (the
-    centroid if given, else an error). For ``mode="crop_center"`` use the richer
-    crop-local pose prompt when crop-local keypoints are present, else the naive
-    center pixel. ``"centroid"`` / ``"box"`` always use their named builder.
+    centroid if given, else an error). ``"centroid"`` / ``"box"`` always use their
+    named builder.
 
     Args:
         mode: One of :data:`PROMPT_MODES`.
-        hw: ``(height, width)`` of the image being prompted. For ``crop_center``
-            this is the crop size.
-        keypoints: ``(n, 2)`` xy keypoints (image- or crop-local space depending
-            on the call site). Required for ``pose`` / ``box``.
+        hw: ``(height, width)`` of the image being prompted.
+        keypoints: ``(n, 2)`` xy keypoints in full-frame space. Required for
+            ``pose`` / ``box``.
         centroid: ``(2,)`` anchor xy. Required for ``centroid``; used as the
             pose-fallback point when ``mode="pose"`` and no keypoint is visible.
         margin_frac: Keypoint-box margin fraction.
@@ -317,14 +284,6 @@ def prompt_for_instance(
         raise ValueError(
             f"Unknown prompt mode {mode!r}; expected one of {PROMPT_MODES}."
         )
-
-    if mode == "crop_center":
-        if keypoints is not None and len(visible_keypoints(keypoints)) > 0:
-            # Pose-if-exists rule, in crop-local space.
-            return pose_prompt(
-                keypoints, hw, margin_frac=margin_frac, margin_min=margin_min
-            )
-        return crop_center_prompt(hw)
 
     if mode == "centroid":
         if centroid is None:

--- a/sleap_nn/inference/sam/prompts.py
+++ b/sleap_nn/inference/sam/prompts.py
@@ -1,0 +1,365 @@
+"""Prompt builders for SAM-prompted instance segmentation (PR-A).
+
+A *prompt* is the geometric hint handed to a SAM backend
+(:mod:`sleap_nn.inference.sam.backends`) for one instance: positive point
+coordinates, an optional box, and the keypoint-box used by the candidate
+rejection heuristic (:func:`sleap_nn.inference.sam.backends._pick`). All
+coordinates are in the pixel space of the image the backend will encode (the
+full frame for the pose/centroid/box modes, the crop for the top-down
+crop-center-pixel mode).
+
+Four prompt modes (v1 = prompted-only, PLAN L3), each validated by a prototype:
+
+* :func:`pose_prompt` — every visible keypoint as a positive point **plus** the
+  padded keypoint box (the locked exp-07 recipe; cleanest — P1).
+* :func:`centroid_prompt` — a single positive point (the predicted centroid /
+  anchor, or the mean of the visible keypoints); ``multimask_output`` is
+  essential and the keypoint box is kept only for candidate rejection (P1/P2).
+* :func:`box_prompt` — the padded pose/crop box as the only prompt, no points
+  (leaks between adjacent animals; secondary — P1/P2).
+* :func:`crop_center_prompt` — the naive crop center ``(w/2, h/2)`` of an
+  instance-centered crop; needs only a centroid, no pose (the top-down seam,
+  byte-identical packaging — P2).
+
+The product rule (PLAN L3 / P2): use the pose prompt when an instance has
+visible keypoints, else fall back to the centroid/crop-center point.
+:func:`prompt_for_instance` implements exactly that dispatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Locked SAM prompt recipe constants (harvested from #642 / exp-07; PLAN §1).
+# These are the single source of truth for the default prompt recipe.
+# ---------------------------------------------------------------------------
+#: Keypoint-box margin: ``max(SAM_BOX_MARGIN_MIN, SAM_BOX_MARGIN_FRAC * side)``.
+SAM_BOX_MARGIN_FRAC: float = 0.6
+SAM_BOX_MARGIN_MIN: float = 15.0
+
+#: Available prompt modes (v1; PLAN L3). ``"pose"`` falls back to a center point
+#: per-instance when no keypoints are visible (the product rule).
+PROMPT_MODES: Tuple[str, ...] = ("pose", "centroid", "box", "crop_center")
+
+
+@dataclass
+class SamPrompt:
+    """A built SAM prompt for one instance.
+
+    Attributes:
+        point_coords: ``(n, 2)`` float32 positive-point xy, or ``None`` when the
+            prompt is box-only.
+        point_labels: ``(n,)`` int32 labels (all ``1`` — positive; automatic
+            prompting uses no negatives, PLAN §2.2). ``None`` iff
+            ``point_coords`` is ``None``.
+        box: ``[x0, y0, x1, y1]`` float32 box prompt, or ``None`` when the prompt
+            is point-only.
+        reject_box: ``[x0, y0, x1, y1]`` float32 box used **only** by the
+            candidate-rejection heuristic (:func:`backends._pick`) — never passed
+            to SAM. Always populated so :func:`backends._pick` can size-reject the
+            whole-arena candidate even in point-only modes.
+        mode: The originating mode tag (``"pose"`` / ``"centroid"`` / ``"box"`` /
+            ``"crop_center"``), carried for diagnostics / overlays.
+    """
+
+    point_coords: Optional[np.ndarray]
+    point_labels: Optional[np.ndarray]
+    box: Optional[np.ndarray]
+    reject_box: np.ndarray
+    mode: str
+
+
+def visible_keypoints(points: np.ndarray) -> np.ndarray:
+    """Return the finite ``(m, 2)`` rows of an ``(n, 2)`` keypoint array.
+
+    Drops any keypoint with a non-finite (``NaN`` / ``inf``) x or y, matching the
+    prototype's ``k[np.isfinite(k).all(1)]`` visibility filter.
+
+    Args:
+        points: ``(n, 2)`` xy keypoints (may carry ``NaN`` for missing nodes).
+
+    Returns:
+        ``(m, 2)`` float32 array of the visible keypoints (``m`` may be 0).
+    """
+    pts = np.asarray(points, dtype=np.float32).reshape(-1, 2)
+    return pts[np.isfinite(pts).all(axis=1)]
+
+
+def kpt_box(
+    pos: np.ndarray,
+    hw: Tuple[int, int],
+    margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    margin_min: float = SAM_BOX_MARGIN_MIN,
+) -> np.ndarray:
+    """Padded keypoint bounding box ``[x0, y0, x1, y1]`` clamped to ``hw``.
+
+    Harvested verbatim from #642 ``_kpt_box`` (the locked exp-07 recipe): the
+    per-axis margin is ``max(margin_min, margin_frac * side)``, so the box grows
+    with the instance but never collapses below ``margin_min`` px for a small or
+    degenerate (single-point) instance.
+
+    Args:
+        pos: ``(n, 2)`` visible xy keypoints (no NaNs; ``n >= 1``).
+        hw: ``(height, width)`` of the image the box lives in.
+        margin_frac: Box margin as a fraction of the box side length.
+        margin_min: Minimum box margin (px) per axis.
+
+    Returns:
+        ``float32`` array ``[x0, y0, x1, y1]`` clamped to ``[0, w-1] x [0, h-1]``.
+    """
+    pos = np.asarray(pos, dtype=np.float32).reshape(-1, 2)
+    x0, y0 = pos.min(0)
+    x1, y1 = pos.max(0)
+    mx = max(margin_min, margin_frac * (x1 - x0))
+    my = max(margin_min, margin_frac * (y1 - y0))
+    return np.array(
+        [
+            max(0.0, x0 - mx),
+            max(0.0, y0 - my),
+            min(hw[1] - 1.0, x1 + mx),
+            min(hw[0] - 1.0, y1 + my),
+        ],
+        np.float32,
+    )
+
+
+def pose_prompt(
+    keypoints: np.ndarray,
+    hw: Tuple[int, int],
+    margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    margin_min: float = SAM_BOX_MARGIN_MIN,
+) -> SamPrompt:
+    """Pose prompt: visible keypoints as positive points + the padded kpt-box.
+
+    The strongest prompt (P1: containment 1.0, 72% single-component, no
+    blow-ups). No negative points (automatic prompting only; PLAN §2.2).
+
+    Args:
+        keypoints: ``(n, 2)`` xy keypoints; non-finite rows are dropped here.
+        hw: ``(height, width)`` of the image being prompted.
+        margin_frac: Keypoint-box margin fraction (:func:`kpt_box`).
+        margin_min: Keypoint-box minimum margin (:func:`kpt_box`).
+
+    Returns:
+        A :class:`SamPrompt` with both ``point_coords`` and ``box`` set.
+
+    Raises:
+        ValueError: If no keypoints are visible (caller should fall back to a
+            center point — see :func:`prompt_for_instance`).
+    """
+    pts = visible_keypoints(keypoints)
+    if len(pts) == 0:
+        raise ValueError(
+            "pose_prompt requires at least one visible keypoint; the caller "
+            "should fall back to a centroid/crop-center point."
+        )
+    box = kpt_box(pts, hw, margin_frac=margin_frac, margin_min=margin_min)
+    return SamPrompt(
+        point_coords=pts.astype(np.float32),
+        point_labels=np.ones(len(pts), np.int32),
+        box=box,
+        reject_box=box,
+        mode="pose",
+    )
+
+
+def centroid_prompt(
+    point: np.ndarray,
+    hw: Tuple[int, int],
+    keypoints: Optional[np.ndarray] = None,
+    margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    margin_min: float = SAM_BOX_MARGIN_MIN,
+) -> SamPrompt:
+    """Centroid prompt: a single positive point, ``multimask_output`` essential.
+
+    The box is **not** passed to SAM (a lone point is maximally ambiguous —
+    P1/P2); it is computed only for the candidate-rejection heuristic. When
+    ``keypoints`` is given the keypoint box is used; otherwise a fixed margin box
+    around the point is used as the reject box.
+
+    Args:
+        point: The ``(2,)`` anchor xy (predicted centroid / mean point).
+        hw: ``(height, width)`` of the image being prompted.
+        keypoints: Optional ``(n, 2)`` keypoints to size the reject box; when
+            absent a ``margin_min``-radius box around ``point`` is used.
+        margin_frac: Reject-box margin fraction.
+        margin_min: Reject-box minimum margin.
+
+    Returns:
+        A :class:`SamPrompt` with ``point_coords`` set and ``box`` ``None``.
+    """
+    pt = np.asarray(point, dtype=np.float32).reshape(1, 2)
+    vis = visible_keypoints(keypoints) if keypoints is not None else np.empty((0, 2))
+    if len(vis) > 0:
+        reject = kpt_box(vis, hw, margin_frac=margin_frac, margin_min=margin_min)
+    else:
+        cx, cy = float(pt[0, 0]), float(pt[0, 1])
+        reject = np.array(
+            [
+                max(0.0, cx - margin_min),
+                max(0.0, cy - margin_min),
+                min(hw[1] - 1.0, cx + margin_min),
+                min(hw[0] - 1.0, cy + margin_min),
+            ],
+            np.float32,
+        )
+    return SamPrompt(
+        point_coords=pt,
+        point_labels=np.ones(1, np.int32),
+        box=None,
+        reject_box=reject,
+        mode="centroid",
+    )
+
+
+def box_prompt(
+    keypoints: np.ndarray,
+    hw: Tuple[int, int],
+    margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    margin_min: float = SAM_BOX_MARGIN_MIN,
+) -> SamPrompt:
+    """Box prompt: the padded pose/crop box as the only prompt, no points.
+
+    Secondary mode (P1/P2: leaks between adjacent animals). The same box is both
+    the SAM prompt and the reject box.
+
+    Args:
+        keypoints: ``(n, 2)`` xy keypoints; non-finite rows are dropped here.
+        hw: ``(height, width)`` of the image being prompted.
+        margin_frac: Keypoint-box margin fraction (:func:`kpt_box`).
+        margin_min: Keypoint-box minimum margin (:func:`kpt_box`).
+
+    Returns:
+        A :class:`SamPrompt` with ``box`` set and ``point_coords`` ``None``.
+
+    Raises:
+        ValueError: If no keypoints are visible.
+    """
+    pts = visible_keypoints(keypoints)
+    if len(pts) == 0:
+        raise ValueError("box_prompt requires at least one visible keypoint.")
+    box = kpt_box(pts, hw, margin_frac=margin_frac, margin_min=margin_min)
+    return SamPrompt(
+        point_coords=None,
+        point_labels=None,
+        box=box,
+        reject_box=box,
+        mode="box",
+    )
+
+
+def crop_center_prompt(crop_hw: Tuple[int, int]) -> SamPrompt:
+    """Top-down crop-center-pixel prompt: the naive crop center ``(w/2, h/2)``.
+
+    For an instance-centered crop, the crop center *is* the centroid (the crop
+    math centers it there). Needs only a centroid — no pose (P2). The reject box
+    is the full crop extent.
+
+    Args:
+        crop_hw: ``(crop_h, crop_w)`` of the crop being prompted.
+
+    Returns:
+        A :class:`SamPrompt` with a single center ``point_coords`` and the full
+        crop as the reject box.
+    """
+    ch, cw = int(crop_hw[0]), int(crop_hw[1])
+    center = np.array([[cw / 2.0, ch / 2.0]], np.float32)
+    reject = np.array([0.0, 0.0, cw - 1.0, ch - 1.0], np.float32)
+    return SamPrompt(
+        point_coords=center,
+        point_labels=np.ones(1, np.int32),
+        box=None,
+        reject_box=reject,
+        mode="crop_center",
+    )
+
+
+def prompt_for_instance(
+    mode: str,
+    hw: Tuple[int, int],
+    keypoints: Optional[np.ndarray] = None,
+    centroid: Optional[np.ndarray] = None,
+    margin_frac: float = SAM_BOX_MARGIN_FRAC,
+    margin_min: float = SAM_BOX_MARGIN_MIN,
+) -> SamPrompt:
+    """Dispatch to the right prompt builder, applying the L3 product rule.
+
+    The product rule (PLAN L3 / P2): for ``mode="pose"`` use the pose prompt when
+    the instance has visible keypoints, else fall back to a center point (the
+    centroid if given, else an error). For ``mode="crop_center"`` use the richer
+    crop-local pose prompt when crop-local keypoints are present, else the naive
+    center pixel. ``"centroid"`` / ``"box"`` always use their named builder.
+
+    Args:
+        mode: One of :data:`PROMPT_MODES`.
+        hw: ``(height, width)`` of the image being prompted. For ``crop_center``
+            this is the crop size.
+        keypoints: ``(n, 2)`` xy keypoints (image- or crop-local space depending
+            on the call site). Required for ``pose`` / ``box``.
+        centroid: ``(2,)`` anchor xy. Required for ``centroid``; used as the
+            pose-fallback point when ``mode="pose"`` and no keypoint is visible.
+        margin_frac: Keypoint-box margin fraction.
+        margin_min: Keypoint-box minimum margin.
+
+    Returns:
+        A built :class:`SamPrompt`.
+
+    Raises:
+        ValueError: If ``mode`` is unknown, or a required prompt source is
+            missing (e.g. ``mode="box"`` with no visible keypoints, or
+            ``mode="pose"`` with neither keypoints nor a centroid fallback).
+    """
+    if mode not in PROMPT_MODES:
+        raise ValueError(
+            f"Unknown prompt mode {mode!r}; expected one of {PROMPT_MODES}."
+        )
+
+    if mode == "crop_center":
+        if keypoints is not None and len(visible_keypoints(keypoints)) > 0:
+            # Pose-if-exists rule, in crop-local space.
+            return pose_prompt(
+                keypoints, hw, margin_frac=margin_frac, margin_min=margin_min
+            )
+        return crop_center_prompt(hw)
+
+    if mode == "centroid":
+        if centroid is None:
+            if keypoints is not None and len(visible_keypoints(keypoints)) > 0:
+                centroid = visible_keypoints(keypoints).mean(0)
+            else:
+                raise ValueError(
+                    "centroid prompt requires a centroid (or visible keypoints "
+                    "to average)."
+                )
+        return centroid_prompt(
+            centroid,
+            hw,
+            keypoints=keypoints,
+            margin_frac=margin_frac,
+            margin_min=margin_min,
+        )
+
+    if mode == "box":
+        return box_prompt(keypoints, hw, margin_frac=margin_frac, margin_min=margin_min)
+
+    # mode == "pose": pose-if-exists-else-center (the L3 product rule).
+    has_kpts = keypoints is not None and len(visible_keypoints(keypoints)) > 0
+    if has_kpts:
+        return pose_prompt(
+            keypoints, hw, margin_frac=margin_frac, margin_min=margin_min
+        )
+    if centroid is not None:
+        return centroid_prompt(
+            centroid,
+            hw,
+            keypoints=None,
+            margin_frac=margin_frac,
+            margin_min=margin_min,
+        )
+    raise ValueError(
+        "pose prompt has no visible keypoints and no centroid fallback was " "provided."
+    )

--- a/sleap_nn/inference/segmentation_convert.py
+++ b/sleap_nn/inference/segmentation_convert.py
@@ -10,7 +10,7 @@ identically.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 import numpy as np
 
@@ -23,6 +23,9 @@ def build_predicted_segmentation_mask(
     score: float,
     scale: Tuple[float, float] = (1.0, 1.0),
     offset: Tuple[float, float] = (0.0, 0.0),
+    instance: "Optional[sio.PredictedInstance]" = None,
+    track: "Optional[sio.Track]" = None,
+    tracking_score: Optional[float] = None,
 ) -> "sio.PredictedSegmentationMask":
     """Build a ``sio.PredictedSegmentationMask`` from a boolean mask array.
 
@@ -36,19 +39,35 @@ def build_predicted_segmentation_mask(
         offset: Origin ``(x, y)`` of the mask in image pixels. The segmentation
             layer keeps this ``(0.0, 0.0)`` because every preprocessing pad is
             bottom-right (valid content top-left aligned).
+        instance: Optional paired ``sio.PredictedInstance`` set on the mask's
+            ``instance`` field (PLAN L8 — populated when the mask was produced
+            from a pose/centroid, making correction referential not positional).
+            Defaults to ``None`` so existing model-driven callers are unchanged.
+        track: Optional ``sio.Track`` set on the mask's ``track`` field (PLAN L8).
+        tracking_score: Optional track-assignment confidence set on the mask's
+            ``tracking_score`` field.
 
     Returns:
         A ``sio.PredictedSegmentationMask`` (RLE-backed) carrying ``score`` and
-        the ``scale``/``offset`` that map it back to image pixels.
+        the ``scale``/``offset`` that map it back to image pixels, plus the
+        optional ``instance``/``track``/``tracking_score`` provenance.
     """
     import sleap_io as sio
 
     mask = np.ascontiguousarray(mask, dtype=bool)
+    kwargs: dict[str, Any] = {}
+    if instance is not None:
+        kwargs["instance"] = instance
+    if track is not None:
+        kwargs["track"] = track
+    if tracking_score is not None:
+        kwargs["tracking_score"] = float(tracking_score)
     return sio.PredictedSegmentationMask.from_numpy(
         mask,
         score=float(score),
         scale=(float(scale[0]), float(scale[1])),
         offset=(float(offset[0]), float(offset[1])),
+        **kwargs,
     )
 
 

--- a/tests/inference/sam/test_backends.py
+++ b/tests/inference/sam/test_backends.py
@@ -1,0 +1,179 @@
+"""Unit tests for the SAM1 backend (CPU; a fake SamPredictor, no real SAM)."""
+
+import numpy as np
+import pytest
+
+from sleap_nn.inference.sam.backends import (
+    SAM_PRED_IOU_MIN,
+    SamBackend,
+    _pick,
+    _to_3ch_clahe,
+    disjointify,
+    own_containment,
+)
+from sleap_nn.inference.sam.prompts import pose_prompt
+
+
+class FakeSamPredictor:
+    """Stand-in for ``segment_anything.SamPredictor``.
+
+    ``set_image`` records the encoded image size; ``predict`` returns a fixed set
+    of candidate masks + predicted-IoU scores (3 candidates, ``multimask_output``
+    shape) so the backend's selection / packaging can be tested deterministically.
+    """
+
+    def __init__(self, candidates):
+        # candidates: list of (mask (H,W) bool, score float)
+        self._candidates = candidates
+        self.encoded_shape = None
+        self.last_call = None
+
+    def set_image(self, rgb):
+        assert rgb.ndim == 3 and rgb.shape[-1] == 3
+        self.encoded_shape = rgb.shape[:2]
+
+    def predict(
+        self, point_coords=None, point_labels=None, box=None, multimask_output=True
+    ):
+        self.last_call = dict(
+            point_coords=point_coords,
+            point_labels=point_labels,
+            box=box,
+            multimask_output=multimask_output,
+        )
+        masks = np.stack([c[0] for c in self._candidates]).astype(bool)
+        scores = np.array([c[1] for c in self._candidates], np.float32)
+        return masks, scores, None
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+def test_to_3ch_clahe_shape_and_dtype():
+    gray = (np.random.rand(20, 30) * 255).astype(np.uint8)
+    rgb = _to_3ch_clahe(gray, clahe=True)
+    assert rgb.shape == (20, 30, 3)
+    assert rgb.dtype == np.uint8
+    rgb2 = _to_3ch_clahe(gray, clahe=False)
+    # No-CLAHE path just replicates channels.
+    np.testing.assert_array_equal(rgb2[..., 0], gray)
+
+
+def test_pick_rejects_whole_arena_candidate():
+    h, w = 50, 50
+    small = _disk(h, w, 25, 25, 5)
+    huge = np.ones((h, w), bool)  # whole-arena over-confident candidate
+    masks = np.stack([huge, small])
+    scores = np.array([0.99, 0.80], np.float32)  # huge has the higher score
+    box = np.array([20, 20, 30, 30], np.float32)
+    # Despite the higher score, the huge candidate is area-rejected -> pick small.
+    assert _pick(masks, scores, box) == 1
+
+
+def test_pick_takes_best_score_among_survivors():
+    h, w = 50, 50
+    a = _disk(h, w, 25, 25, 5)
+    b = _disk(h, w, 25, 25, 6)
+    masks = np.stack([a, b])
+    scores = np.array([0.7, 0.9], np.float32)
+    box = np.array([10, 10, 40, 40], np.float32)
+    assert _pick(masks, scores, box) == 1
+
+
+def test_own_containment_score():
+    mask = _disk(50, 50, 25, 25, 10)
+    inside = np.array([[25.0, 25.0], [20.0, 20.0]])
+    assert own_containment(mask, inside, (50, 50)) == 1.0
+    half = np.array([[25.0, 25.0], [0.0, 0.0]])
+    assert own_containment(mask, half, (50, 50)) == 0.5
+    assert own_containment(mask, np.empty((0, 2)), (50, 50)) == 0.0
+
+
+def test_disjointify_resolves_overlap_by_nearest_keypoint():
+    h, w = 40, 40
+    # Two overlapping masks; keypoints seed the Voronoi assignment.
+    m0 = _disk(h, w, 20, 15, 12)
+    m1 = _disk(h, w, 20, 25, 12)
+    k0 = [[15.0, 20.0]]
+    k1 = [[25.0, 20.0]]
+    out = disjointify([m0, m1], [k0, k1])
+    # Result is exactly disjoint.
+    assert not (out[0] & out[1]).any()
+    # Each instance keeps its own keypoint pixel.
+    assert out[0][20, 15]
+    assert out[1][20, 25]
+
+
+def test_disjointify_noop_when_uncontested():
+    h, w = 30, 30
+    m0 = _disk(h, w, 10, 10, 5)
+    m1 = _disk(h, w, 20, 20, 5)
+    out = disjointify([m0, m1], [[[10.0, 10.0]], [[20.0, 20.0]]])
+    np.testing.assert_array_equal(out[0], m0)
+    np.testing.assert_array_equal(out[1], m1)
+
+
+def test_sam_backend_masks_contract():
+    h, w = 64, 64
+    chosen = _disk(h, w, 32, 32, 10)
+    huge = np.ones((h, w), bool)
+    pred = FakeSamPredictor(
+        candidates=[(huge, 0.99), (chosen, 0.85), (_disk(h, w, 32, 32, 4), 0.5)]
+    )
+    backend = SamBackend(pred)
+    kpts = np.array([[28.0, 28.0], [36.0, 36.0]])
+    prompts = [pose_prompt(kpts, (h, w))]
+    masks, scores = backend.masks(np.zeros((h, w), np.uint8), prompts)
+    assert len(masks) == 1 and len(scores) == 1
+    # The whole-arena candidate (idx 0, score 0.99) is rejected; idx 1 wins.
+    np.testing.assert_array_equal(masks[0], chosen)
+    assert abs(scores[0] - 0.85) < 1e-6
+    # The backend encoded the image once at the frame size.
+    assert pred.encoded_shape == (h, w)
+    # The pose prompt forwarded both points and the box.
+    assert pred.last_call["point_coords"].shape == (2, 2)
+    assert pred.last_call["box"] is not None
+
+
+def test_sam_backend_empty_prompts():
+    backend = SamBackend(FakeSamPredictor(candidates=[(np.zeros((8, 8), bool), 0.5)]))
+    masks, scores = backend.masks(np.zeros((8, 8), np.uint8), [])
+    assert masks == [] and scores == []
+
+
+def test_sam_backend_pred_iou_min_attribute():
+    backend = SamBackend(FakeSamPredictor(candidates=[(np.zeros((8, 8), bool), 0.5)]))
+    # SAM1's nominal floor; reported (not gated) — carried for SAM3 parity.
+    assert backend.pred_iou_min == SAM_PRED_IOU_MIN
+
+
+def test_sam_backend_raw_score_is_not_gated():
+    # A low predicted-IoU still produces a mask + the raw score (no drop-gate).
+    h, w = 32, 32
+    chosen = _disk(h, w, 16, 16, 6)
+    backend = SamBackend(FakeSamPredictor(candidates=[(chosen, 0.10)]))
+    masks, scores = backend.masks(
+        np.zeros((h, w), np.uint8), [pose_prompt(np.array([[16.0, 16.0]]), (h, w))]
+    )
+    assert masks[0].any()
+    assert abs(scores[0] - 0.10) < 1e-6
+
+
+def test_load_sam_predictor_missing_dependency(monkeypatch):
+    # Simulate `segment-anything` not installed.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "segment_anything":
+            raise ImportError("no module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    from sleap_nn.inference.sam.backends import _load_sam_predictor
+
+    with pytest.raises(ImportError, match="sleap-nn\\[sam\\]"):
+        _load_sam_predictor("/tmp/nope.pth")

--- a/tests/inference/sam/test_e2e_gpu.py
+++ b/tests/inference/sam/test_e2e_gpu.py
@@ -1,0 +1,149 @@
+"""GPU + real-SAM end-to-end smoke for the prompted mask producer.
+
+Gated on (a) CUDA, (b) ``segment-anything`` installed, and (c) a ViT-H
+checkpoint + the prototype val ``.slp`` being present — so it skips cleanly in
+CI (which has none of these) and runs only on a GPU box with the SAM assets.
+This is the single end-to-end check that the *real* SAM path
+(load -> encode -> prompt -> pick -> PredictedSegmentationMask -> SLP) works;
+every other test uses a fake backend.
+"""
+
+import importlib.util
+import os
+
+import numpy as np
+import pytest
+import torch
+
+import sleap_io as sio
+
+_CKPT = (
+    "/home/talmo/code/sleap-nn/scratch/2026-06-03-segmentation-methods/"
+    "experiments/07-sam-pseudomasks/models/sam_vit_h_4b8939.pth"
+)
+_VAL = (
+    "/home/talmo/code/sleap-nn/scratch/2026-06-03-segmentation-methods/data/"
+    "mice_of_seg_val.pkg.slp"
+)
+
+pytestmark = pytest.mark.skipif(
+    not (
+        torch.cuda.is_available()
+        and importlib.util.find_spec("segment_anything") is not None
+        and os.path.exists(_CKPT)
+        and os.path.exists(_VAL)
+    ),
+    reason="needs CUDA + segment-anything + the SAM ViT-H checkpoint + val .slp",
+)
+
+
+def test_sam_pose_masks_end_to_end(tmp_path):
+    from sleap_nn.inference.sam import run_sam_segmentation
+
+    labels = sio.load_slp(_VAL)
+    skel = labels.skeletons[0]
+    # The val file carries GT ``sio.Instance`` poses; convert them to predicted
+    # instances so the PLAN-L8 ``mask.instance`` pairing is genuinely exercised
+    # (a predicted mask is never pinned to a GT user annotation). Two frames is
+    # plenty for a smoke test (SAM encode is the slow part).
+    pred_lfs = []
+    for lf in labels.labeled_frames[:2]:
+        pred_insts = []
+        for inst in lf.instances:
+            pts = inst.numpy()[:, :2]
+            n = pts.shape[0]
+            pred_insts.append(
+                sio.PredictedInstance.from_numpy(
+                    points_data=pts,
+                    skeleton=skel,
+                    point_scores=np.ones(n, np.float32),
+                    score=1.0,
+                )
+            )
+        pred_lfs.append(
+            sio.LabeledFrame(
+                video=lf.video, frame_idx=lf.frame_idx, instances=pred_insts
+            )
+        )
+    small = sio.Labels(
+        videos=list(labels.videos), skeletons=[skel], labeled_frames=pred_lfs
+    )
+
+    out_path = tmp_path / "sam_pose_e2e.pkg.slp"
+    overlay_path = tmp_path / "sam_pose_e2e_overlay.png"
+    out = run_sam_segmentation(
+        small,
+        mask_backend="sam",
+        prompt_mode="pose",
+        sam_checkpoint=_CKPT,
+        device="cuda",
+        output_path=out_path.as_posix(),
+        overlay_path=overlay_path.as_posix(),
+    )
+
+    # Produced masks on at least one frame.
+    assert any(len(lf.masks) > 0 for lf in out.labeled_frames)
+    for lf in out.labeled_frames:
+        for m in lf.masks:
+            assert isinstance(m, sio.PredictedSegmentationMask)
+            assert np.isfinite(m.score)
+            # PLAN L8: the mask is paired to its source predicted instance.
+            assert m.instance is not None
+            # A real mask has area.
+            assert np.asarray(m.data, dtype=bool).any()
+
+    # The embedded SLP + overlay PNG are written and reload.
+    assert out_path.exists()
+    assert overlay_path.exists()
+    sio.load_slp(out_path.as_posix())
+
+
+def test_sam_crop_center_seam_end_to_end():
+    """The crop-center seam produces masks that land at the centroid in-frame."""
+    from sleap_nn.inference.sam.backends import SamBackend
+    from sleap_nn.inference.sam.mask_layer import FindInstanceMaskSAM
+    from sleap_nn.inference.layers.topdown_segmentation import (
+        TopDownSegmentationLayer,
+    )
+    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+    labels = sio.load_slp(_VAL)
+    lf = labels.labeled_frames[0]
+    img = np.asarray(lf.image)
+    if img.ndim == 3:
+        img = img[..., 0]
+    H, W = img.shape
+    inst = lf.instances[0]
+    kpts = inst.numpy()[:, :2]
+    kpts = kpts[np.isfinite(kpts).all(1)]
+    centroid = kpts.mean(0)
+
+    backend = SamBackend.from_checkpoint(_CKPT, device="cuda")
+    layer = TopDownSegmentationLayer.__new__(TopDownSegmentationLayer)
+    layer.centroid_layer = None
+    layer.centered_instance_layer = FindInstanceMaskSAM(backend)
+    layer.crop_size = (256, 256)
+    layer.centroid_nms = False
+    layer.centroid_nms_threshold = 0.5
+    layer.return_crops = False
+    layer.mask_output = "mask"
+    layer.polygon_epsilon = 0.01
+
+    image_4d = torch.as_tensor(img, dtype=torch.float32)[None, None]
+    out = layer._run_stage_2(
+        image_4d,
+        torch.tensor([[[float(centroid[0]), float(centroid[1])]]]),
+        torch.tensor([[1.0]]),
+        torch.tensor([[True]]),
+        eff_scale=torch.tensor([1.0]),
+    )
+    pred = out.pred_masks[0][0]
+    m = sio.PredictedSegmentationMask.from_numpy(
+        pred["mask"], score=pred["score"], scale=pred["scale"], offset=pred["offset"]
+    )
+    decoded = decode_mask_to_image_res(m)
+    ys, xs = np.nonzero(decoded)
+    assert xs.size > 0
+    # The mask lands near the centroid (within a crop half-extent), not at origin.
+    assert abs(xs.mean() - centroid[0]) <= 128
+    assert abs(ys.mean() - centroid[1]) <= 128

--- a/tests/inference/sam/test_e2e_gpu.py
+++ b/tests/inference/sam/test_e2e_gpu.py
@@ -17,13 +17,17 @@ import torch
 
 import sleap_io as sio
 
-_CKPT = (
+# Asset paths are overridable via env vars so any GPU box can run this smoke
+# (defaults point at the prototype assets on the dev machine).
+_CKPT = os.environ.get(
+    "SLEAP_NN_SAM_CKPT",
     "/home/talmo/code/sleap-nn/scratch/2026-06-03-segmentation-methods/"
-    "experiments/07-sam-pseudomasks/models/sam_vit_h_4b8939.pth"
+    "experiments/07-sam-pseudomasks/models/sam_vit_h_4b8939.pth",
 )
-_VAL = (
+_VAL = os.environ.get(
+    "SLEAP_NN_SAM_VAL",
     "/home/talmo/code/sleap-nn/scratch/2026-06-03-segmentation-methods/data/"
-    "mice_of_seg_val.pkg.slp"
+    "mice_of_seg_val.pkg.slp",
 )
 
 pytestmark = pytest.mark.skipif(
@@ -96,54 +100,3 @@ def test_sam_pose_masks_end_to_end(tmp_path):
     assert out_path.exists()
     assert overlay_path.exists()
     sio.load_slp(out_path.as_posix())
-
-
-def test_sam_crop_center_seam_end_to_end():
-    """The crop-center seam produces masks that land at the centroid in-frame."""
-    from sleap_nn.inference.sam.backends import SamBackend
-    from sleap_nn.inference.sam.mask_layer import FindInstanceMaskSAM
-    from sleap_nn.inference.layers.topdown_segmentation import (
-        TopDownSegmentationLayer,
-    )
-    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
-
-    labels = sio.load_slp(_VAL)
-    lf = labels.labeled_frames[0]
-    img = np.asarray(lf.image)
-    if img.ndim == 3:
-        img = img[..., 0]
-    H, W = img.shape
-    inst = lf.instances[0]
-    kpts = inst.numpy()[:, :2]
-    kpts = kpts[np.isfinite(kpts).all(1)]
-    centroid = kpts.mean(0)
-
-    backend = SamBackend.from_checkpoint(_CKPT, device="cuda")
-    layer = TopDownSegmentationLayer.__new__(TopDownSegmentationLayer)
-    layer.centroid_layer = None
-    layer.centered_instance_layer = FindInstanceMaskSAM(backend)
-    layer.crop_size = (256, 256)
-    layer.centroid_nms = False
-    layer.centroid_nms_threshold = 0.5
-    layer.return_crops = False
-    layer.mask_output = "mask"
-    layer.polygon_epsilon = 0.01
-
-    image_4d = torch.as_tensor(img, dtype=torch.float32)[None, None]
-    out = layer._run_stage_2(
-        image_4d,
-        torch.tensor([[[float(centroid[0]), float(centroid[1])]]]),
-        torch.tensor([[1.0]]),
-        torch.tensor([[True]]),
-        eff_scale=torch.tensor([1.0]),
-    )
-    pred = out.pred_masks[0][0]
-    m = sio.PredictedSegmentationMask.from_numpy(
-        pred["mask"], score=pred["score"], scale=pred["scale"], offset=pred["offset"]
-    )
-    decoded = decode_mask_to_image_res(m)
-    ys, xs = np.nonzero(decoded)
-    assert xs.size > 0
-    # The mask lands near the centroid (within a crop half-extent), not at origin.
-    assert abs(xs.mean() - centroid[0]) <= 128
-    assert abs(ys.mean() - centroid[1]) <= 128

--- a/tests/inference/sam/test_mask_layer.py
+++ b/tests/inference/sam/test_mask_layer.py
@@ -1,0 +1,359 @@
+"""Unit tests for the SAM mask layers (CPU; a fake backend, no real SAM).
+
+Covers:
+* :class:`FindInstanceMaskSAM` ``.predict(crops)`` contract (shapes ``(N,1,h,w)``
+  / ``(N,1)``), and its parity packaging through ``TopDownSegmentationLayer.
+  _run_stage_2`` -> ``decode_mask_to_image_res`` (the crop-center seam lands at
+  the centroid, byte-identical to the trained-model seg layer).
+* :class:`SamSegmentationLayer` full-frame placement + ``instance=``/``track=``
+  population + SLP round-trip.
+* ``mask_backend`` is explicit / required (no default).
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import sleap_io as sio
+
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.sam.mask_layer import (
+    FindInstanceMaskSAM,
+    SamSegmentationLayer,
+    place_full,
+)
+from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+class FakeBackend:
+    """A :class:`MaskBackend`-shaped fake that returns a fixed mask per prompt.
+
+    ``mask_fn(image, prompt)`` produces one ``(H, W)`` bool mask; the score is a
+    fixed value. Records each encoded image for assertions.
+    """
+
+    pred_iou_min = 0.88
+
+    def __init__(self, mask_fn, score=0.77):
+        self._mask_fn = mask_fn
+        self._score = score
+        self.encoded = []
+
+    def masks(self, image, prompts):
+        image = np.asarray(image)
+        self.encoded.append(image.shape)
+        out_masks, out_scores = [], []
+        for p in prompts:
+            out_masks.append(self._mask_fn(image, p).astype(bool))
+            out_scores.append(float(self._score))
+        return out_masks, out_scores
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def test_place_full_inverse_of_crop_extract():
+    crop = _disk(20, 20, 10, 10, 5)
+    full = place_full(crop, (30, 40), (100, 100))
+    ys, xs = np.nonzero(full)
+    # Crop center (10,10) at tl (30,40) -> image (40, 50).
+    assert abs(xs.mean() - 40.0) <= 1.0
+    assert abs(ys.mean() - 50.0) <= 1.0
+
+
+def test_place_full_clips_off_frame():
+    # A 20x20 crop at tl (-5, -5) into a 30x30 frame: the bottom-right 15x15 of
+    # the crop survives at the frame origin; the rest is clipped off-frame.
+    crop = np.ones((20, 20), bool)
+    full = place_full(crop, (-5, -5), (30, 30))
+    assert full[:15, :15].all()
+    assert full.sum() == 15 * 15
+    # Nothing outside the placed 15x15 block.
+    assert not full[15:, :].any()
+    assert not full[:, 15:].any()
+
+
+# --------------------------------------------------------------------------- FindInstanceMaskSAM
+
+
+def test_find_instance_mask_sam_predict_contract():
+    h = w = 64
+
+    def center_disk(image, prompt):
+        # The prompt is the crop center; return a disk there.
+        cx, cy = prompt.point_coords[0]
+        return _disk(h, w, cy, cx, 8)
+
+    layer = FindInstanceMaskSAM(FakeBackend(center_disk))
+    crops = torch.zeros(3, 1, h, w)
+    out = layer.predict(crops)
+    assert out.crops.shape == (3, 1, h, w)
+    assert out.instance_scores.shape == (3, 1)
+    # Masks are {0,1} float; non-empty (the center disk).
+    assert out.crops.max() == 1.0 and out.crops.min() == 0.0
+    assert out.crops[0, 0].sum() > 0
+
+
+def test_find_instance_mask_sam_empty_crops():
+    layer = FindInstanceMaskSAM(FakeBackend(lambda i, p: np.zeros((8, 8), bool)))
+    out = layer.predict(torch.zeros(0, 1, 8, 8))
+    assert out.crops.shape == (0, 1, 8, 8)
+    assert out.instance_scores.shape == (0, 1)
+
+
+def test_find_instance_mask_sam_rejects_wrong_ndim():
+    layer = FindInstanceMaskSAM(FakeBackend(lambda i, p: np.zeros((8, 8), bool)))
+    with pytest.raises(ValueError):
+        layer.predict(torch.zeros(8, 8))
+
+
+def _make_topdown_with_sam(backend, crop_size):
+    """Build a TopDownSegmentationLayer with a FindInstanceMaskSAM stage 2."""
+    from sleap_nn.inference.layers.topdown_segmentation import TopDownSegmentationLayer
+
+    layer = TopDownSegmentationLayer.__new__(TopDownSegmentationLayer)
+    layer.centroid_layer = None
+    layer.centered_instance_layer = FindInstanceMaskSAM(backend)
+    layer.crop_size = crop_size
+    layer.centroid_nms = False
+    layer.centroid_nms_threshold = 0.5
+    layer.return_crops = False
+    layer.mask_output = "mask"
+    layer.polygon_epsilon = 0.01
+    return layer
+
+
+def test_sam_crop_center_seam_lands_at_centroid_through_decode():
+    """The crop-center SAM mask packs to the centroid (top-down seam parity).
+
+    Mirrors ``test_topdown_seg_offset_placement_through_decode`` but with the SAM
+    stage 2 — the inherited ``_run_stage_2`` offset/scale contract must place the
+    crop-center mask at the full-frame centroid, NOT at the origin.
+    """
+    ch = cw = 64
+    cx, cy = 200.0, 150.0
+
+    def center_disk(image, prompt):
+        px, py = prompt.point_coords[0]
+        return _disk(image.shape[0], image.shape[1], py, px, 6)
+
+    layer = _make_topdown_with_sam(FakeBackend(center_disk, score=0.77), (ch, cw))
+    image = torch.zeros(1, 1, 512, 512)
+    centroids = torch.tensor([[[cx, cy]]])
+    out = layer._run_stage_2(
+        image,
+        centroids,
+        torch.tensor([[0.5]]),
+        torch.tensor([[True]]),
+        eff_scale=torch.tensor([1.0]),
+    )
+    inst = out.pred_masks[0][0]
+    # SAM emits at crop-pixel res -> output_stride=1, input_scale=1 -> scale=(1,1).
+    assert inst["scale"] == (1.0, 1.0)
+    # Score is the backend's raw SAM score (not the centroid confidence).
+    assert abs(inst["score"] - 0.77) < 1e-6
+    # offset = floored crop top-left ~ (cx - cw/2, cy - ch/2).
+    ox, oy = inst["offset"]
+    assert abs(ox - (cx - cw / 2)) <= 1.0
+    assert abs(oy - (cy - ch / 2)) <= 1.0
+
+    m = sio.PredictedSegmentationMask.from_numpy(
+        inst["mask"], score=inst["score"], scale=inst["scale"], offset=inst["offset"]
+    )
+    decoded = decode_mask_to_image_res(m)
+    ys, xs = np.nonzero(decoded)
+    assert xs.size > 0
+    assert abs(xs.mean() - cx) <= 4.0 and abs(ys.mean() - cy) <= 4.0
+    # Decisively not at the origin.
+    assert xs.mean() > cw / 4 and ys.mean() > ch / 4
+
+
+# --------------------------------------------------------------------------- SamSegmentationLayer
+
+
+def _labels_with_one_pose(h=100, w=120):
+    skel = sio.Skeleton([sio.Node("a"), sio.Node("b"), sio.Node("c")])
+    pts = np.array([[40.0, 50.0], [60.0, 70.0], [np.nan, np.nan]])
+    track = sio.Track("m0")
+    inst = sio.PredictedInstance.from_numpy(
+        points_data=pts,
+        skeleton=skel,
+        point_scores=np.array([0.9, 0.8, 0.0]),
+        score=0.85,
+    )
+    inst.track = track
+    inst.tracking_score = 0.95
+    video = sio.Video.from_filename("dummy.mp4")
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    # Attach a synthetic image so masks_for_frame has something to encode.
+    img = (np.random.rand(h, w) * 255).astype(np.uint8)
+    return skel, video, lf, img, track, inst
+
+
+def test_sam_segmentation_layer_populates_instance_and_track():
+    skel, video, lf, img, track, inst = _labels_with_one_pose()
+
+    def kpt_disk(image, prompt):
+        # A disk over the keypoints.
+        pts = prompt.point_coords
+        c = pts.mean(0)
+        return _disk(image.shape[0], image.shape[1], c[1], c[0], 12)
+
+    layer = SamSegmentationLayer(FakeBackend(kpt_disk, score=0.66), prompt_mode="pose")
+    frame_masks = layer.masks_for_frame(img, [inst])
+    assert len(frame_masks) == 1
+    d = frame_masks[0]
+    assert d["scale"] == (1.0, 1.0) and d["offset"] == (0.0, 0.0)
+    assert abs(d["score"] - 0.66) < 1e-6
+    # PLAN L8: instance + track populated.
+    assert d["instance"] is inst
+    assert d["track"] is track
+    assert abs(d["tracking_score"] - 0.95) < 1e-6
+
+    # Package via the standard path; the sio mask carries the provenance.
+    masks = Outputs(pred_masks=[frame_masks]).to_masks(0)
+    assert len(masks) == 1
+    m = masks[0]
+    assert isinstance(m, sio.PredictedSegmentationMask)
+    assert m.instance is inst
+    assert m.track is track
+    assert abs(m.tracking_score - 0.95) < 1e-6
+    assert abs(m.score - 0.66) < 1e-6
+
+
+def test_sam_segmentation_layer_gt_instance_not_set_as_instance():
+    """A GT ``sio.Instance`` (not a prediction) is NOT pinned to ``mask.instance``."""
+    skel = sio.Skeleton([sio.Node("a"), sio.Node("b")])
+    gt = sio.Instance.from_numpy(np.array([[40.0, 50.0], [60.0, 70.0]]), skeleton=skel)
+    img = (np.random.rand(100, 120) * 255).astype(np.uint8)
+
+    layer = SamSegmentationLayer(
+        FakeBackend(lambda image, p: _disk(image.shape[0], image.shape[1], 60, 50, 12)),
+        prompt_mode="pose",
+    )
+    frame_masks = layer.masks_for_frame(img, [gt])
+    assert len(frame_masks) == 1
+    assert frame_masks[0]["instance"] is None
+
+
+def test_sam_segmentation_layer_skips_instances_without_prompt():
+    skel = sio.Skeleton([sio.Node("a")])
+    img = (np.random.rand(40, 40) * 255).astype(np.uint8)
+    # An instance with no visible keypoints and no centroid -> skipped.
+    empty = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[np.nan, np.nan]]),
+        skeleton=skel,
+        point_scores=np.array([0.0]),
+        score=0.0,
+    )
+    layer = SamSegmentationLayer(
+        FakeBackend(lambda image, p: np.ones((40, 40), bool)), prompt_mode="pose"
+    )
+    assert layer.masks_for_frame(img, [empty]) == []
+
+
+def test_sam_segmentation_layer_rejects_crop_center_mode():
+    with pytest.raises(ValueError):
+        SamSegmentationLayer(object(), prompt_mode="crop_center")
+
+
+def test_sam_segmentation_disjointify_multi_instance():
+    skel = sio.Skeleton([sio.Node("a")])
+    img = (np.random.rand(50, 50) * 255).astype(np.uint8)
+    i0 = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[15.0, 25.0]]),
+        skeleton=skel,
+        point_scores=np.array([0.9]),
+        score=0.9,
+    )
+    i1 = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[35.0, 25.0]]),
+        skeleton=skel,
+        point_scores=np.array([0.9]),
+        score=0.9,
+    )
+
+    def big_disk(image, prompt):
+        c = prompt.point_coords[0]
+        return _disk(50, 50, c[1], c[0], 18)  # overlapping
+
+    layer = SamSegmentationLayer(
+        FakeBackend(big_disk), prompt_mode="pose", disjointify_masks=True
+    )
+    out = layer.masks_for_frame(img, [i0, i1])
+    assert len(out) == 2
+    # After disjointify the two masks do not overlap.
+    assert not (out[0]["mask"] & out[1]["mask"]).any()
+
+
+def test_sam_segmentation_slp_round_trip(tmp_path):
+    skel, video, lf, img, track, inst = _labels_with_one_pose()
+
+    def kpt_disk(image, prompt):
+        c = prompt.point_coords.mean(0)
+        return _disk(image.shape[0], image.shape[1], c[1], c[0], 12)
+
+    layer = SamSegmentationLayer(FakeBackend(kpt_disk), prompt_mode="pose")
+    frame_masks = layer.masks_for_frame(img, [inst])
+    masks = Outputs(pred_masks=[frame_masks]).to_masks(0)
+    out = sio.Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[
+            sio.LabeledFrame(video=video, frame_idx=0, instances=[inst], masks=masks)
+        ],
+    )
+    out.tracks = [track]
+    path = tmp_path / "sam_masks.slp"
+    out.save(path.as_posix())
+    reloaded = sio.load_slp(path.as_posix())
+    assert len(reloaded.labeled_frames) == 1
+    rf = reloaded.labeled_frames[0]
+    assert len(rf.masks) == 1
+    rm = rf.masks[0]
+    assert isinstance(rm, sio.PredictedSegmentationMask)
+    assert np.isfinite(rm.score)
+    # The track round-trips (referenced by name on reload).
+    assert rm.track is not None
+    assert rm.track.name == "m0"
+
+
+# --------------------------------------------------------------------------- mask_backend required
+
+
+def test_get_mask_backend_required_no_default():
+    from sleap_nn.inference.sam import get_mask_backend
+
+    with pytest.raises(ValueError):
+        get_mask_backend(None)
+
+
+def test_get_mask_backend_unknown_name():
+    from sleap_nn.inference.sam import get_mask_backend
+
+    with pytest.raises(ValueError):
+        get_mask_backend("not-a-backend")
+
+
+def test_get_mask_backend_sam3_not_yet():
+    from sleap_nn.inference.sam import get_mask_backend
+
+    with pytest.raises(NotImplementedError):
+        get_mask_backend("sam3")
+
+
+def test_run_predict_mask_backend_rejects_model_paths():
+    from sleap_nn.inference.run import predict
+
+    with pytest.raises(ValueError, match="do not also pass"):
+        predict(
+            "dummy.slp",
+            mask_backend="sam",
+            model_paths=["/tmp/some_model"],
+            device="cpu",
+        )

--- a/tests/inference/sam/test_mask_layer.py
+++ b/tests/inference/sam/test_mask_layer.py
@@ -1,10 +1,6 @@
-"""Unit tests for the SAM mask layers (CPU; a fake backend, no real SAM).
+"""Unit tests for the SAM mask layer (CPU; a fake backend, no real SAM).
 
 Covers:
-* :class:`FindInstanceMaskSAM` ``.predict(crops)`` contract (shapes ``(N,1,h,w)``
-  / ``(N,1)``), and its parity packaging through ``TopDownSegmentationLayer.
-  _run_stage_2`` -> ``decode_mask_to_image_res`` (the crop-center seam lands at
-  the centroid, byte-identical to the trained-model seg layer).
 * :class:`SamSegmentationLayer` full-frame placement + ``instance=``/``track=``
   population + SLP round-trip.
 * ``mask_backend`` is explicit / required (no default).
@@ -12,17 +8,11 @@ Covers:
 
 import numpy as np
 import pytest
-import torch
 
 import sleap_io as sio
 
 from sleap_nn.inference.outputs import Outputs
-from sleap_nn.inference.sam.mask_layer import (
-    FindInstanceMaskSAM,
-    SamSegmentationLayer,
-    place_full,
-)
-from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+from sleap_nn.inference.sam.mask_layer import SamSegmentationLayer
 
 
 def _disk(h, w, cy, cx, r):
@@ -52,125 +42,6 @@ class FakeBackend:
             out_masks.append(self._mask_fn(image, p).astype(bool))
             out_scores.append(float(self._score))
         return out_masks, out_scores
-
-
-# --------------------------------------------------------------------------- helpers
-
-
-def test_place_full_inverse_of_crop_extract():
-    crop = _disk(20, 20, 10, 10, 5)
-    full = place_full(crop, (30, 40), (100, 100))
-    ys, xs = np.nonzero(full)
-    # Crop center (10,10) at tl (30,40) -> image (40, 50).
-    assert abs(xs.mean() - 40.0) <= 1.0
-    assert abs(ys.mean() - 50.0) <= 1.0
-
-
-def test_place_full_clips_off_frame():
-    # A 20x20 crop at tl (-5, -5) into a 30x30 frame: the bottom-right 15x15 of
-    # the crop survives at the frame origin; the rest is clipped off-frame.
-    crop = np.ones((20, 20), bool)
-    full = place_full(crop, (-5, -5), (30, 30))
-    assert full[:15, :15].all()
-    assert full.sum() == 15 * 15
-    # Nothing outside the placed 15x15 block.
-    assert not full[15:, :].any()
-    assert not full[:, 15:].any()
-
-
-# --------------------------------------------------------------------------- FindInstanceMaskSAM
-
-
-def test_find_instance_mask_sam_predict_contract():
-    h = w = 64
-
-    def center_disk(image, prompt):
-        # The prompt is the crop center; return a disk there.
-        cx, cy = prompt.point_coords[0]
-        return _disk(h, w, cy, cx, 8)
-
-    layer = FindInstanceMaskSAM(FakeBackend(center_disk))
-    crops = torch.zeros(3, 1, h, w)
-    out = layer.predict(crops)
-    assert out.crops.shape == (3, 1, h, w)
-    assert out.instance_scores.shape == (3, 1)
-    # Masks are {0,1} float; non-empty (the center disk).
-    assert out.crops.max() == 1.0 and out.crops.min() == 0.0
-    assert out.crops[0, 0].sum() > 0
-
-
-def test_find_instance_mask_sam_empty_crops():
-    layer = FindInstanceMaskSAM(FakeBackend(lambda i, p: np.zeros((8, 8), bool)))
-    out = layer.predict(torch.zeros(0, 1, 8, 8))
-    assert out.crops.shape == (0, 1, 8, 8)
-    assert out.instance_scores.shape == (0, 1)
-
-
-def test_find_instance_mask_sam_rejects_wrong_ndim():
-    layer = FindInstanceMaskSAM(FakeBackend(lambda i, p: np.zeros((8, 8), bool)))
-    with pytest.raises(ValueError):
-        layer.predict(torch.zeros(8, 8))
-
-
-def _make_topdown_with_sam(backend, crop_size):
-    """Build a TopDownSegmentationLayer with a FindInstanceMaskSAM stage 2."""
-    from sleap_nn.inference.layers.topdown_segmentation import TopDownSegmentationLayer
-
-    layer = TopDownSegmentationLayer.__new__(TopDownSegmentationLayer)
-    layer.centroid_layer = None
-    layer.centered_instance_layer = FindInstanceMaskSAM(backend)
-    layer.crop_size = crop_size
-    layer.centroid_nms = False
-    layer.centroid_nms_threshold = 0.5
-    layer.return_crops = False
-    layer.mask_output = "mask"
-    layer.polygon_epsilon = 0.01
-    return layer
-
-
-def test_sam_crop_center_seam_lands_at_centroid_through_decode():
-    """The crop-center SAM mask packs to the centroid (top-down seam parity).
-
-    Mirrors ``test_topdown_seg_offset_placement_through_decode`` but with the SAM
-    stage 2 — the inherited ``_run_stage_2`` offset/scale contract must place the
-    crop-center mask at the full-frame centroid, NOT at the origin.
-    """
-    ch = cw = 64
-    cx, cy = 200.0, 150.0
-
-    def center_disk(image, prompt):
-        px, py = prompt.point_coords[0]
-        return _disk(image.shape[0], image.shape[1], py, px, 6)
-
-    layer = _make_topdown_with_sam(FakeBackend(center_disk, score=0.77), (ch, cw))
-    image = torch.zeros(1, 1, 512, 512)
-    centroids = torch.tensor([[[cx, cy]]])
-    out = layer._run_stage_2(
-        image,
-        centroids,
-        torch.tensor([[0.5]]),
-        torch.tensor([[True]]),
-        eff_scale=torch.tensor([1.0]),
-    )
-    inst = out.pred_masks[0][0]
-    # SAM emits at crop-pixel res -> output_stride=1, input_scale=1 -> scale=(1,1).
-    assert inst["scale"] == (1.0, 1.0)
-    # Score is the backend's raw SAM score (not the centroid confidence).
-    assert abs(inst["score"] - 0.77) < 1e-6
-    # offset = floored crop top-left ~ (cx - cw/2, cy - ch/2).
-    ox, oy = inst["offset"]
-    assert abs(ox - (cx - cw / 2)) <= 1.0
-    assert abs(oy - (cy - ch / 2)) <= 1.0
-
-    m = sio.PredictedSegmentationMask.from_numpy(
-        inst["mask"], score=inst["score"], scale=inst["scale"], offset=inst["offset"]
-    )
-    decoded = decode_mask_to_image_res(m)
-    ys, xs = np.nonzero(decoded)
-    assert xs.size > 0
-    assert abs(xs.mean() - cx) <= 4.0 and abs(ys.mean() - cy) <= 4.0
-    # Decisively not at the origin.
-    assert xs.mean() > cw / 4 and ys.mean() > ch / 4
 
 
 # --------------------------------------------------------------------------- SamSegmentationLayer
@@ -257,9 +128,9 @@ def test_sam_segmentation_layer_skips_instances_without_prompt():
     assert layer.masks_for_frame(img, [empty]) == []
 
 
-def test_sam_segmentation_layer_rejects_crop_center_mode():
+def test_sam_segmentation_layer_rejects_unknown_mode():
     with pytest.raises(ValueError):
-        SamSegmentationLayer(object(), prompt_mode="crop_center")
+        SamSegmentationLayer(object(), prompt_mode="nope")
 
 
 def test_sam_segmentation_disjointify_multi_instance():

--- a/tests/inference/sam/test_prompts.py
+++ b/tests/inference/sam/test_prompts.py
@@ -1,0 +1,159 @@
+"""Unit tests for the SAM prompt builders (CPU; no SAM)."""
+
+import numpy as np
+import pytest
+
+from sleap_nn.inference.sam.prompts import (
+    PROMPT_MODES,
+    SamPrompt,
+    box_prompt,
+    centroid_prompt,
+    crop_center_prompt,
+    kpt_box,
+    pose_prompt,
+    prompt_for_instance,
+    visible_keypoints,
+)
+
+
+def test_visible_keypoints_drops_non_finite():
+    pts = np.array([[1.0, 2.0], [np.nan, 3.0], [4.0, np.inf], [5.0, 6.0]])
+    vis = visible_keypoints(pts)
+    assert vis.shape == (2, 2)
+    np.testing.assert_allclose(vis, [[1.0, 2.0], [5.0, 6.0]])
+
+
+def test_kpt_box_margin_and_clamp():
+    # Two keypoints; side = 20 px each axis -> margin = max(15, 0.6*20) = 15.
+    pts = np.array([[10.0, 20.0], [30.0, 40.0]])
+    box = kpt_box(pts, (100, 120))
+    np.testing.assert_allclose(box, [0.0, 5.0, 45.0, 55.0])
+    # Clamps to [0, w-1] x [0, h-1].
+    assert box[0] >= 0 and box[1] >= 0
+    assert box[2] <= 119 and box[3] <= 99
+
+
+def test_kpt_box_single_point_uses_min_margin():
+    # A degenerate (single-point) instance: side 0 -> margin = margin_min.
+    pts = np.array([[50.0, 50.0]])
+    box = kpt_box(pts, (200, 200))
+    np.testing.assert_allclose(box, [35.0, 35.0, 65.0, 65.0])
+
+
+def test_pose_prompt_points_and_box():
+    pts = np.array([[10.0, 20.0], [30.0, 40.0], [np.nan, np.nan]])
+    p = pose_prompt(pts, (100, 120))
+    assert p.mode == "pose"
+    # Non-finite row dropped -> 2 positive points, all label 1.
+    assert p.point_coords.shape == (2, 2)
+    assert p.point_labels.tolist() == [1, 1]
+    # Box is present and equals the reject box.
+    assert p.box is not None
+    np.testing.assert_allclose(p.box, p.reject_box)
+
+
+def test_pose_prompt_requires_visible_keypoints():
+    with pytest.raises(ValueError):
+        pose_prompt(np.array([[np.nan, np.nan]]), (50, 50))
+
+
+def test_centroid_prompt_point_only_no_box():
+    p = centroid_prompt(np.array([25.0, 35.0]), (100, 100))
+    assert p.mode == "centroid"
+    assert p.point_coords.shape == (1, 2)
+    np.testing.assert_allclose(p.point_coords[0], [25.0, 35.0])
+    # The box is NEVER passed to SAM in centroid mode (point is ambiguous).
+    assert p.box is None
+    # A reject box still exists for the candidate-rejection heuristic.
+    assert p.reject_box.shape == (4,)
+
+
+def test_centroid_prompt_reject_box_from_keypoints_when_given():
+    kpts = np.array([[10.0, 20.0], [30.0, 40.0]])
+    p = centroid_prompt(np.array([20.0, 30.0]), (100, 120), keypoints=kpts)
+    np.testing.assert_allclose(p.reject_box, kpt_box(kpts, (100, 120)))
+
+
+def test_box_prompt_box_only_no_points():
+    pts = np.array([[10.0, 20.0], [30.0, 40.0]])
+    p = box_prompt(pts, (100, 120))
+    assert p.mode == "box"
+    assert p.point_coords is None
+    assert p.point_labels is None
+    assert p.box is not None
+    np.testing.assert_allclose(p.box, p.reject_box)
+
+
+def test_crop_center_prompt_is_center_pixel():
+    p = crop_center_prompt((64, 80))  # (h, w)
+    assert p.mode == "crop_center"
+    # Center pixel is (w/2, h/2) = (40, 32).
+    np.testing.assert_allclose(p.point_coords[0], [40.0, 32.0])
+    # Reject box is the full crop extent.
+    np.testing.assert_allclose(p.reject_box, [0.0, 0.0, 79.0, 63.0])
+
+
+def test_prompt_for_instance_pose_with_keypoints():
+    p = prompt_for_instance(
+        "pose", (100, 120), keypoints=np.array([[10.0, 20.0], [30.0, 40.0]])
+    )
+    assert p.mode == "pose"
+    assert p.point_coords.shape == (2, 2)
+
+
+def test_prompt_for_instance_pose_falls_back_to_centroid_point():
+    # The L3 product rule: no visible keypoints -> center-point fallback.
+    p = prompt_for_instance(
+        "pose",
+        (100, 120),
+        keypoints=np.array([[np.nan, np.nan]]),
+        centroid=np.array([50.0, 60.0]),
+    )
+    assert p.mode == "centroid"
+    np.testing.assert_allclose(p.point_coords[0], [50.0, 60.0])
+
+
+def test_prompt_for_instance_pose_no_fallback_raises():
+    with pytest.raises(ValueError):
+        prompt_for_instance("pose", (50, 50), keypoints=None, centroid=None)
+
+
+def test_prompt_for_instance_centroid_means_keypoints_when_no_centroid():
+    p = prompt_for_instance(
+        "centroid", (100, 100), keypoints=np.array([[10.0, 20.0], [30.0, 40.0]])
+    )
+    np.testing.assert_allclose(p.point_coords[0], [20.0, 30.0])
+
+
+def test_prompt_for_instance_crop_center_prefers_pose_when_local_keypoints():
+    # crop_center with crop-local keypoints uses the richer pose prompt.
+    p = prompt_for_instance(
+        "crop_center", (64, 64), keypoints=np.array([[20.0, 20.0], [40.0, 40.0]])
+    )
+    assert p.mode == "pose"
+
+
+def test_prompt_for_instance_crop_center_naive_when_no_keypoints():
+    p = prompt_for_instance("crop_center", (64, 64), keypoints=None)
+    assert p.mode == "crop_center"
+    np.testing.assert_allclose(p.point_coords[0], [32.0, 32.0])
+
+
+def test_prompt_for_instance_unknown_mode_raises():
+    with pytest.raises(ValueError):
+        prompt_for_instance("nope", (10, 10))
+
+
+def test_prompt_modes_constant():
+    assert PROMPT_MODES == ("pose", "centroid", "box", "crop_center")
+
+
+def test_sam_prompt_is_a_dataclass():
+    p = SamPrompt(
+        point_coords=None,
+        point_labels=None,
+        box=np.zeros(4, np.float32),
+        reject_box=np.zeros(4, np.float32),
+        mode="box",
+    )
+    assert p.mode == "box"

--- a/tests/inference/sam/test_prompts.py
+++ b/tests/inference/sam/test_prompts.py
@@ -8,7 +8,6 @@ from sleap_nn.inference.sam.prompts import (
     SamPrompt,
     box_prompt,
     centroid_prompt,
-    crop_center_prompt,
     kpt_box,
     pose_prompt,
     prompt_for_instance,
@@ -84,15 +83,6 @@ def test_box_prompt_box_only_no_points():
     np.testing.assert_allclose(p.box, p.reject_box)
 
 
-def test_crop_center_prompt_is_center_pixel():
-    p = crop_center_prompt((64, 80))  # (h, w)
-    assert p.mode == "crop_center"
-    # Center pixel is (w/2, h/2) = (40, 32).
-    np.testing.assert_allclose(p.point_coords[0], [40.0, 32.0])
-    # Reject box is the full crop extent.
-    np.testing.assert_allclose(p.reject_box, [0.0, 0.0, 79.0, 63.0])
-
-
 def test_prompt_for_instance_pose_with_keypoints():
     p = prompt_for_instance(
         "pose", (100, 120), keypoints=np.array([[10.0, 20.0], [30.0, 40.0]])
@@ -125,27 +115,13 @@ def test_prompt_for_instance_centroid_means_keypoints_when_no_centroid():
     np.testing.assert_allclose(p.point_coords[0], [20.0, 30.0])
 
 
-def test_prompt_for_instance_crop_center_prefers_pose_when_local_keypoints():
-    # crop_center with crop-local keypoints uses the richer pose prompt.
-    p = prompt_for_instance(
-        "crop_center", (64, 64), keypoints=np.array([[20.0, 20.0], [40.0, 40.0]])
-    )
-    assert p.mode == "pose"
-
-
-def test_prompt_for_instance_crop_center_naive_when_no_keypoints():
-    p = prompt_for_instance("crop_center", (64, 64), keypoints=None)
-    assert p.mode == "crop_center"
-    np.testing.assert_allclose(p.point_coords[0], [32.0, 32.0])
-
-
 def test_prompt_for_instance_unknown_mode_raises():
     with pytest.raises(ValueError):
         prompt_for_instance("nope", (10, 10))
 
 
 def test_prompt_modes_constant():
-    assert PROMPT_MODES == ("pose", "centroid", "box", "crop_center")
+    assert PROMPT_MODES == ("pose", "centroid", "box")
 
 
 def test_sam_prompt_is_a_dataclass():

--- a/tests/inference/sam/test_run_sam_segmentation.py
+++ b/tests/inference/sam/test_run_sam_segmentation.py
@@ -1,0 +1,369 @@
+"""CPU-only tests for the wired SAM inference-MVP surface (a fake backend).
+
+No real SAM, no CUDA: every test injects a :class:`FakeBackend` (the
+``backend=`` hook / a patched ``get_mask_backend``) so checkpoint loading and the
+SAM encoder are never touched. Three target areas:
+
+* :func:`sleap_nn.inference.sam.run_sam_segmentation` orchestration — masks
+  emitted, ``.slp`` + overlay written, ``frames=`` subsetting, no-prompt skip,
+  ``disjointify_masks``.
+* :func:`sleap_nn.inference.run.predict` SAM short-circuit success path +
+  forwarding of the ``sam_*`` / ``overlay_path`` / ``frames`` knobs.
+* :func:`sleap_nn.inference.sam.overlay.save_mask_overlay` happy path + the two
+  ``None`` returns (no frames / no masks).
+
+The image source is the embedded-image fixture ``minimal_instance.pkg.slp`` so
+``lf.image`` actually yields pixels (required by ``masks_for_frame`` / overlay),
+with its GT ``sio.Instance`` poses rebuilt as ``sio.PredictedInstance`` so the
+PLAN-L8 ``mask.instance`` pairing is exercised.
+"""
+
+import numpy as np
+
+import sleap_io as sio
+
+import sleap_nn.inference.sam as sam_pkg
+from sleap_nn.inference.outputs import Outputs
+from sleap_nn.inference.run import predict
+from sleap_nn.inference.sam import run_sam_segmentation
+from sleap_nn.inference.sam.mask_layer import SamSegmentationLayer
+from sleap_nn.inference.sam.overlay import save_mask_overlay
+
+
+def _disk(h, w, cy, cx, r):
+    """A boolean ``(h, w)`` disk of radius ``r`` centered at ``(cy, cx)``."""
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+class FakeBackend:
+    """A :class:`MaskBackend`-shaped fake returning a fixed mask per prompt.
+
+    ``mask_fn(image, prompt)`` produces one ``(H, W)`` bool mask; the score is a
+    fixed value. Records each encoded image shape for assertions.
+    """
+
+    pred_iou_min = 0.88
+
+    def __init__(self, mask_fn, score=0.77):
+        """Stash the per-prompt ``mask_fn`` and the fixed score."""
+        self._mask_fn, self._score, self.encoded = mask_fn, score, []
+
+    def masks(self, image, prompts):
+        """Return ``(masks, scores)`` for the prompts; record the image shape."""
+        import numpy as np
+
+        image = np.asarray(image)
+        self.encoded.append(image.shape)
+        ms, ss = [], []
+        for p in prompts:
+            ms.append(self._mask_fn(image, p).astype(bool))
+            ss.append(float(self._score))
+        return ms, ss
+
+
+def _prompt_disk(radius=15):
+    """A ``mask_fn`` placing a disk centered on the prompt's mean point."""
+
+    def mask_fn(image, prompt):
+        c = prompt.point_coords.mean(0)
+        return _disk(image.shape[0], image.shape[1], c[1], c[0], radius)
+
+    return mask_fn
+
+
+def _pose_labels(minimal_instance, frame_indices=(0,)):
+    """Build an in-memory ``sio.Labels`` of ``PredictedInstance`` poses.
+
+    Loads the embedded-image fixture (so ``lf.image`` yields pixels), converts
+    each GT ``sio.Instance`` to a ``sio.PredictedInstance`` (PLAN-L8 pairing), and
+    rebuilds one ``LabeledFrame`` per requested ``frame_idx`` reusing the same
+    video/poses (the fixture has a single frame; extra indices let us exercise
+    ``frames=`` subsetting deterministically).
+    """
+    src = sio.load_slp(str(minimal_instance))
+    skel = src.skeletons[0]
+    gt_lf = src.labeled_frames[0]
+
+    new_lfs = []
+    for frame_idx in frame_indices:
+        preds = []
+        for inst in gt_lf.instances:
+            pts = inst.numpy()[:, :2]
+            n = pts.shape[0]
+            preds.append(
+                sio.PredictedInstance.from_numpy(
+                    points_data=pts,
+                    skeleton=skel,
+                    point_scores=np.ones(n),
+                    score=1.0,
+                )
+            )
+        new_lfs.append(
+            sio.LabeledFrame(video=gt_lf.video, frame_idx=frame_idx, instances=preds)
+        )
+
+    return sio.Labels(videos=list(src.videos), skeletons=[skel], labeled_frames=new_lfs)
+
+
+# --------------------------------------------------------------------------- run_sam_segmentation
+
+
+def test_run_sam_segmentation_emits_masks(minimal_instance):
+    """It returns Labels with >=1 frame carrying a paired PredictedSegmentationMask."""
+    labels = _pose_labels(minimal_instance)
+    backend = FakeBackend(_prompt_disk())
+
+    out = run_sam_segmentation(labels, "sam", backend=backend, prompt_mode="pose")
+
+    assert isinstance(out, sio.Labels)
+    assert len(out.labeled_frames) >= 1
+    masked = [lf for lf in out.labeled_frames if lf.masks]
+    assert masked, "expected >=1 frame carrying PredictedSegmentationMask"
+    m = masked[0].masks[0]
+    assert isinstance(m, sio.PredictedSegmentationMask)
+    # PLAN-L8: predicted-instance pairing is exercised.
+    assert m.instance is not None
+    # The backend encoded the full frame.
+    assert backend.encoded, "backend.masks() was never called"
+
+
+def test_run_sam_segmentation_writes_output_slp(minimal_instance, tmp_path):
+    """``output_path`` is written and reloads via ``sio.load_slp`` with masks."""
+    labels = _pose_labels(minimal_instance)
+    out_path = tmp_path / "o.slp"
+
+    out = run_sam_segmentation(
+        labels,
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        output_path=out_path,
+    )
+    assert any(lf.masks for lf in out.labeled_frames)
+    assert out_path.exists()
+
+    reloaded = sio.load_slp(out_path.as_posix())
+    rmasks = [m for lf in reloaded.labeled_frames for m in lf.masks]
+    assert rmasks, "reloaded .slp has no masks"
+    assert all(isinstance(m, sio.PredictedSegmentationMask) for m in rmasks)
+
+
+def test_run_sam_segmentation_writes_overlay_png(minimal_instance, tmp_path):
+    """``overlay_path`` writes a review PNG to disk."""
+    labels = _pose_labels(minimal_instance)
+    overlay_path = tmp_path / "o.png"
+
+    run_sam_segmentation(
+        labels,
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        overlay_path=overlay_path,
+    )
+    assert overlay_path.exists()
+
+
+def test_run_sam_segmentation_frames_subset_existing(minimal_instance):
+    """``frames=[0]`` masks only the requested (existing) frame."""
+    # Two frames (idx 0 and 1); request only frame 0. The frames= filter runs
+    # before any image is read, so the (image-less) idx-1 frame is dropped
+    # before its pixels are ever fetched — only frame 0 (the embedded image)
+    # is encoded and masked.
+    labels = _pose_labels(minimal_instance, frame_indices=(0, 1))
+
+    out = run_sam_segmentation(
+        labels,
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        frames=[0],
+    )
+    assert len(out.labeled_frames) == 1
+    assert int(out.labeled_frames[0].frame_idx) == 0
+    assert out.labeled_frames[0].masks
+
+
+def test_run_sam_segmentation_frames_subset_nonexistent(minimal_instance):
+    """A ``frames=`` index that matches no frame yields empty output."""
+    labels = _pose_labels(minimal_instance, frame_indices=(0,))
+
+    out = run_sam_segmentation(
+        labels,
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        frames=[999],  # no such frame_idx
+    )
+    assert out.labeled_frames == []
+
+
+def test_run_sam_segmentation_skips_frames_without_prompt(minimal_instance):
+    """A frame whose instances yield no prompt (all-NaN kpts) is skipped."""
+    # A frame whose only instance has all-NaN keypoints yields no prompt -> skip.
+    src = sio.load_slp(str(minimal_instance))
+    skel = src.skeletons[0]
+    gt_lf = src.labeled_frames[0]
+    n = gt_lf.instances[0].numpy().shape[0]
+    empty = sio.PredictedInstance.from_numpy(
+        points_data=np.full((n, 2), np.nan),
+        skeleton=skel,
+        point_scores=np.zeros(n),
+        score=0.0,
+    )
+    lf = sio.LabeledFrame(
+        video=gt_lf.video, frame_idx=gt_lf.frame_idx, instances=[empty]
+    )
+    labels = sio.Labels(videos=list(src.videos), skeletons=[skel], labeled_frames=[lf])
+
+    out = run_sam_segmentation(
+        labels, "sam", backend=FakeBackend(_prompt_disk()), prompt_mode="pose"
+    )
+    assert out.labeled_frames == []
+
+
+def test_run_sam_segmentation_disjointify_multi_instance(minimal_instance):
+    """``disjointify_masks=True`` runs without error on a >=2-instance frame."""
+    # The fixture frame already has 2 instances; large overlapping disks +
+    # disjointify must run without error and produce disjoint masks.
+    labels = _pose_labels(minimal_instance)
+    assert len(labels.labeled_frames[0].instances) >= 2
+
+    out = run_sam_segmentation(
+        labels,
+        "sam",
+        backend=FakeBackend(_prompt_disk(radius=80)),
+        prompt_mode="pose",
+        disjointify_masks=True,
+    )
+    lf = out.labeled_frames[0]
+    assert len(lf.masks) == 2
+
+
+# --------------------------------------------------------------------------- predict() short-circuit
+
+
+def test_predict_sam_short_circuit_success(minimal_instance, tmp_path):
+    """``predict(mask_backend='sam', ...)`` returns masks + writes the .slp."""
+    labels = _pose_labels(minimal_instance)
+    out_path = tmp_path / "p.slp"
+    fb = FakeBackend(_prompt_disk())
+
+    orig = sam_pkg.get_mask_backend
+    sam_pkg.get_mask_backend = lambda *a, **k: fb
+    try:
+        out = predict(
+            labels,
+            mask_backend="sam",
+            device="cpu",
+            sam_prompt_mode="pose",
+            output_path=out_path,
+        )
+    finally:
+        sam_pkg.get_mask_backend = orig
+
+    assert isinstance(out, sio.Labels)
+    masked = [lf for lf in out.labeled_frames if lf.masks]
+    assert masked, "predict() returned no masks"
+    assert out_path.exists()
+    reloaded = sio.load_slp(out_path.as_posix())
+    assert any(lf.masks for lf in reloaded.labeled_frames)
+
+
+def test_predict_sam_forwards_kwargs(minimal_instance, tmp_path, monkeypatch):
+    """``predict`` forwards the SAM knobs / overlay_path / frames downstream."""
+    labels = _pose_labels(minimal_instance, frame_indices=(0, 1))
+    captured = {}
+
+    def fake_run_sam_segmentation(source, mask_backend, **kwargs):
+        captured["source"] = source
+        captured["mask_backend"] = mask_backend
+        captured.update(kwargs)
+        # Return a minimal Labels so predict()'s downstream save path is happy.
+        return sio.Labels(
+            videos=list(labels.videos),
+            skeletons=list(labels.skeletons),
+            labeled_frames=[],
+        )
+
+    monkeypatch.setattr(
+        "sleap_nn.inference.sam.run_sam_segmentation", fake_run_sam_segmentation
+    )
+
+    overlay_path = tmp_path / "ov.png"
+    out = predict(
+        labels,
+        mask_backend="sam",
+        device="cpu",
+        sam_prompt_mode="centroid",
+        sam_anchor_ind=1,
+        sam_disjointify_masks=True,
+        overlay_path=overlay_path,
+        frames=[1],
+    )
+
+    assert isinstance(out, sio.Labels)
+    assert captured["mask_backend"] == "sam"
+    assert captured["prompt_mode"] == "centroid"
+    assert captured["anchor_ind"] == 1
+    assert captured["disjointify_masks"] is True
+    assert captured["overlay_path"] == overlay_path
+    assert captured["frames"] == [1]
+
+
+# --------------------------------------------------------------------------- save_mask_overlay
+
+
+def _frame_with_masks(minimal_instance):
+    """A ``sio.Labels`` whose single frame carries real ``PredictedSegmentationMask``s.
+
+    Masks are built through the standard path (``masks_for_frame`` ->
+    ``Outputs.to_masks``) so they are genuine masks with scale/offset.
+    """
+    labels = _pose_labels(minimal_instance)
+    lf = labels.labeled_frames[0]
+    layer = SamSegmentationLayer(FakeBackend(_prompt_disk()), prompt_mode="pose")
+    frame_masks = layer.masks_for_frame(lf.image, lf.instances)
+    assert frame_masks, "expected non-empty frame masks for the overlay fixture"
+    masks = Outputs(pred_masks=[frame_masks]).to_masks(0)
+    masked_lf = sio.LabeledFrame(
+        video=lf.video,
+        frame_idx=lf.frame_idx,
+        instances=list(lf.instances),
+        masks=masks,
+    )
+    return sio.Labels(
+        videos=list(labels.videos),
+        skeletons=list(labels.skeletons),
+        labeled_frames=[masked_lf],
+    )
+
+
+def test_save_mask_overlay_happy_path(minimal_instance, tmp_path):
+    """It writes a PNG that ``cv2.imread`` reloads as an (H, W, 3) image."""
+    import cv2
+
+    labels = _frame_with_masks(minimal_instance)
+    out_path = tmp_path / "overlay.png"
+
+    result = save_mask_overlay(labels, out_path)
+    assert result is not None
+    assert result.exists()
+
+    img = cv2.imread(result.as_posix())
+    assert img is not None
+    assert img.ndim == 3 and img.shape[-1] == 3
+
+
+def test_save_mask_overlay_returns_none_no_frames(tmp_path):
+    """It returns ``None`` when the labels have no frames."""
+    labels = sio.Labels(videos=[], skeletons=[], labeled_frames=[])
+    assert save_mask_overlay(labels, tmp_path / "none.png") is None
+
+
+def test_save_mask_overlay_returns_none_no_masks(minimal_instance, tmp_path):
+    """It returns ``None`` when the frame carries no masks."""
+    # A frame with image + instances but no masks attached.
+    labels = _pose_labels(minimal_instance)
+    assert not labels.labeled_frames[0].masks
+    assert save_mask_overlay(labels, tmp_path / "none.png") is None


### PR DESCRIPTION
## SAM1 prompted inference segmentation — the foundation

**SAM is used to *predict* per-instance masks** for an existing pose/centroid `.slp` so a human can review/correct them in the GUI, then train — **not** to auto-generate training GT (the pivot). This PR adds the SAM1 prompted-mask producer, the `MaskBackend` interface, and default-preserving `run.predict()` wiring. SAM3 (#648) and reconciliation/re-tracking (#646) land behind the same surfaces.

> Draft: do not merge / do not mark ready yet.

### New package — `sleap_nn/inference/sam/`

| File | Role |
|---|---|
| `prompts.py` | `pose` / `centroid` / `box` prompt builders + the product rule (pose-if-visible-else-centroid-point). Harvested `kpt_box` + recipe constants. CPU, SAM-free. |
| `backends.py` | `MaskBackend` interface + `SamBackend` (SAM1 ViT-H, lazy `segment-anything`). Harvested `_pick`, `own_containment` (now a raw **score**, no drop-gate), `disjointify`, `_load_sam_predictor`, CLAHE. |
| `mask_layer.py` | `SamSegmentationLayer` — the full-frame producer. |
| `overlay.py` | Review-PNG util (PLAN L4). |
| `__init__.py` | `get_mask_backend` (explicit `mask_backend`, **no default**) + `run_sam_segmentation` orchestration. |

### Entry point

`run.predict(mask_backend="sam", ...)` → `run_sam_segmentation`: loads a pose `.slp`, prompts SAM per instance, and emits `PredictedSegmentationMask` (raw score, full-frame identity scale/offset, `instance=`/`track=` populated per L8). `frames=` subsets which frames are masked. The model-driven `predict()` path is **byte-identical when `mask_backend is None`**; `model_paths`/`export_dir` are rejected in SAM mode.

### Scope (MVP = inference only)

- v1 is **prompted-only** (pose/centroid/box) and **review-only** (masks + overlay PNG). GUI correction round-trip and unprompted ("everything") mask generation are deferred.
- The top-down crop-center seam was **cut from this PR**: it had no entry-point wiring and required a trained centroid model, contradicting the "mask an existing `.slp`" MVP. It returns together with its dispatch in a later iteration; the wired full-frame producer fully covers the MVP.
- No CLI flags yet — the GUI/frontend calls `run.predict(...)` directly; a CLI surface is a cheap follow-up.

### Locked decisions

**L1** new code under `inference/sam/`. **L2** `mask_backend` explicit/required (`None` & unknown raise; `"sam3"` reserved for #648). **L3** prompted-only + product rule. **L8** `mask.instance`/`track`/`tracking_score` populated for predicted poses (referential, not positional, correction); GT instances never pinned to a predicted mask.

### Default-preserving shared-code touches

`segmentation_convert.build_predicted_segmentation_mask` / `Outputs.to_masks` forward optional `instance`/`track`/`tracking_score` (default absent → trained seg layers unchanged). Lazy `[sam]` extra (`segment-anything`; cv2 comes from the base `opencv-python`). `uv.lock` regenerated.

### Tests

`tests/inference/sam/` — CI-safe via a fake `SamPredictor`/backend (no checkpoint): prompt geometry, backend `_pick`/raw-score/`disjointify`, `SamSegmentationLayer` placement + `instance`/`track` + SLP round-trip, `run_sam_segmentation` orchestration (output `.slp` + overlay PNG, `frames` subset, empty-prompt skip, disjointify), the `predict()` SAM short-circuit + kwarg forwarding, `save_mask_overlay`, and `mask_backend` required/unknown. Plus a GPU-marked real-SAM e2e smoke (`test_e2e_gpu.py`, asset paths via `SLEAP_NN_SAM_CKPT`/`_VAL`, skips cleanly without CUDA).

```
black --check clean ; ruff clean ; tests/inference/sam green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
