### PR TITLE
feat(seg): SAM-inference §3 tech-debt, backend globals→class args, predict CLI surface

### DIFF
--- a/docs/guides/sam-inference-segmentation.md
+++ b/docs/guides/sam-inference-segmentation.md
@@ -107,9 +107,9 @@ labels = run_sam_segmentation(
 Two SAM3 specifics are handled automatically and are **never** shared with SAM1:
 
 - **Recalibrated score floor (`0.5`).** SAM3's predicted-IoU is on a lower scale,
-  so its per-model floor is `SAM3_PRED_IOU_MIN = 0.5` (SAM1's `0.88` would reject
-  ~100% of SAM3 masks as a pure calibration artifact). As with SAM1 the raw score
-  is reported, not gated on.
+  so its per-model floor (`Sam3Backend.pred_iou_min`) defaults to `0.5` (SAM1's
+  `0.88` would reject ~100% of SAM3 masks as a pure calibration artifact). As with
+  SAM1 the raw score is reported, not gated on.
 - **Speckle cleanup.** Raw SAM3 masks are fragmented (~14 connected components);
   each chosen mask is passed through a morphological open + close + keep-the-
   keypoint-connected-component cleanup (~1 component, ~97% area retained).
@@ -125,9 +125,12 @@ The same masks are produced from the `sleap-nn predict` command (and its hidden
 `infer` alias) by passing `--mask_backend`. When set, the input `.slp` is treated
 as a pose file and masks are produced from its existing instances — there is **no
 trained segmentation model**, so `--mask_backend` is **mutually exclusive with
-`--model_paths`** (do not pass it). The `.slp` output is saved with images
-**embedded**, so a `.pkg.slp` source can be reviewed/corrected in the GUI without
-the original frames.
+`--model_paths`** (do not pass it). The `.slp` output is saved like the regular
+prediction path — images are **not** re-embedded; the output backreferences the
+input's source media via provenance (small output; a `.pkg.slp` input stays
+matchable to its source videos), and the masks always serialize into the `.slp`.
+Only `--output_format slp` is supported (the SLEAP Analysis HDF5 format stores
+poses/tracks, not segmentation masks).
 
 SAM1 (ungated):
 

--- a/docs/guides/sam-inference-segmentation.md
+++ b/docs/guides/sam-inference-segmentation.md
@@ -119,6 +119,43 @@ SAM3 also runs **all instances of a frame in a single batched forward pass**
 weights, so it is exercised manually / nightly; the recipe (floor, cleanup,
 batched call) is unit-tested against a mocked SAM3.
 
+## CLI
+
+The same masks are produced from the `sleap-nn predict` command (and its hidden
+`infer` alias) by passing `--mask_backend`. When set, the input `.slp` is treated
+as a pose file and masks are produced from its existing instances — there is **no
+trained segmentation model**, so `--mask_backend` is **mutually exclusive with
+`--model_paths`** (do not pass it). The `.slp` output is saved with images
+**embedded**, so a `.pkg.slp` source can be reviewed/corrected in the GUI without
+the original frames.
+
+SAM1 (ungated):
+
+```bash
+sleap-nn predict \
+    -i poses.pkg.slp \
+    --mask_backend sam \
+    --sam_checkpoint /path/to/sam_vit_h_4b8939.pth \
+    --sam_prompt_mode pose \
+    --overlay_path review_frame0.png \
+    -o poses_with_masks.pkg.slp
+```
+
+SAM3 (gated `facebook/sam3`, needs the `[sam3]` extra):
+
+```bash
+sleap-nn predict \
+    -i poses.pkg.slp \
+    --mask_backend sam3 \
+    --sam3_model_id facebook/sam3 \
+    --sam_prompt_mode pose \
+    -o poses_with_masks.pkg.slp
+```
+
+Every flag also has a dash-spelled alias (`--mask-backend`, `--sam-checkpoint`,
+`--sam-model-type`, `--sam-prompt-mode`, `--sam-anchor-ind`,
+`--sam-disjointify-masks`, `--sam3-model-id`, `--overlay-path`).
+
 ## Prompt modes
 
 | Mode | Prompt | Needs | Notes |

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1029,6 +1029,16 @@ def track(**kwargs):
     kwargs.pop("centroid_peak_threshold", None)
     kwargs.pop("centroid_output", None)
     kwargs.pop("filter_min_centroid_distance", None)
+    # SAM prompted-mask flags are new-flow-only (legacy run_inference rejects
+    # them); inert here.
+    kwargs.pop("mask_backend", None)
+    kwargs.pop("sam_checkpoint", None)
+    kwargs.pop("sam_model_type", None)
+    kwargs.pop("sam_prompt_mode", None)
+    kwargs.pop("sam_anchor_ind", None)
+    kwargs.pop("sam_disjointify_masks", None)
+    kwargs.pop("sam3_model_id", None)
+    kwargs.pop("overlay_path", None)
 
     return run_inference(**kwargs)
 
@@ -1347,6 +1357,17 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
 
     from sleap_nn.inference.predictor import Predictor
 
+    # The SAM mask path produces masks from existing poses; it never tracks.
+    # Without this guard, `--mask_backend ... --tracking` (no --model_paths)
+    # would fall into the retrack short-circuit below, which ignores
+    # mask_backend and silently produces no masks. Fail loudly instead.
+    if kwargs.get("mask_backend") and kwargs.get("tracking"):
+        raise click.UsageError(
+            "--tracking is not supported with --mask_backend; the SAM mask path "
+            "operates on the existing poses in the input .slp only. Run them "
+            "separately."
+        )
+
     # ── Tracking-only retrack: no model_paths, --tracking on a .slp ────
     if not kwargs.get("model_paths") and kwargs.get("tracking"):
         return _run_retrack_only(kwargs, Predictor)
@@ -1466,6 +1487,24 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         "mask_output": kwargs.get("mask_output", "mask"),
         "polygon_epsilon": kwargs.get("polygon_epsilon", 0.01),
     }
+    # SAM prompted-mask producer (§1.4): when --mask_backend is set, masks are
+    # produced from the poses already in the input .slp (no trained seg model).
+    # run.predict() short-circuits on mask_backend and ignores the inert model
+    # knobs carried in predict_kwargs. No --tracking, so this path is not caught
+    # by the retrack short-circuit above. model_paths stays empty (the SAM path
+    # rejects model_paths), so do not pass --model_paths alongside --mask_backend.
+    if kwargs.get("mask_backend"):
+        predict_kwargs["mask_backend"] = kwargs["mask_backend"]
+        predict_kwargs["sam_checkpoint"] = kwargs.get("sam_checkpoint")
+        predict_kwargs["sam_model_type"] = kwargs.get("sam_model_type", "vit_h")
+        predict_kwargs["sam_prompt_mode"] = kwargs.get("sam_prompt_mode", "pose")
+        predict_kwargs["sam_anchor_ind"] = kwargs.get("sam_anchor_ind")
+        predict_kwargs["sam_disjointify_masks"] = bool(
+            kwargs.get("sam_disjointify_masks")
+        )
+        predict_kwargs["sam3_model_id"] = kwargs.get("sam3_model_id", "facebook/sam3")
+        predict_kwargs["overlay_path"] = kwargs.get("overlay_path")
+
     preprocess_config = _build_preprocess_config(kwargs)
     if preprocess_config is not None:
         predict_kwargs["preprocess_config"] = preprocess_config
@@ -2148,6 +2187,81 @@ def _common_inference_options(f):
             "polygon/both, as a fraction of each contour's perimeter. Larger = "
             "coarser polygons. 0 disables simplification (bottom-up segmentation "
             "models only).",
