### PR TITLE
feat(seg): training viz — overlay predicted per-instance masks (#627)

### DIFF
--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -562,6 +562,9 @@ class UnifiedVizCallback(Callback):
         self.viz_class_maps = model_type == "multi_class_bottomup"
         self.viz_center_heatmap = model_type == "bottomup_segmentation"
         self.viz_offsets = model_type == "bottomup_segmentation"
+        # Colored grouped per-instance mask overlay (bottom-up seg only; the
+        # grouped masks come from the offset-grouping in get_visualization_data).
+        self.viz_instance_masks = model_type == "bottomup_segmentation"
         # GT-vs-prediction mask overlay for both segmentation model types.
         self.viz_gt_mask = model_type in (
             "bottomup_segmentation",
@@ -613,6 +616,8 @@ class UnifiedVizCallback(Callback):
             kwargs["include_offsets"] = True
         if self.viz_gt_mask:
             kwargs["include_gt_mask"] = True
+        if self.viz_instance_masks:
+            kwargs["include_instance_masks"] = True
 
         # Access lightning_model lazily from model_trainer
         return self.model_trainer.lightning_model.get_visualization_data(
@@ -668,6 +673,13 @@ class UnifiedVizCallback(Callback):
         if self.viz_gt_mask and data.gt_mask is not None:
             fig = self._mpl_renderer.render_gt_mask(data)
             fig_path = self.local_save_dir / f"{prefix}.gt_mask.{epoch:04d}.png"
+            fig.savefig(fig_path, format="png")
+            plt.close(fig)
+
+        # Colored grouped per-instance mask overlay (bottom-up segmentation)
+        if self.viz_instance_masks and data.instance_masks is not None:
+            fig = self._mpl_renderer.render_instance_masks(data)
+            fig_path = self.local_save_dir / f"{prefix}.instance_masks.{epoch:04d}.png"
             fig.savefig(fig_path, format="png")
             plt.close(fig)
 
@@ -807,6 +819,19 @@ class UnifiedVizCallback(Callback):
                 caption=f"{prefix.title()} GT vs Pred Mask Epoch {epoch}",
             )
 
+        # Colored grouped per-instance mask overlay (bottom-up segmentation)
+        if self.viz_instance_masks and data.instance_masks is not None:
+            inst_fig = self._mpl_renderer.render_instance_masks(data)
+            buf = BytesIO()
+            inst_fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+            buf.seek(0)
+            plt.close(inst_fig)
+            inst_pil = PILImage.open(buf)
+            log_dict[f"viz/{prefix}/instance_masks"] = wandb.Image(
+                inst_pil,
+                caption=f"{prefix.title()} Instance Masks Epoch {epoch}",
+            )
+
         if log_dict:
             log_dict["epoch"] = epoch
             wandb_logger.experiment.log(log_dict, commit=False)
@@ -838,6 +863,10 @@ class UnifiedVizCallback(Callback):
             if self.viz_gt_mask and data.gt_mask is not None:
                 columns.append(f"{prefix.title()} GT Mask")
                 table_data[0].append(log_dict.get(f"viz/{prefix}/gt_mask"))
+
+            if self.viz_instance_masks and data.instance_masks is not None:
+                columns.append(f"{prefix.title()} Instance Masks")
+                table_data[0].append(log_dict.get(f"viz/{prefix}/instance_masks"))
 
             table = wandb.Table(columns=columns, data=table_data)
             wandb_logger.experiment.log(

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -2774,6 +2774,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
         include_center_heatmap: bool = False,
         include_offsets: bool = False,
         include_gt_mask: bool = False,
+        include_instance_masks: bool = False,
     ) -> VisualizationData:
         """Extract visualization data from a sample.
 
@@ -2789,6 +2790,9 @@ class BottomUpSegmentationLightningModule(LightningModel):
                 separate offset-magnitude visualization.
             include_gt_mask: If True, include the ground-truth foreground mask
                 for a GT-vs-prediction overlay.
+            include_instance_masks: If True, keep the grouped per-instance masks
+                (already computed by the offset-grouping below) for a colored
+                instance-mask overlay. No extra forward/grouping pass is run.
 
         Returns:
             VisualizationData with foreground map and center locations.
@@ -2845,6 +2849,13 @@ class BottomUpSegmentationLightningModule(LightningModel):
             cx, cy = inst["center"]
             pred_centers.append([cx / output_stride, cy / output_stride])
 
+        # Keep the grouped per-instance masks (already produced above; no second
+        # grouping pass) for a colored instance-mask overlay. Each is a (H, W)
+        # bool at output-stride resolution — the same grid as ``fg_prob``.
+        instance_masks = None
+        if include_instance_masks:
+            instance_masks = [inst["mask"] for inst in instances]
+
         # Format as (N, 1, 2) arrays for plot_peaks (instances, nodes, 2)
         if len(gt_centers) > 0:
             gt_pts = np.array(gt_centers).reshape(-1, 1, 2)
@@ -2885,6 +2896,7 @@ class BottomUpSegmentationLightningModule(LightningModel):
             pred_center_heatmap=center_hmap,
             pred_offsets=offsets,
             gt_mask=gt_mask,
+            instance_masks=instance_masks,
         )
 
     def visualize_example(self, sample):

--- a/sleap_nn/training/utils.py
+++ b/sleap_nn/training/utils.py
@@ -268,6 +268,12 @@ class VisualizationData:
         gt_mask: Ground-truth foreground mask (H, W) or (H, W, 1) for segmentation
             models, optional. Rendered as a translucent overlay so the predicted
             foreground probability can be compared against truth each epoch.
+        instance_masks: Grouped predicted per-instance masks for bottom-up
+            segmentation, as a list of ``(H, W)`` boolean arrays at output-stride
+            resolution (one per detected instance), optional. Rendered as a
+            colored overlay (one color per instance) so instance separation — the
+            model's actual output — is visible each epoch. These are the masks the
+            offset-grouping in ``get_visualization_data`` already computes.
     """
 
     image: np.ndarray
@@ -283,6 +289,7 @@ class VisualizationData:
     pred_center_heatmap: Optional[np.ndarray] = None
     pred_offsets: Optional[np.ndarray] = None
     gt_mask: Optional[np.ndarray] = None
+    instance_masks: Optional[List[np.ndarray]] = None
 
 
 class MatplotlibRenderer:
@@ -446,6 +453,100 @@ class MatplotlibRenderer:
                 -0.5,
             ],
         )
