### PR TITLE
chore(deps): pin sleap-io to >=0.8.0,<0.9.0 from PyPI (drop git override)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    # Instance segmentation (SegmentationMask / Labels.get_masks) tracks sleap-io
-    # main (0.8.0), which is not yet on PyPI. Pinned to a main commit for
-    # reproducibility; switch to a PyPI version constraint once 0.8.0 releases.
-    "sleap-io>=0.8.0",
+    # Instance segmentation (SegmentationMask / Labels.get_masks) requires the
+    # sleap-io 0.8.0 annotation architecture. Fenced below 0.9.0 so a future
+    # major bump (with its own breaking changes) is an explicit, audited upgrade.
+    "sleap-io>=0.8.0,<0.9.0",
     "numpy",
     "torch",
     "torchvision>=0.20.0",
@@ -164,16 +164,6 @@ conflicts = [
 ]
 
 [tool.uv.sources]
-# sleap-io 0.8.0 is not yet released on PyPI; track main for the segmentation
-# (SegmentationMask / Labels.get_masks) APIs. Pinned to a commit for
-# reproducibility — update or drop once sleap-io 0.8.0 is published.
-# Bumped to include the eval video-matching fix (sleap-io#473/#476): the AUTO
-# video matcher now resolves effective shape through the source_video chain, so an
-# embedded-subset GT video matches its restored-original prediction counterpart
-# (fixes "Empty Frame Pairs" in the post-training segmentation/centroid eval on
-# embedded .pkg.slp). Also carries the top-down-seg viz render fixes (#470/#468/
-# #466 on top of #461 + #465).
-sleap-io = { git = "https://github.com/talmolab/sleap-io.git", rev = "04d0b65e9c61aedfab055c7baf950c0814ff6d86" }
 torch = [
     { index = "pytorch-cpu", extra = "torch-cpu" },
     # `cpu`/`gpu` are first-class extras (see [project.optional-dependencies]).


### PR DESCRIPTION
## Summary

- sleap-io **0.8.0 is now published on PyPI** (2026-06-25). This replaces the temporary `[tool.uv.sources]` git-rev override (`04d0b65`, a 0.8.0 dev build) with the released **0.8.0 from PyPI**, version-fenced **`>=0.8.0,<0.9.0`**.
- The upper fence makes a future sleap-io major bump (with its own breaking changes) an explicit, audited upgrade rather than an implicit one.
- Regenerated `uv.lock` — sleap-io now resolves from the PyPI registry; torch/cuDNN extras are unchanged.

## Changes

- `pyproject.toml`: `sleap-io>=0.8.0` → `sleap-io>=0.8.0,<0.9.0`; removed the `[tool.uv.sources] sleap-io = { git = ... }` override and its stale comment block.
- `uv.lock`: `sleap-io` source flips from git → `registry = "https://pypi.org/simple"` at `0.8.0`.

## Validation

- `uv lock --check` clean; the CI `#632` cuDNN-attachment guard clause is still present in `uv.lock`.
- Synced a fresh env to PyPI 0.8.0 and ran the inference save/analysis suite (`tests/inference/test_run.py`) **plus** the 0.8.0 compatibility regression tests (from #659) against it: **32 passed**. Released 0.8.0 (which now includes #483/#490/#495/#368/#480 — the behaviors those tests guard) is confirmed non-breaking for sleap-nn.

## Context

P0 of the sleap-io 0.8.0 compatibility plan. Merges first; #659 (P1 regression tests) and the P2 remote-input PR rebase on top.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)