### PR TITLE
feat(infer): configurable image-embedding & source-video controls for prediction output .slp (#652)

### DIFF
--- a/docs/guides/sam-inference-segmentation.md
+++ b/docs/guides/sam-inference-segmentation.md
@@ -126,11 +126,34 @@ The same masks are produced from the `sleap-nn predict` command (and its hidden
 as a pose file and masks are produced from its existing instances — there is **no
 trained segmentation model**, so `--mask_backend` is **mutually exclusive with
 `--model_paths`** (do not pass it). The `.slp` output is saved like the regular
-prediction path — images are **not** re-embedded; the output backreferences the
-input's source media via provenance (small output; a `.pkg.slp` input stays
-matchable to its source videos), and the masks always serialize into the `.slp`.
-Only `--output_format slp` is supported (the SLEAP Analysis HDF5 format stores
-poses/tracks, not segmentation masks).
+prediction path — by default images are **not** re-embedded; the output
+backreferences the input's source media via provenance (small output; a
+`.pkg.slp` input stays matchable to its source videos), and the masks always
+serialize into the `.slp`. Only `--output_format slp` is supported (the SLEAP
+Analysis HDF5 format stores poses/tracks, not segmentation masks).
+
+### Controlling image embedding (`--embed` / `--restore_source_videos`)
+
+Two independent flags (also `embed` / `restore_source_videos` API kwargs on
+`predict` and `run_sam_segmentation`) control how the output `.slp` references
+image data. The defaults preserve today's behavior exactly.
+
+- `--embed` (`auto` | `true` | `false`, default `false`): the embedding policy.
+  `false` never embeds and backreferences the source media (today's behavior);
+  `true` embeds images into a self-contained `.pkg.slp`-style output; `auto`
+  embeds only when the input was itself an embedded `.pkg.slp`.
+- `--restore_source_videos` / `--no-restore_source_videos` (default
+  `--restore_source_videos`): on a non-embedding save, restore references to the
+  original source video files (provenance), or use `--no-restore_source_videos`
+  to keep references to the input `.pkg.slp` file(s) instead. Ignored when
+  embedding. Maps to sleap-io's `restore_original_videos`.
+
+```bash
+# Embed images into a self-contained output .pkg.slp:
+sleap-nn predict -i poses.pkg.slp --mask_backend sam \
+    --sam_checkpoint /path/to/sam_vit_h_4b8939.pth \
+    --embed true -o poses_with_masks.pkg.slp
+```
 
 SAM1 (ungated):
 

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1534,6 +1534,8 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
             )
         ),
         "output_format": kwargs.get("output_format") or "slp",
+        "embed": kwargs.get("embed") or "false",
+        "restore_source_videos": kwargs.get("restore_source_videos", True),
         # Bottom-up PAF grouping knobs (inert for non-bottom-up models). #583.
         "max_edge_length_ratio": kwargs.get("max_edge_length_ratio", 0.25),
         "dist_penalty_weight": kwargs.get("dist_penalty_weight", 1.0),
@@ -1717,7 +1719,11 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
 
     output_path = kwargs.get("output_path") or f"{src}.slp"
     save_predictions(
-        out, output_path, output_format=kwargs.get("output_format") or "slp"
+        out,
+        output_path,
+        output_format=kwargs.get("output_format") or "slp",
+        embed=kwargs.get("embed") or "false",
+        restore_source_videos=kwargs.get("restore_source_videos", True),
     )
     return out
 
@@ -1910,6 +1916,15 @@ def _run_stream_to_file(
             "--stream-to-file only supports --output_format slp. Drop "
             "--stream-to-file to write analysis HDF5 via the in-memory path."
         )
+    if (kwargs.get("embed") or "false") != "false" or (
+        kwargs.get("restore_source_videos", True) is False
+    ):
+        raise click.UsageError(
+            "--embed / --restore_source_videos are not supported with "
+            "--stream-to-file: the incremental writer saves with sleap-io "
+            "defaults (no embedding, original-video refs restored). Drop "
+            "--stream-to-file to control embedding."
+        )
     if not kwargs.get("model_paths"):
         raise click.UsageError("--model_paths is required for --stream-to-file.")
     data_path = kwargs.get("data_path")
@@ -2062,6 +2077,24 @@ def _common_inference_options(f):
             type=click.Choice(["slp", "analysis_h5", "both"], case_sensitive=False),
             default="slp",
             help="Output format: 'slp' (SLEAP labels file, the default), 'analysis_h5' (SLEAP Analysis HDF5, one '.analysis.h5' per video), or 'both'.",