+        return fig
+
+    #: Distinct per-instance overlay colors (RGB, 0-1), cycled by instance index.
+    _INSTANCE_COLORS = [
+        (1.0, 0.31, 0.31),
+        (0.31, 1.0, 0.31),
+        (0.31, 0.31, 1.0),
+        (1.0, 1.0, 0.31),
+        (1.0, 0.31, 1.0),
+        (0.31, 1.0, 1.0),
+        (1.0, 0.63, 0.31),
+        (0.63, 0.31, 1.0),
+    ]
+
+    def render_instance_masks(
+        self, data: VisualizationData
+    ) -> matplotlib.figure.Figure:
+        """Render grouped predicted per-instance masks as a colored overlay.
+
+        Each predicted instance's mask (from the offset-grouping that already runs
+        in ``get_visualization_data``) is drawn in a distinct color on the input
+        image, so instance separation — the model's actual output, and the single
+        most informative seg diagnostic — is visible each epoch. When a GT
+        foreground mask is present (``gt_mask``), its silhouette is outlined for
+        reference. Empty instance lists render the plain image (no instances
+        detected this epoch).
+
+        Args:
+            data: VisualizationData with ``instance_masks`` populated (a list of
+                ``(H, W)`` boolean masks at output-stride resolution).
+
+        Returns:
+            A matplotlib Figure object.
+        """
+        if data.instance_masks is None:
+            raise ValueError(
+                "instance_masks is None, cannot render instance-mask overlay"
+            )
+
+        img = data.image
+        scale = 1.0
+        if img.shape[0] < 512:
+            scale = 2.0
+        if img.shape[0] < 256:
+            scale = 4.0
+
+        fig = plot_img(img, dpi=72 * scale, scale=scale)
+        ax = plt.gca()
+
+        masks = [np.asarray(m, dtype=bool) for m in data.instance_masks]
+        masks = [m[..., 0] if m.ndim == 3 else m for m in masks]
+        if masks:
+            h, w = masks[0].shape[:2]
+            mask_output_scale = h / img.shape[0]
+            extent = [
+                -0.5,
+                w / mask_output_scale - 0.5,
+                h / mask_output_scale - 0.5,
+                -0.5,
+            ]
+            # Build a translucent RGBA overlay: one color per instance, alpha only
+            # where that instance's mask is set (background stays transparent).
+            overlay = np.zeros((h, w, 4), dtype=np.float32)
+            for i, m in enumerate(masks):
+                if m.shape[:2] != (h, w):
+                    continue
+                r, g, b = self._INSTANCE_COLORS[i % len(self._INSTANCE_COLORS)]
+                overlay[m, 0] = r
+                overlay[m, 1] = g
+                overlay[m, 2] = b
+                overlay[m, 3] = 0.5
+            ax.imshow(overlay, origin="upper", extent=extent, interpolation="nearest")
+
+        # Optional GT foreground silhouette outline for reference.
+        if data.gt_mask is not None:
+            gt = np.asarray(data.gt_mask)
+            if gt.ndim == 3:
+                gt = gt[..., 0]
+            gt = gt.astype(np.float32)
+            gt_output_scale = gt.shape[0] / img.shape[0]
+            gextent = [
+                -0.5,
+                gt.shape[1] / gt_output_scale - 0.5,
+                gt.shape[0] / gt_output_scale - 0.5,
+                -0.5,
+            ]
+            ax.contour(
+                np.linspace(gextent[0], gextent[1], gt.shape[1]),
+                np.linspace(gextent[3], gextent[2], gt.shape[0]),
+                gt,
+                levels=[0.5],
+                colors="white",
+                linewidths=1.0,
+            )
         return fig
 
 

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -530,6 +530,96 @@ class TestUnifiedVizCallbackSegmentation:
 
         plt.close(fig)
 
