### PR TITLE
ci: make codecov coverage upload non-blocking (fail_ci_if_error: false)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,16 @@ jobs:
           uv run --frozen --extra torch-cpu pytest --cov=sleap_nn --cov-report=xml --durations=-1 tests/
 
       - name: Upload coverage
-        if: github.repository == 'talmolab/sleap-nn' 
+        if: github.repository == 'talmolab/sleap-nn'
         uses: codecov/codecov-action@v5
         with:
-          fail_ci_if_error: true
+          # Coverage upload must NOT gate merges. The codecov-action verifies the
+          # uploader binary against a GPG key fetched from a public keyserver, which
+          # fails intermittently (codecov/codecov-action#1876: "Could not verify
+          # signature") independently of codecov's backend; with fail_ci_if_error:true
+          # those transient keyserver/upload hiccups turned every affected PR's CI red
+          # despite all tests passing. Coverage still uploads when the keyserver is
+          # reachable; it just no longer fails the job when it isn't.
+          fail_ci_if_error: false
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem

Every recent sleap-nn PR's `Tests` jobs are going **red on the `Upload coverage` step**, not on the tests. The `Run pytest` step passes on mac/ubuntu/windows; the job fails only because `codecov/codecov-action@v5` errors with **"Could not verify signature"** and we have `fail_ci_if_error: true`.

That codecov step verifies the downloaded uploader binary against a GPG key fetched from a **public keyserver** — a known, historically *intermittent* failure ([codecov/codecov-action#1876](https://github.com/codecov/codecov-action/issues/1876), also #1279/#1288) that is **independent of codecov's backend** (status page: *all systems operational*). It's currently failing persistently across multiple open PRs (`feat/seg-fragment-merge-postproc`, `feat/seg-center-sigma-default`, `feat/seg-sam-reconciliation`, …), blocking merges despite all tests passing.

## Fix

Set **`fail_ci_if_error: false`** on the codecov upload step. Coverage still uploads whenever the keyserver/codecov are reachable; it just no longer fails the CI job (and gates merges) when the upload/signature step hiccups. This is codecov's documented mitigation for exactly this class of failure, and matches the convention that coverage upload is informational, not a merge gate.

## Notes / alternatives considered

- **`skip-validation`** on the action would bypass just the GPG check but drops the uploader-integrity verification (security trade-off) — not chosen.
- **Bumping `@v5` → `@v6.0.1`** (May 2026) is reasonable hygiene (it carries a template-injection security fix) but its changelog does **not** address the signature failure, so it wouldn't fix this on its own. Left as optional follow-up to keep this change minimal.
- Coverage reporting itself is unaffected on healthy runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)