+        ),
+        click.option(
+            "--embed",
+            type=click.Choice(["auto", "true", "false"], case_sensitive=False),
+            default="false",
+            help="Image-embedding policy for a .slp output: 'false' (default; "
+            "never embed, backreference source media), 'true' (embed images "
+            "into a self-contained .pkg.slp-style file), or 'auto' (embed iff "
+            "the input was itself an embedded .pkg.slp). Only applies to .slp output.",
+        ),
+        click.option(
+            "--restore_source_videos/--no-restore_source_videos",
+            "restore_source_videos",
+            default=True,
+            help="On a non-embedding .slp save, restore references to the "
+            "original source video files (default). Use "
+            "--no-restore_source_videos to keep references to the input "
+            ".pkg.slp file(s) instead. Ignored when embedding.",
         ),
         click.option(
             "--device",

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -131,11 +131,53 @@ def save_analysis_h5_files(
     return written_paths
 
 
+def _video_has_embedded_images(video) -> bool:
+    """Best-effort: does this loaded video carry embedded image frames?
+
+    A video loaded from a ``.pkg.slp`` preserves its original media as
+    ``source_video`` provenance — the same signal sleap-io's
+    ``restore_original_videos`` keys off. Falls back to the backend's
+    ``has_embedded_images`` flag for embedded videos saved without source
+    provenance; backend access is guarded defensively (an unopened video
+    currently just returns ``backend=None``, but a future/custom ``Video`` could
+    make ``.backend`` a lazy property) so detection never raises.
+    """
+    if getattr(video, "source_video", None) is not None:
+        return True
+    try:
+        backend = video.backend
+    except Exception:
+        return False
+    return bool(getattr(backend, "has_embedded_images", False))
+
+
+def _resolve_embed(embed, labels) -> bool:
+    """Resolve the ``embed`` control (``"auto"``/``"true"``/``"false"`` or bool) to bool.
+
+    ``"auto"`` -> ``True`` iff any video in ``labels`` carries embedded images.
+    """
+    if isinstance(embed, bool):
+        return embed
+    value = str(embed).strip().lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    if value == "auto":
+        return any(
+            _video_has_embedded_images(v)
+            for v in (getattr(labels, "videos", None) or [])
+        )
+    raise ValueError(f"Invalid embed={embed!r}; expected 'auto', 'true', or 'false'.")
+
+
 def save_predictions(
     labels: sio.Labels,
     output_path: Union[str, Path],
     output_format: str = "slp",
     video_index: Optional[int] = None,
+    embed: Union[str, bool] = "false",
+    restore_source_videos: bool = True,
 ) -> List[Path]:
     """Save predicted ``Labels`` to disk in the requested format(s).
 
@@ -147,6 +189,17 @@ def save_predictions(
             ``"both"``.
         video_index: Restrict the analysis HDF5 export to a single video index;
             ``None`` exports every video with predicted frames.
+        embed: Image-embedding policy for the ``.slp`` output, one of
+            ``"false"`` (the default; never embed, backreference source media —
+            today's behavior), ``"true"`` (embed images into a self-contained
+            ``.pkg.slp``-style file), or ``"auto"`` (embed iff the input was
+            itself an embedded ``.pkg.slp``). A bool passes through unchanged.
+            Only applies to ``.slp`` output.
+        restore_source_videos: On a non-embedding ``.slp`` save, ``True`` (the
+            default) restores references to the original source video files;
+            ``False`` keeps references to the input ``.pkg.slp`` file(s). Maps
+            to sleap-io's ``restore_original_videos`` and is ignored when
+            embedding.
 
     Returns:
         The list of analysis HDF5 paths written (empty when
@@ -164,7 +217,11 @@ def save_predictions(
         )
 
     if output_format in ("slp", "both"):
-        labels.save(Path(output_path).as_posix())
+        labels.save(
+            Path(output_path).as_posix(),
+            embed=_resolve_embed(embed, labels),
+            restore_original_videos=restore_source_videos,
+        )
 
     h5_paths: List[Path] = []
     if output_format in ("analysis_h5", "both"):
@@ -241,6 +298,8 @@ def predict(
     # Output
     output_path: Optional[str] = None,
     output_format: str = "slp",
+    embed: Union[str, bool] = "false",
+    restore_source_videos: bool = True,
     clean_empty_frames: bool = False,
     progress_callback: Optional[Callable[[int, int], None]] = None,
     tracking_progress_callback: Optional[Callable[[int, int], None]] = None,
@@ -349,6 +408,15 @@ def predict(
             One of ``"slp"`` (the default), ``"analysis_h5"`` (a SLEAP Analysis
             HDF5 file, one ``.analysis.h5`` per video), or ``"both"``. Analysis
             HDF5 paths are derived from ``output_path``.
+        embed: Image-embedding policy for a ``.slp`` output, one of ``"false"``
+            (the default; never embed, backreference source media — today's
+            behavior), ``"true"`` (embed images into a self-contained
+            ``.pkg.slp``-style file), or ``"auto"`` (embed iff the input was
+            itself an embedded ``.pkg.slp``). Only applies to ``.slp`` output.
+        restore_source_videos: On a non-embedding ``.slp`` save, ``True`` (the
+            default) restores references to the original source video files;
+            ``False`` keeps references to the input ``.pkg.slp`` file(s).
+            Ignored when embedding.
         clean_empty_frames: Drop frames with no instances.
         progress_callback: ``(processed_frames, total_frames)`` callback
             invoked after each batch (counts are in frames).
@@ -397,8 +465,9 @@ def predict(
                 "poses/tracks, not segmentation masks."
             )
         # Save handling lives in ``run_sam_segmentation``, which mirrors the
-        # regular prediction path: it backreferences the source media via
-        # provenance and never re-embeds images (small output; see its docs).
+        # regular prediction path: by default it backreferences the source media
+        # via provenance and does not re-embed images (small output; see its
+        # docs). The ``embed`` / ``restore_source_videos`` controls are forwarded.
         labels = run_sam_segmentation(
             source,
             mask_backend,
@@ -413,6 +482,8 @@ def predict(
             overlay_path=overlay_path,
             frames=frames,
             clean_empty_frames=clean_empty_frames,
+            embed=embed,
+            restore_source_videos=restore_source_videos,
         )
         return labels
 
@@ -512,6 +583,12 @@ def predict(
     )
 
     if output_path is not None:
-        save_predictions(labels, output_path, output_format=output_format)
+        save_predictions(
+            labels,
+            output_path,
+            output_format=output_format,
+            embed=embed,
+            restore_source_videos=restore_source_videos,
+        )
 
     return labels

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -30,7 +30,7 @@ so importing this package on a default install is cheap and dependency-free.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from sleap_nn.inference.sam.backends import MaskBackend, Sam3Backend, SamBackend
 from sleap_nn.inference.sam.mask_layer import SamSegmentationLayer
@@ -156,6 +156,8 @@ def run_sam_segmentation(
     overlay_path: Optional[str] = None,
     frames: Optional[Sequence[int]] = None,
     clean_empty_frames: bool = False,
+    embed: Union[str, bool] = "false",
+    restore_source_videos: bool = True,
 ):
     """Predict per-instance masks for a pose ``.slp`` with a SAM backend.
 
@@ -181,10 +183,11 @@ def run_sam_segmentation(
             (skips loading); when given, ``mask_backend`` is still validated for
             the name but the checkpoint/device args are ignored.
         output_path: Optional ``.slp`` path to save the result to. Saved like the
-            regular prediction path (``labels.save``): images are **never**
-            re-embedded — the output backreferences the source media via
-            provenance, so a ``.pkg.slp`` input stays matchable to its source
-            videos without bloating the output.
+            regular prediction path (``labels.save``): the embedding policy is
+            **configurable** via ``embed`` and defaults to ``"false"`` — images
+            are not re-embedded and the output backreferences the source media
+            via provenance, so a ``.pkg.slp`` input stays matchable to its
+            source videos without bloating the output.
         overlay_path: Optional path to write a review overlay PNG of the first
             frame.
         frames: Optional frame indices (matched against ``lf.frame_idx``) to
@@ -195,6 +198,15 @@ def run_sam_segmentation(
             regular prediction path's ``--no_empty_frames``. A frame that has
             poses but no mask is NOT empty (its instances are retained) and is
             kept.
+        embed: Image-embedding policy for the ``.slp`` output, one of
+            ``"false"`` (the default; never embed, backreference source media),
+            ``"true"`` (embed images into a self-contained ``.pkg.slp``-style
+            file), or ``"auto"`` (embed iff the input was itself an embedded
+            ``.pkg.slp``). A bool passes through unchanged.
+        restore_source_videos: On a non-embedding save, ``True`` (the default)
+            restores references to the original source video files; ``False``
+            keeps references to the input ``.pkg.slp`` file(s). Maps to
+            sleap-io's ``restore_original_videos`` and is ignored when embedding.
 
     Returns:
         A new ``sio.Labels`` with per-frame ``PredictedSegmentationMask`` (and the
@@ -272,15 +284,23 @@ def run_sam_segmentation(
     if output_path is not None:
         out_path = Path(output_path).expanduser()
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        # Save exactly like the regular prediction path (``labels.save(path)``):
-        # NEVER re-embed images — that is large and wasteful. The output
+        # Save like the regular prediction path (``labels.save(path)``). The
+        # embedding policy is configurable and defaults to ``embed="false"``: do
+        # NOT re-embed images — that is large and wasteful. By default the output
         # backreferences the source media via provenance (sleap-io's default
         # ``embed=False``). A ``.pkg.slp`` input is typically aggregated training
         # data; its frames stay matchable to the source videos (by comparing
         # source-video provenance) without copying pixels into the output, even
         # if those videos are no longer on disk. The masks always serialize into
-        # the ``.slp`` regardless.
-        out.save(out_path.as_posix())
+        # the ``.slp`` regardless. ``out.videos`` are the input videos, so
+        # ``source_video`` provenance is intact for ``embed="auto"`` detection.
+        from sleap_nn.inference.run import _resolve_embed
+
+        out.save(
+            out_path.as_posix(),
+            embed=_resolve_embed(embed, out),
+            restore_original_videos=restore_source_videos,
+        )
     if overlay_path is not None:
         # Flag masks below the backend's per-model nominal predicted-IoU floor
         # (SAM1 0.88 / SAM3 0.5) so the review overlay surfaces low-confidence

--- a/tests/cli/test_flag_validation.py
+++ b/tests/cli/test_flag_validation.py
@@ -67,6 +67,53 @@ def test_stream_to_file_with_no_empty_frames_raises_usage_error():
     assert "no_empty_frames" in result.output.lower()
 
 
+def test_stream_to_file_with_embed_raises_usage_error():
+    """``--stream-to-file`` + ``--embed true`` is rejected (#652).
+
+    The incremental writer saves with sleap-io defaults, so an embedding
+    request would be silently dropped; fail loudly instead.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "predict",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--stream-to-file",
+            "/tmp/out.slp",
+            "--embed",
+            "true",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "embed" in result.output.lower()
+    assert "stream-to-file" in result.output
+
+
+def test_stream_to_file_with_no_restore_source_videos_raises_usage_error():
+    """``--stream-to-file`` + ``--no-restore_source_videos`` is rejected (#652)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "predict",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--stream-to-file",
+            "/tmp/out.slp",
+            "--no-restore_source_videos",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "restore_source_videos" in result.output.lower()
+    assert "stream-to-file" in result.output
+
+
 def test_write_interval_without_stream_to_file_errors():
     """``--write-interval`` alone is meaningless and rejected."""
     runner = CliRunner()
@@ -180,6 +227,50 @@ def test_stream_to_file_invokes_new_predictor_flow(tmp_path):
     assert result.exit_code == 0, result.output
     assert mock_factory.called
     assert stub_predictor.predict_to_file.called
+
+
+def test_embed_invalid_choice_rejected():
+    """``--embed`` only accepts auto/true/false; an unknown value is rejected (#652)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "predict",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--embed",
+            "maybe",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "embed" in result.output.lower()
+
+
+def test_embed_choice_case_insensitive(tmp_path):
+    """``--embed TRUE`` is normalized to lowercase and forwarded (#652)."""
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        return_value=MagicMock(),
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--output_path",
+                str(tmp_path / "out.slp"),
+                "--embed",
+                "TRUE",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.call_args[1]["embed"] == "true"
 
 
 def test_unknown_flag_rejected_cleanly():

--- a/tests/cli/test_predict_command.py
+++ b/tests/cli/test_predict_command.py
@@ -472,6 +472,42 @@ def test_predict_retrack_only_dispatches_to_predictor_retrack(tmp_path):
         tracked.save.assert_called_once()
 
 
+def test_predict_retrack_only_forwards_embed_and_restore(tmp_path):
+    """Retrack-only save forwards ``--embed`` / ``--restore_source_videos`` (#652)."""
+    runner = CliRunner()
+    fake_labels = MagicMock()
+    fake_labels.videos = []
+    fake_labels.skeletons = []
+    fake_labels.labeled_frames = []
+    tracked = MagicMock()
+    with (
+        patch("sleap_io.load_slp", return_value=fake_labels),
+        patch("sleap_nn.inference.predictor.Predictor.retrack", return_value=tracked),
+        patch("sleap_nn.predict.run_inference") as mock_legacy,
+        patch("sleap_nn.inference.run.save_predictions") as mock_save,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.slp",
+                "--tracking",
+                "--output_path",
+                str(tmp_path / "out.slp"),
+                "--embed",
+                "true",
+                "--no-restore_source_videos",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert not mock_legacy.called
+        assert mock_save.called
+        call_kwargs = mock_save.call_args[1]
+        assert call_kwargs["embed"] == "true"
+        assert call_kwargs["restore_source_videos"] is False
+
+
 def test_predict_paf_workers_zero_no_warning(tmp_path):
     """``--paf-workers 0`` is the default, must not emit a warning."""
     runner = CliRunner()
@@ -844,3 +880,129 @@ def test_predict_stream_to_file_rejects_non_slp_format(tmp_path):
     )
     assert isinstance(result.exception, click.UsageError)
     assert "only supports --output_format slp" in result.exception.message
+
+
+def test_predict_forwards_embed_and_restore(tmp_path):
+    """``--embed`` / ``--no-restore_source_videos`` propagate to ``predict()`` (#652)."""
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        return_value=MagicMock(),
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--output_path",
+                str(out),
+                "--embed",
+                "true",
+                "--no-restore_source_videos",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.called
+    call_kwargs = mock_predict.call_args[1]
+    assert call_kwargs["embed"] == "true"
+    assert call_kwargs["restore_source_videos"] is False
+
+
+def test_predict_embed_restore_defaults(tmp_path):
+    """Without the new flags, predict() gets the byte-for-byte defaults (#652)."""
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        return_value=MagicMock(),
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--output_path",
+                str(out),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.called
+    call_kwargs = mock_predict.call_args[1]
+    assert call_kwargs["embed"] == "false"
+    assert call_kwargs["restore_source_videos"] is True
+
+
+def test_predict_embed_restore_explicit_defaults_accepted(tmp_path):
+    """Explicit default values for the new flags parse and forward (#652).
+
+    Unlike the bare-default test above (which would still pass if the options
+    were deleted, because the kwargs fall back to the same defaults), this
+    passes ``--embed false`` / ``--restore_source_videos`` explicitly, so it
+    fails if the options are removed entirely (Click would reject them).
+    """
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        return_value=MagicMock(),
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--output_path",
+                str(out),
+                "--embed",
+                "false",
+                "--restore_source_videos",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.called
+    call_kwargs = mock_predict.call_args[1]
+    assert call_kwargs["embed"] == "false"
+    assert call_kwargs["restore_source_videos"] is True
+
+
+def test_predict_forwards_embed_auto(tmp_path):
+    """``--embed auto`` reaches predict() verbatim for input-driven resolution (#652).
+
+    ``auto`` is resolved to a concrete bool deep in the save path (against the
+    loaded labels), so the CLI must forward the literal ``"auto"`` string rather
+    than pre-resolving it. This guards that headline value end-to-end at the CLI
+    layer (the other CLI tests only cover ``true``/``false``).
+    """
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        return_value=MagicMock(),
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--output_path",
+                str(out),
+                "--embed",
+                "auto",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.called
+    assert mock_predict.call_args[1]["embed"] == "auto"

--- a/tests/inference/sam/test_run_sam_segmentation.py
+++ b/tests/inference/sam/test_run_sam_segmentation.py
@@ -197,6 +197,82 @@ def test_run_sam_segmentation_clean_empty_frames(minimal_instance):
     assert cleaned.labeled_frames[0].masks
 
 
+def test_run_sam_segmentation_embed_true_self_contained(minimal_instance, tmp_path):
+    """``embed="true"`` writes a self-contained .slp larger than ``embed="false"``.
+
+    #652: the embedding policy is configurable. With ``embed="true"`` the output
+    carries pixel data and reloads with a video reporting embedded images; it is
+    strictly larger than the default ``embed="false"`` (backreference) output.
+    """
+    from sleap_nn.inference.run import _video_has_embedded_images
+
+    out_false = tmp_path / "embed_false.slp"
+    out_true = tmp_path / "embed_true.slp"
+
+    run_sam_segmentation(
+        str(minimal_instance),
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        output_path=out_false,
+        embed="false",
+    )
+    run_sam_segmentation(
+        str(minimal_instance),
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        output_path=out_true,
+        embed="true",
+    )
+    assert out_false.exists() and out_true.exists()
+    assert out_true.stat().st_size > out_false.stat().st_size
+    reloaded = sio.load_slp(out_true.as_posix())
+    assert any(_video_has_embedded_images(v) for v in reloaded.videos)
+    # Masks still serialize in both cases.
+    assert any(lf.masks for lf in reloaded.labeled_frames)
+
+
+def test_run_sam_segmentation_restore_source_videos_controls_refs(
+    minimal_instance, tmp_path
+):
+    """``restore_source_videos`` toggles the reloaded video filename reference.
+
+    #652: on a non-embedding save, default ``True`` restores the original source
+    video reference (the .mp4); ``False`` keeps the input ``.pkg.slp`` reference.
+    """
+    src = sio.load_slp(str(minimal_instance))
+    source_name = Path(src.videos[0].source_video.filename).name
+    input_name = Path(str(minimal_instance)).name
+
+    out_restore = tmp_path / "restore_true.slp"
+    out_keep = tmp_path / "restore_false.slp"
+
+    run_sam_segmentation(
+        str(minimal_instance),
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        output_path=out_restore,
+        restore_source_videos=True,
+    )
+    run_sam_segmentation(
+        str(minimal_instance),
+        "sam",
+        backend=FakeBackend(_prompt_disk()),
+        prompt_mode="pose",
+        output_path=out_keep,
+        restore_source_videos=False,
+    )
+
+    restored = sio.load_slp(out_restore.as_posix())
+    kept = sio.load_slp(out_keep.as_posix())
+    # Default True -> the original source .mp4 reference.
+    assert Path(restored.videos[0].filename).name == source_name
+    # False -> the input .pkg.slp reference is kept.
+    assert Path(kept.videos[0].filename).name == input_name
+
+
 def test_run_sam_segmentation_writes_overlay_png(minimal_instance, tmp_path):
     """``overlay_path`` writes a review PNG to disk."""
     labels = _pose_labels(minimal_instance)
@@ -473,6 +549,66 @@ def test_predict_sam_forwards_kwargs(minimal_instance, tmp_path, monkeypatch):
     assert captured["disjointify_masks"] is True
     assert captured["overlay_path"] == overlay_path
     assert captured["frames"] == [1]
+
+
+def test_predict_sam_forwards_embed_restore(minimal_instance, tmp_path, monkeypatch):
+    """``predict`` forwards embed / restore_source_videos into run_sam_segmentation."""
+    labels = _pose_labels(minimal_instance)
+    captured = {}
+
+    def fake_run_sam_segmentation(source, mask_backend, **kwargs):
+        captured.update(kwargs)
+        return sio.Labels(
+            videos=list(labels.videos),
+            skeletons=list(labels.skeletons),
+            labeled_frames=[],
+        )
+
+    monkeypatch.setattr(
+        "sleap_nn.inference.sam.run_sam_segmentation", fake_run_sam_segmentation
+    )
+
+    predict(
+        labels,
+        mask_backend="sam",
+        device="cpu",
+        sam_prompt_mode="pose",
+        output_path=tmp_path / "e.slp",
+        embed="auto",
+        restore_source_videos=False,
+    )
+    assert captured["embed"] == "auto"
+    assert captured["restore_source_videos"] is False
+
+
+def test_predict_sam_default_embed_restore_forwarded(
+    minimal_instance, tmp_path, monkeypatch
+):
+    """Default predict() forwards the byte-for-byte defaults to run_sam_segmentation."""
+    labels = _pose_labels(minimal_instance)
+    captured = {}
+
+    def fake_run_sam_segmentation(source, mask_backend, **kwargs):
+        captured.update(kwargs)
+        return sio.Labels(
+            videos=list(labels.videos),
+            skeletons=list(labels.skeletons),
+            labeled_frames=[],
+        )
+
+    monkeypatch.setattr(
+        "sleap_nn.inference.sam.run_sam_segmentation", fake_run_sam_segmentation
+    )
+
+    predict(
+        labels,
+        mask_backend="sam",
+        device="cpu",
+        sam_prompt_mode="pose",
+        output_path=tmp_path / "e.slp",
+    )
+    assert captured["embed"] == "false"
+    assert captured["restore_source_videos"] is True
 
 
 # --------------------------------------------------------------------------- save_mask_overlay

--- a/tests/inference/test_run.py
+++ b/tests/inference/test_run.py
@@ -15,6 +15,8 @@ import pytest
 import sleap_io as sio
 
 from sleap_nn.inference.run import (
+    _resolve_embed,
+    _video_has_embedded_images,
     predict,
     save_analysis_h5_files,
     save_predictions,
@@ -288,3 +290,173 @@ def test_predict_forwards_output_format(tmp_path):
             output_format="both",
         )
     assert mock_save.call_args.kwargs["output_format"] == "both"
+
+
+# --- embed / restore_source_videos controls (#652) -------------------------
+
+
+def test_resolve_embed_bool_passthrough():
+    """A bool ``embed`` passes through unchanged (no labels inspection)."""
+    assert _resolve_embed(True, None) is True
+    assert _resolve_embed(False, None) is False
+
+
+def test_resolve_embed_string_true_false_case_insensitive():
+    """``"true"``/``"false"`` resolve regardless of case/whitespace."""
+    assert _resolve_embed("true", None) is True
+    assert _resolve_embed("TRUE", None) is True
+    assert _resolve_embed("  True  ", None) is True
+    assert _resolve_embed("false", None) is False
+    assert _resolve_embed("FALSE", None) is False
+
+
+def test_resolve_embed_invalid_string_raises():
+    """An unrecognized ``embed`` string is a ValueError."""
+    with pytest.raises(ValueError, match="Invalid embed"):
+        _resolve_embed("maybe", None)
+
+
+def test_resolve_embed_auto_true_when_video_has_source():
+    """``"auto"`` -> True when a video carries ``source_video`` provenance."""
+    video = MagicMock()
+    video.source_video = MagicMock(name="source")
+    labels = MagicMock()
+    labels.videos = [video]
+    assert _resolve_embed("auto", labels) is True
+
+
+def test_resolve_embed_auto_false_for_plain_media_video():
+    """``"auto"`` -> False for a plain (non-embedded) MediaVideo labels.
+
+    A ``Video.from_filename`` (no ``.pkg.slp`` provenance) has ``source_video``
+    None and no embedded backend, so ``auto`` does not embed.
+    """
+    video = sio.Video.from_filename(
+        "tests/data/json_format_v1/centered_pair_low_quality.mp4",
+        open_backend=False,
+    )
+    assert video.source_video is None
+    labels = sio.Labels(videos=[video], skeletons=[], labeled_frames=[])
+    assert _resolve_embed("auto", labels) is False
+
+
+def test_video_has_embedded_images_source_video_signal():
+    """``source_video`` provenance is the primary embedded-images signal."""
+    video = MagicMock()
+    video.source_video = MagicMock(name="source")
+    assert _video_has_embedded_images(video) is True
+
+
+def test_video_has_embedded_images_backend_fallback():
+    """Falls back to ``backend.has_embedded_images`` when no source provenance."""
+    video = MagicMock()
+    video.source_video = None
+    video.backend.has_embedded_images = True
+    assert _video_has_embedded_images(video) is True
+
+
+def test_video_has_embedded_images_backend_access_guarded():
+    """A backend that raises on access never propagates; returns False."""
+
+    class _Raises:
+        source_video = None
+
+        @property
+        def backend(self):
+            raise RuntimeError("missing media")
+
+    assert _video_has_embedded_images(_Raises()) is False
+
+
+def test_video_has_embedded_images_plain_video_false():
+    """No source, backend without the flag -> False."""
+    video = MagicMock()
+    video.source_video = None
+    video.backend = MagicMock(spec=[])  # no has_embedded_images attribute
+    assert _video_has_embedded_images(video) is False
+
+
+def test_save_predictions_forwards_embed_and_restore_to_labels_save():
+    """save_predictions forwards resolved embed + restore_original_videos."""
+    labels = MagicMock()
+    labels.videos = []
+    save_predictions(
+        labels,
+        "out.slp",
+        output_format="slp",
+        embed="true",
+        restore_source_videos=False,
+    )
+    assert labels.save.call_args.kwargs["embed"] is True
+    assert labels.save.call_args.kwargs["restore_original_videos"] is False
+
+
+def test_save_predictions_default_embed_false_restore_true():
+    """Defaults preserve today's behavior: embed=False, restore=True."""
+    labels = MagicMock()
+    labels.videos = []
+    save_predictions(labels, "out.slp", output_format="slp")
+    assert labels.save.call_args.kwargs["embed"] is False
+    assert labels.save.call_args.kwargs["restore_original_videos"] is True
+
+
+def test_save_predictions_embed_true_writes_self_contained_slp(
+    minimal_instance, tmp_path
+):
+    """A real round-trip: embed='true' writes a larger self-contained .slp."""
+    labels = sio.load_slp(minimal_instance.as_posix())
+    out_false = tmp_path / "preds_false.slp"
+    out_true = tmp_path / "preds_true.slp"
+    save_predictions(labels, out_false, output_format="slp", embed="false")
+    save_predictions(labels, out_true, output_format="slp", embed="true")
+    assert out_false.exists()
+    assert out_true.exists()
+    # The embedded output carries pixel data and is strictly larger; it also
+    # round-trips to Labels whose video reports embedded images.
+    assert out_true.stat().st_size > out_false.stat().st_size
+    reloaded = sio.load_slp(out_true.as_posix())
+    assert any(_video_has_embedded_images(v) for v in reloaded.videos)
+
+
+def test_predict_forwards_embed_and_restore_to_save_predictions(tmp_path):
+    """predict() threads embed/restore_source_videos into save_predictions."""
+    pred = _mock_predictor()
+    out = tmp_path / "out.slp"
+    with (
+        patch(
+            "sleap_nn.inference.predictor.Predictor.from_model_paths",
+            return_value=pred,
+        ),
+        patch("sleap_nn.inference.run.save_predictions") as mock_save,
+    ):
+        predict(
+            "video.mp4",
+            model_paths=["/m"],
+            device="cpu",
+            output_path=str(out),
+            embed="auto",
+            restore_source_videos=False,
+        )
+    assert mock_save.call_args.kwargs["embed"] == "auto"
+    assert mock_save.call_args.kwargs["restore_source_videos"] is False
+
+
+def test_predict_default_embed_restore_forwarded(tmp_path):
+    """Without overrides, predict() forwards the byte-for-byte defaults."""
+    pred = _mock_predictor()
+    out = tmp_path / "out.slp"
+    with (
+        patch(
+            "sleap_nn.inference.predictor.Predictor.from_model_paths",
+            return_value=pred,
+        ),
+        patch("sleap_nn.inference.run.save_predictions") as mock_save,
+    ):
+        predict(
+            "video.mp4",
+            model_paths=["/m"],
+            device="cpu",
+            output_path=str(out),
+        )
+    assert mock_save.call_args.kwargs["embed"] == "false"
+    assert mock_save.call_args.kwargs["restore_source_videos"] is True


### PR DESCRIPTION
## Summary

Closes #652. Surfaces sleap-io's image-embedding controls on the prediction save path as **both API kwargs and `sleap-nn predict` CLI flags**. Until now the output `.slp` used a fixed policy with no override; this makes the policy *configurable* while keeping the conservative default introduced in #650 (`embed=False`, `restore_original_videos=True`) **byte-for-byte unchanged**.

Two independent controls, mapping directly onto `sio.Labels.save(embed=..., restore_original_videos=...)`, **`.slp`-output only**:

### 1. `embed` — `auto` | `true` | `false` (default `false`)
- **`false`** (default): never embed; backreference the source media (current behavior).
- **`true`**: embed images into a self-contained `.pkg.slp`-style output.
- **`auto`**: embed **iff the input was itself embedded** (a `.pkg.slp` carrying embedded frames); otherwise behaves like `false`.

### 2. `restore_source_videos` — bool (default `true`)
Maps to `restore_original_videos`. On a non-embedding save: `true` restores references to the original source video files; `false` keeps references to the input `.pkg.slp`. (sleap-io ignores it when embedding.)

## API

Added `embed: str|bool = "false"` and `restore_source_videos: bool = True` to:
- `sleap_nn.inference.run.predict(...)`
- `sleap_nn.inference.run.save_predictions(...)`
- `sleap_nn.inference.sam.run_sam_segmentation(...)`

…forwarded to `Labels.save`. Two new module-level helpers in `run.py` resolve the policy:
- `_resolve_embed(embed, labels)` — normalizes `auto`/`true`/`false` (or a bool) to a concrete bool; `auto` → `True` iff any input video carries embedded frames.
- `_video_has_embedded_images(video)` — detection keys off `source_video` provenance (the cheap, no-file-open signal sleap-io's own `restore_original_videos` uses), with a guarded `backend.has_embedded_images` fallback for embedded-without-source videos.

## CLI (`sleap-nn predict` / `infer`)

- `--embed [auto|true|false]` (default `false`)
- `--restore_source_videos / --no-restore_source_videos` (default `true`)

Added to the shared inference option list and forwarded through **every** save surface: regular predict → `save_predictions`, SAM → `run_sam_segmentation`, the exported ONNX/TensorRT branch, and the retrack-only path. The legacy `track` command (separate option list) is untouched.

`--stream-to-file` **rejects** non-default `--embed`/`--restore_source_videos` with a clear `UsageError` — the incremental writer saves with sleap-io defaults and cannot honor them, so the combo fails loudly instead of silently dropping the request.

## Implementation notes

- `auto` detection resolves to a concrete bool *before* `Labels.save`, against the loaded labels (in the SAM path, `out.videos` are the input videos, so provenance is intact).
- The SAM path is already `.slp`-only (`analysis_h5`/`both` rejected — that format can't represent masks); these controls are `.slp`-only there too.
- Defaults preserve #650's never-re-embed behavior exactly.

## Adversarial review

Implemented and reviewed via a multi-agent workflow (4 independent review lenses: sleap-io semantics, wiring completeness, test adequacy, regressions/backcompat). **0 blockers, 0 majors.** The review caught one real wiring gap — `--stream-to-file` silently ignored the new flags — now closed with the loud guard above. Remaining items were nits (comment-accuracy, extra regression-guard tests), addressed where worthwhile.

## Testing

All run on the CPU build (CI is CPU-only):
- `black --check` and `ruff check sleap_nn/` clean.
- New/affected suites green: `tests/inference/test_run.py`, `tests/inference/sam/test_run_sam_segmentation.py`, `tests/cli/test_predict_command.py`, `tests/cli/test_flag_validation.py` (+ provenance/frame-selection adjacents) — **92 + collateral passed**.
- Coverage: `_resolve_embed` truth table (incl. invalid + `auto` both ways), `_video_has_embedded_images` signals/guards, `save_predictions`/`predict`/`run_sam_segmentation`/CLI forwarding (`true`/`false`/`auto`/defaults), real `embed="true"` self-contained round-trip, `restore_source_videos` reference behavior, and the `--stream-to-file` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)