+    def test_segmentation_enables_instance_mask_viz(self):
+        """A bottom-up seg model enables the colored instance-mask overlay (#627)."""
+        cb = self._callback()
+        assert cb.viz_instance_masks is True
+
+    def test_centered_instance_seg_disables_instance_mask_viz(self):
+        """Centered-instance seg has no grouped instances -> no instance-mask viz."""
+        cb = UnifiedVizCallback(
+            model_trainer=MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="centered_instance_segmentation",
+            save_local=False,
+        )
+        assert cb.viz_instance_masks is False
+
+    def test_get_viz_data_requests_instance_masks(self):
+        """``_get_viz_data`` asks the module for the grouped instance masks."""
+        mt = MagicMock()
+        cb = self._callback(model_trainer=mt)
+        cb._get_viz_data({"image": np.zeros((1, 8, 8))})
+        _, kwargs = mt.lightning_model.get_visualization_data.call_args
+        assert kwargs.get("include_instance_masks") is True
+
+    def test_render_instance_masks_produces_figure(self):
+        """``render_instance_masks`` renders a colored overlay from a mask list."""
+        from sleap_nn.training.utils import MatplotlibRenderer, VisualizationData
+
+        m0 = np.zeros((32, 32), dtype=bool)
+        m0[4:12, 4:12] = True
+        m1 = np.zeros((32, 32), dtype=bool)
+        m1[18:28, 18:28] = True
+        data = VisualizationData(
+            image=np.random.rand(64, 64, 3).astype(np.float32),
+            pred_confmaps=np.random.rand(64, 64, 1).astype(np.float32),
+            pred_peaks=np.zeros((0, 1, 2)),
+            pred_peak_values=np.zeros((0,)),
+            gt_instances=np.zeros((0, 1, 2)),
+            instance_masks=[m0, m1],
+            gt_mask=(np.random.rand(64, 64) > 0.5),
+        )
+        fig = MatplotlibRenderer().render_instance_masks(data)
+        assert fig is not None
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+    def test_render_instance_masks_empty_list(self):
+        """An empty instance list renders the plain image without error."""
+        from sleap_nn.training.utils import MatplotlibRenderer, VisualizationData
+
+        data = VisualizationData(
+            image=np.random.rand(64, 64, 3).astype(np.float32),
+            pred_confmaps=np.random.rand(64, 64, 1).astype(np.float32),
+            pred_peaks=np.zeros((0, 1, 2)),
+            pred_peak_values=np.zeros((0,)),
+            gt_instances=np.zeros((0, 1, 2)),
+            instance_masks=[],
+        )
+        fig = MatplotlibRenderer().render_instance_masks(data)
+        assert fig is not None
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+    def test_save_local_writes_instance_masks_png(self, tmp_path):
+        """The new ``_save_local_viz`` branch writes an instance-mask PNG (#627)."""
+        from sleap_nn.training.utils import VisualizationData
+
+        cb = UnifiedVizCallback(
+            model_trainer=MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="bottomup_segmentation",
+            save_local=True,
+            local_save_dir=tmp_path,
+        )
+        m = np.zeros((32, 32), dtype=bool)
+        m[4:12, 4:12] = True
+        data = VisualizationData(
+            image=np.random.rand(64, 64, 3).astype(np.float32),
+            pred_confmaps=np.random.rand(64, 64, 1).astype(np.float32),
+            pred_peaks=np.zeros((0, 1, 2)),
+            pred_peak_values=np.zeros((0,)),
+            gt_instances=np.zeros((0, 1, 2)),
+            instance_masks=[m],
+        )
+        cb._save_local_viz(data, prefix="train", epoch=3)
+        assert (tmp_path / "train.instance_masks.0003.png").exists()
+
 
 class TestMatplotlibSaver:
     """Tests for MatplotlibSaver callback."""