+        ),
+        # SAM prompted-mask producer ───────────────────────────────────
+        # These produce masks from the poses already in the input .slp; no
+        # trained seg model is involved, so they are mutually exclusive with
+        # --model_paths (do not pass it). Inert unless --mask_backend is set.
+        click.option(
+            "--mask_backend",
+            "--mask-backend",
+            "mask_backend",
+            type=click.Choice(["sam", "sam3"], case_sensitive=False),
+            default=None,
+            help="Produce instance masks from the poses in the input .slp using "
+            "a SAM backend: 'sam' (SAM1, needs --sam_checkpoint) or 'sam3' "
+            "(needs --sam3_model_id). No trained segmentation model is used, so "
+            "do not pass --model_paths. Off by default.",
+        ),
+        click.option(
+            "--sam_checkpoint",
+            "--sam-checkpoint",
+            "sam_checkpoint",
+            type=str,
+            default=None,
+            help="Path to the SAM1 checkpoint (required for --mask_backend sam).",
+        ),
+        click.option(
+            "--sam_model_type",
+            "--sam-model-type",
+            "sam_model_type",
+            type=str,
+            default="vit_h",
+            help="SAM1 model registry key (e.g. 'vit_h', 'vit_l', 'vit_b').",
+        ),
+        click.option(
+            "--sam_prompt_mode",
+            "--sam-prompt-mode",
+            "sam_prompt_mode",
+            type=click.Choice(["pose", "centroid", "box"]),
+            default="pose",
+            help="How poses are turned into SAM prompts: 'pose' (all keypoints "
+            "as point prompts), 'centroid' (single anchor point), or 'box' "
+            "(instance bounding box).",
+        ),
+        click.option(
+            "--sam_anchor_ind",
+            "--sam-anchor-ind",
+            "sam_anchor_ind",
+            type=int,
+            default=None,
+            help="Centroid anchor node index for --sam_prompt_mode centroid.",
+        ),
+        click.option(
+            "--sam_disjointify_masks",
+            "--sam-disjointify-masks",
+            "sam_disjointify_masks",
+            is_flag=True,
+            default=False,
+            help="Make per-frame masks disjoint when a frame has >=2 instances.",
+        ),
+        click.option(
+            "--sam3_model_id",
+            "--sam3-model-id",
+            "sam3_model_id",
+            type=str,
+            default="facebook/sam3",
+            help="Hugging Face model id for the gated SAM3 backend "
+            "(--mask_backend sam3).",
+        ),
+        click.option(
+            "--overlay_path",
+            "--overlay-path",
+            "overlay_path",
+            type=str,
+            default=None,
+            help="Optional review-overlay PNG path written by the SAM mask "
+            "path (--mask_backend).",
         ),
         click.option(
             "--queue_maxsize",

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1094,6 +1094,16 @@ def _run_inference_impl(**kwargs):
     else:
         kwargs["frames"] = None
 
+    # The SAM mask path is in-memory only (it masks an existing .slp); it does not
+    # use the streaming Predictor. Guard here so the combo fails with a SAM-aware
+    # message instead of _run_stream_to_file's misleading "--model_paths is
+    # required" (the SAM path actually forbids --model_paths).
+    if stream_to_file is not None and kwargs.get("mask_backend"):
+        raise click.UsageError(
+            "--mask_backend is not supported with --stream-to-file; the SAM mask "
+            "path runs in-memory on an existing .slp. Run without --stream-to-file."
+        )
+
     # Exported ONNX/TRT model directories run through the in-memory flow only.
     _mps = kwargs["model_paths"]
     if (
@@ -1368,6 +1378,30 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
             "separately."
         )
 
+    # The SAM mask path consumes a pose .slp / sio.Labels directly via
+    # run_sam_segmentation, NOT the Provider/Predictor flow. The label-status
+    # frame filters select inference frames by annotation status, which does not
+    # map onto masking the poses already present; reject them clearly rather than
+    # crash deep in run_sam_segmentation (which would ``Path()`` a LabelsProvider
+    # -> TypeError). ``--video_index`` and ``--frames`` ARE supported (below).
+    if kwargs.get("mask_backend"):
+        _sam_unsupported = [
+            f"--{flag}"
+            for flag in (
+                "only_labeled_frames",
+                "only_suggested_frames",
+                "exclude_user_labeled",
+                "only_predicted_frames",
+            )
+            if kwargs.get(flag)
+        ]
+        if _sam_unsupported:
+            raise click.UsageError(
+                f"{', '.join(_sam_unsupported)} not supported with --mask_backend; "
+                "it masks the poses already in the input .slp. Use --frames to "
+                "subset frames, or pre-filter the .slp."
+            )
+
     # ── Tracking-only retrack: no model_paths, --tracking on a .slp ────
     if not kwargs.get("model_paths") and kwargs.get("tracking"):
         return _run_retrack_only(kwargs, Predictor)
@@ -1404,14 +1438,19 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         scoped, target_video = _scope_labels_to_video(
             sio.load_slp(str(src)), video_index, frames=kwargs.get("frames")
         )
-        source = LabelsProvider(
-            labels=scoped,
-            batch_size=kwargs.get("batch_size", 4),
-            only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
-            only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
-            exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
-            only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
-        )
+        if kwargs.get("mask_backend"):
+            # run_sam_segmentation accepts a sio.Labels directly; pass the scoped
+            # Labels (not a LabelsProvider, which it cannot consume).
+            source = scoped
+        else:
+            source = LabelsProvider(
+                labels=scoped,
+                batch_size=kwargs.get("batch_size", 4),
+                only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
+                only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
+                exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
+                only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
+            )
         _vfn = getattr(target_video, "filename", None)
         scoped_video_name = Path(str(_vfn)).stem if _vfn else f"video_{video_index}"
     elif src.suffix == ".slp" and has_slp_filters:

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -208,6 +208,7 @@ def predict(
     mask_backend: Optional[str] = None,
     sam_checkpoint: Optional[str] = None,
     sam_model_type: str = "vit_h",
+    sam3_model_id: str = "facebook/sam3",
     sam_prompt_mode: str = "pose",
     sam_anchor_ind: Optional[int] = None,
     sam_disjointify_masks: bool = False,
@@ -297,6 +298,8 @@ def predict(
             (the default) leaves the model-driven path untouched.
         sam_checkpoint: SAM1 checkpoint path (required for ``mask_backend="sam"``).
         sam_model_type: SAM1 model registry key.
+        sam3_model_id: Hugging Face model id for the gated SAM3 path
+            (``mask_backend="sam3"``); defaults to ``"facebook/sam3"``.
         sam_prompt_mode: ``"pose"`` / ``"centroid"`` / ``"box"`` (PLAN §2.2).
         sam_anchor_ind: Centroid anchor node index for ``sam_prompt_mode="centroid"``.
         sam_disjointify_masks: Make per-frame masks disjoint when >=2 instances.
@@ -358,20 +361,41 @@ def predict(
             )
         from sleap_nn.inference.sam import run_sam_segmentation
 
+        # Embed asymmetry fix (§3.5a): the SAM ``.slp`` output must embed images
+        # so a ``.pkg.slp`` source can be reviewed/corrected in the GUI without
+        # the original frames. ``run_sam_segmentation`` saves embedded
+        # (``labels.save(embed=True)``) when handed ``output_path``, while a plain
+        # ``save_predictions`` would not — so for the ``slp``/``both`` formats we
+        # pass ``output_path`` into ``run_sam_segmentation`` and let it embed.
+        # The analysis HDF5 (``analysis_h5``/``both``) is still produced via
+        # ``save_predictions`` so no output format regresses.
+        sam_output_format = str(output_format).lower()
+        if output_path is not None and sam_output_format not in (
+            "slp",
+            "analysis_h5",
+            "both",
+        ):
+            raise ValueError(
+                f"Invalid output_format: {output_format!r}. Must be one of "
+                "('slp', 'analysis_h5', 'both')."
+            )
+        sam_save_slp = output_path if sam_output_format in ("slp", "both") else None
         labels = run_sam_segmentation(
             source,
             mask_backend,
             prompt_mode=sam_prompt_mode,
             sam_checkpoint=sam_checkpoint,
             sam_model_type=sam_model_type,
+            sam3_model_id=sam3_model_id,
             device=device,
             anchor_ind=sam_anchor_ind,
             disjointify_masks=sam_disjointify_masks,
+            output_path=sam_save_slp,
             overlay_path=overlay_path,
             frames=frames,
         )
-        if output_path is not None:
-            save_predictions(labels, output_path, output_format=output_format)
+        if output_path is not None and sam_output_format in ("analysis_h5", "both"):
+            save_predictions(labels, output_path, output_format="analysis_h5")
         return labels
 
     if model_paths and export_dir:

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -387,6 +387,7 @@ def predict(
             output_path=output_path,
             overlay_path=overlay_path,
             frames=frames,
+            clean_empty_frames=clean_empty_frames,
         )
         return labels
 

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -361,25 +361,19 @@ def predict(
             )
         from sleap_nn.inference.sam import run_sam_segmentation
 
-        # Embed asymmetry fix (§3.5a): the SAM ``.slp`` output must embed images
-        # so a ``.pkg.slp`` source can be reviewed/corrected in the GUI without
-        # the original frames. ``run_sam_segmentation`` saves embedded
-        # (``labels.save(embed=True)``) when handed ``output_path``, while a plain
-        # ``save_predictions`` would not — so for the ``slp``/``both`` formats we
-        # pass ``output_path`` into ``run_sam_segmentation`` and let it embed.
-        # The analysis HDF5 (``analysis_h5``/``both``) is still produced via
-        # ``save_predictions`` so no output format regresses.
-        sam_output_format = str(output_format).lower()
-        if output_path is not None and sam_output_format not in (
-            "slp",
-            "analysis_h5",
-            "both",
-        ):
+        # Segmentation masks only serialize to ``.slp``: the SLEAP Analysis HDF5
+        # format stores poses/tracks, not ``PredictedSegmentationMask``, so it
+        # would silently drop the masks (the actual output). Reject it up front
+        # rather than write a mask-less ``.h5``.
+        if output_path is not None and str(output_format).lower() != "slp":
             raise ValueError(
-                f"Invalid output_format: {output_format!r}. Must be one of "
-                "('slp', 'analysis_h5', 'both')."
+                f"mask_backend output only supports output_format='slp' (got "
+                f"{output_format!r}); the SLEAP Analysis HDF5 format stores "
+                "poses/tracks, not segmentation masks."
             )
-        sam_save_slp = output_path if sam_output_format in ("slp", "both") else None
+        # Save handling lives in ``run_sam_segmentation``, which mirrors the
+        # regular prediction path: it backreferences the source media via
+        # provenance and never re-embeds images (small output; see its docs).
         labels = run_sam_segmentation(
             source,
             mask_backend,
@@ -390,12 +384,10 @@ def predict(
             device=device,
             anchor_ind=sam_anchor_ind,
             disjointify_masks=sam_disjointify_masks,
-            output_path=sam_save_slp,
+            output_path=output_path,
             overlay_path=overlay_path,
             frames=frames,
         )
-        if output_path is not None and sam_output_format in ("analysis_h5", "both"):
-            save_predictions(labels, output_path, output_format="analysis_h5")
         return labels
 
     if model_paths and export_dir:

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -229,10 +229,15 @@ def run_sam_segmentation(
     new_lfs = []
     for lf in source_lfs:
         frame_masks = layer.masks_for_frame(lf.image, lf.instances)
-        if not frame_masks:
-            continue
-        # Reuse the standard packaging path (build_predicted_segmentation_mask).
-        masks = Outputs(pred_masks=[frame_masks]).to_masks(0)
+        # Always emit the frame for review continuity (§3.5b): when SAM yields no
+        # mask, keep the frame (video/frame_idx/instances unchanged) with an empty
+        # ``masks=[]`` rather than dropping it — the poses must survive for
+        # correction, and a missing frame would silently disappear from review.
+        if frame_masks:
+            # Reuse the standard packaging path (build_predicted_segmentation_mask).
+            masks = Outputs(pred_masks=[frame_masks]).to_masks(0)
+        else:
+            masks = []
         new_lfs.append(
             sio.LabeledFrame(
                 video=lf.video,
@@ -253,6 +258,9 @@ def run_sam_segmentation(
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out.save(out_path.as_posix(), embed=True)
     if overlay_path is not None:
-        save_mask_overlay(out, overlay_path)
+        # Flag masks below the backend's per-model nominal predicted-IoU floor
+        # (SAM1 0.88 / SAM3 0.5) so the review overlay surfaces low-confidence
+        # masks a human should scrutinize (§3.3 — consume pred_iou_min).
+        save_mask_overlay(out, overlay_path, low_score_threshold=backend.pred_iou_min)
 
     return out

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -16,8 +16,8 @@ Public surface
 * :func:`run_sam_segmentation` — end-to-end orchestration: load a pose ``.slp``,
   run the chosen backend with the chosen prompt mode, emit
   ``sio.PredictedSegmentationMask`` (raw score + ``instance=``/``track=``
-  populated, PLAN L8) onto each frame, and optionally save an embedded ``.slp``
-  + a review overlay PNG.
+  populated, PLAN L8) onto each frame, and optionally save the ``.slp``
+  (backreferencing the input's images, not re-embedding) + a review overlay PNG.
 * :func:`retrack` (+ :mod:`~sleap_nn.inference.sam.reconciliation` primitives) —
   the torch-less "refine existing tracks" path: correct an existing
   pose/centroid tracker's identities from identity-consistent per-frame masks.
@@ -179,7 +179,11 @@ def run_sam_segmentation(
         backend: A pre-built :class:`~.backends.MaskBackend` to use directly
             (skips loading); when given, ``mask_backend`` is still validated for
             the name but the checkpoint/device args are ignored.
-        output_path: Optional path to save the result embedded (``.slp``).
+        output_path: Optional ``.slp`` path to save the result to. Saved like the
+            regular prediction path (``labels.save``): images are **never**
+            re-embedded — the output backreferences the source media via
+            provenance, so a ``.pkg.slp`` input stays matchable to its source
+            videos without bloating the output.
         overlay_path: Optional path to write a review overlay PNG of the first
             frame.
         frames: Optional frame indices (matched against ``lf.frame_idx``) to
@@ -256,7 +260,15 @@ def run_sam_segmentation(
     if output_path is not None:
         out_path = Path(output_path).expanduser()
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        out.save(out_path.as_posix(), embed=True)
+        # Save exactly like the regular prediction path (``labels.save(path)``):
+        # NEVER re-embed images — that is large and wasteful. The output
+        # backreferences the source media via provenance (sleap-io's default
+        # ``embed=False``). A ``.pkg.slp`` input is typically aggregated training
+        # data; its frames stay matchable to the source videos (by comparing
+        # source-video provenance) without copying pixels into the output, even
+        # if those videos are no longer on disk. The masks always serialize into
+        # the ``.slp`` regardless.
+        out.save(out_path.as_posix())
     if overlay_path is not None:
         # Flag masks below the backend's per-model nominal predicted-IoU floor
         # (SAM1 0.88 / SAM3 0.5) so the review overlay surfaces low-confidence

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -155,6 +155,7 @@ def run_sam_segmentation(
     output_path: Optional[str] = None,
     overlay_path: Optional[str] = None,
     frames: Optional[Sequence[int]] = None,
+    clean_empty_frames: bool = False,
 ):
     """Predict per-instance masks for a pose ``.slp`` with a SAM backend.
 
@@ -189,6 +190,11 @@ def run_sam_segmentation(
         frames: Optional frame indices (matched against ``lf.frame_idx``) to
             restrict masking to; ``None`` masks every labeled frame. SAM encoding
             is the slow step, so subsetting here avoids unrequested compute.
+        clean_empty_frames: If ``True``, drop fully-empty output frames (no
+            instances and no masks) before saving/returning, mirroring the
+            regular prediction path's ``--no_empty_frames``. A frame that has
+            poses but no mask is NOT empty (its instances are retained) and is
+            kept.
 
     Returns:
         A new ``sio.Labels`` with per-frame ``PredictedSegmentationMask`` (and the
@@ -256,6 +262,12 @@ def run_sam_segmentation(
         skeletons=list(labels.skeletons),
         labeled_frames=new_lfs,
     )
+
+    if clean_empty_frames:
+        # Mirror the regular path's --no_empty_frames: drop frames with no
+        # annotations. A posed-but-mask-less frame keeps its instances and is
+        # NOT dropped; only fully-empty source frames are removed.
+        out.clean(frames=True, skeletons=False)
 
     if output_path is not None:
         out_path = Path(output_path).expanduser()

--- a/sleap_nn/inference/sam/backends.py
+++ b/sleap_nn/inference/sam/backends.py
@@ -23,8 +23,8 @@ install never needs either.
 
 SAM3 specifics (NEVER shared with SAM1; harvested from the closed #643): its
 predicted-IoU is on a lower scale, so the per-model floor is recalibrated to
-:data:`SAM3_PRED_IOU_MIN` (``0.5``, **not** SAM1's ``0.88``), and its raw masks
-are speckly/fragmented, so each is passed through :func:`_cleanup_speckle`
+:attr:`Sam3Backend.pred_iou_min` (``0.5``, **not** SAM1's ``0.88``), and its raw
+masks are speckly/fragmented, so each is passed through :func:`_cleanup_speckle`
 (morphological open + close + keep-keypoint-component) before it is returned.
 """
 
@@ -38,51 +38,12 @@ import numpy as np
 
 from sleap_nn.inference.sam.prompts import SamPrompt
 
-# ---------------------------------------------------------------------------
-# Locked SAM1 recipe constants (harvested from #642 / exp-07; PLAN §1).
-# ---------------------------------------------------------------------------
-#: SAM1 candidate rejection: drop candidates whose area exceeds this * box-area
-#: (kills SAM's over-confident whole-arena candidate).
-SAM_MAX_BOX_AREA_FACTOR: float = 1.5
-#: CLAHE parameters applied to the grayscale image before encoding (SAM1).
-CLAHE_CLIP_LIMIT: float = 3.0
-CLAHE_TILE_GRID: Tuple[int, int] = (8, 8)
-#: SAM1's nominal predicted-IoU floor. Carried as a per-model attribute so the
-#: SAM3 backend can override it (SAM3 uses a recalibrated 0.5, PLAN §2.3);
-#: SAM1's raw predicted-IoU is reported as the mask score, not used as a gate.
-SAM_PRED_IOU_MIN: float = 0.88
-
-# ---------------------------------------------------------------------------
-# Locked SAM3 recipe constants (harvested from #643; PLAN §1/§2.3).
-#
-# SAM3 (Meta SAM 3, via the transformers ``Sam3Tracker*`` image visual-prompt
-# path) is a SECOND mask backend that reuses the IDENTICAL keypoint+box prompt /
-# candidate-rejection recipe as SAM1. It differs in two ways these constants
-# encode — and which must NEVER be folded into SAM1's:
-#   1. ``iou_scores`` (predicted-IoU) are on a LOWER scale than SAM1 (median
-#      ~0.68 vs SAM1's ~0.95). SAM1's ``SAM_PRED_IOU_MIN=0.88`` floor applied
-#      verbatim would drop ~100% of SAM3 masks as a pure calibration artifact,
-#      so the SAM3 floor is recalibrated to 0.5 (~SAM1's 0.88 in percentile
-#      terms). The floor is reported as the per-model attribute, not gated on.
-#   2. Raw SAM3 masks are speckly/fragmented (median ~14 connected components per
-#      mask vs SAM1's 1), with ~97% of the area in the keypoint-connected
-#      component. The speckle is cosmetic and removed by a morphological
-#      open + close + keep-keypoint-component cleanup (:func:`_cleanup_speckle`,
-#      -> median 1 component, ~97% area retained).
-# ---------------------------------------------------------------------------
-#: Minimum/nominal SAM3 predicted-IoU (recalibrated; NEVER share SAM1's 0.88).
-SAM3_PRED_IOU_MIN: float = 0.5
-#: Morphological radius (px) for the SAM3 speckle open + close cleanup.
-SAM3_CLEANUP_RADIUS: int = 3
-#: Default gated Hugging Face model id for the SAM3 image visual-prompt path.
-SAM3_MODEL_ID: str = "facebook/sam3"
-
 
 def _to_3ch_clahe(
     img_gray: np.ndarray,
     clahe: bool = True,
-    clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
-    clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
+    clahe_clip_limit: float = 3.0,
+    clahe_tile_grid: Tuple[int, int] = (8, 8),
 ) -> np.ndarray:
     """Grayscale ``(H, W)`` -> optional CLAHE -> 3-channel uint8 (SAM's input).
 
@@ -112,7 +73,7 @@ def _pick(
     masks: np.ndarray,
     scores: np.ndarray,
     box: np.ndarray,
-    max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
+    max_box_area_factor: float = 1.5,
 ) -> int:
     """Pick the best SAM candidate-mask index (harvested verbatim from #642).
 
@@ -167,7 +128,7 @@ def own_containment(mask: np.ndarray, kpts: np.ndarray, hw: Tuple[int, int]) -> 
 def _cleanup_speckle(
     mask: np.ndarray,
     kpts: np.ndarray,
-    radius: int = SAM3_CLEANUP_RADIUS,
+    radius: int = 3,
 ) -> np.ndarray:
     """De-speckle a (SAM3) mask, keeping the keypoint-connected blob.
 
@@ -298,7 +259,7 @@ def _load_sam_predictor(
     return SamPredictor(sam)
 
 
-def _load_sam3(model_id: str = SAM3_MODEL_ID, device: str = "cuda"):
+def _load_sam3(model_id: str = "facebook/sam3", device: str = "cuda"):
     """Lazily load the SAM3 image visual-prompt model + processor (#643).
 
     Uses the transformers ``Sam3TrackerModel`` / ``Sam3TrackerProcessor`` *image*
@@ -316,7 +277,8 @@ def _load_sam3(model_id: str = SAM3_MODEL_ID, device: str = "cuda"):
     ``docs/guides/sam-inference-segmentation.md``.
 
     Args:
-        model_id: Hugging Face model id (default :data:`SAM3_MODEL_ID`).
+        model_id: Hugging Face model id (default ``"facebook/sam3"``, the gated
+            SAM3 image visual-prompt path).
         device: Torch device to place the model on.
 
     Returns:
@@ -358,8 +320,12 @@ class MaskBackend(ABC):
     explicit (PLAN L2) — see :func:`sleap_nn.inference.sam.get_mask_backend`.
     """
 
-    #: Per-model nominal predicted-IoU floor (SAM1: 0.88; SAM3 recalibrates).
-    pred_iou_min: float = SAM_PRED_IOU_MIN
+    #: Per-model nominal predicted-IoU floor. Defaults to SAM1's ``0.88``;
+    #: :class:`Sam3Backend` overrides it with a recalibrated ``0.5`` (SAM3's
+    #: predicted-IoU is on a lower scale, PLAN §2.3). Carried as a per-model
+    #: attribute so SAM3 can override it; SAM1's raw predicted-IoU is reported as
+    #: the mask score, not used as a gate.
+    pred_iou_min: float = 0.88
 
     @abstractmethod
     def masks(
@@ -403,12 +369,21 @@ class SamBackend(MaskBackend):
         self,
         predictor,
         clahe: bool = True,
-        max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
-        clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
-        clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
-        pred_iou_min: float = SAM_PRED_IOU_MIN,
+        max_box_area_factor: float = 1.5,
+        clahe_clip_limit: float = 3.0,
+        clahe_tile_grid: Tuple[int, int] = (8, 8),
+        pred_iou_min: float = 0.88,
     ) -> None:
-        """Stash the predictor and the (model-specific) recipe knobs."""
+        """Stash the predictor and the (model-specific) recipe knobs.
+
+        The recipe defaults are the locked SAM1 values (harvested from #642 /
+        exp-07; PLAN §1): ``max_box_area_factor=1.5`` drops candidates whose area
+        exceeds ``1.5 * box-area`` (kills SAM's over-confident whole-arena
+        candidate, see :func:`_pick`); ``clahe_clip_limit=3.0`` /
+        ``clahe_tile_grid=(8, 8)`` are the CLAHE parameters applied to the
+        grayscale image before encoding; ``pred_iou_min=0.88`` is SAM1's nominal
+        predicted-IoU floor, reported (not gated) and carried for SAM3 parity.
+        """
         self.predictor = predictor
         self.clahe = bool(clahe)
         self.max_box_area_factor = float(max_box_area_factor)
@@ -525,13 +500,18 @@ class Sam3Backend(MaskBackend):
     :class:`SamBackend`, but two SAM3 specifics are mandatory and NEVER shared
     with SAM1 (PLAN §2.3, harvested from #643):
 
-    * **Recalibrated floor.** SAM3's predicted-IoU is on a lower scale, so the
-      per-model :attr:`pred_iou_min` defaults to :data:`SAM3_PRED_IOU_MIN`
-      (``0.5``), never SAM1's ``0.88``. As with SAM1 the raw chosen-candidate
-      score is reported, not gated on.
-    * **Speckle cleanup.** Each chosen mask is passed through
-      :func:`_cleanup_speckle` (morphological open + close + keep-keypoint-
-      component) before it is returned.
+    * **Recalibrated floor.** SAM3's ``iou_scores`` (predicted-IoU) are on a
+      LOWER scale than SAM1 (median ~0.68 vs SAM1's ~0.95). SAM1's ``0.88`` floor
+      applied verbatim would drop ~100% of SAM3 masks as a pure calibration
+      artifact, so the per-model :attr:`pred_iou_min` defaults to ``0.5``
+      (~SAM1's ``0.88`` in percentile terms), never SAM1's ``0.88``. As with SAM1
+      the raw chosen-candidate score is reported, not gated on.
+    * **Speckle cleanup.** Raw SAM3 masks are speckly/fragmented (median ~14
+      connected components per mask vs SAM1's 1), with ~97% of the area in the
+      keypoint-connected component. The speckle is cosmetic, so each chosen mask
+      is passed through :func:`_cleanup_speckle` (morphological open + close +
+      keep-keypoint-component, -> median 1 component, ~97% area retained) before
+      it is returned. Mandatory for SAM3; SAM1 masks are already solid.
 
     Unlike SAM1's per-prompt loop, SAM3 runs **all prompts for the frame in a
     single batched forward pass** (each prompt is one object), matching #643's
@@ -548,11 +528,14 @@ class Sam3Backend(MaskBackend):
         clahe_clip_limit: CLAHE clip limit.
         clahe_tile_grid: CLAHE tile grid.
         cleanup_radius: Speckle-cleanup morphological radius (px).
-        pred_iou_min: Per-model nominal predicted-IoU floor (default
-            :data:`SAM3_PRED_IOU_MIN`); reported, not gated.
+        pred_iou_min: Per-model nominal predicted-IoU floor (default ``0.5``,
+            recalibrated; NEVER SAM1's ``0.88``); reported, not gated.
     """
 
-    pred_iou_min: float = SAM3_PRED_IOU_MIN
+    #: SAM3's recalibrated predicted-IoU floor. NEVER SAM1's ``0.88`` (SAM3's
+    #: predicted-IoU is on a lower scale; the ``0.5`` value is ~SAM1's ``0.88`` in
+    #: percentile terms). Reported as the per-model score, not gated on.
+    pred_iou_min: float = 0.5
 
     def __init__(
         self,
@@ -560,13 +543,22 @@ class Sam3Backend(MaskBackend):
         processor,
         device: str = "cuda",
         clahe: bool = True,
-        max_box_area_factor: float = SAM_MAX_BOX_AREA_FACTOR,
-        clahe_clip_limit: float = CLAHE_CLIP_LIMIT,
-        clahe_tile_grid: Tuple[int, int] = CLAHE_TILE_GRID,
-        cleanup_radius: int = SAM3_CLEANUP_RADIUS,
-        pred_iou_min: float = SAM3_PRED_IOU_MIN,
+        max_box_area_factor: float = 1.5,
+        clahe_clip_limit: float = 3.0,
+        clahe_tile_grid: Tuple[int, int] = (8, 8),
+        cleanup_radius: int = 3,
+        pred_iou_min: float = 0.5,
     ) -> None:
-        """Stash the model/processor and the (SAM3-specific) recipe knobs."""
+        """Stash the model/processor and the (SAM3-specific) recipe knobs.
+
+        The SAM1-shared recipe defaults match :class:`SamBackend`
+        (``max_box_area_factor=1.5``, ``clahe_clip_limit=3.0``,
+        ``clahe_tile_grid=(8, 8)``). The SAM3-specific defaults are
+        ``cleanup_radius=3`` (the morphological open + close radius (px) for the
+        mandatory speckle cleanup) and ``pred_iou_min=0.5`` (the recalibrated
+        floor; NEVER SAM1's ``0.88``, since SAM3's predicted-IoU is on a lower
+        scale).
+        """
         self.model = model
         self.processor = processor
         self.device = str(device)
@@ -580,14 +572,14 @@ class Sam3Backend(MaskBackend):
     @classmethod
     def from_pretrained(
         cls,
-        model_id: str = SAM3_MODEL_ID,
+        model_id: str = "facebook/sam3",
         device: str = "cuda",
         **kwargs,
     ) -> "Sam3Backend":
         """Build a backend by lazily loading the gated SAM3 model + processor.
 
         Args:
-            model_id: Hugging Face model id (default :data:`SAM3_MODEL_ID`).
+            model_id: Hugging Face model id (default ``"facebook/sam3"``).
             device: Torch device for the model.
             **kwargs: Forwarded to :class:`Sam3Backend` (e.g. ``clahe``).
 

--- a/sleap_nn/inference/sam/overlay.py
+++ b/sleap_nn/inference/sam/overlay.py
@@ -30,15 +30,33 @@ _COLORS = [
     (160, 80, 255),
 ]
 
+#: Fixed warning color (RGB) for low-score masks flagged for human review.
+_WARNING_COLOR = (255, 0, 0)
 
-def save_mask_overlay(labels, path, frame_index: int = 0) -> Optional[Path]:
+
+def save_mask_overlay(
+    labels,
+    path,
+    frame_index: int = 0,
+    low_score_threshold: Optional[float] = None,
+) -> Optional[Path]:
     """Render image + colored per-instance mask overlay for one labeled frame.
+
+    When ``low_score_threshold`` is given, any mask whose ``.score`` falls below
+    it is rendered as a *low-score flag* so a human reviewer knows to scrutinize
+    it: its contour is drawn in a fixed warning color (:data:`_WARNING_COLOR`)
+    with a thicker outline, and a ``"!{score:.2f}"`` text label is drawn near the
+    mask centroid. Masks at/above the threshold (and all masks when the threshold
+    is ``None``) render normally with their cycled per-instance :data:`_COLORS`.
 
     Args:
         labels: A ``sio.Labels`` whose frames carry
             ``sio.PredictedSegmentationMask`` objects.
         path: Output PNG path.
         frame_index: Which labeled frame to render (default the first).
+        low_score_threshold: Optional score floor; masks with ``.score`` strictly
+            below it are flagged in the warning style (see above). ``None``
+            (default) disables flagging and renders every mask normally.
 
     Returns:
         The written ``Path`` on success, or ``None`` if there were no frames /
@@ -73,12 +91,34 @@ def save_mask_overlay(labels, path, frame_index: int = 0) -> Optional[Path]:
         mm = np.zeros((H, W), bool)
         hh, ww = min(H, decoded.shape[0]), min(W, decoded.shape[1])
         mm[:hh, :ww] = decoded[:hh, :ww]
+
+        score = float(getattr(m, "score", 0.0))
+        low_score = low_score_threshold is not None and score < low_score_threshold
+
         c = np.array(_COLORS[i % len(_COLORS)], dtype=np.float32)
         rgb[mm] = 0.5 * rgb[mm] + 0.5 * c
         cnts, _ = cv2.findContours(
             mm.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        cv2.drawContours(rgb, cnts, -1, tuple(int(x) for x in c), 2)
+        if low_score:
+            # Flag for review: thicker warning-colored outline + score label so a
+            # reviewer can spot masks below the per-model nominal floor.
+            cv2.drawContours(rgb, cnts, -1, _WARNING_COLOR, 4)
+            ys, xs = np.nonzero(mm)
+            if xs.size:
+                cy, cx = int(ys.mean()), int(xs.mean())
+                cv2.putText(
+                    rgb,
+                    f"!{score:.2f}",
+                    (cx, cy),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.5,
+                    _WARNING_COLOR,
+                    1,
+                    cv2.LINE_AA,
+                )
+        else:
+            cv2.drawContours(rgb, cnts, -1, tuple(int(x) for x in c), 2)
 
     out_path = Path(path).expanduser()
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/sleap_nn/inference/sam/reconciliation.py
+++ b/sleap_nn/inference/sam/reconciliation.py
@@ -1,11 +1,25 @@
 """ID reconciliation for matching SAM3 masks to poses or input masks.
 
-Lifted **verbatim** from ``talmolab/sam-track`` (BSD-3-Clause) at commit
+Lifted from ``talmolab/sam-track`` (BSD-3-Clause) at commit
 ``7b2531d92b5035f5f83016b12350f7c394b92522``:
 
     https://github.com/talmolab/sam-track/blob/7b2531d92b5035f5f83016b12350f7c394b92522/src/sam_track/reconciliation.py
 
-Only this attribution header was added; the implementation below is unchanged.
+This attribution header was added, and the implementation was subsequently
+modified in sleap-nn. The changes relative to the upstream source are:
+
+- ``IDReconciler.compute_cost_matrix`` was vectorized across masks (numerically
+  identical to the original triple-loop).
+- Keypoint visibility now requires BOTH x and y to be finite (both-axes NaN
+  check), replacing the inherited x-only test, in both ``compute_cost_matrix``
+  and ``match_frame``.
+- The implicit default ``match_predicate`` is now
+  ``require_min_keypoints_inside(3)`` instead of the weaker
+  ``default_match_predicate`` (>= 1 keypoint inside).
+- ``match_frame`` now validates per-frame lengths (masks vs. object_ids vs.
+  scores) and raises a descriptive ``ValueError`` naming the frame.
+- The previously-undocumented ``ignore_gt_tracks`` attribute is documented in
+  the ``IDReconciler`` class docstring (doc-only; no behavior change).
 
 BSD 3-Clause License
 
@@ -168,6 +182,8 @@ class IDReconciler:
         skeleton: The SLEAP skeleton for node name lookups.
         exclude_nodes: Set of node names to exclude from matching.
         match_predicates: List of predicates that must all pass for a valid match.
+        ignore_gt_tracks: If True, do not propagate GT track names onto
+            assignments (track_name is set to None).
 
     Example:
         >>> reconciler = IDReconciler(
@@ -192,9 +208,16 @@ class IDReconciler:
     _assignments: list[TrackAssignment] = field(default_factory=list, repr=False)
 
     def __post_init__(self):
-        """Add default predicate if none provided."""
+        """Add default predicate if none provided.
+
+        The implicit default requires at least 3 keypoints inside the mask. The
+        weaker ``default_match_predicate`` (>= 1) is kept defined for direct use
+        but is no longer the implicit default. ``require_min_keypoints_inside``
+        is defined later in this module; it resolves at call time, so referencing
+        it here is fine.
+        """
         if not self.match_predicates:
-            self.match_predicates = [default_match_predicate]
+            self.match_predicates = [require_min_keypoints_inside(3)]
 
     def compute_cost_matrix(
         self,
@@ -223,10 +246,12 @@ class IDReconciler:
 
         # Get node names for filtering
         node_names = [n.name for n in self.skeleton.nodes]
+        height, width = masks.shape[1], masks.shape[2]
 
         for i, pose in enumerate(poses):
             coords = pose.numpy()
-            visible_mask = ~np.isnan(coords[:, 0])
+            # Keypoint is visible only if BOTH x and y are finite.
+            visible_mask = ~np.isnan(coords).any(axis=1)
 
             # Apply node exclusion filter
             if self.exclude_nodes:
@@ -236,15 +261,26 @@ class IDReconciler:
 
             visible_coords = coords[visible_mask].astype(int)
 
-            for j, mask in enumerate(masks):
-                inside_count = 0
-                for x, y in visible_coords:
-                    if 0 <= y < mask.shape[0] and 0 <= x < mask.shape[1]:
-                        if mask[y, x]:
-                            inside_count += 1
+            if len(visible_coords) == 0:
+                continue
 
-                # Negative because Hungarian minimizes cost
-                cost[i, j] = -inside_count
+            xs = visible_coords[:, 0]
+            ys = visible_coords[:, 1]
+
+            # Bounds check: keypoints outside the mask are not counted.
+            in_bounds = (xs >= 0) & (xs < width) & (ys >= 0) & (ys < height)
+            if not in_bounds.any():
+                continue
+
+            xs_in = xs[in_bounds]
+            ys_in = ys[in_bounds]
+
+            # Vectorize across masks: masks[:, ys, xs] is (n_masks, n_kpts);
+            # summing over keypoints gives per-mask inside counts.
+            inside_counts = masks[:, ys_in, xs_in].astype(bool).sum(axis=1)
+
+            # Negative because Hungarian minimizes cost.
+            cost[i, :] = -inside_counts
 
         return cost
 
@@ -282,6 +318,14 @@ class IDReconciler:
         if masks.ndim == 4 and masks.shape[1] == 1:
             masks = masks.squeeze(axis=1)
 
+        # Validate per-frame lengths so a mismatch surfaces clearly here rather
+        # than as a bare IndexError deeper in the loop.
+        if len(object_ids) != len(masks) or len(scores) != len(masks):
+            raise ValueError(
+                f"match_frame: frame {frame_idx} has {len(masks)} masks but "
+                f"{len(object_ids)} object_ids / {len(scores)} scores"
+            )
+
         # Compute cost matrix and solve assignment
         cost = self.compute_cost_matrix(poses, masks)
         row_ind, col_ind = linear_sum_assignment(cost)
@@ -294,9 +338,10 @@ class IDReconciler:
             pose = poses[pose_idx]
             mask = masks[mask_idx]
 
-            # Calculate visibility (excluding filtered nodes)
+            # Calculate visibility (excluding filtered nodes). A keypoint is
+            # visible only if BOTH x and y are finite.
             coords = pose.numpy()
-            visible_mask = ~np.isnan(coords[:, 0])
+            visible_mask = ~np.isnan(coords).any(axis=1)
             if self.exclude_nodes:
                 for j, name in enumerate(node_names):
                     if name in self.exclude_nodes:

--- a/sleap_nn/inference/sam/retrack.py
+++ b/sleap_nn/inference/sam/retrack.py
@@ -12,8 +12,8 @@ prototype P3) is:
 
 1. **Match.** At each frame, Hungarian-match poses to masks by keypoints-inside
    (:class:`~sleap_nn.inference.sam.reconciliation.IDReconciler`), gated by a
-   match predicate (the default requires >=1 keypoint inside; a stricter
-   ``require_min_keypoints_inside(3)`` is recommended for re-tracking).
+   match predicate (the default requires >=3 keypoints inside, i.e.
+   ``require_min_keypoints_inside(3)``, the recommended strength for re-tracking).
 2. **Build anchors.** Treat *trusted* frames (by default the frames whose
    instances carry GT/user track labels, else all frames) as identity anchors,
    yielding a sparse ``frame -> {mask_obj_id: track_name}`` map.
@@ -176,8 +176,9 @@ def retrack(
         scores: Optional per-frame mask confidence scores, ``scores[i]`` shape
             ``(N_i,)``. Defaults to all-ones when omitted.
         match_predicates: Predicates (all must pass) gating a valid match. When
-            ``None``, :class:`IDReconciler`'s default (>=1 keypoint inside) is
-            used. ``require_min_keypoints_inside(3)`` is recommended.
+            ``None``, :class:`IDReconciler`'s default
+            (``require_min_keypoints_inside(3)``, i.e. >=3 keypoints inside) is
+            used.
         exclude_nodes: Node names to ignore when counting keypoints-inside
             (e.g. unreliable tail nodes).
         anchor_frame_indices: Explicit positions into ``labeled_frames`` to use

--- a/tests/inference/sam/test_backends.py
+++ b/tests/inference/sam/test_backends.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from sleap_nn.inference.sam.backends import (
-    SAM_PRED_IOU_MIN,
     SamBackend,
     _pick,
     _to_3ch_clahe,
@@ -146,7 +145,8 @@ def test_sam_backend_empty_prompts():
 def test_sam_backend_pred_iou_min_attribute():
     backend = SamBackend(FakeSamPredictor(candidates=[(np.zeros((8, 8), bool), 0.5)]))
     # SAM1's nominal floor; reported (not gated) — carried for SAM3 parity.
-    assert backend.pred_iou_min == SAM_PRED_IOU_MIN
+    assert backend.pred_iou_min == 0.88
+    assert backend.pred_iou_min == SamBackend.pred_iou_min
 
 
 def test_sam_backend_raw_score_is_not_gated():

--- a/tests/inference/sam/test_overlay.py
+++ b/tests/inference/sam/test_overlay.py
@@ -1,0 +1,122 @@
+"""CPU-only tests for the low-score review flag in ``save_mask_overlay``.
+
+No SAM / torch model: a tiny synthetic image and two
+``sio.PredictedSegmentationMask`` objects (one above, one below a chosen
+threshold) built through the codebase's standard packaging path
+(``build_predicted_segmentation_mask``) exercise §3.3 — ``pred_iou_min`` consumed
+as a per-model review signal. We assert the overlay PNG is written with and
+without the flag, and that turning the flag on changes the rendered pixels
+(more warning-red).
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+import sleap_io as sio
+
+from sleap_nn.inference.segmentation_convert import build_predicted_segmentation_mask
+from sleap_nn.inference.sam.overlay import save_mask_overlay
+
+
+def _disk(h, w, cy, cx, r):
+    """A boolean ``(h, w)`` disk of radius ``r`` centered at ``(cy, cx)``."""
+    yy, xx = np.ogrid[:h, :w]
+    return ((yy - cy) ** 2 + (xx - cx) ** 2) <= r**2
+
+
+def _labels_two_masks(tmp_path, high_score=0.95, low_score=0.40):
+    """A ``sio.Labels`` with one frame carrying two masks at distinct scores.
+
+    A tiny PNG is written to ``tmp_path`` and loaded as a ``sio.Video`` (so
+    ``lf.image`` yields real pixels without any heavyweight fixture), and the two
+    masks are built through the codebase's standard
+    ``build_predicted_segmentation_mask`` path so they are genuine
+    ``sio.PredictedSegmentationMask`` objects with full-res scale/offset.
+
+    Args:
+        tmp_path: Pytest tmp dir to write the backing image into.
+        high_score: Score for the first (above-threshold) mask.
+        low_score: Score for the second (below-threshold) mask.
+    """
+    import cv2
+
+    h, w = 64, 64
+    img_path = Path(tmp_path) / "frame.png"
+    cv2.imwrite(img_path.as_posix(), np.zeros((h, w, 3), dtype=np.uint8))
+    video = sio.Video.from_filename(img_path.as_posix())
+
+    m_high = build_predicted_segmentation_mask(_disk(h, w, 18, 18, 10), high_score)
+    m_low = build_predicted_segmentation_mask(_disk(h, w, 46, 46, 10), low_score)
+
+    lf = sio.LabeledFrame(video=video, frame_idx=0, masks=[m_high, m_low])
+    return sio.Labels(videos=[video], skeletons=[], labeled_frames=[lf])
+
+
+def _red_pixels(img_bgr):
+    """Count strongly-red BGR pixels (warning color is RGB (255, 0, 0))."""
+    b, g, r = img_bgr[..., 0], img_bgr[..., 1], img_bgr[..., 2]
+    return int(np.count_nonzero((r > 200) & (g < 80) & (b < 80)))
+
+
+def test_save_mask_overlay_no_threshold_writes_png(tmp_path):
+    """``low_score_threshold=None`` writes a PNG and renders both masks."""
+    import cv2
+
+    labels = _labels_two_masks(tmp_path)
+    out_path = tmp_path / "overlay.png"
+
+    result = save_mask_overlay(labels, out_path, low_score_threshold=None)
+    assert result is not None
+    assert result.exists()
+
+    img = cv2.imread(result.as_posix())
+    assert img is not None
+    assert img.ndim == 3 and img.shape[-1] == 3
+
+
+def test_save_mask_overlay_threshold_between_scores_writes_png(tmp_path):
+    """A threshold between the two scores still writes a PNG without error."""
+    import cv2
+
+    labels = _labels_two_masks(tmp_path, high_score=0.95, low_score=0.40)
+    out_path = tmp_path / "overlay_flagged.png"
+
+    # 0.5 sits between the two scores, so exactly one mask is flagged.
+    result = save_mask_overlay(labels, out_path, low_score_threshold=0.5)
+    assert result is not None
+    assert result.exists()
+
+    img = cv2.imread(result.as_posix())
+    assert img is not None and img.ndim == 3 and img.shape[-1] == 3
+
+
+def test_save_mask_overlay_flag_changes_rendering(tmp_path):
+    """Flagging a low-score mask adds warning-red pixels vs the unflagged render."""
+    import cv2
+
+    labels = _labels_two_masks(tmp_path, high_score=0.95, low_score=0.40)
+
+    off_path = tmp_path / "off.png"
+    on_path = tmp_path / "on.png"
+
+    save_mask_overlay(labels, off_path, low_score_threshold=None)
+    save_mask_overlay(labels, on_path, low_score_threshold=0.5)
+
+    off = cv2.imread(off_path.as_posix())
+    on = cv2.imread(on_path.as_posix())
+    assert off is not None and on is not None
+
+    # The flagged render must differ from the unflagged one and carry strictly
+    # more warning-red pixels (thicker red contour + the "!{score}" label).
+    assert not np.array_equal(off, on)
+    assert _red_pixels(on) > _red_pixels(off)
+
+
+def test_save_mask_overlay_returns_path(tmp_path):
+    """The returned value is the written ``Path`` and points at the PNG."""
+    labels = _labels_two_masks(tmp_path)
+    out_path = tmp_path / "ret.png"
+    result = save_mask_overlay(labels, out_path, low_score_threshold=0.5)
+    assert isinstance(result, Path)
+    assert result == out_path

--- a/tests/inference/sam/test_reconciliation.py
+++ b/tests/inference/sam/test_reconciliation.py
@@ -249,6 +249,98 @@ class TestIDReconciler:
         # Only tail (90, 90) should be counted, which is in mask 0 (covers 5:95, 5:95)
         assert cost[0, 0] == -1  # 1 keypoint inside
 
+    def test_compute_cost_matrix_vectorized_parity(self, simple_skeleton):
+        """Test the vectorized cost matrix gives exact negative-counts.
+
+        Hand-built case covering: keypoints inside multiple masks, an
+        out-of-bounds keypoint, and a NaN (invisible) keypoint that must be
+        excluded by the both-axes finite check.
+        """
+        reconciler = IDReconciler(skeleton=simple_skeleton)
+
+        # 5x5 masks.
+        # Mask 0: left half columns 0-2 set.
+        mask0 = np.zeros((5, 5), dtype=bool)
+        mask0[:, 0:3] = True
+        # Mask 1: a single pixel at (y=1, x=4).
+        mask1 = np.zeros((5, 5), dtype=bool)
+        mask1[1, 4] = True
+        masks = np.stack([mask0, mask1])
+
+        # Pose A: head (1, 1) -> in mask0 only; body (4, 1) -> in mask1 only;
+        #         tail (10, 10) -> out of bounds (counted in neither).
+        coords_a = np.array([[1, 1], [4, 1], [10, 10]], dtype=np.float64)
+        pose_a = sio.Instance.from_numpy(coords_a, skeleton=simple_skeleton)
+
+        # Pose B: head (0, 0) -> in mask0; body (2, 4) -> in mask0;
+        #         tail (nan, nan) -> invisible, excluded by both-axes check.
+        coords_b = np.array([[0, 0], [2, 4], [np.nan, np.nan]], dtype=np.float64)
+        pose_b = sio.Instance.from_numpy(coords_b, skeleton=simple_skeleton)
+
+        cost = reconciler.compute_cost_matrix([pose_a, pose_b], masks)
+
+        # Pose A: 1 kpt in mask0, 1 kpt in mask1.
+        # Pose B: 2 kpts in mask0, 0 in mask1.
+        expected = np.array([[-1, -1], [-2, 0]], dtype=float)
+        np.testing.assert_array_equal(cost, expected)
+
+    def test_match_frame_length_mismatch_raises(
+        self, reconciler, sample_poses, sample_masks
+    ):
+        """Test per-frame length mismatch raises a ValueError naming the frame."""
+        # 2 masks but only 1 object_id (not caused by negative-id padding).
+        object_ids = np.array([0])
+
+        with pytest.raises(ValueError, match="frame 7"):
+            reconciler.match_frame(
+                frame_idx=7,
+                poses=sample_poses,
+                masks=sample_masks,
+                object_ids=object_ids,
+            )
+
+    def test_stricter_default_rejects_two_keypoints_inside(self, simple_skeleton):
+        """Test the stricter default rejects a 2-keypoints-inside match.
+
+        The old >= 1 default predicate (``default_match_predicate``) would have
+        accepted this match; the new ``require_min_keypoints_inside(3)`` default
+        rejects it.
+        """
+        # Mask covering (5:95, 5:95).
+        mask = np.zeros((400, 400), dtype=bool)
+        mask[5:95, 5:95] = True
+        masks = np.stack([mask])
+
+        # Pose with only 2 keypoints inside the mask; tail is far outside.
+        coords = np.array([[10, 10], [50, 50], [300, 300]], dtype=np.float64)
+        pose = sio.Instance.from_numpy(coords, skeleton=simple_skeleton)
+
+        # Stricter default: 2 inside < 3 -> rejected.
+        strict = IDReconciler(skeleton=simple_skeleton)
+        assert (
+            strict.match_frame(
+                frame_idx=0,
+                poses=[pose],
+                masks=masks,
+                object_ids=np.array([0]),
+            )
+            == []
+        )
+
+        # Old behavior (explicit >= 1 predicate): 2 inside >= 1 -> accepted.
+        lenient = IDReconciler(
+            skeleton=simple_skeleton,
+            match_predicates=[default_match_predicate],
+        )
+        assignments = lenient.match_frame(
+            frame_idx=0,
+            poses=[pose],
+            masks=masks,
+            object_ids=np.array([0]),
+        )
+        assert len(assignments) == 1
+        assert assignments[0].sam3_obj_id == 0
+
 
 class TestMatchPredicates:
     """Tests for match predicate functions."""

--- a/tests/inference/sam/test_retrack.py
+++ b/tests/inference/sam/test_retrack.py
@@ -256,7 +256,8 @@ class TestRetrackBehavior:
         frames, masks, obj_ids, _ = _build_swap_clip(
             skeleton, n_frames=2, swap_window=(0, 0)
         )
-        # Excluding all nodes makes every match fail the >=1 predicate.
+        # Excluding all nodes makes every match fail the default predicate
+        # (0 keypoints inside < the default require_min_keypoints_inside(3)).
         result = retrack(
             frames,
             masks,

--- a/tests/inference/sam/test_run_sam_segmentation.py
+++ b/tests/inference/sam/test_run_sam_segmentation.py
@@ -152,6 +152,51 @@ def test_run_sam_segmentation_writes_output_slp(minimal_instance, tmp_path):
     assert all(isinstance(m, sio.PredictedSegmentationMask) for m in rmasks)
 
 
+def test_run_sam_segmentation_clean_empty_frames(minimal_instance):
+    """clean_empty_frames drops 0-instance frames but keeps posed (mask-bearing) ones."""
+    src = sio.load_slp(str(minimal_instance))
+    skel = src.skeletons[0]
+    gt = src.labeled_frames[0]
+    preds = [
+        sio.PredictedInstance.from_numpy(
+            points_data=i.numpy()[:, :2],
+            skeleton=skel,
+            point_scores=np.ones(i.numpy().shape[0]),
+            score=1.0,
+        )
+        for i in gt.instances
+    ]
+    posed = sio.LabeledFrame(video=gt.video, frame_idx=gt.frame_idx, instances=preds)
+    # A 0-instance frame (reuse the embedded frame_idx so lf.image still resolves).
+    empty = sio.LabeledFrame(video=gt.video, frame_idx=gt.frame_idx, instances=[])
+    labels = sio.Labels(
+        videos=list(src.videos), skeletons=[skel], labeled_frames=[posed, empty]
+    )
+
+    # Default keeps the empty frame (matches the regular path's default).
+    kept = run_sam_segmentation(
+        labels,
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        clean_empty_frames=False,
+    )
+    assert len(kept.labeled_frames) == 2
+
+    # clean_empty_frames=True drops only the 0-instance frame; the posed (and now
+    # mask-bearing) frame is kept.
+    cleaned = run_sam_segmentation(
+        labels,
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        clean_empty_frames=True,
+    )
+    assert len(cleaned.labeled_frames) == 1
+    assert cleaned.labeled_frames[0].instances
+    assert cleaned.labeled_frames[0].masks
+
+
 def test_run_sam_segmentation_writes_overlay_png(minimal_instance, tmp_path):
     """``overlay_path`` writes a review PNG to disk."""
     labels = _pose_labels(minimal_instance)

--- a/tests/inference/sam/test_run_sam_segmentation.py
+++ b/tests/inference/sam/test_run_sam_segmentation.py
@@ -282,21 +282,23 @@ def test_predict_sam_short_circuit_success(minimal_instance, tmp_path):
     assert any(lf.masks for lf in reloaded.labeled_frames)
 
 
-def test_predict_sam_slp_output_embeds_images(minimal_instance, tmp_path):
-    """§3.5a: the predict() SAM ``.slp`` output embeds images for review.
+def test_predict_sam_slp_output_not_embedded(minimal_instance, tmp_path):
+    """§3.5a: the predict() SAM ``.slp`` output NEVER re-embeds images.
 
-    A ``.pkg.slp`` source must round-trip with image data so a reviewer can open
-    the output without the original media. With ``output_format="slp"`` (default)
-    predict() routes ``output_path`` into ``run_sam_segmentation``, which saves
-    embedded (``labels.save(embed=True)``).
+    Mirroring the regular prediction path, the output backreferences the source
+    media via provenance instead of copying pixels (re-embedding is large and
+    wasteful, and a ``.pkg.slp`` input stays matchable to its source videos
+    regardless). The masks always serialize; only the image bytes are not
+    duplicated.
     """
-    out_path = tmp_path / "embedded.slp"
+    out_path = tmp_path / "out.slp"
+    src_pkg = Path(str(minimal_instance))
     fb = FakeBackend(_prompt_disk())
 
     orig = sam_pkg.get_mask_backend
     sam_pkg.get_mask_backend = lambda *a, **k: fb
     try:
-        # Pass the .pkg.slp path directly so the embed has real source frames.
+        # Pass the .pkg.slp path directly (the common SAM input: embedded frames).
         predict(
             str(minimal_instance),
             mask_backend="sam",
@@ -309,12 +311,14 @@ def test_predict_sam_slp_output_embeds_images(minimal_instance, tmp_path):
 
     assert out_path.exists()
     reloaded = sio.load_slp(out_path.as_posix())
-    # Embedded: the video now points at the output .slp itself (HDF5-embedded),
-    # not back at the original source media, and the pixels reload.
+    # Masks serialize into the .slp ...
+    assert any(lf.masks for lf in reloaded.labeled_frames)
+    # ... but images are NOT re-embedded: the video does not point at the output
+    # itself (no self-embed), and the output is smaller than the embedded input
+    # (no pixel duplication).
     rv = reloaded.videos[0]
-    assert Path(rv.filename).resolve() == out_path.resolve()
-    img = reloaded.labeled_frames[0].image
-    assert img is not None and img.size > 0
+    assert Path(rv.filename).resolve() != out_path.resolve()
+    assert out_path.stat().st_size < src_pkg.stat().st_size
 
 
 def test_predict_sam_forwards_sam3_model_id(minimal_instance, tmp_path):
@@ -352,15 +356,15 @@ def test_predict_sam_forwards_sam3_model_id(minimal_instance, tmp_path):
 
 
 @pytest.mark.parametrize("output_format", ["analysis_h5", "both"])
-def test_predict_sam_output_format_h5(minimal_instance, tmp_path, output_format):
-    """§3.5a: ``analysis_h5``/``both`` write the .h5 (+ embedded .slp for ``both``).
+def test_predict_sam_rejects_non_slp_output_format(
+    minimal_instance, tmp_path, output_format
+):
+    """The SAM path rejects output formats that cannot represent masks.
 
-    Guards the no-double-save + no-embed-regression invariants of the SAM
-    output-format branch (run.py): ``analysis_h5`` writes ONLY the analysis HDF5
-    (no .slp); ``both`` writes the analysis HDF5 *and* a single embedded .slp
-    (the SAM branch hands ``run_sam_segmentation`` the embed save and passes only
-    ``output_format="analysis_h5"`` to ``save_predictions``, so the .slp is never
-    written twice / non-embedded).
+    The SLEAP Analysis HDF5 format stores poses/tracks, not
+    ``PredictedSegmentationMask`` — requesting ``analysis_h5``/``both`` would
+    silently drop the masks (the actual output), so predict() raises instead of
+    writing a mask-less ``.h5``.
     """
     out_path = tmp_path / "p.slp"
     fb = FakeBackend(_prompt_disk())
@@ -368,30 +372,21 @@ def test_predict_sam_output_format_h5(minimal_instance, tmp_path, output_format)
     orig = sam_pkg.get_mask_backend
     sam_pkg.get_mask_backend = lambda *a, **k: fb
     try:
-        # Pass the .pkg.slp path directly so a "both" embed has real frames.
-        predict(
-            str(minimal_instance),
-            mask_backend="sam",
-            device="cpu",
-            sam_prompt_mode="pose",
-            output_path=out_path,
-            output_format=output_format,
-        )
+        with pytest.raises(ValueError, match="only supports output_format='slp'"):
+            predict(
+                str(minimal_instance),
+                mask_backend="sam",
+                device="cpu",
+                sam_prompt_mode="pose",
+                output_path=out_path,
+                output_format=output_format,
+            )
     finally:
         sam_pkg.get_mask_backend = orig
 
-    # The analysis HDF5 is written for both formats.
-    assert list(tmp_path.glob("*.analysis.h5")), "analysis HDF5 was not written"
-    if output_format == "both":
-        # "both" also writes an embedded .slp (video points at the output itself).
-        assert out_path.exists()
-        reloaded = sio.load_slp(out_path.as_posix())
-        assert Path(reloaded.videos[0].filename).resolve() == out_path.resolve()
-        img = reloaded.labeled_frames[0].image
-        assert img is not None and img.size > 0
-    else:
-        # "analysis_h5" writes ONLY the .h5 — no .slp (matches the legacy path).
-        assert not out_path.exists()
+    # Nothing was written (we rejected before producing any output).
+    assert not out_path.exists()
+    assert not list(tmp_path.glob("*.analysis.h5"))
 
 
 def test_predict_sam_forwards_kwargs(minimal_instance, tmp_path, monkeypatch):

--- a/tests/inference/sam/test_run_sam_segmentation.py
+++ b/tests/inference/sam/test_run_sam_segmentation.py
@@ -18,7 +18,10 @@ with its GT ``sio.Instance`` poses rebuilt as ``sio.PredictedInstance`` so the
 PLAN-L8 ``mask.instance`` pairing is exercised.
 """
 
+from pathlib import Path
+
 import numpy as np
+import pytest
 
 import sleap_io as sio
 
@@ -198,9 +201,14 @@ def test_run_sam_segmentation_frames_subset_nonexistent(minimal_instance):
     assert out.labeled_frames == []
 
 
-def test_run_sam_segmentation_skips_frames_without_prompt(minimal_instance):
-    """A frame whose instances yield no prompt (all-NaN kpts) is skipped."""
-    # A frame whose only instance has all-NaN keypoints yields no prompt -> skip.
+def test_run_sam_segmentation_emits_frame_without_prompt(minimal_instance):
+    """A frame whose instances yield no prompt (all-NaN kpts) is emitted, masks=[].
+
+    §3.5b: for review continuity the frame is retained (poses preserved) with an
+    empty ``masks=[]`` rather than dropped when SAM yields no mask.
+    """
+    # A frame whose only instance has all-NaN keypoints yields no prompt -> no
+    # mask, but the frame (and its pose) must survive.
     src = sio.load_slp(str(minimal_instance))
     skel = src.skeletons[0]
     gt_lf = src.labeled_frames[0]
@@ -219,7 +227,11 @@ def test_run_sam_segmentation_skips_frames_without_prompt(minimal_instance):
     out = run_sam_segmentation(
         labels, "sam", backend=FakeBackend(_prompt_disk()), prompt_mode="pose"
     )
-    assert out.labeled_frames == []
+    assert len(out.labeled_frames) == 1
+    out_lf = out.labeled_frames[0]
+    assert int(out_lf.frame_idx) == int(gt_lf.frame_idx)
+    assert list(out_lf.masks) == []  # no mask emitted...
+    assert len(out_lf.instances) == 1  # ...but the pose is retained
 
 
 def test_run_sam_segmentation_disjointify_multi_instance(minimal_instance):
@@ -268,6 +280,118 @@ def test_predict_sam_short_circuit_success(minimal_instance, tmp_path):
     assert out_path.exists()
     reloaded = sio.load_slp(out_path.as_posix())
     assert any(lf.masks for lf in reloaded.labeled_frames)
+
+
+def test_predict_sam_slp_output_embeds_images(minimal_instance, tmp_path):
+    """§3.5a: the predict() SAM ``.slp`` output embeds images for review.
+
+    A ``.pkg.slp`` source must round-trip with image data so a reviewer can open
+    the output without the original media. With ``output_format="slp"`` (default)
+    predict() routes ``output_path`` into ``run_sam_segmentation``, which saves
+    embedded (``labels.save(embed=True)``).
+    """
+    out_path = tmp_path / "embedded.slp"
+    fb = FakeBackend(_prompt_disk())
+
+    orig = sam_pkg.get_mask_backend
+    sam_pkg.get_mask_backend = lambda *a, **k: fb
+    try:
+        # Pass the .pkg.slp path directly so the embed has real source frames.
+        predict(
+            str(minimal_instance),
+            mask_backend="sam",
+            device="cpu",
+            sam_prompt_mode="pose",
+            output_path=out_path,
+        )
+    finally:
+        sam_pkg.get_mask_backend = orig
+
+    assert out_path.exists()
+    reloaded = sio.load_slp(out_path.as_posix())
+    # Embedded: the video now points at the output .slp itself (HDF5-embedded),
+    # not back at the original source media, and the pixels reload.
+    rv = reloaded.videos[0]
+    assert Path(rv.filename).resolve() == out_path.resolve()
+    img = reloaded.labeled_frames[0].image
+    assert img is not None and img.size > 0
+
+
+def test_predict_sam_forwards_sam3_model_id(minimal_instance, tmp_path):
+    """``sam3_model_id`` flows predict() -> run_sam_segmentation -> get_mask_backend.
+
+    §3.2: capture the ``sam3_model_id`` reaching ``get_mask_backend`` (the real
+    backend builder) to prove the value is threaded end-to-end. No real SAM3 is
+    loaded — ``get_mask_backend`` is monkeypatched to a fake.
+    """
+    labels = _pose_labels(minimal_instance)
+    captured = {}
+
+    orig = sam_pkg.get_mask_backend
+
+    def fake_get_mask_backend(mask_backend, **kwargs):
+        captured["mask_backend"] = mask_backend
+        captured["sam3_model_id"] = kwargs.get("sam3_model_id")
+        return FakeBackend(_prompt_disk())
+
+    sam_pkg.get_mask_backend = fake_get_mask_backend
+    try:
+        predict(
+            labels,
+            mask_backend="sam3",
+            device="cpu",
+            sam_prompt_mode="pose",
+            sam3_model_id="acme/custom-sam3",
+            output_path=tmp_path / "s3.slp",
+        )
+    finally:
+        sam_pkg.get_mask_backend = orig
+
+    assert captured["mask_backend"] == "sam3"
+    assert captured["sam3_model_id"] == "acme/custom-sam3"
+
+
+@pytest.mark.parametrize("output_format", ["analysis_h5", "both"])
+def test_predict_sam_output_format_h5(minimal_instance, tmp_path, output_format):
+    """§3.5a: ``analysis_h5``/``both`` write the .h5 (+ embedded .slp for ``both``).
+
+    Guards the no-double-save + no-embed-regression invariants of the SAM
+    output-format branch (run.py): ``analysis_h5`` writes ONLY the analysis HDF5
+    (no .slp); ``both`` writes the analysis HDF5 *and* a single embedded .slp
+    (the SAM branch hands ``run_sam_segmentation`` the embed save and passes only
+    ``output_format="analysis_h5"`` to ``save_predictions``, so the .slp is never
+    written twice / non-embedded).
+    """
+    out_path = tmp_path / "p.slp"
+    fb = FakeBackend(_prompt_disk())
+
+    orig = sam_pkg.get_mask_backend
+    sam_pkg.get_mask_backend = lambda *a, **k: fb
+    try:
+        # Pass the .pkg.slp path directly so a "both" embed has real frames.
+        predict(
+            str(minimal_instance),
+            mask_backend="sam",
+            device="cpu",
+            sam_prompt_mode="pose",
+            output_path=out_path,
+            output_format=output_format,
+        )
+    finally:
+        sam_pkg.get_mask_backend = orig
+
+    # The analysis HDF5 is written for both formats.
+    assert list(tmp_path.glob("*.analysis.h5")), "analysis HDF5 was not written"
+    if output_format == "both":
+        # "both" also writes an embedded .slp (video points at the output itself).
+        assert out_path.exists()
+        reloaded = sio.load_slp(out_path.as_posix())
+        assert Path(reloaded.videos[0].filename).resolve() == out_path.resolve()
+        img = reloaded.labeled_frames[0].image
+        assert img is not None and img.size > 0
+    else:
+        # "analysis_h5" writes ONLY the .h5 — no .slp (matches the legacy path).
+        assert not out_path.exists()
 
 
 def test_predict_sam_forwards_kwargs(minimal_instance, tmp_path, monkeypatch):

--- a/tests/inference/sam/test_sam3_backend.py
+++ b/tests/inference/sam/test_sam3_backend.py
@@ -7,15 +7,14 @@ pair. They lock the SAM3-specific recipe (recalibrated 0.5 floor — NEVER SAM1'
 the clean, actionable error raised when `transformers`/SAM3 is unavailable.
 """
 
+import inspect
+
 import numpy as np
 import pytest
 
 from sleap_nn.inference.sam import MASK_BACKENDS, get_mask_backend
 from sleap_nn.inference.sam.backends import (
-    SAM3_CLEANUP_RADIUS,
-    SAM3_MODEL_ID,
-    SAM3_PRED_IOU_MIN,
-    SAM_PRED_IOU_MIN,
+    SamBackend,
     Sam3Backend,
     _cleanup_speckle,
     _cleanup_seed,
@@ -142,19 +141,25 @@ def test_get_mask_backend_none_raises():
 # Recipe constants — the SAM3 floor must NOT be SAM1's (regression guard).
 # ---------------------------------------------------------------------------
 def test_sam3_floor_is_recalibrated_not_sam1():
-    assert SAM3_PRED_IOU_MIN == 0.5
-    assert SAM3_PRED_IOU_MIN != SAM_PRED_IOU_MIN  # never share SAM1's 0.88
-    assert SAM3_MODEL_ID == "facebook/sam3"
-    assert SAM3_CLEANUP_RADIUS == 3
+    assert Sam3Backend.pred_iou_min == 0.5
+    # Never share SAM1's 0.88.
+    assert Sam3Backend.pred_iou_min != SamBackend.pred_iou_min
+    assert SamBackend.pred_iou_min == 0.88
+    # Look defaults up by name (robust to future parameter reordering).
+    assert (
+        inspect.signature(Sam3Backend.from_pretrained).parameters["model_id"].default
+        == "facebook/sam3"
+    )
+    assert inspect.signature(_cleanup_speckle).parameters["radius"].default == 3
 
 
 def test_sam3_backend_pred_iou_min_attribute():
     backend, _, _ = _backend(
         np.zeros((1, 1, 8, 8), bool), np.zeros((1, 1), np.float32), (8, 8)
     )
-    assert backend.pred_iou_min == SAM3_PRED_IOU_MIN
+    assert backend.pred_iou_min == 0.5
     # Class-level default, too (so a future caller reading the type sees 0.5).
-    assert Sam3Backend.pred_iou_min == SAM3_PRED_IOU_MIN
+    assert Sam3Backend.pred_iou_min == 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +172,7 @@ def test_cleanup_speckle_keeps_keypoint_blob_drops_speckle():
     speck = _disk(h, w, 5, 5, 1)
     mask = blob | speck
     kpts = np.array([[30.0, 30.0]])
-    cleaned = _cleanup_speckle(mask, kpts, radius=SAM3_CLEANUP_RADIUS)
+    cleaned = _cleanup_speckle(mask, kpts, radius=3)
     # The keypoint blob survives; the isolated speck is gone.
     assert cleaned[30, 30]
     assert not cleaned[5, 5]
@@ -190,7 +195,7 @@ def test_cleanup_speckle_falls_back_to_largest_when_no_keypoint_inside():
     small = _disk(h, w, 50, 50, 4)
     mask = big | small
     # Keypoint lands in neither component (all-background) -> largest is kept.
-    out = _cleanup_speckle(mask, np.array([[0.0, 0.0]]), radius=SAM3_CLEANUP_RADIUS)
+    out = _cleanup_speckle(mask, np.array([[0.0, 0.0]]), radius=3)
     assert out[30, 30]
     assert not out[50, 50]
 

--- a/tests/inference/sam/test_sam3_e2e_gpu.py
+++ b/tests/inference/sam/test_sam3_e2e_gpu.py
@@ -1,0 +1,249 @@
+"""GPU + real-transformers end-to-end smoke for the SAM3 mask backend.
+
+Every other SAM3 test (``test_sam3_backend.py``) mocks the transformers
+``Sam3TrackerModel`` / ``Sam3TrackerProcessor`` pair with ``FakeSam3Model`` /
+``FakeSam3Processor``. Those fakes assert the assumed transformers SAM3 contract
+*tautologically* — they hand back exactly the shapes the backend reads, so a
+real drift in the transformers API would never trip them. This test is the
+single place the *real* SAM3 image visual-prompt path is exercised end to end
+(load gated ``facebook/sam3`` -> processor -> ``Sam3TrackerModel`` forward ->
+``post_process_masks`` -> ``_pick`` -> ``_cleanup_speckle`` -> bool masks), and
+where the literal class names ``Sam3TrackerModel`` / ``Sam3TrackerProcessor``
+are confirmed to resolve (they are imported transitively by
+``Sam3Backend.from_pretrained`` -> ``_load_sam3``).
+
+Gating (mirrors ``test_e2e_gpu.py``) — it SKIPS CLEANLY in CI, which has none of:
+  * ``torch.cuda.is_available()`` (SAM3 is GPU-only end to end);
+  * ``transformers`` importable (the ``sleap_nn[sam3]`` extra; SAM3 needs
+    ``transformers>=5``);
+  * a resolvable gated-weights signal — ``HF_TOKEN`` in the env, OR a cached
+    ``~/.cache/huggingface/token`` (from ``huggingface-cli login``), OR
+    ``SLEAP_NN_SAM3_MODEL`` pointing at local/override weights (which also
+    overrides the model id passed to ``from_pretrained``); and
+  * the prototype val ``.slp`` present (reuses ``SLEAP_NN_SAM_VAL`` like
+    ``test_e2e_gpu.py``).
+
+CROSS-CHECK of the assumed transformers SAM3 contract
+-----------------------------------------------------
+The fakes encode a contract the backend (``Sam3Backend.masks``) depends on but
+never verifies against the real library. When this test runs against real SAM3
+it must FAIL LOUDLY if any of these break:
+
+  * The processor output is a mapping carrying ``original_sizes`` — the backend
+    passes ``inputs["original_sizes"]`` straight into ``post_process_masks``
+    (``FakeSam3Processor.__call__`` returns ``original_sizes=[hw]``).
+  * The model output carries ``pred_masks`` AND ``iou_scores`` (consumed as
+    ``out.pred_masks`` / ``out.iou_scores``; ``FakeSam3Model.__call__`` returns
+    a ``_FakeOut`` with exactly those two attributes).
+  * ``processor.post_process_masks(..., binarize=True)`` returns a PER-IMAGE
+    list whose first element is a ``(n_obj, n_cand, H, W)`` tensor
+    (``FakeSam3Processor.post_process_masks`` returns ``[(n_obj, n_cand, H, W)]``;
+    the backend takes ``[0]``).
+  * ``iou_scores`` has shape ``(1, n_obj, n_cand)`` — the backend reads
+    ``out.iou_scores.float().cpu().numpy()[0]`` to get ``(n_obj, n_cand)``
+    (``FakeSam3Model`` emits ``self._scores[None, ...]``).
+
+Each assertion below ties back to one of those contract points so a real-library
+drift is caught here rather than silently passing the fakes.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+import sleap_io as sio
+
+# Reuse the same val asset env var/default as ``test_e2e_gpu.py`` so any GPU box
+# can point both smokes at the same prototype data.
+_VAL = os.environ.get(
+    "SLEAP_NN_SAM_VAL",
+    "/home/talmo/code/sleap-nn/scratch/2026-06-03-segmentation-methods/data/"
+    "mice_of_seg_val.pkg.slp",
+)
+
+# ``facebook/sam3`` is GATED. Authentication is resolvable from any of:
+#   * the ``HF_TOKEN`` env var,
+#   * a cached token from ``huggingface-cli login``
+#     (``~/.cache/huggingface/token``), or
+#   * ``SLEAP_NN_SAM3_MODEL`` pointing at local/override weights (no auth needed),
+# which ALSO overrides the model id handed to ``from_pretrained`` (so a box with
+# local weights need not touch the gated hub at all). Do NOT import a module
+# global for the model id (it was removed in the globals refactor); use
+# ``Sam3Backend.from_pretrained``'s default ("facebook/sam3") unless overridden.
+_SAM3_MODEL_OVERRIDE = os.environ.get("SLEAP_NN_SAM3_MODEL")
+_HF_TOKEN = os.environ.get("HF_TOKEN")
+_HF_CACHED_TOKEN = (Path("~/.cache/huggingface/token").expanduser()).is_file()
+_HAS_GATED_WEIGHTS = bool(_SAM3_MODEL_OVERRIDE) or bool(_HF_TOKEN) or _HF_CACHED_TOKEN
+
+pytestmark = pytest.mark.skipif(
+    not (
+        torch.cuda.is_available()
+        and importlib.util.find_spec("transformers") is not None
+        and _HAS_GATED_WEIGHTS
+        and os.path.exists(_VAL)
+    ),
+    reason=(
+        "needs CUDA + transformers + a gated-weights signal "
+        "(HF_TOKEN / cached HF token / SLEAP_NN_SAM3_MODEL) + val .slp"
+    ),
+)
+
+
+def _pred_labels_two_frames():
+    """Two-frame ``sio.Labels`` of PredictedInstance poses from the val .slp.
+
+    Mirrors ``test_e2e_gpu.py``: the val file carries GT ``sio.Instance`` poses;
+    convert them to ``PredictedInstance`` so the predicted-mask -> instance
+    pairing is genuinely exercised. Two frames is plenty (the SAM3 forward is the
+    slow part).
+    """
+    labels = sio.load_slp(_VAL)
+    skel = labels.skeletons[0]
+    pred_lfs = []
+    for lf in labels.labeled_frames[:2]:
+        pred_insts = []
+        for inst in lf.instances:
+            pts = inst.numpy()[:, :2]
+            n = pts.shape[0]
+            pred_insts.append(
+                sio.PredictedInstance.from_numpy(
+                    points_data=pts,
+                    skeleton=skel,
+                    point_scores=np.ones(n, np.float32),
+                    score=1.0,
+                )
+            )
+        pred_lfs.append(
+            sio.LabeledFrame(
+                video=lf.video, frame_idx=lf.frame_idx, instances=pred_insts
+            )
+        )
+    return sio.Labels(
+        videos=list(labels.videos), skeletons=[skel], labeled_frames=pred_lfs
+    )
+
+
+def _n_components(mask):
+    """Number of connected components in a boolean mask (8-connectivity)."""
+    from scipy import ndimage
+
+    _, n = ndimage.label(np.asarray(mask, dtype=bool))
+    return n
+
+
+def test_sam3_backend_masks_real_contract():
+    """Real SAM3 ``backend.masks`` honors the shape/cleanup contract the fakes assert.
+
+    Builds pose prompts for one frame and drives ``Sam3Backend.masks`` directly so
+    the cross-check (above) fails loudly if the transformers SAM3 surface drifts:
+    the processor must expose ``original_sizes``, the model output must carry
+    ``pred_masks`` + ``iou_scores``, ``post_process_masks(binarize=True)`` must be
+    a per-image list of ``(n_obj, n_cand, H, W)``, and ``iou_scores`` must be
+    ``(1, n_obj, n_cand)``. Any of those breaking raises inside ``backend.masks``
+    rather than silently passing the tautological fakes.
+    """
+    from sleap_nn.inference.sam.backends import Sam3Backend
+    from sleap_nn.inference.sam.prompts import pose_prompt
+
+    small = _pred_labels_two_frames()
+
+    # Construct the REAL backend. ``from_pretrained`` imports
+    # ``Sam3TrackerModel`` / ``Sam3TrackerProcessor`` (the literal class names the
+    # fakes stand in for); a NameError/ImportError here means those names no
+    # longer resolve in the installed transformers. Use the default model id
+    # ("facebook/sam3") unless an explicit local/override is supplied.
+    model_id = _SAM3_MODEL_OVERRIDE or "facebook/sam3"
+    backend = Sam3Backend.from_pretrained(model_id=model_id, device="cuda")
+
+    # One frame's worth of pose prompts in full-frame pixel space.
+    lf = small.labeled_frames[0]
+    image = lf.image
+    img = np.asarray(image)
+    if img.ndim == 3:
+        img = img[..., 0]
+    h, w = img.shape[:2]
+
+    prompts = []
+    for inst in lf.instances:
+        pts = inst.numpy()[:, :2]
+        # Skip an all-NaN instance (pose_prompt needs >=1 visible keypoint).
+        if np.isfinite(pts).all(axis=1).any():
+            prompts.append(pose_prompt(pts, (h, w)))
+    assert prompts, "val frame must yield at least one pose prompt"
+
+    masks, scores = backend.masks(image, prompts)
+
+    # Contract: one mask + one score per prompt (the batched single-call path
+    # returns ``len(prompts)`` of each).
+    assert len(masks) == len(prompts) == len(scores)
+
+    any_area = False
+    for m, s in zip(masks, scores):
+        m = np.asarray(m)
+        # Each mask is a boolean (H, W) array matching the image HxW. This pins
+        # the ``post_process_masks -> [0] -> (n_obj, n_cand, H, W)`` reshape: a
+        # drift to per-object lists or transposed (H, W) would trip the shape
+        # check (the backend itself also guards this and would raise).
+        assert m.dtype == bool
+        assert m.shape == (h, w)
+        # The raw chosen-candidate iou score is finite (read from the
+        # ``(1, n_obj, n_cand)`` ``iou_scores`` -> ``[0]`` -> per-object row).
+        assert np.isfinite(s)
+        if m.any():
+            any_area = True
+            # Mandatory SAM3 speckle cleanup ran: every non-empty returned mask
+            # is a SINGLE connected component (raw SAM3 masks are ~14 components;
+            # ``_cleanup_speckle`` collapses them to ~1). If cleanup were skipped
+            # this would be >1 for the speckly real masks.
+            assert _n_components(m) == 1
+    # At least one mask has area (SAM3 found a real silhouette on a GT pose).
+    assert any_area
+
+
+def test_sam3_pose_masks_end_to_end(tmp_path):
+    """Full ``run_sam_segmentation(mask_backend="sam3", ...)`` smoke (mirrors SAM1).
+
+    Drives the SAM3 path through the same orchestration the SAM1 e2e test uses,
+    asserting the emitted ``PredictedSegmentationMask`` objects carry finite
+    scores, real area, are paired to their source predicted instance, and reload
+    from the embedded ``.slp``.
+    """
+    from sleap_nn.inference.sam import run_sam_segmentation
+
+    small = _pred_labels_two_frames()
+
+    out_path = tmp_path / "sam3_pose_e2e.pkg.slp"
+    overlay_path = tmp_path / "sam3_pose_e2e_overlay.png"
+    model_id = _SAM3_MODEL_OVERRIDE or "facebook/sam3"
+    out = run_sam_segmentation(
+        small,
+        mask_backend="sam3",
+        prompt_mode="pose",
+        sam3_model_id=model_id,
+        device="cuda",
+        output_path=out_path.as_posix(),
+        overlay_path=overlay_path.as_posix(),
+    )
+
+    # Produced masks on at least one frame.
+    assert any(len(lf.masks) > 0 for lf in out.labeled_frames)
+    for lf in out.labeled_frames:
+        for m in lf.masks:
+            assert isinstance(m, sio.PredictedSegmentationMask)
+            assert np.isfinite(m.score)
+            # The mask is paired to its source predicted instance (PLAN L8).
+            assert m.instance is not None
+            data = np.asarray(m.data, dtype=bool)
+            # A real mask has area...
+            assert data.any()
+            # ...and the SAM3 speckle cleanup left a single connected component.
+            assert _n_components(data) == 1
+
+    # The embedded SLP + overlay PNG are written and reload.
+    assert out_path.exists()
+    assert overlay_path.exists()
+    sio.load_slp(out_path.as_posix())

--- a/tests/inference/sam/test_sam3_e2e_gpu.py
+++ b/tests/inference/sam/test_sam3_e2e_gpu.py
@@ -127,12 +127,24 @@ def _pred_labels_two_frames():
     )
 
 
-def _n_components(mask):
-    """Number of connected components in a boolean mask (8-connectivity)."""
+def _dominant_component_fraction(mask):
+    """Fraction of mask pixels held by its largest connected component.
+
+    ``_cleanup_speckle`` keeps the *set* of components containing a visible
+    keypoint, so an articulated pose can rarely leave >1 blob; the documented
+    contract is "~97% of the area in one component", not a hard single count.
+    """
     from scipy import ndimage
 
-    _, n = ndimage.label(np.asarray(mask, dtype=bool))
-    return n
+    m = np.asarray(mask, dtype=bool)
+    total = int(m.sum())
+    if total == 0:
+        return 0.0
+    labels_arr, n = ndimage.label(m)
+    if n == 0:
+        return 0.0
+    sizes = ndimage.sum(np.ones_like(labels_arr), labels_arr, range(1, n + 1))
+    return float(np.max(sizes)) / total
 
 
 def test_sam3_backend_masks_real_contract():
@@ -195,11 +207,14 @@ def test_sam3_backend_masks_real_contract():
         assert np.isfinite(s)
         if m.any():
             any_area = True
-            # Mandatory SAM3 speckle cleanup ran: every non-empty returned mask
-            # is a SINGLE connected component (raw SAM3 masks are ~14 components;
-            # ``_cleanup_speckle`` collapses them to ~1). If cleanup were skipped
-            # this would be >1 for the speckly real masks.
-            assert _n_components(m) == 1
+            # Mandatory SAM3 speckle cleanup ran: each non-empty mask is
+            # dominated by a single connected component (raw SAM3 masks are ~14
+            # components; ``_cleanup_speckle`` collapses to ~1 with ~97% of the
+            # area in one blob). Assert the documented dominant-component contract
+            # (>=90% area in the largest component) rather than an exact count of
+            # 1 — cleanup keeps the SET of keypoint-containing components, so an
+            # articulated pose can legitimately leave a small second blob.
+            assert _dominant_component_fraction(m) >= 0.9
     # At least one mask has area (SAM3 found a real silhouette on a GT pose).
     assert any_area
 
@@ -210,13 +225,13 @@ def test_sam3_pose_masks_end_to_end(tmp_path):
     Drives the SAM3 path through the same orchestration the SAM1 e2e test uses,
     asserting the emitted ``PredictedSegmentationMask`` objects carry finite
     scores, real area, are paired to their source predicted instance, and reload
-    from the embedded ``.slp``.
+    from the saved ``.slp`` (saved like the regular path — not re-embedded).
     """
     from sleap_nn.inference.sam import run_sam_segmentation
 
     small = _pred_labels_two_frames()
 
-    out_path = tmp_path / "sam3_pose_e2e.pkg.slp"
+    out_path = tmp_path / "sam3_pose_e2e.slp"
     overlay_path = tmp_path / "sam3_pose_e2e_overlay.png"
     model_id = _SAM3_MODEL_OVERRIDE or "facebook/sam3"
     out = run_sam_segmentation(
@@ -240,10 +255,10 @@ def test_sam3_pose_masks_end_to_end(tmp_path):
             data = np.asarray(m.data, dtype=bool)
             # A real mask has area...
             assert data.any()
-            # ...and the SAM3 speckle cleanup left a single connected component.
-            assert _n_components(data) == 1
+            # ...and the SAM3 speckle cleanup left a dominant single component.
+            assert _dominant_component_fraction(data) >= 0.9
 
-    # The embedded SLP + overlay PNG are written and reload.
+    # The saved .slp + overlay PNG are written and reload.
     assert out_path.exists()
     assert overlay_path.exists()
     sio.load_slp(out_path.as_posix())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,6 +236,144 @@ class TestTrackCommand:
             assert "--kf_node_indices" in result.output
 
 
+class TestPredictSamBackend:
+    """`predict --mask_backend` forwards SAM args to run.predict (§1.4).
+
+    The SAM path is offline here: ``sleap_nn.inference.run.predict`` is patched
+    to a capturing stub, so no SAM/torch weights are loaded.
+    """
+
+    def test_mask_backend_sam_forwards_args(self):
+        """`--mask_backend sam` forwards mask_backend/sam_checkpoint/overlay_path."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    "x.slp",
+                    "--mask_backend",
+                    "sam",
+                    "--sam_checkpoint",
+                    "c.pth",
+                    "--overlay_path",
+                    "o.png",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_predict.called
+            call_kwargs = mock_predict.call_args[1]
+            assert call_kwargs["mask_backend"] == "sam"
+            assert call_kwargs["sam_checkpoint"] == "c.pth"
+            assert call_kwargs["overlay_path"] == "o.png"
+            # The SAM path uses no trained seg model.
+            assert call_kwargs["model_paths"] is None
+
+    def test_mask_backend_with_tracking_errors(self):
+        """`--mask_backend ... --tracking` fails loudly (not a silent no-op)."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                ["predict", "-i", "x.slp", "--mask_backend", "sam", "--tracking"],
+            )
+        # UsageError -> non-zero exit, a clear message, and predict never runs
+        # (otherwise this would silently route into retrack and produce no masks).
+        assert result.exit_code != 0
+        assert "not supported with --mask_backend" in result.output
+        assert not mock_predict.called
+
+    def test_mask_backend_sam3_forwards_model_id(self):
+        """`--mask_backend sam3 --sam3_model_id foo/bar` forwards sam3_model_id."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    "x.slp",
+                    "--mask_backend",
+                    "sam3",
+                    "--sam3_model_id",
+                    "foo/bar",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_predict.called
+            call_kwargs = mock_predict.call_args[1]
+            assert call_kwargs["mask_backend"] == "sam3"
+            assert call_kwargs["sam3_model_id"] == "foo/bar"
+
+    def test_mask_backend_dash_aliases_parse(self):
+        """Dash-spelled SAM aliases parse and forward to run.predict."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    "x.slp",
+                    "--mask-backend",
+                    "sam",
+                    "--sam-checkpoint",
+                    "c.pth",
+                    "--sam-prompt-mode",
+                    "centroid",
+                    "--sam-anchor-ind",
+                    "2",
+                    "--sam-disjointify-masks",
+                    "--overlay-path",
+                    "o.png",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_predict.called
+            call_kwargs = mock_predict.call_args[1]
+            assert call_kwargs["mask_backend"] == "sam"
+            assert call_kwargs["sam_checkpoint"] == "c.pth"
+            assert call_kwargs["sam_prompt_mode"] == "centroid"
+            assert call_kwargs["sam_anchor_ind"] == 2
+            assert call_kwargs["sam_disjointify_masks"] is True
+            assert call_kwargs["overlay_path"] == "o.png"
+
+    def test_no_mask_backend_omits_sam_args(self):
+        """Without --mask_backend, no SAM args are forwarded (existing path)."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    "x.slp",
+                    "--model_paths",
+                    "/fake/model",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_predict.called
+            call_kwargs = mock_predict.call_args[1]
+            assert "mask_backend" not in call_kwargs
+
+    def test_predict_help_lists_sam_flags(self):
+        """`predict --help` documents the SAM flags (§1.4)."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["predict", "--help"])
+        assert result.exit_code == 0
+        assert "--mask_backend" in result.output
+        assert "--sam_checkpoint" in result.output
+        assert "--sam3_model_id" in result.output
+        assert "--overlay_path" in result.output
+
+
 class TestEvalCommand:
     """Tests for eval command using CliRunner."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -286,6 +286,78 @@ class TestPredictSamBackend:
         assert "not supported with --mask_backend" in result.output
         assert not mock_predict.called
 
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--only_labeled_frames",
+            "--only_suggested_frames",
+            "--exclude_user_labeled",
+            "--only_predicted_frames",
+        ],
+    )
+    def test_mask_backend_filter_flags_rejected(self, flag):
+        """Label-status frame filters are rejected (not crashed) with --mask_backend."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli, ["predict", "-i", "x.slp", "--mask_backend", "sam", flag]
+            )
+        # Clear UsageError before any file load — not a TypeError deep in the SAM path.
+        assert result.exit_code != 0
+        assert "not supported with --mask_backend" in result.output
+        assert not mock_predict.called
+
+    def test_mask_backend_stream_to_file_rejected(self, tmp_path):
+        """--mask_backend + --stream-to-file fails with a SAM-aware message."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    "x.slp",
+                    "--mask_backend",
+                    "sam",
+                    "--stream-to-file",
+                    str(tmp_path / "out.slp"),
+                ],
+            )
+        assert result.exit_code != 0
+        assert "not supported with --stream-to-file" in result.output
+        assert not mock_predict.called
+
+    def test_mask_backend_video_index_passes_labels(self, minimal_instance):
+        """--mask_backend + --video_index passes a scoped sio.Labels (no crash).
+
+        Regression for the LabelsProvider-as-source TypeError: the SAM path takes a
+        sio.Labels directly, so --video_index must hand it the scoped Labels rather
+        than a LabelsProvider.
+        """
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    str(minimal_instance),
+                    "--mask_backend",
+                    "sam",
+                    "--sam_checkpoint",
+                    "c.pth",
+                    "--video_index",
+                    "0",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_predict.called
+        source = mock_predict.call_args[0][0]
+        assert isinstance(source, sio.Labels)
+
     def test_mask_backend_sam3_forwards_model_id(self):
         """`--mask_backend sam3 --sam3_model_id foo/bar` forwards sam3_model_id."""
         runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,21 @@ from sleap_nn.cli import cli, print_version, parse_path_map, show_training_help
 from sleap_nn import __version__
 import sleap_io as sio
 import torch
+import re
+
+
+def _norm_cli_output(s: str) -> str:
+    """Normalize rich-click output for substring checks.
+
+    rich-click renders error messages inside a word-wrapped, bordered panel, so a
+    multi-word phrase gets split across lines (with box-drawing chars + padding)
+    at narrow terminal widths (e.g. CI's 80 cols). Strip ANSI + box-drawing
+    characters and collapse whitespace so a phrase match is wrap-width-independent.
+    """
+    s = re.sub(r"\x1b\[[0-9;]*m", "", s)  # ANSI color codes
+    s = re.sub(r"[│┃▏▕─━┌┐└┘╭╮╰╯┄┅|]", " ", s)  # panel box-drawing chars
+    return re.sub(r"\s+", " ", s)
+
 
 # =============================================================================
 # CliRunner-based tests (in-process, tracked by coverage)
@@ -283,7 +298,7 @@ class TestPredictSamBackend:
         # UsageError -> non-zero exit, a clear message, and predict never runs
         # (otherwise this would silently route into retrack and produce no masks).
         assert result.exit_code != 0
-        assert "not supported with --mask_backend" in result.output
+        assert "not supported with --mask_backend" in _norm_cli_output(result.output)
         assert not mock_predict.called
 
     @pytest.mark.parametrize(
@@ -305,7 +320,7 @@ class TestPredictSamBackend:
             )
         # Clear UsageError before any file load — not a TypeError deep in the SAM path.
         assert result.exit_code != 0
-        assert "not supported with --mask_backend" in result.output
+        assert "not supported with --mask_backend" in _norm_cli_output(result.output)
         assert not mock_predict.called
 
     def test_mask_backend_stream_to_file_rejected(self, tmp_path):
@@ -326,7 +341,7 @@ class TestPredictSamBackend:
                 ],
             )
         assert result.exit_code != 0
-        assert "not supported with --stream-to-file" in result.output
+        assert "not supported with --stream-to-file" in _norm_cli_output(result.output)
         assert not mock_predict.called
 
     def test_mask_backend_video_index_passes_labels(self, minimal_instance):


### PR DESCRIPTION
## Summary

Follow-up to the merged SAM-inference MVP stack (#647 / #648 / #646). This PR clears the deferred **§3 tech-debt** for the SAM prompted-mask inference path (tracked in `scratch/.../DEFERRED.md`), promotes the backend recipe constants from **module globals to class args** (maintainer request), and adds the missing **`sleap-nn predict` SAM CLI surface** (§1.4) so the SAM path is reachable from the command line for the first time.

It also includes a self-correction and a skeptical self-audit (see **Review history** below): an initial "embed" fix was wrong and was reverted to mirror the regular prediction path, and a follow-up audit of the whole PR caught and fixed a crash plus several smaller divergences.

No issue is *closed* by this PR; it spawned the follow-up enhancement **#652** (configurable image-embedding controls).

---

## Backend module globals → class args

Scope (confirmed with maintainer): **backend recipe knobs only.** The 7 module-level recipe globals in `sleap_nn/inference/sam/backends.py` are removed and inlined as class attributes / constructor defaults, with the recipe rationale relocated into the class docstrings:

`SAM_MAX_BOX_AREA_FACTOR`, `CLAHE_CLIP_LIMIT`, `CLAHE_TILE_GRID`, `SAM_PRED_IOU_MIN`, `SAM3_PRED_IOU_MIN`, `SAM3_CLEANUP_RADIUS`, `SAM3_MODEL_ID`.

- **No numeric value or behavior changed** (verified by the audit: every inlined default equals its old global). `SamBackend.pred_iou_min == 0.88`, `Sam3Backend.pred_iou_min == 0.5`, etc. are now class attrs/defaults.
- Validation registries (`PROMPT_MODES`, `MASK_BACKENDS`) and cosmetic `_COLORS` are intentionally **left as-is**.
- ⚠️ These names are no longer importable from `backends`; the only in-tree importers were the two SAM test modules, updated accordingly.

---

## §3 tech-debt

| Item | Change |
|---|---|
| **§3.1** | New gated real-library SAM3 smoke test (`test_sam3_e2e_gpu.py`): skipif on CUDA + `transformers` + gated weights + val asset; **skips cleanly in CI**. Cross-checks the faked `transformers` contract + the literal `Sam3TrackerModel`/`Sam3TrackerProcessor` names. |
| **§3.2** | Thread `sam3_model_id` through `run.predict()` (+ CLI), symmetric with SAM1's checkpoint args. |
| **§3.3** | Consume the previously-unused per-model `pred_iou_min` as a **review signal** — low-score masks flagged in the overlay (warning color + `!score` label). |
| **§3.4** | **Harden `reconciliation.py`** (overrides the L6 "verbatim" lock — attribution header now enumerates the local edits): vectorize `IDReconciler.compute_cost_matrix` (numerically identical — audit-verified on randomized inputs), both-axes NaN visibility, stricter default predicate `require_min_keypoints_inside(3)`, per-frame length validation raising a frame-named `ValueError`. |
| **§3.5** | **Save behavior now mirrors the regular prediction path** — see below. And **stop dropping frames** with no mask (emit with `masks=[]`, poses retained), which converges to sleap-io's `Labels.clean()` convention (the old `continue` was the divergence). |

### §3.5 save behavior (the corrected design)

The SAM `.slp` output **never re-embeds images**. It saves exactly like the regular path (`labels.save(path)`, sleap-io default `embed=False`): the output backreferences the source media via provenance — small output, and a `.pkg.slp` input (typically aggregated training data) stays matchable to its source videos even if those videos are off-disk. The masks always serialize into the `.slp` regardless. `output_format` `analysis_h5`/`both` is **rejected** for `mask_backend` (the SLEAP Analysis HDF5 format stores poses/tracks, not `PredictedSegmentationMask`, so it would silently drop the masks).

> The first commit mistakenly forced `embed=True` ("for review"); empirical round-trips showed that was ~2.7× bloat and diverged from every other prediction. Reverted to the regular-path behavior. Configurable embedding is tracked in **#652**.

---

## §1.4 — CLI surface (new)

8 flags added to `sleap-nn predict` (and the hidden `infer` alias), underscore + dash spellings, forwarded through `_run_in_memory_new_flow`:

`--mask_backend`, `--sam_checkpoint`, `--sam_model_type`, `--sam_prompt_mode`, `--sam_anchor_ind`, `--sam_disjointify_masks`, `--sam3_model_id`, `--overlay_path`.

**Guards (fail loudly, never silently mis-handle):**
- `--mask_backend ... --tracking` → `UsageError` (SAM masks existing poses; it doesn't track).
- `--mask_backend ... --stream-to-file` → `UsageError` (SAM is in-memory only).
- `--mask_backend` + label-status filters (`--only_labeled_frames`/`--only_suggested_frames`/`--exclude_user_labeled`/`--only_predicted_frames`) → `UsageError` (don't map onto masking existing poses).
- `--video_index` **is** supported (passes the scoped `sio.Labels`); `--frames` and `--no_empty_frames` are honored.

### Example usage

```bash
# SAM1 (ViT-H): mask the poses in an existing .pkg.slp, write a review overlay
sleap-nn predict -i poses.pkg.slp \
  --mask_backend sam --sam_checkpoint sam_vit_h_4b8939.pth \
  --sam_prompt_mode pose --overlay_path review.png \
  -o poses.masked.slp

# SAM3 (gated facebook/sam3): same path via the transformers backend
sleap-nn predict -i poses.pkg.slp \
  --mask_backend sam3 --sam3_model_id facebook/sam3 \
  -o poses.masked.slp
```

`--mask_backend` is mutually exclusive with `--model_paths`; the `.slp` output backreferences the input's media (not re-embedded).

---

## API changes

- `run.predict(...)` — new param `sam3_model_id: str = "facebook/sam3"`. The SAM branch saves via `run_sam_segmentation` (mirrors the regular path), threads `clean_empty_frames`, and rejects non-`slp` `output_format`.
- `run_sam_segmentation(...)` — new `clean_empty_frames: bool = False`; `output_path` now saves like the regular path (never re-embeds).
- `overlay.save_mask_overlay(...)` — new optional `low_score_threshold: Optional[float] = None` (default `None` ⇒ unchanged render).
- `backends` — the 7 recipe constants are no longer module attributes (now class attrs/defaults).
- `IDReconciler` default `match_predicate` changed from `default_match_predicate` (≥1) to `require_min_keypoints_inside(3)`.

### Behavior changes to note for reviewers

1. **`IDReconciler` default predicate is stricter** (≥3 vs ≥1). Low risk: no in-tree producer yet (PR-D deferred); the existing `retrack()` relies on the implicit default and its docstrings were updated. Callers wanting the old behavior pass `match_predicates=[default_match_predicate]`.
2. **`run_sam_segmentation` keeps empty (mask-less) frames** with poses retained, and honors `clean_empty_frames` to drop fully-empty frames (0 instances) — matching the regular path.
3. **SAM `.slp` output is never re-embedded** (backreferences source media). `analysis_h5`/`both` rejected for `mask_backend`.
4. **CLI** rejects `--mask_backend` with `--tracking` / `--stream-to-file` / label-status filters (previously silent no-ops or a crash).

---

## Design decisions & reasoning

- **§3.4 overrides locked decision L6.** `reconciliation.py` is no longer a byte-for-byte lift of `sam-track`; the BSD-3 header retains the license + pinned-commit permalink but enumerates the local modifications. (`DEFERRED.md` annotated as stale on this point.)
- **Save mirrors the regular path, never embeds.** Re-embedding duplicates large image data for no benefit; provenance keeps `.pkg.slp` frames matchable to source videos. Empirically validated (file-size + reload round-trips).
- **`analysis_h5` rejected, not silently honored** — it can't represent masks; writing a mask-less `.h5` would be misleading.
- **Stricter default predicate** reflects the validated re-tracking recipe; `default_match_predicate` stays available for explicit opt-in.
- **Globals refactor scoped to recipe knobs** — registries/cosmetics are vocabulary, not per-instance tunables.

---

## Out of scope (still deferred)

PR-D (SAM3 mask-native video tracker — the real producer for `retrack()`), the top-down crop-center seam, unprompted masks, masks-as-aux-training, the upstream sleap-io `PredictedSegmentationMask.to_user()` + SLEAP GUI mask-edit issues, the cosmetic backend-neutral `sam3_obj_id`/`sam3_score` aliases, the trained-top-down-seg `mask.instance` retrofit, and configurable image-embedding controls (**#652**).

---

## Review history (3 commits)

1. `feat(seg)` — the §3 tech-debt, globals refactor, and CLI surface (multi-agent implemented + reviewed).
2. `fix(seg): never re-embed` — reverted a wrong "force-embed" fix to mirror the regular path; reject `analysis_h5`/`both`.
3. `fix(seg): skeptical-audit findings` — fixed a `--video_index`/filter-flag **crash** (LabelsProvider passed as source), the misleading stream-to-file error, the silently-dropped `clean_empty_frames`, stale embed-claim docs, stale ≥1-predicate docstrings, and an over-strict SAM3-e2e component assertion.

---

## Testing

- `tests/inference/sam/` → **162 passed / 2 skipped** (the 2 skips are the GPU-gated e2e smokes).
- `tests/test_cli.py` → **52 passed** — SAM flags (+ dash aliases), all guards (`--tracking` / `--stream-to-file` / filters / `--video_index`), and forwarding.
- Coverage added: vectorized cost-matrix parity, length-mismatch `ValueError`, stricter-default rejection, overlay low-score flag, `sam3_model_id` threading, never-re-embed output, `analysis_h5`/`both` rejection, `clean_empty_frames`, dropped-frames-now-retained.
- `black --check` (286 files) and `ruff check sleap_nn/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)