### PR TITLE
feat(seg): SAM3 prompted mask backend (opt-in, mask_backend="sam3")

### DIFF
--- a/docs/guides/sam-inference-segmentation.md
+++ b/docs/guides/sam-inference-segmentation.md
@@ -30,12 +30,30 @@ Download a SAM checkpoint (e.g.
 [`sam_vit_h_4b8939.pth`](https://github.com/facebookresearch/segment-anything#model-checkpoints))
 and pass its path via `sam_checkpoint=`.
 
+SAM3 (`mask_backend="sam3"`) is a second, **gated** backend behind its own extra:
+
+```bash
+pip install "sleap-nn[sam3]"
+```
+
+SAM3 lives in the gated [`facebook/sam3`](https://huggingface.co/facebook/sam3)
+Hugging Face repo and ships in `transformers>=5`. You must request access, then
+authenticate (`huggingface-cli login` or set `HF_TOKEN`) with an approved
+account. SAM3 also typically wants torch `cu130`, which **may not co-install**
+with the rest of sleap-nn: keep it in its own environment, or run the SAM3 image
+path out-of-process (write the raw masks + bookkeeping to an `.npz`) and assemble
+the `.slp` back in the sleap-nn venv. Selecting `mask_backend="sam3"` without
+`transformers` raises a clear, actionable `ImportError` pointing at this install
++ auth.
+
 ## The backend is explicit — there is no default
 
 `mask_backend` is **required** when you ask for SAM masks; nothing is selected
-silently. `"sam"` is SAM1 (this PR); `"sam3"` (the gated SAM3 image path) lands
-in a follow-up behind the `sleap_nn[sam3]` extra. Each backend stores its own
-**raw** per-model score in `PredictedSegmentationMask.score`.
+silently. `"sam"` is SAM1 (ungated, the `sleap_nn[sam]` extra); `"sam3"` is the
+gated SAM3 image path (`facebook/sam3` via `transformers`, the `sleap_nn[sam3]`
+extra). Each backend stores its own **raw** per-model score in
+`PredictedSegmentationMask.score` — and SAM3's score is on a lower scale than
+SAM1's, so its recalibrated floor (`0.5`) is **never** SAM1's `0.88`.
 
 ## Predict masks for a pose `.slp`
 
@@ -70,6 +88,36 @@ labels = run_sam_segmentation(
     device="cuda",
 )
 ```
+
+## SAM3 backend
+
+`mask_backend="sam3"` swaps SAM1 for Meta SAM 3's image visual-prompt path
+(`Sam3TrackerModel`) behind the same interface and the same prompt modes:
+
+```python
+labels = run_sam_segmentation(
+    "poses.pkg.slp",
+    mask_backend="sam3",        # gated facebook/sam3, needs the [sam3] extra
+    prompt_mode="pose",
+    device="cuda",
+    # sam3_model_id="facebook/sam3",  # the default
+)
+```
+
+Two SAM3 specifics are handled automatically and are **never** shared with SAM1:
+
+- **Recalibrated score floor (`0.5`).** SAM3's predicted-IoU is on a lower scale,
+  so its per-model floor is `SAM3_PRED_IOU_MIN = 0.5` (SAM1's `0.88` would reject
+  ~100% of SAM3 masks as a pure calibration artifact). As with SAM1 the raw score
+  is reported, not gated on.
+- **Speckle cleanup.** Raw SAM3 masks are fragmented (~14 connected components);
+  each chosen mask is passed through a morphological open + close + keep-the-
+  keypoint-connected-component cleanup (~1 component, ~97% area retained).
+
+SAM3 also runs **all instances of a frame in a single batched forward pass**
+(SAM1 loops per instance). End-to-end SAM3 is GPU-only and needs the gated
+weights, so it is exercised manually / nightly; the recipe (floor, cleanup,
+batched call) is unit-tested against a mocked SAM3.
 
 ## Prompt modes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,9 @@ sam = [
 # co-install with the rest of sleap-nn — install it on its own or run the SAM3
 # image path out-of-process and assemble the `.slp` in the sleap-nn venv (the
 # two-venv handoff, PLAN §2.3 / DQ6). See docs/guides/sam-inference-segmentation.md.
+# cv2 (CLAHE / speckle cleanup) comes from the base `opencv-python` dependency.
 sam3 = [
     "transformers>=5.0",
-    "opencv-python-headless>=4.5",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,17 @@ tensorrt = [
 sam = [
     "segment-anything>=1.0",
 ]
+# SAM3 prompted-mask inference (`mask_backend="sam3"`). Lazy: imported only inside
+# the SAM3 backend, so the default install never needs it. SAM3 lives in the gated
+# `facebook/sam3` HF repo (request access + `huggingface-cli login` / set HF_TOKEN)
+# and ships in `transformers>=5`. It typically wants torch cu130, which may NOT
+# co-install with the rest of sleap-nn — install it on its own or run the SAM3
+# image path out-of-process and assemble the `.slp` in the sleap-nn venv (the
+# two-venv handoff, PLAN §2.3 / DQ6). See docs/guides/sam-inference-segmentation.md.
+sam3 = [
+    "transformers>=5.0",
+    "opencv-python-headless>=4.5",
+]
 
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv sync`)

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -2,8 +2,8 @@
 
 The pivot (PLAN / README): SAM is used to *predict* per-instance masks for an
 existing pose/centroid ``.slp`` so a human can review/correct them in the GUI,
-then train — **not** to auto-generate training GT. This package is the SAM1
-prompted producer + its backend interface; SAM3, reconciliation, and the
+then train — **not** to auto-generate training GT. This package is the SAM1 +
+SAM3 prompted producers + their backend interface; reconciliation and the
 mask-native tracker land in later PRs behind the same surfaces.
 
 Public surface

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -9,9 +9,9 @@ mask-native tracker land in later PRs behind the same surfaces.
 Public surface
 --------------
 * :func:`get_mask_backend` — **explicit, no-default** backend selection
-  (PLAN L2). ``"sam"`` builds a SAM1 :class:`~.backends.SamBackend`; an unknown
-  or omitted name raises. ``"sam3"`` is reserved for PR-B and currently errors
-  with a pointer.
+  (PLAN L2). ``"sam"`` builds a SAM1 :class:`~.backends.SamBackend`; ``"sam3"``
+  builds a SAM3 :class:`~.backends.Sam3Backend` (gated ``facebook/sam3`` via the
+  ``sleap_nn[sam3]`` extra); an unknown or omitted name raises.
 * :func:`run_sam_segmentation` — end-to-end orchestration: load a pose ``.slp``,
   run the chosen backend with the chosen prompt mode, emit
   ``sio.PredictedSegmentationMask`` (raw score + ``instance=``/``track=``
@@ -27,13 +27,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional, Sequence
 
-from sleap_nn.inference.sam.backends import MaskBackend, SamBackend
+from sleap_nn.inference.sam.backends import MaskBackend, Sam3Backend, SamBackend
 from sleap_nn.inference.sam.mask_layer import SamSegmentationLayer
 from sleap_nn.inference.sam.prompts import PROMPT_MODES, SamPrompt
 
 __all__ = [
     "MaskBackend",
     "SamBackend",
+    "Sam3Backend",
     "SamSegmentationLayer",
     "SamPrompt",
     "PROMPT_MODES",
@@ -51,6 +52,7 @@ def get_mask_backend(
     *,
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
+    sam3_model_id: str = "facebook/sam3",
     device: str = "cuda",
     **kwargs,
 ) -> MaskBackend:
@@ -58,10 +60,13 @@ def get_mask_backend(
 
     Args:
         mask_backend: The backend name. ``"sam"`` builds a SAM1
-            :class:`~.backends.SamBackend`; ``"sam3"`` is reserved for PR-B.
-            There is no default — the caller must name one.
+            :class:`~.backends.SamBackend`; ``"sam3"`` builds a SAM3
+            :class:`~.backends.Sam3Backend`. There is no default — the caller must
+            name one.
         sam_checkpoint: Path to the SAM1 checkpoint (required for ``"sam"``).
         sam_model_type: SAM1 model registry key.
+        sam3_model_id: Hugging Face model id for the SAM3 path (gated; the
+            ``sleap_nn[sam3]`` extra). Used only for ``"sam3"``.
         device: Torch device for the model.
         **kwargs: Forwarded to the backend constructor (e.g. ``clahe``).
 
@@ -70,7 +75,8 @@ def get_mask_backend(
 
     Raises:
         ValueError: If ``mask_backend`` is not a registered name.
-        NotImplementedError: If ``mask_backend == "sam3"`` (lands in PR-B).
+        ImportError: If ``mask_backend == "sam3"`` and ``transformers`` (with SAM3
+            support) is not installed — with an actionable install/auth message.
     """
     if mask_backend is None:
         raise ValueError(
@@ -86,9 +92,10 @@ def get_mask_backend(
             **kwargs,
         )
     if name == "sam3":
-        raise NotImplementedError(
-            "mask_backend='sam3' is added in PR-B (the SAM3 backend behind the "
-            "'sam3' extra). Use mask_backend='sam' for SAM1."
+        return Sam3Backend.from_pretrained(
+            model_id=sam3_model_id,
+            device=device,
+            **kwargs,
         )
     raise ValueError(
         f"Unknown mask_backend {mask_backend!r}; expected one of {MASK_BACKENDS}."
@@ -102,6 +109,7 @@ def run_sam_segmentation(
     prompt_mode: str = "pose",
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
+    sam3_model_id: str = "facebook/sam3",
     device: str = "cuda",
     anchor_ind: Optional[int] = None,
     disjointify_masks: bool = False,
@@ -126,6 +134,7 @@ def run_sam_segmentation(
         sam_checkpoint: SAM1 checkpoint path (required for ``"sam"`` unless a
             pre-built ``backend`` is passed).
         sam_model_type: SAM1 model registry key.
+        sam3_model_id: Hugging Face model id for the gated SAM3 path (``"sam3"``).
         device: Torch device for the model.
         anchor_ind: Optional centroid anchor node index for ``"centroid"``.
         disjointify_masks: Make per-frame masks disjoint when >=2 instances.
@@ -158,6 +167,7 @@ def run_sam_segmentation(
             mask_backend,
             sam_checkpoint=sam_checkpoint,
             sam_model_type=sam_model_type,
+            sam3_model_id=sam3_model_id,
             device=device,
         )
     elif mask_backend not in MASK_BACKENDS:

--- a/sleap_nn/inference/sam/backends.py
+++ b/sleap_nn/inference/sam/backends.py
@@ -641,10 +641,16 @@ class Sam3Backend(MaskBackend):
         )
 
         # Build batched per-object prompts (one image, each prompt an object).
-        # A prompt may carry points, a box, or both — forward whatever it has.
+        # Mirror SAM1 (``SamBackend.masks``): forward only a prompt's real
+        # ``box`` — never ``reject_box``, which exists solely for the
+        # candidate-rejection heuristic (:func:`_pick`). Point-only prompts
+        # (e.g. ``centroid`` mode, ``box is None``) carry no box; feeding them
+        # ``reject_box`` would hand SAM3 a whole-frame "segment everything" box
+        # and make SAM3 diverge from SAM1 on identical input.
         obj_points: List[List[List[float]]] = []
         obj_labels: List[List[int]] = []
         obj_boxes: List[List[float]] = []
+        any_box = False
         for prompt in prompts:
             pc = prompt.point_coords
             pl = prompt.point_labels
@@ -655,16 +661,23 @@ class Sam3Backend(MaskBackend):
             else:
                 obj_points.append([])
                 obj_labels.append([])
-            box = prompt.box if prompt.box is not None else prompt.reject_box
-            obj_boxes.append([float(v) for v in np.asarray(box).reshape(4)])
+            if prompt.box is not None:
+                obj_boxes.append([float(v) for v in np.asarray(prompt.box).reshape(4)])
+                any_box = True
+            else:
+                obj_boxes.append([])
 
-        inputs = self.processor(
+        processor_kwargs = dict(
             images=rgb,
             input_points=[obj_points],
             input_labels=[obj_labels],
-            input_boxes=[obj_boxes],
             return_tensors="pt",
-        ).to(self.device)
+        )
+        # Only forward boxes when a prompt actually has one (pose / box modes);
+        # a frame of point-only prompts forwards no boxes at all.
+        if any_box:
+            processor_kwargs["input_boxes"] = [obj_boxes]
+        inputs = self.processor(**processor_kwargs).to(self.device)
         with torch.no_grad():
             out = self.model(**inputs, multimask_output=True)
         post = self.processor.post_process_masks(

--- a/sleap_nn/inference/sam/backends.py
+++ b/sleap_nn/inference/sam/backends.py
@@ -6,17 +6,26 @@ turning a list of :class:`~sleap_nn.inference.sam.prompts.SamPrompt` into one
 boolean mask + a raw per-model score per prompt.
 
 PR-A ships :class:`SamBackend` (SAM1, ViT-H, Apache-2.0, ungated; the
-``sleap_nn[sam]`` extra). The model-specific recipe constants
-(:data:`SamBackend.pred_iou_min`, the candidate-rejection factor, the keypoint
-box margins, CLAHE) and the candidate-selection / score helpers
-(:func:`_pick`, :func:`own_containment`, :func:`disjointify`) are harvested from
-the closed #642 (``sleap_nn/data/pseudomasks.py``) and the exp-07 locked recipe,
-repurposed to emit a *raw score* rather than to drive a drop-gate (PLAN §1).
+``sleap_nn[sam]`` extra). PR-B adds :class:`Sam3Backend` (Meta SAM 3, gated
+``facebook/sam3`` via ``transformers``; the ``sleap_nn[sam3]`` extra). The
+model-specific recipe constants (:data:`SamBackend.pred_iou_min`, the
+candidate-rejection factor, the keypoint box margins, CLAHE) and the
+candidate-selection / score helpers (:func:`_pick`, :func:`own_containment`,
+:func:`disjointify`) are harvested from the closed #642
+(``sleap_nn/data/pseudomasks.py``) and the exp-07 locked recipe, repurposed to
+emit a *raw score* rather than to drive a drop-gate (PLAN §1).
 
 Backend selection is **explicit / required** (PLAN L2): there is no default
-``mask_backend``; the caller names ``"sam"`` (this backend) and a later PR adds
-``"sam3"`` behind the same :class:`MaskBackend` interface. The SAM import is
-lazy so the default sleap-nn install never needs ``segment-anything``.
+``mask_backend``; the caller names ``"sam"`` (SAM1) or ``"sam3"`` (SAM3) and both
+honor the same :class:`MaskBackend` interface. The heavy imports
+(``segment-anything`` / ``transformers``) are lazy so the default sleap-nn
+install never needs either.
+
+SAM3 specifics (NEVER shared with SAM1; harvested from the closed #643): its
+predicted-IoU is on a lower scale, so the per-model floor is recalibrated to
+:data:`SAM3_PRED_IOU_MIN` (``0.5``, **not** SAM1's ``0.88``), and its raw masks
+are speckly/fragmented, so each is passed through :func:`_cleanup_speckle`
+(morphological open + close + keep-keypoint-component) before it is returned.
 """
 
 from __future__ import annotations
@@ -38,10 +47,35 @@ SAM_MAX_BOX_AREA_FACTOR: float = 1.5
 #: CLAHE parameters applied to the grayscale image before encoding (SAM1).
 CLAHE_CLIP_LIMIT: float = 3.0
 CLAHE_TILE_GRID: Tuple[int, int] = (8, 8)
-#: SAM1's nominal predicted-IoU floor. Carried as a per-model attribute so a
-#: future SAM3 backend can override it (SAM3 uses a recalibrated 0.5, PLAN §2.3);
+#: SAM1's nominal predicted-IoU floor. Carried as a per-model attribute so the
+#: SAM3 backend can override it (SAM3 uses a recalibrated 0.5, PLAN §2.3);
 #: SAM1's raw predicted-IoU is reported as the mask score, not used as a gate.
 SAM_PRED_IOU_MIN: float = 0.88
+
+# ---------------------------------------------------------------------------
+# Locked SAM3 recipe constants (harvested from #643; PLAN §1/§2.3).
+#
+# SAM3 (Meta SAM 3, via the transformers ``Sam3Tracker*`` image visual-prompt
+# path) is a SECOND mask backend that reuses the IDENTICAL keypoint+box prompt /
+# candidate-rejection recipe as SAM1. It differs in two ways these constants
+# encode — and which must NEVER be folded into SAM1's:
+#   1. ``iou_scores`` (predicted-IoU) are on a LOWER scale than SAM1 (median
+#      ~0.68 vs SAM1's ~0.95). SAM1's ``SAM_PRED_IOU_MIN=0.88`` floor applied
+#      verbatim would drop ~100% of SAM3 masks as a pure calibration artifact,
+#      so the SAM3 floor is recalibrated to 0.5 (~SAM1's 0.88 in percentile
+#      terms). The floor is reported as the per-model attribute, not gated on.
+#   2. Raw SAM3 masks are speckly/fragmented (median ~14 connected components per
+#      mask vs SAM1's 1), with ~97% of the area in the keypoint-connected
+#      component. The speckle is cosmetic and removed by a morphological
+#      open + close + keep-keypoint-component cleanup (:func:`_cleanup_speckle`,
+#      -> median 1 component, ~97% area retained).
+# ---------------------------------------------------------------------------
+#: Minimum/nominal SAM3 predicted-IoU (recalibrated; NEVER share SAM1's 0.88).
+SAM3_PRED_IOU_MIN: float = 0.5
+#: Morphological radius (px) for the SAM3 speckle open + close cleanup.
+SAM3_CLEANUP_RADIUS: int = 3
+#: Default gated Hugging Face model id for the SAM3 image visual-prompt path.
+SAM3_MODEL_ID: str = "facebook/sam3"
 
 
 def _to_3ch_clahe(
@@ -130,6 +164,58 @@ def own_containment(mask: np.ndarray, kpts: np.ndarray, hw: Tuple[int, int]) -> 
     return inside / len(kpts)
 
 
+def _cleanup_speckle(
+    mask: np.ndarray,
+    kpts: np.ndarray,
+    radius: int = SAM3_CLEANUP_RADIUS,
+) -> np.ndarray:
+    """De-speckle a (SAM3) mask, keeping the keypoint-connected blob.
+
+    Harvested verbatim from #643 ``_cleanup_speckle``. Raw SAM3 masks are
+    fragmented into many tiny connected components. This applies a morphological
+    open (drop specks) + close (fill pinholes), then keeps only the connected
+    component(s) that contain one of the instance's visible keypoints — falling
+    back to the largest component if the cleanup detached every keypoint, or to
+    the untouched mask if opening erased it entirely. The result is a single
+    coherent silhouette that retains ~97% of the original area while collapsing
+    the component count to ~1. Mandatory for SAM3 (PLAN §2.3); SAM1 masks are
+    already solid and never run through this.
+
+    Args:
+        mask: ``(H, W)`` boolean mask for one instance.
+        kpts: ``(n, 2)`` visible xy keypoints for that instance (the seeds whose
+            connected component is kept).
+        radius: Morphological structuring-element radius (px) for open/close.
+
+    Returns:
+        Cleaned ``(H, W)`` boolean mask.
+    """
+    import cv2
+    from scipy import ndimage
+
+    mask = np.asarray(mask, dtype=bool)
+    if not mask.any():
+        return mask
+    k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * radius + 1, 2 * radius + 1))
+    mm = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_OPEN, k)
+    mm = cv2.morphologyEx(mm, cv2.MORPH_CLOSE, k)
+    labels_arr, n = ndimage.label(mm)
+    if n == 0:
+        # Opening erased everything (a very thin mask) -> keep the raw mask.
+        return mask
+    h, w = mm.shape
+    keep = set()
+    for x, y in np.asarray(kpts, dtype=np.float32).reshape(-1, 2):
+        xi, yi = int(round(float(x))), int(round(float(y)))
+        if 0 <= yi < h and 0 <= xi < w and labels_arr[yi, xi] > 0:
+            keep.add(int(labels_arr[yi, xi]))
+    if not keep:
+        # Cleanup detached every keypoint -> keep the largest component.
+        sizes = ndimage.sum(np.ones_like(labels_arr), labels_arr, range(1, n + 1))
+        keep = {int(np.argmax(sizes)) + 1}
+    return np.isin(labels_arr, list(keep))
+
+
 def disjointify(
     masks: Sequence[np.ndarray], kpts: Sequence[np.ndarray]
 ) -> List[np.ndarray]:
@@ -210,6 +296,57 @@ def _load_sam_predictor(
 
     sam = sam_model_registry[model_type](checkpoint=ckpt.as_posix()).to(device)
     return SamPredictor(sam)
+
+
+def _load_sam3(model_id: str = SAM3_MODEL_ID, device: str = "cuda"):
+    """Lazily load the SAM3 image visual-prompt model + processor (#643).
+
+    Uses the transformers ``Sam3TrackerModel`` / ``Sam3TrackerProcessor`` *image*
+    visual-prompt path (NOT the video-tracking or text classes; those land in
+    PR-D). The model is loaded in ``bfloat16`` on ``device`` and set to
+    ``.eval()``.
+
+    ``facebook/sam3`` is a **gated** Hugging Face model: authentication comes
+    from a cached HF token (``huggingface-cli login`` /
+    ``~/.cache/huggingface/token``) or the ``HF_TOKEN`` env var, handled
+    transparently by ``transformers``. The two-venv env reality (PLAN §2.3, DQ6):
+    SAM3 needs ``transformers>=5`` + torch cu130 + the gated weights, which may
+    not co-install with the sleap-nn venv; install it on its own or run the SAM3
+    image path out-of-process and assemble the ``.slp`` in the sleap-nn venv. See
+    ``docs/guides/sam-inference-segmentation.md``.
+
+    Args:
+        model_id: Hugging Face model id (default :data:`SAM3_MODEL_ID`).
+        device: Torch device to place the model on.
+
+    Returns:
+        Tuple ``(model, processor)``.
+
+    Raises:
+        ImportError: If ``transformers`` (with SAM3 support) is not installed.
+    """
+    import torch
+
+    try:
+        from transformers import Sam3TrackerModel, Sam3TrackerProcessor
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "mask_backend='sam3' requires the optional 'transformers' dependency "
+            "with SAM3 support (transformers>=5.0). Install it with "
+            '`pip install "sleap-nn[sam3]"`. Note that facebook/sam3 is a GATED '
+            "model: run `huggingface-cli login` (or set HF_TOKEN) with an account "
+            "that has been granted access. SAM3 may need its own environment "
+            "(transformers>=5 + torch cu130 + the gated weights); see "
+            "docs/guides/sam-inference-segmentation.md for the two-venv handoff."
+        ) from e
+
+    model = (
+        Sam3TrackerModel.from_pretrained(model_id)
+        .to(device, dtype=torch.bfloat16)
+        .eval()
+    )
+    processor = Sam3TrackerProcessor.from_pretrained(model_id)
+    return model, processor
 
 
 class MaskBackend(ABC):
@@ -356,4 +493,203 @@ class SamBackend(MaskBackend):
         for m in out_masks:
             if m.shape[:2] != (h, w):
                 raise ValueError(f"SAM returned a {m.shape} mask for a {(h, w)} image.")
+        return out_masks, out_scores
+
+
+def _cleanup_seed(prompt: SamPrompt) -> np.ndarray:
+    """The keypoints used to seed :func:`_cleanup_speckle` for one SAM3 prompt.
+
+    The positive points (pose keypoints / centroid / crop center) are the natural
+    component seeds. A box-only prompt (``box`` mode) has no points, so its box
+    center is used instead so the cleanup still keeps the central blob.
+
+    Args:
+        prompt: A built :class:`~sleap_nn.inference.sam.prompts.SamPrompt`.
+
+    Returns:
+        ``(n, 2)`` float32 xy seed keypoints (``n >= 1``).
+    """
+    if prompt.point_coords is not None and len(prompt.point_coords):
+        return np.asarray(prompt.point_coords, dtype=np.float32).reshape(-1, 2)
+    box = np.asarray(prompt.reject_box, dtype=np.float32).reshape(4)
+    return np.array(
+        [[(box[0] + box[2]) / 2.0, (box[1] + box[3]) / 2.0]], dtype=np.float32
+    )
+
+
+class Sam3Backend(MaskBackend):
+    """SAM3 (Meta SAM 3) prompted-mask backend (the ``sleap_nn[sam3]`` extra).
+
+    Wraps a lazily loaded transformers ``Sam3TrackerModel`` + ``Sam3TrackerProcessor``
+    image visual-prompt pair. Honors the same :class:`MaskBackend` surface as
+    :class:`SamBackend`, but two SAM3 specifics are mandatory and NEVER shared
+    with SAM1 (PLAN §2.3, harvested from #643):
+
+    * **Recalibrated floor.** SAM3's predicted-IoU is on a lower scale, so the
+      per-model :attr:`pred_iou_min` defaults to :data:`SAM3_PRED_IOU_MIN`
+      (``0.5``), never SAM1's ``0.88``. As with SAM1 the raw chosen-candidate
+      score is reported, not gated on.
+    * **Speckle cleanup.** Each chosen mask is passed through
+      :func:`_cleanup_speckle` (morphological open + close + keep-keypoint-
+      component) before it is returned.
+
+    Unlike SAM1's per-prompt loop, SAM3 runs **all prompts for the frame in a
+    single batched forward pass** (each prompt is one object), matching #643's
+    ``_sam3_instance_masks``. The candidate selection (:func:`_pick`) and the
+    raw-score contract are identical to SAM1.
+
+    Args:
+        model: A ready ``Sam3TrackerModel`` (e.g. from :func:`_load_sam3` or
+            injected for testing).
+        processor: The matching ``Sam3TrackerProcessor``.
+        device: Torch device the prompt tensors are moved to.
+        clahe: Whether to CLAHE-equalize before encoding.
+        max_box_area_factor: Candidate-rejection factor (:func:`_pick`).
+        clahe_clip_limit: CLAHE clip limit.
+        clahe_tile_grid: CLAHE tile grid.
+        cleanup_radius: Speckle-cleanup morphological radius (px).
+        pred_iou_min: Per-model nominal predicted-IoU floor (default
+            :data:`SAM3_PRED_IOU_MIN`); reported, not gated.
+    """
+
+    pred_iou_min: float = SAM3_PRED_IOU_MIN
+
+    def __init__(
+        self,
+        model,
+        processor,
+        device: str = "cuda",
+        clahe: bool = True,
+        max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+        clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
+        clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
+        cleanup_radius: int = SAM3_CLEANUP_RADIUS,
+        pred_iou_min: float = SAM3_PRED_IOU_MIN,
+    ) -> None:
+        """Stash the model/processor and the (SAM3-specific) recipe knobs."""
+        self.model = model
+        self.processor = processor
+        self.device = str(device)
+        self.clahe = bool(clahe)
+        self.max_box_area_factor = float(max_box_area_factor)
+        self.clahe_clip_limit = float(clahe_clip_limit)
+        self.clahe_tile_grid = tuple(clahe_tile_grid)
+        self.cleanup_radius = int(cleanup_radius)
+        self.pred_iou_min = float(pred_iou_min)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_id: str = SAM3_MODEL_ID,
+        device: str = "cuda",
+        **kwargs,
+    ) -> "Sam3Backend":
+        """Build a backend by lazily loading the gated SAM3 model + processor.
+
+        Args:
+            model_id: Hugging Face model id (default :data:`SAM3_MODEL_ID`).
+            device: Torch device for the model.
+            **kwargs: Forwarded to :class:`Sam3Backend` (e.g. ``clahe``).
+
+        Returns:
+            A ready :class:`Sam3Backend`.
+
+        Raises:
+            ImportError: If ``transformers`` (with SAM3 support) is absent.
+        """
+        model, processor = _load_sam3(model_id=model_id, device=device)
+        return cls(model, processor, device=device, **kwargs)
+
+    def masks(
+        self, image: np.ndarray, prompts: Sequence[SamPrompt]
+    ) -> Tuple[List[np.ndarray], List[float]]:
+        """Encode ``image`` once, run all prompts batched, return masks + scores.
+
+        Mirrors #643's ``_sam3_instance_masks``: one batched forward pass over all
+        prompts (each prompt is an object), :func:`_pick` to choose a candidate,
+        :func:`_cleanup_speckle` to de-fragment, and the raw chosen predicted-IoU
+        as the per-mask score.
+
+        Args:
+            image: ``(H, W)`` grayscale (or ``(H, W, C)``) image / crop.
+            prompts: Per-instance :class:`SamPrompt` in ``image`` pixel space.
+
+        Returns:
+            ``(masks, scores)`` with one ``(H, W)`` boolean mask + raw
+            predicted-IoU per prompt (on SAM3's lower scale). An empty prompt list
+            returns ``([], [])``.
+        """
+        import torch
+
+        prompts = list(prompts)
+        img = np.asarray(image)
+        if img.ndim == 3:
+            img = img[..., 0]
+        img = np.ascontiguousarray(img).astype(np.uint8)
+        h, w = img.shape[:2]
+
+        out_masks: List[np.ndarray] = [np.zeros((h, w), bool) for _ in prompts]
+        out_scores: List[float] = [0.0 for _ in prompts]
+        if not prompts:
+            return out_masks, out_scores
+
+        rgb = _to_3ch_clahe(
+            img,
+            clahe=self.clahe,
+            clahe_clip_limit=self.clahe_clip_limit,
+            clahe_tile_grid=self.clahe_tile_grid,
+        )
+
+        # Build batched per-object prompts (one image, each prompt an object).
+        # A prompt may carry points, a box, or both — forward whatever it has.
+        obj_points: List[List[List[float]]] = []
+        obj_labels: List[List[int]] = []
+        obj_boxes: List[List[float]] = []
+        for prompt in prompts:
+            pc = prompt.point_coords
+            pl = prompt.point_labels
+            if pc is not None and len(pc):
+                obj_points.append([[float(x), float(y)] for x, y in pc])
+                labels = [int(v) for v in pl] if pl is not None else [1] * len(pc)
+                obj_labels.append(labels)
+            else:
+                obj_points.append([])
+                obj_labels.append([])
+            box = prompt.box if prompt.box is not None else prompt.reject_box
+            obj_boxes.append([float(v) for v in np.asarray(box).reshape(4)])
+
+        inputs = self.processor(
+            images=rgb,
+            input_points=[obj_points],
+            input_labels=[obj_labels],
+            input_boxes=[obj_boxes],
+            return_tensors="pt",
+        ).to(self.device)
+        with torch.no_grad():
+            out = self.model(**inputs, multimask_output=True)
+        post = self.processor.post_process_masks(
+            out.pred_masks, original_sizes=inputs["original_sizes"], binarize=True
+        )[
+            0
+        ]  # (n_obj, n_cand, H, W) bool
+        post = np.asarray(post.cpu().numpy()).astype(bool)
+        scores = np.asarray(out.iou_scores.float().cpu().numpy()[0])  # (n_obj, n_cand)
+
+        for j, prompt in enumerate(prompts):
+            cand_masks = post[j]
+            cand_scores = scores[j]
+            b = _pick(
+                cand_masks, cand_scores, prompt.reject_box, self.max_box_area_factor
+            )
+            mask = _cleanup_speckle(
+                cand_masks[b], _cleanup_seed(prompt), self.cleanup_radius
+            )
+            out_masks[j] = mask.astype(bool)
+            out_scores[j] = float(cand_scores[b])
+
+        for m in out_masks:
+            if m.shape[:2] != (h, w):
+                raise ValueError(
+                    f"SAM3 returned a {m.shape} mask for a {(h, w)} image."
+                )
         return out_masks, out_scores

--- a/tests/inference/sam/test_mask_layer.py
+++ b/tests/inference/sam/test_mask_layer.py
@@ -211,11 +211,24 @@ def test_get_mask_backend_unknown_name():
         get_mask_backend("not-a-backend")
 
 
-def test_get_mask_backend_sam3_not_yet():
+def test_get_mask_backend_sam3_clean_import_error(monkeypatch):
+    # PR-B implements mask_backend="sam3"; with transformers absent it raises a
+    # clean, actionable ImportError (not NotImplementedError, not a bare
+    # ModuleNotFoundError). The full SAM3 backend is covered in test_sam3_backend.
+    import builtins
+
     from sleap_nn.inference.sam import get_mask_backend
 
-    with pytest.raises(NotImplementedError):
-        get_mask_backend("sam3")
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "transformers":
+            raise ImportError("no module named transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match=r"sleap-nn\[sam3\]"):
+        get_mask_backend("sam3", device="cpu")
 
 
 def test_run_predict_mask_backend_rejects_model_paths():

--- a/tests/inference/sam/test_sam3_backend.py
+++ b/tests/inference/sam/test_sam3_backend.py
@@ -23,7 +23,6 @@ from sleap_nn.inference.sam.backends import (
 from sleap_nn.inference.sam.prompts import (
     box_prompt,
     centroid_prompt,
-    crop_center_prompt,
     pose_prompt,
 )
 
@@ -245,6 +244,11 @@ def test_sam3_masks_batched_contract_and_cleanup():
     assert not masks[0][2, 2]
     # A single batched call over BOTH objects (the SAM3 batched path).
     assert len(proc.last_call["input_points"][0]) == 2
+    # Pose prompts carry a box -> input_boxes is forwarded, one per object, and
+    # is the prompt's real box (NOT reject_box).
+    assert proc.last_call["input_boxes"] is not None
+    assert len(proc.last_call["input_boxes"][0]) == 2
+    np.testing.assert_allclose(proc.last_call["input_boxes"][0][0], list(p0.box))
     # Mask shapes honor the (H, W) contract.
     for m in masks:
         assert m.shape == (h, w)
@@ -273,18 +277,23 @@ def test_sam3_masks_raw_score_is_not_gated():
     assert abs(scores[0] - 0.10) < 1e-5
 
 
-def test_sam3_masks_crop_center_prompt():
-    # The top-down crop-center prompt (points-only) seeds cleanup at the center.
+def test_sam3_masks_point_only_prompt_forwards_no_box():
+    # Point-only prompts (centroid mode, box is None) must NOT forward a box to
+    # SAM3. Feeding reject_box as a real box would hand SAM3 a whole-frame
+    # "segment everything" hint and make it diverge from SAM1 — a regression
+    # guard for the reject_box-as-box bug.
     h, w = 48, 48
     blob = _disk(h, w, 24, 24, 9)
     cands = np.stack([np.stack([blob])])
     backend, proc, _ = _backend(cands, np.array([[0.7]], np.float32), (h, w))
-    masks, scores = backend.masks(
-        np.zeros((h, w), np.uint8), [crop_center_prompt((h, w))]
-    )
+    prompt = centroid_prompt(np.array([24.0, 24.0]), (h, w))
+    assert prompt.box is None  # centroid mode is point-only
+    masks, scores = backend.masks(np.zeros((h, w), np.uint8), [prompt])
     assert masks[0][24, 24]
-    # The crop-center point was forwarded as this object's single positive point.
-    assert proc.last_call["input_points"][0][0] == [[w / 2.0, h / 2.0]]
+    # The centroid point was forwarded as this object's single positive point...
+    assert proc.last_call["input_points"][0][0] == [[24.0, 24.0]]
+    # ...and NO box was forwarded for the point-only prompt (the fix).
+    assert proc.last_call["input_boxes"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inference/sam/test_sam3_backend.py
+++ b/tests/inference/sam/test_sam3_backend.py
@@ -1,0 +1,328 @@
+"""Unit tests for the SAM3 backend (CPU; a fake transformers SAM3, no weights).
+
+SAM3 (`mask_backend="sam3"`) is gated (`facebook/sam3`) and GPU-only end-to-end,
+so every test here mocks the transformers `Sam3TrackerModel` / `Sam3TrackerProcessor`
+pair. They lock the SAM3-specific recipe (recalibrated 0.5 floor — NEVER SAM1's
+0.88 — and the mandatory speckle cleanup), the batched single-call contract, and
+the clean, actionable error raised when `transformers`/SAM3 is unavailable.
+"""
+
+import numpy as np
+import pytest
+
+from sleap_nn.inference.sam import MASK_BACKENDS, get_mask_backend
+from sleap_nn.inference.sam.backends import (
+    SAM3_CLEANUP_RADIUS,
+    SAM3_MODEL_ID,
+    SAM3_PRED_IOU_MIN,
+    SAM_PRED_IOU_MIN,
+    Sam3Backend,
+    _cleanup_speckle,
+    _cleanup_seed,
+)
+from sleap_nn.inference.sam.prompts import (
+    box_prompt,
+    centroid_prompt,
+    crop_center_prompt,
+    pose_prompt,
+)
+
+
+def _disk(h, w, cy, cx, r):
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+# ---------------------------------------------------------------------------
+# Fake transformers SAM3 surface.
+# ---------------------------------------------------------------------------
+class _FakeTensor:
+    """Minimal stand-in for a torch tensor: carries a numpy array + .cpu/.float."""
+
+    def __init__(self, arr):
+        self._arr = np.asarray(arr)
+
+    def float(self):
+        return _FakeTensor(self._arr.astype(np.float32))
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._arr
+
+
+class _FakeInputs(dict):
+    """Processor output: a dict carrying ``original_sizes`` + a no-op ``.to``."""
+
+    def to(self, device):
+        return self
+
+
+class FakeSam3Processor:
+    """Stand-in for ``Sam3TrackerProcessor``.
+
+    ``__call__`` records the batched prompt structure and returns the inputs
+    dict; ``post_process_masks`` returns the fixed per-object candidate masks the
+    test seeded (as ``[ (n_obj, n_cand, H, W) ]``).
+    """
+
+    def __init__(self, candidate_masks, hw):
+        # candidate_masks: (n_obj, n_cand, H, W) bool
+        self._cands = np.asarray(candidate_masks, bool)
+        self._hw = hw
+        self.last_call = None
+
+    def __call__(
+        self,
+        images=None,
+        input_points=None,
+        input_labels=None,
+        input_boxes=None,
+        return_tensors=None,
+    ):
+        self.last_call = dict(
+            images=images,
+            input_points=input_points,
+            input_labels=input_labels,
+            input_boxes=input_boxes,
+        )
+        return _FakeInputs(original_sizes=[self._hw])
+
+    def post_process_masks(self, pred_masks, original_sizes=None, binarize=True):
+        # Mirror transformers' API: returns a per-image list of (n_obj,n_cand,H,W).
+        return [_FakeTensor(self._cands)]
+
+
+class _FakeOut:
+    def __init__(self, pred_masks, iou_scores):
+        self.pred_masks = pred_masks
+        self.iou_scores = iou_scores
+
+
+class FakeSam3Model:
+    """Stand-in for ``Sam3TrackerModel``: returns fixed iou scores per object."""
+
+    def __init__(self, iou_scores):
+        # iou_scores: (n_obj, n_cand)
+        self._scores = np.asarray(iou_scores, np.float32)
+        self.called = False
+
+    def __call__(self, multimask_output=True, **inputs):
+        self.called = True
+        # pred_masks is opaque to the backend (post_process_masks handles it).
+        return _FakeOut(
+            pred_masks=None, iou_scores=_FakeTensor(self._scores[None, ...])
+        )
+
+
+def _backend(candidate_masks, iou_scores, hw, **kwargs):
+    proc = FakeSam3Processor(candidate_masks, hw)
+    model = FakeSam3Model(iou_scores)
+    return Sam3Backend(model, proc, device="cpu", **kwargs), proc, model
+
+
+# ---------------------------------------------------------------------------
+# Backend selection (explicit, no default — PLAN L2).
+# ---------------------------------------------------------------------------
+def test_sam3_is_a_registered_backend():
+    assert "sam3" in MASK_BACKENDS
+
+
+def test_get_mask_backend_unknown_name_raises():
+    with pytest.raises(ValueError, match="Unknown mask_backend"):
+        get_mask_backend("nope")
+
+
+def test_get_mask_backend_none_raises():
+    with pytest.raises(ValueError, match="required and has no default"):
+        get_mask_backend(None)
+
+
+# ---------------------------------------------------------------------------
+# Recipe constants — the SAM3 floor must NOT be SAM1's (regression guard).
+# ---------------------------------------------------------------------------
+def test_sam3_floor_is_recalibrated_not_sam1():
+    assert SAM3_PRED_IOU_MIN == 0.5
+    assert SAM3_PRED_IOU_MIN != SAM_PRED_IOU_MIN  # never share SAM1's 0.88
+    assert SAM3_MODEL_ID == "facebook/sam3"
+    assert SAM3_CLEANUP_RADIUS == 3
+
+
+def test_sam3_backend_pred_iou_min_attribute():
+    backend, _, _ = _backend(
+        np.zeros((1, 1, 8, 8), bool), np.zeros((1, 1), np.float32), (8, 8)
+    )
+    assert backend.pred_iou_min == SAM3_PRED_IOU_MIN
+    # Class-level default, too (so a future caller reading the type sees 0.5).
+    assert Sam3Backend.pred_iou_min == SAM3_PRED_IOU_MIN
+
+
+# ---------------------------------------------------------------------------
+# Speckle cleanup (mandatory for SAM3; harvested from #643).
+# ---------------------------------------------------------------------------
+def test_cleanup_speckle_keeps_keypoint_blob_drops_speckle():
+    h, w = 60, 60
+    blob = _disk(h, w, 30, 30, 10)
+    # Add a detached speck far away.
+    speck = _disk(h, w, 5, 5, 1)
+    mask = blob | speck
+    kpts = np.array([[30.0, 30.0]])
+    cleaned = _cleanup_speckle(mask, kpts, radius=SAM3_CLEANUP_RADIUS)
+    # The keypoint blob survives; the isolated speck is gone.
+    assert cleaned[30, 30]
+    assert not cleaned[5, 5]
+    # Single connected component after cleanup.
+    from scipy import ndimage
+
+    _, n = ndimage.label(cleaned)
+    assert n == 1
+
+
+def test_cleanup_speckle_empty_mask_is_noop():
+    empty = np.zeros((10, 10), bool)
+    out = _cleanup_speckle(empty, np.array([[5.0, 5.0]]))
+    assert not out.any()
+
+
+def test_cleanup_speckle_falls_back_to_largest_when_no_keypoint_inside():
+    h, w = 60, 60
+    big = _disk(h, w, 30, 30, 12)
+    small = _disk(h, w, 50, 50, 4)
+    mask = big | small
+    # Keypoint lands in neither component (all-background) -> largest is kept.
+    out = _cleanup_speckle(mask, np.array([[0.0, 0.0]]), radius=SAM3_CLEANUP_RADIUS)
+    assert out[30, 30]
+    assert not out[50, 50]
+
+
+def test_cleanup_seed_uses_points_else_box_center():
+    pts = np.array([[3.0, 4.0], [5.0, 6.0]], np.float32)
+    p = pose_prompt(pts, (50, 50))
+    seed = _cleanup_seed(p)
+    np.testing.assert_allclose(seed, pts)
+    # Box-only prompt: seed is the reject-box center.
+    b = box_prompt(pts, (50, 50))
+    seed_box = _cleanup_seed(b)
+    rb = b.reject_box
+    np.testing.assert_allclose(
+        seed_box[0], [(rb[0] + rb[2]) / 2.0, (rb[1] + rb[3]) / 2.0]
+    )
+
+
+# ---------------------------------------------------------------------------
+# The batched .masks() contract (mocked SAM3).
+# ---------------------------------------------------------------------------
+def test_sam3_masks_batched_contract_and_cleanup():
+    h, w = 64, 64
+    # Two instances, each with two candidates: the whole-arena over-confident
+    # candidate (rejected by _pick despite a higher score) and the real blob.
+    huge = np.ones((h, w), bool)
+    blob0 = _disk(h, w, 20, 20, 8) | _disk(h, w, 2, 2, 1)  # blob + a speck
+    blob1 = _disk(h, w, 44, 44, 8)
+    cands = np.stack(
+        [
+            np.stack([huge, blob0]),  # obj 0
+            np.stack([huge, blob1]),  # obj 1
+        ]
+    )
+    scores = np.array([[0.99, 0.62], [0.99, 0.55]], np.float32)
+    backend, proc, model = _backend(cands, scores, (h, w))
+
+    p0 = pose_prompt(np.array([[20.0, 20.0]]), (h, w))
+    p1 = pose_prompt(np.array([[44.0, 44.0]]), (h, w))
+    masks, out_scores = backend.masks(np.zeros((h, w), np.uint8), [p0, p1])
+
+    assert model.called
+    assert len(masks) == 2 and len(out_scores) == 2
+    # Whole-arena candidate rejected -> the real blob is chosen for both.
+    assert masks[0][20, 20] and masks[1][44, 44]
+    assert not masks[0].all() and not masks[1].all()
+    # The raw chosen SAM3 score is reported (not the rejected 0.99).
+    assert abs(out_scores[0] - 0.62) < 1e-5
+    assert abs(out_scores[1] - 0.55) < 1e-5
+    # Speckle cleanup ran: the detached speck on obj 0 is gone.
+    assert not masks[0][2, 2]
+    # A single batched call over BOTH objects (the SAM3 batched path).
+    assert len(proc.last_call["input_points"][0]) == 2
+    # Mask shapes honor the (H, W) contract.
+    for m in masks:
+        assert m.shape == (h, w)
+
+
+def test_sam3_masks_empty_prompts():
+    backend, _, model = _backend(
+        np.zeros((1, 1, 8, 8), bool), np.zeros((1, 1), np.float32), (8, 8)
+    )
+    masks, scores = backend.masks(np.zeros((8, 8), np.uint8), [])
+    assert masks == [] and scores == []
+    # No forward pass on an empty frame.
+    assert not model.called
+
+
+def test_sam3_masks_raw_score_is_not_gated():
+    # A low SAM3 score (below the 0.5 floor) still yields a mask + the raw score.
+    h, w = 32, 32
+    blob = _disk(h, w, 16, 16, 6)
+    cands = np.stack([np.stack([blob])])  # (1 obj, 1 cand, H, W)
+    backend, _, _ = _backend(cands, np.array([[0.10]], np.float32), (h, w))
+    masks, scores = backend.masks(
+        np.zeros((h, w), np.uint8), [centroid_prompt(np.array([16.0, 16.0]), (h, w))]
+    )
+    assert masks[0].any()
+    assert abs(scores[0] - 0.10) < 1e-5
+
+
+def test_sam3_masks_crop_center_prompt():
+    # The top-down crop-center prompt (points-only) seeds cleanup at the center.
+    h, w = 48, 48
+    blob = _disk(h, w, 24, 24, 9)
+    cands = np.stack([np.stack([blob])])
+    backend, proc, _ = _backend(cands, np.array([[0.7]], np.float32), (h, w))
+    masks, scores = backend.masks(
+        np.zeros((h, w), np.uint8), [crop_center_prompt((h, w))]
+    )
+    assert masks[0][24, 24]
+    # The crop-center point was forwarded as this object's single positive point.
+    assert proc.last_call["input_points"][0][0] == [[w / 2.0, h / 2.0]]
+
+
+# ---------------------------------------------------------------------------
+# Clean error when transformers / SAM3 is unavailable (the env reality).
+# ---------------------------------------------------------------------------
+def test_load_sam3_missing_transformers(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "transformers":
+            raise ImportError("no module named transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    from sleap_nn.inference.sam.backends import _load_sam3
+
+    with pytest.raises(ImportError, match=r"sleap-nn\[sam3\]"):
+        _load_sam3()
+
+
+def test_get_mask_backend_sam3_clean_error_without_transformers(monkeypatch):
+    # Selecting the sam3 backend with transformers absent raises the actionable
+    # ImportError (not NotImplementedError, not a bare ModuleNotFoundError).
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "transformers":
+            raise ImportError("no module named transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError) as ei:
+        get_mask_backend("sam3", device="cpu")
+    msg = str(ei.value)
+    assert "transformers>=5" in msg
+    assert "facebook/sam3" in msg  # the gated-model auth pointer
+    assert "huggingface-cli login" in msg


### PR DESCRIPTION
> **Stacked on #647** (PR-A). Its base retargets to `main` and rebases after #647 lands; the diff here is the SAM3 delta only.

Adds a second, **opt-in** prompted-mask backend `Sam3Backend` (Meta SAM 3 image visual-prompt path, gated `facebook/sam3` via `transformers`) behind the existing `MaskBackend` interface, selected by the explicit `mask_backend="sam3"` (PLAN L2 — still no default, no fallback). SAM1 and the default install are unchanged (heavy imports stay lazy). Harvested from the closed #643.

### What lands

- **`backends.py`** — `Sam3Backend` honors the same `masks(image, prompts) -> (masks, scores)` contract as SAM1, but runs **all per-frame prompts in one batched `Sam3TrackerModel` forward**, `_pick`-selects a candidate, and `_cleanup_speckle`-de-fragments each mask (raw SAM3 masks ~14 components → ~1, ~97% area retained; SAM1 masks never run through it). Stores the **raw** per-model score (no drop-gate). Like SAM1, it forwards a SAM box **only when the prompt actually has one** — point-only modes (centroid) forward no box, never `reject_box`. `from_pretrained` lazily loads the gated model with a clear, actionable `ImportError`. Constants are model-aware and never shared with SAM1: `SAM3_PRED_IOU_MIN=0.5` (SAM1's `0.88` would drop ~100% of SAM3 masks as a calibration artifact), `SAM3_CLEANUP_RADIUS=3`, `SAM3_MODEL_ID="facebook/sam3"`.
- **`__init__.py`** — `get_mask_backend("sam3")` builds `Sam3Backend` (replacing the PR-A `NotImplementedError` placeholder); `sam3_model_id` threads through.
- **`pyproject.toml`** — lazy `[sam3]` extra (`transformers>=5`; cv2 from the base `opencv-python`). Documents the two-venv / torch-cu130 env reality (DQ6): SAM3 may not co-install — install it on its own, or run the image path out-of-process (`.npz` handoff) and assemble the `.slp` in the sleap-nn venv.
- **docs** — SAM3 backend section + gated install/auth + the env handoff.

### Default-preserving

SAM3 imports stay lazy → the default install needs neither `transformers` nor the gated weights; `run.py`/`outputs.py`/`segmentation_convert.py`/`predictor.py` are untouched; SAM1 and the model-driven path are byte-identical.

### Tests (CPU, mocked SAM3 — no gated weights in CI)

`test_sam3_backend.py`: backend selection; the recalibrated floor (regression guard that it is **never** SAM1's `0.88`); `_cleanup_speckle` (keep-keypoint-blob / largest-component fallback / empty no-op); the batched `.masks()` contract incl. whole-arena candidate rejection + raw-score reporting; **a regression guard that point-only prompts forward NO box and pose prompts forward the real box (not `reject_box`)**; and the clean `ImportError` when `transformers` is monkeypatched away. `test_mask_layer.py`: the `sam3`-not-yet placeholder becomes the "clean ImportError without transformers" contract.

End-to-end SAM3 is GPU + gated → manual/nightly only. `uv.lock` regenerated for `[sam3]`. `black --check` + `ruff check sleap_nn/` + the `tests/inference/sam/` suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