### PR DESCRIPTION
Closes #627.

## Summary

Bottom-up segmentation training viz logged the foreground probability map, center heatmap, detected centers, and offset-field magnitude — but **never the grouped per-instance masks that are the model's actual output**. The masks were even computed inside `get_visualization_data` (via `group_instances_from_offsets`) and then discarded; only the centers were kept. So the single most informative diagnostic — *are instances cleanly separated?* — was invisible during training.

This adds the colored per-instance mask overlay, logged each epoch for both train and val.

## What changed

- **`VisualizationData.instance_masks`** (`sleap_nn/training/utils.py`) — new field: a list of `(H, W)` boolean masks at output-stride resolution, one per detected instance. Optional, default `None` (backward-compatible; it's the last dataclass field).
- **Reuse the already-grouped masks** (`lightning_modules.py`, bottom-up seg `get_visualization_data`) — behind `include_instance_masks`, keep `inst["mask"]` from the **same** `group_instances_from_offsets` call already used for the predicted centers. **No second forward/grouping pass** (instrumented during review: 1 group call, 1 forward call, identical with the flag on/off).
- **`MatplotlibRenderer.render_instance_masks`** (`utils.py`) — draws each instance in a distinct cycled color (translucent overlay, transparent background) on the input image, with an optional GT-foreground silhouette outline. Reuses the established extent/scale convention (`plot_confmaps` / `render_gt_mask` / `render_offsets`), so output-stride ≠ 1 maps correctly.
- **`UnifiedVizCallback`** (`callbacks.py`) — wired exactly like the sibling seg viz modes:
  - `viz_instance_masks` flag (bottom-up-seg only),
  - `include_instance_masks` data request in `_get_viz_data`,
  - local PNG `{prefix}.instance_masks.{epoch:04d}.png`,
  - wandb image `viz/{prefix}/instance_masks`,
  - wandb table column.

## Acceptance criteria

| Criterion | Status |
|---|---|
| 1. Colored per-instance mask overlay for train + val when `save_viz_imgs_wandb` is on | ✅ |
| 2. Masks come from the existing grouping call (no extra forward/grouping pass) | ✅ (instrumented) |
| 3. A `UnifiedVizCallback` test covers the new branch | ✅ |
| 4. *(Optional)* per-epoch instance IoU/P/R under `eval/*`, gated by a config flag default-off | ✅ **already implemented** — see below |

### Criterion 4: already implemented (not re-added)

`SegmentationEvaluationCallback` — added in **#649**, *after* this issue was filed — already provides the optional per-epoch instance metric: it logs `eval/val/mask_mean_iou`, `mask_precision`, `mask_recall`, `mask_f1` (+ counts, `best/` summaries) under `eval/*`, computed with the same `match_masks` IoU matcher, gated by `trainer_config.eval.enabled` (default `False`), every `eval_frequency` epochs — and it piggybacks on the existing validation pass rather than running a separate subset eval. So this PR intentionally does **not** re-implement it; doing so would duplicate working machinery. (Verified during review: wired in `model_trainer.py` for both seg model types, with the seg `validation_step` collecting the per-instance masks.)

## Scope notes

- Instance-mask overlay is **bottom-up-segmentation only** — it's the grouped-instances diagnostic. `centered_instance_segmentation` (single centered mask) keeps its existing foreground/GT-mask overlay; its `get_visualization_data` never receives the new kwarg, so there's no signature-mismatch risk.
- Overlapping masks are handled (and in practice `group_instances_from_offsets` returns disjoint masks); empty lists, all-False masks, shape-mismatched masks, and `(H,W,1)` masks all render without error.

## Testing

- 6 new tests in `tests/training/test_callbacks.py`: flag on/off scoping (bottom-up enables, centered-instance does not), the kwarg request, render with masks + GT silhouette, empty-list render, and the local-save branch writing the PNG.
- Full callback suite: **113 passed**. `black --check` (287 files) and `ruff check sleap_nn/` clean.
- An adversarial review (empirical) confirmed the extent math across strides/aspect-ratios, the no-extra-pass claim, the no-deprecated-API claim, and that criterion 4 is genuinely pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)