### PR TITLE
feat(predict): accept remote URLs (http/s3/gs/...) as --data_path

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1378,6 +1378,90 @@ def _is_export_dir(path: str) -> bool:
     return p.is_dir() and ((p / "model.onnx").exists() or (p / "model.trt").exists())
 
 
+# Remote URL schemes sleap-io 0.8.0 can load directly (fsspec for ``.slp``, PyAV
+# for video). Mirrors ``sleap_io.io._remote._URL_SCHEMES``; kept local to avoid
+# importing a private symbol (pinned by the ``sleap-io>=0.8.0,<0.9.0`` fence).
+# Single-letter schemes (e.g. a Windows ``C:`` drive) are intentionally absent,
+# so absolute Windows paths are treated as local.
+_REMOTE_URL_SCHEMES = frozenset({"http", "https", "s3", "gs", "gcs", "az", "abfs"})
+
+
+def _is_remote_url(data_path: object) -> bool:
+    """Return ``True`` if ``data_path`` is a remote URL sleap-io can load."""
+    from urllib.parse import urlparse
+
+    s = str(data_path)
+    return bool(s) and urlparse(s).scheme.lower() in _REMOTE_URL_SCHEMES
+
+
+def _resolve_data_path(data_path: object) -> "tuple[str, str, bool]":
+    """Resolve a ``--data_path`` to ``(source_str, suffix, is_url)``.
+
+    Local paths are normalized through :class:`pathlib.Path` (unchanged
+    behavior). Remote URLs are passed through verbatim — ``Path()`` collapses
+    ``scheme://`` (and flips separators to backslashes on Windows), corrupting
+    the URL before it reaches sleap-io's URL-aware loaders. A URL's suffix is
+    taken from its path component so ``.slp`` vs. video routing still works and
+    any query string / fragment is ignored.
+    """
+    from pathlib import Path
+    from urllib.parse import urlparse
+
+    if _is_remote_url(data_path):
+        s = str(data_path)
+        return s, Path(urlparse(s).path).suffix, True
+    p = Path(data_path)
+    return str(p), p.suffix, False
+
+
+def _default_predictions_path(
+    source_str: str, is_url: bool, scoped_video_name: "Optional[str]" = None
+) -> str:
+    """Derive the default ``.slp`` output path from the input source.
+
+    Local inputs write alongside the input (``<data_path>.slp``), matching legacy
+    behavior. Remote inputs cannot be written next to the source, so the output
+    lands in the current working directory under the URL's basename.
+    """
+    from pathlib import Path
+    from urllib.parse import urlparse
+
+    base = (
+        Path(urlparse(source_str).path).name or "predictions" if is_url else source_str
+    )
+    if scoped_video_name is not None:
+        return f"{Path(base).with_suffix('')}.{scoped_video_name}.predictions.slp"
+    return f"{base}.slp"
+
+
+def _build_remote_kwargs(kwargs: dict) -> dict:
+    """Collect remote-loading options (``--headers`` / ``--stream-mode``).
+
+    Returns a (possibly empty) mapping suitable for ``**``-forwarding to
+    ``sio.load_slp`` / ``sio.load_video`` (and the providers' ``remote_kwargs``).
+    """
+    import json
+
+    remote: dict = {}
+    headers = kwargs.get("headers")
+    if headers:
+        try:
+            parsed = json.loads(headers)
+        except (TypeError, ValueError) as e:
+            raise click.UsageError(
+                "--headers must be a JSON object string, e.g. "
+                '\'{"Authorization": "Bearer ..."}\' '
+                f"(got {headers!r}): {e}"
+            )
+        if not isinstance(parsed, dict):
+            raise click.UsageError("--headers JSON must be an object (key/value map).")
+        remote["headers"] = parsed
+    stream_mode = kwargs.get("stream_mode")
+    if stream_mode:
+        remote["stream_mode"] = stream_mode
+    return remote
+
+
 def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     """Run the new ``predict()`` flow synchronously and save the resulting Labels.
 
@@ -1433,7 +1517,11 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     from sleap_nn.inference.providers import LabelsProvider, VideoProvider
     from sleap_nn.inference.run import predict
 
-    src = Path(kwargs["data_path"])
+    # Resolve the input: local paths normalize through Path(); remote URLs pass
+    # through verbatim (Path() would corrupt scheme://). Remote auth/stream
+    # options (--headers/--stream-mode) are forwarded to the URL-aware loaders.
+    source_str, src_suffix, src_is_url = _resolve_data_path(kwargs["data_path"])
+    remote_kwargs = _build_remote_kwargs(kwargs)
 
     # Build source: use a provider when CLI-specific filtering or
     # video kwargs are needed, otherwise pass the raw path.
@@ -1451,7 +1539,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     # collide on one output path). Stays None for the non-video_index case. #583.
     scoped_video_name = None
     video_index = kwargs.get("video_index")
-    if src.suffix == ".slp" and video_index is not None:
+    if src_suffix == ".slp" and video_index is not None:
         import sleap_io as sio
 
         # Scope to the requested video (re-indexed to slot 0 so its frames map to
@@ -1460,7 +1548,9 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         # re-attached on output (same as the has_slp_filters path); the output is
         # video-name-suffixed instead. Carries suggestions + the --frames filter.
         scoped, target_video = _scope_labels_to_video(
-            sio.load_slp(str(src)), video_index, frames=kwargs.get("frames")
+            sio.load_slp(source_str, **remote_kwargs),
+            video_index,
+            frames=kwargs.get("frames"),
         )
         if kwargs.get("mask_backend"):
             # run_sam_segmentation accepts a sio.Labels directly; pass the scoped
@@ -1477,28 +1567,39 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
             )
         _vfn = getattr(target_video, "filename", None)
         scoped_video_name = Path(str(_vfn)).stem if _vfn else f"video_{video_index}"
-    elif src.suffix == ".slp" and has_slp_filters:
+    elif src_suffix == ".slp" and has_slp_filters:
         source = LabelsProvider(
-            labels=str(src),
+            labels=source_str,
             batch_size=kwargs.get("batch_size", 4),
             only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
             only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
             exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
             only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
+            remote_kwargs=remote_kwargs or None,
         )
-    elif src.suffix != ".slp" and (
+    elif src_suffix != ".slp" and (
         kwargs.get("video_dataset")
         or kwargs.get("video_input_format", "channels_last") != "channels_last"
+        or remote_kwargs
     ):
         source = VideoProvider(
-            video=str(src),
+            video=source_str,
             batch_size=kwargs.get("batch_size", 4),
             frames=kwargs.get("frames"),
             dataset=kwargs.get("video_dataset"),
             input_format=kwargs.get("video_input_format"),
+            remote_kwargs=remote_kwargs or None,
         )
+    elif src_is_url and src_suffix == ".slp" and remote_kwargs:
+        # A bare remote .slp would otherwise be loaded by predict() without the
+        # remote kwargs; load it here with them and pass the Labels object so
+        # predict()'s frame selection (which keys on a Labels source the same way
+        # it does on a .slp path) is preserved.
+        import sleap_io as sio
+
+        source = sio.load_slp(source_str, **remote_kwargs)
     else:
-        source = str(src)
+        source = source_str
 
     peak_thresh = kwargs.get("peak_threshold", 0.2)
     centroid_thresh = kwargs.get("centroid_peak_threshold") or peak_thresh
@@ -1527,11 +1628,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         "clean_empty_frames": bool(kwargs.get("no_empty_frames")),
         "output_path": (
             kwargs.get("output_path")
-            or (
-                f"{src.with_suffix('')}.{scoped_video_name}.predictions.slp"
-                if scoped_video_name is not None
-                else f"{src}.slp"
-            )
+            or _default_predictions_path(source_str, src_is_url, scoped_video_name)
         ),
         "output_format": kwargs.get("output_format") or "slp",
         "embed": kwargs.get("embed") or "false",
@@ -1654,14 +1751,15 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
 
     import sleap_io as sio
 
-    src = Path(kwargs["data_path"])
-    if src.suffix != ".slp":
+    source_str, src_suffix, src_is_url = _resolve_data_path(kwargs["data_path"])
+    remote_kwargs = _build_remote_kwargs(kwargs)
+    if src_suffix != ".slp":
         raise click.UsageError(
             "Tracking-only mode requires --data_path to be a .slp file. "
             "Pass --model_paths to run inference + tracking."
         )
 
-    labels = sio.load_slp(str(src))
+    labels = sio.load_slp(source_str, **remote_kwargs)
 
     # Scope by --video_index (raises on out-of-range, like the inference paths)
     # and/or --frames, carrying suggestions + the source provenance. #583.
@@ -1709,7 +1807,7 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
     # set it; the new retrack flow previously saved with empty provenance). #583.
     out.provenance = build_tracking_only_provenance(
         input_labels=labels,
-        input_path=str(src),
+        input_path=source_str,
         start_time=_start,
         end_time=datetime.now(),
         tracking_params=_attrs.asdict(tracker_config),
@@ -1717,7 +1815,9 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
     )
     from sleap_nn.inference.run import save_predictions
 
-    output_path = kwargs.get("output_path") or f"{src}.slp"
+    output_path = kwargs.get("output_path") or _default_predictions_path(
+        source_str, src_is_url
+    )
     save_predictions(
         out,
         output_path,
@@ -1986,16 +2086,19 @@ def _run_stream_to_file(
 
     predictor = Predictor.from_model_paths(kwargs["model_paths"], **factory_kwargs)
 
-    src = Path(data_path)
+    source_str, src_suffix, _src_is_url = _resolve_data_path(data_path)
+    remote_kwargs = _build_remote_kwargs(kwargs)
     video_index = kwargs.get("video_index")
-    if src.suffix == ".slp" and video_index is not None:
+    if src_suffix == ".slp" and video_index is not None:
         # Scope streaming inference to the requested video of a multi-video .slp
         # (re-indexed to videos[0] so frames map correctly). Carries suggestions
         # + the --frames filter. #583.
         import sleap_io as sio
 
         scoped, _target_video = _scope_labels_to_video(
-            sio.load_slp(str(src)), video_index, frames=kwargs.get("frames")
+            sio.load_slp(source_str, **remote_kwargs),
+            video_index,
+            frames=kwargs.get("frames"),
         )
         provider = LabelsProvider(
             labels=scoped,
@@ -2005,22 +2108,24 @@ def _run_stream_to_file(
             exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
             only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
         )
-    elif src.suffix == ".slp":
+    elif src_suffix == ".slp":
         provider = LabelsProvider(
-            labels=str(src),
+            labels=source_str,
             batch_size=kwargs.get("batch_size", 4),
             only_labeled_frames=bool(kwargs.get("only_labeled_frames")),
             only_suggested_frames=bool(kwargs.get("only_suggested_frames")),
             exclude_user_labeled=bool(kwargs.get("exclude_user_labeled")),
             only_predicted_frames=bool(kwargs.get("only_predicted_frames")),
+            remote_kwargs=remote_kwargs or None,
         )
     else:
         provider = VideoProvider(
-            video=str(src),
+            video=source_str,
             batch_size=kwargs.get("batch_size", 4),
             frames=kwargs.get("frames"),
             dataset=kwargs.get("video_dataset"),
             input_format=kwargs.get("video_input_format"),
+            remote_kwargs=remote_kwargs or None,
         )
 
     if kwargs.get("gui"):
@@ -2057,7 +2162,27 @@ def _common_inference_options(f):
             "-i",
             type=str,
             required=True,
-            help="Path to data to predict on. Labels (.slp) file or any supported video format.",
+            help="Path to data to predict on. A local Labels (.slp) file or video, "
+            "or a remote URL (http(s)://, s3://, gs://, gcs://, az://, abfs://) to "
+            "a .slp or video that sleap-io can load.",
+        ),
+        click.option(
+            "--headers",
+            type=str,
+            default=None,
+            help="JSON object of HTTP headers for a remote --data_path URL, e.g. "
+            '\'{"Authorization": "Bearer <token>"}\'. Forwarded to the remote '
+            "loader; ignored for local inputs.",
+        ),
+        click.option(
+            "--stream-mode",
+            "--stream_mode",
+            "stream_mode",
+            type=str,
+            default=None,
+            help="Remote read strategy for a --data_path URL (forwarded to "
+            "sleap-io's loader, e.g. 'auto'/'stream'/'download'). Ignored for "
+            "local inputs.",
         ),
         click.option(
             "--model_paths",

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -99,6 +99,10 @@ class VideoProvider:
             ``sio.load_video``).
         input_format: For HDF5-backed videos, ``"channels_last"`` or
             ``"channels_first"`` (forwarded to ``sio.load_video``).
+        remote_kwargs: Optional mapping of remote-loading options forwarded to
+            ``sio.load_video`` when ``video`` is a URL (e.g.
+            ``{"headers": {...}, "stream_mode": "..."}``). Ignored for local
+            paths and pre-loaded ``sio.Video`` instances.
 
     Notes:
         Yields raw ``(B, H, W, C)`` frames as ``np.uint8``. The
@@ -111,6 +115,7 @@ class VideoProvider:
     frames: Optional[list[int]] = None
     dataset: Optional[str] = None
     input_format: Optional[str] = None
+    remote_kwargs: Optional[dict] = None
 
     _sio_video: "Optional[sio.Video]" = attrs.field(
         default=None, init=False, repr=False
@@ -129,6 +134,8 @@ class VideoProvider:
                 kwargs["dataset"] = self.dataset
             if self.input_format is not None:
                 kwargs["input_format"] = self.input_format
+            if self.remote_kwargs:
+                kwargs.update(self.remote_kwargs)
             self._sio_video = sio.load_video(str(self.video), **kwargs)
 
         n_frames = len(self._sio_video)
@@ -182,6 +189,10 @@ class LabelsProvider:
             Mutually exclusive with ``only_labeled_frames``.
         only_predicted_frames: Yield only frames that already have at
             least one predicted instance.
+        remote_kwargs: Optional mapping of remote-loading options forwarded to
+            ``sio.load_slp`` when ``labels`` is a URL (e.g.
+            ``{"headers": {...}, "stream_mode": "..."}``). Ignored for local
+            paths and pre-loaded ``sio.Labels`` instances.
     """
 
     labels: "Union[str, sio.Labels]"
@@ -190,6 +201,7 @@ class LabelsProvider:
     only_suggested_frames: bool = False
     exclude_user_labeled: bool = False
     only_predicted_frames: bool = False
+    remote_kwargs: Optional[dict] = None
 
     _sio_labels: "Optional[sio.Labels]" = attrs.field(
         default=None, init=False, repr=False
@@ -203,7 +215,9 @@ class LabelsProvider:
         if isinstance(self.labels, sio.Labels):
             self._sio_labels = self.labels
         else:
-            self._sio_labels = sio.load_slp(str(self.labels))
+            self._sio_labels = sio.load_slp(
+                str(self.labels), **(self.remote_kwargs or {})
+            )
 
         if self.only_labeled_frames and self.exclude_user_labeled:
             raise ValueError(

--- a/tests/cli/test_predict_remote.py
+++ b/tests/cli/test_predict_remote.py
@@ -1,0 +1,272 @@
+"""Tests for remote-URL (`http(s)://`, `s3://`, ...) inputs to ``sleap-nn predict``.
+
+sleap-io 0.8.0 can load ``.slp`` and video directly from URLs. Previously the
+CLI ran ``Path(data_path)`` on the input, which mangled ``scheme://`` (collapsing
+``//`` and flipping to backslashes on Windows) before it reached sleap-io's
+URL-aware loaders. These tests cover the URL detection/routing helpers, the
+``--headers`` / ``--stream-mode`` remote-option plumbing through the providers,
+and end-to-end routing of a URL through ``predict()`` without mangling.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import sleap_io as sio
+from click.testing import CliRunner
+
+from sleap_nn.cli import (
+    _build_remote_kwargs,
+    _default_predictions_path,
+    _is_remote_url,
+    _resolve_data_path,
+    cli,
+)
+from sleap_nn.inference.providers import LabelsProvider, VideoProvider
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("https://example.com/a.slp", True),
+        ("http://example.com/a.mp4", True),
+        ("s3://bucket/a.slp", True),
+        ("gs://bucket/a.mp4", True),
+        ("gcs://bucket/a.mp4", True),
+        ("az://container/a.slp", True),
+        ("abfs://container/a.slp", True),
+        ("/local/abs/a.slp", False),
+        ("relative/a.mp4", False),
+        ("a.slp", False),
+        ("", False),
+        (r"C:\data\a.slp", False),  # Windows drive letter is not a URL scheme
+        ("C:/data/a.slp", False),
+    ],
+)
+def test_is_remote_url(value, expected):
+    assert _is_remote_url(value) is expected
+
+
+def test_resolve_data_path_local():
+    source_str, suffix, is_url = _resolve_data_path("/fake/path.mp4")
+    assert is_url is False
+    assert suffix == ".mp4"
+    assert Path(source_str) == Path("/fake/path.mp4")
+
+
+def test_resolve_data_path_url_preserves_string_and_parses_suffix():
+    url = "https://example.com/data/clip.mp4?token=abc#frag"
+    source_str, suffix, is_url = _resolve_data_path(url)
+    assert is_url is True
+    assert source_str == url  # verbatim — NOT run through Path()
+    assert suffix == ".mp4"  # from the URL path, ignoring query/fragment
+
+
+def test_resolve_data_path_url_slp():
+    source_str, suffix, is_url = _resolve_data_path("s3://bucket/proj/labels.slp")
+    assert (source_str, suffix, is_url) == ("s3://bucket/proj/labels.slp", ".slp", True)
+
+
+def test_default_predictions_path_local():
+    assert _default_predictions_path("/data/v.mp4", False) == "/data/v.mp4.slp"
+
+
+def test_default_predictions_path_url_uses_basename_in_cwd():
+    # Mirrors the local "[data_path].slp" convention: the URL basename (with its
+    # extension) plus ".slp", written in the cwd.
+    assert _default_predictions_path("https://h/x/clip.mp4", True) == "clip.mp4.slp"
+    assert _default_predictions_path("s3://b/p/labels.slp", True) == "labels.slp.slp"
+
+
+def test_default_predictions_path_scoped():
+    out = _default_predictions_path("/data/multi.slp", False, scoped_video_name="vidA")
+    assert Path(out) == Path("/data/multi.vidA.predictions.slp")
+
+
+def test_build_remote_kwargs_headers_and_stream_mode():
+    remote = _build_remote_kwargs(
+        {"headers": '{"Authorization": "Bearer t"}', "stream_mode": "stream"}
+    )
+    assert remote == {"headers": {"Authorization": "Bearer t"}, "stream_mode": "stream"}
+
+
+def test_build_remote_kwargs_empty():
+    assert _build_remote_kwargs({}) == {}
+    assert _build_remote_kwargs({"headers": None, "stream_mode": None}) == {}
+
+
+def test_build_remote_kwargs_invalid_headers_json():
+    import click
+
+    with pytest.raises(click.UsageError):
+        _build_remote_kwargs({"headers": "not-json"})
+
+
+def test_build_remote_kwargs_headers_not_object():
+    import click
+
+    with pytest.raises(click.UsageError):
+        _build_remote_kwargs({"headers": "[1, 2, 3]"})
+
+
+# ── provider remote-kwargs threading ─────────────────────────────────────────
+def test_video_provider_forwards_remote_kwargs():
+    fake_video = MagicMock()
+    fake_video.__len__.return_value = 3
+    with patch("sleap_io.load_video", return_value=fake_video) as mock_load:
+        VideoProvider(
+            video="https://h/clip.mp4",
+            remote_kwargs={"headers": {"A": "B"}, "stream_mode": "stream"},
+        )
+    mock_load.assert_called_once()
+    assert mock_load.call_args.args[0] == "https://h/clip.mp4"
+    assert mock_load.call_args.kwargs == {
+        "headers": {"A": "B"},
+        "stream_mode": "stream",
+    }
+
+
+def test_labels_provider_forwards_remote_kwargs():
+    with patch("sleap_io.load_slp", return_value=sio.Labels()) as mock_load:
+        LabelsProvider(
+            labels="s3://bucket/labels.slp",
+            remote_kwargs={"headers": {"A": "B"}},
+        )
+    mock_load.assert_called_once()
+    assert mock_load.call_args.args[0] == "s3://bucket/labels.slp"
+    assert mock_load.call_args.kwargs == {"headers": {"A": "B"}}
+
+
+def test_labels_provider_no_remote_kwargs_passes_nothing():
+    with patch("sleap_io.load_slp", return_value=sio.Labels()) as mock_load:
+        LabelsProvider(labels="local.slp")
+    assert mock_load.call_args.kwargs == {}
+
+
+# ── end-to-end CLI routing ───────────────────────────────────────────────────
+def test_predict_remote_video_url_not_path_mangled():
+    """A bare remote video URL reaches predict() verbatim (no Path() mangling)."""
+    runner = CliRunner()
+    url = "https://example.com/data/clip.mp4"
+    with patch(
+        "sleap_nn.inference.run.predict", return_value=MagicMock()
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            ["predict", "--data_path", url, "--model_paths", "/fake/model"],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.call_args[0][0] == url
+    # Output defaults to the URL basename in the cwd (cannot write to the host).
+    assert mock_predict.call_args[1]["output_path"] == "clip.mp4.slp"
+
+
+def test_predict_remote_slp_url_passes_through():
+    """A bare remote .slp URL is passed to predict() as the raw string."""
+    runner = CliRunner()
+    url = "s3://bucket/proj/labels.slp"
+    with patch(
+        "sleap_nn.inference.run.predict", return_value=MagicMock()
+    ) as mock_predict:
+        result = runner.invoke(
+            cli,
+            ["predict", "--data_path", url, "--model_paths", "/fake/model"],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_predict.call_args[0][0] == url
+    assert mock_predict.call_args[1]["output_path"] == "labels.slp.slp"
+
+
+def test_predict_remote_video_url_with_headers_routes_through_provider():
+    """``--headers`` on a video URL routes through a VideoProvider carrying them."""
+    runner = CliRunner()
+    url = "https://example.com/clip.mp4"
+    fake_video = MagicMock()
+    fake_video.__len__.return_value = 3
+    with (
+        patch(
+            "sleap_nn.inference.run.predict", return_value=MagicMock()
+        ) as mock_predict,
+        # The VideoProvider is built eagerly in the CLI, so stub the remote load.
+        patch("sleap_io.load_video", return_value=fake_video) as mock_load_video,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                url,
+                "--model_paths",
+                "/fake/model",
+                "--headers",
+                '{"Authorization": "Bearer t"}',
+                "--stream-mode",
+                "stream",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    # The remote video was loaded with the forwarded headers/stream_mode
+    # (alongside the provider's usual input_format kwarg).
+    assert mock_load_video.call_args.args[0] == url
+    loaded_kwargs = mock_load_video.call_args.kwargs
+    assert loaded_kwargs.get("headers") == {"Authorization": "Bearer t"}
+    assert loaded_kwargs.get("stream_mode") == "stream"
+    source = mock_predict.call_args[0][0]
+    assert isinstance(source, VideoProvider)
+    assert source.video == url
+    assert source.remote_kwargs == {
+        "headers": {"Authorization": "Bearer t"},
+        "stream_mode": "stream",
+    }
+
+
+def test_predict_remote_slp_url_with_headers_loads_with_kwargs():
+    """``--headers`` on a .slp URL loads it with the remote kwargs up front."""
+    runner = CliRunner()
+    url = "s3://bucket/labels.slp"
+    fake_labels = sio.Labels()
+    with (
+        patch(
+            "sleap_nn.inference.run.predict", return_value=MagicMock()
+        ) as mock_predict,
+        patch("sleap_io.load_slp", return_value=fake_labels) as mock_load,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                url,
+                "--model_paths",
+                "/fake/model",
+                "--headers",
+                '{"X": "Y"}',
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    mock_load.assert_called_once()
+    assert mock_load.call_args.args[0] == url
+    assert mock_load.call_args.kwargs == {"headers": {"X": "Y"}}
+    # The loaded Labels object (not the raw URL) is handed to predict().
+    assert mock_predict.call_args[0][0] is fake_labels
+
+
+def test_predict_invalid_headers_errors():
+    """Malformed ``--headers`` JSON fails with a clear non-zero exit."""
+    runner = CliRunner()
+    with patch("sleap_nn.inference.run.predict", return_value=MagicMock()):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "https://h/clip.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--headers",
+                "not-json",
+            ],
+        )
+    assert result.exit_code != 0
+    assert "headers" in result.output.lower()


### PR DESCRIPTION
## Summary

- sleap-io 0.8.0 can load `.slp` and video **directly from URLs**, but `sleap-nn predict` ran `Path(data_path)` on the input first — which corrupts `scheme://` (collapses `//`, and flips to backslashes on Windows) before it ever reaches sleap-io's URL-aware loaders. So remote inputs were effectively unusable.
- This detects remote URLs up front and routes them **verbatim**, and adds `--headers` / `--stream-mode` for authenticated/streamed remote reads. Local-path behavior is unchanged.

## Changes

**`sleap_nn/cli.py`**
- `_is_remote_url()` / `_resolve_data_path()` — a URL (`http(s)`, `s3`, `gs`, `gcs`, `az`, `abfs`) is passed through unmodified; its suffix is parsed from the URL path (so `.slp`-vs-video routing still works and query strings/fragments are ignored). Local paths still normalize through `Path()`.
- `_default_predictions_path()` — URL-safe default output (the URL basename + `.slp`, written in the cwd, since you can't write next to a remote source). Mirrors the local `[data_path].slp` convention.
- `_build_remote_kwargs()` + new `--headers` (JSON object) and `--stream-mode` options.
- Applied across all three input entry points: `_run_in_memory_new_flow`, `_run_retrack_only`, `_run_stream_to_file`.
- A bare remote `.slp` **with** remote kwargs is loaded up front and passed as a `Labels` object (preserving `predict()`'s frame-selection semantics) so auth/stream options are honored; without remote kwargs it passes through as a string for `predict()` to load lazily.

**`sleap_nn/inference/providers.py`**
- `VideoProvider` / `LabelsProvider` gain a `remote_kwargs` passthrough, forwarded to `sio.load_video` / `sio.load_slp`.

## Example

```bash
sleap-nn predict -i https://example.com/clip.mp4 -m model/        # → clip.mp4.slp
sleap-nn predict -i s3://bucket/proj/labels.slp -m model/
sleap-nn predict -i https://host/private.mp4 -m model/ \
  --headers '{"Authorization": "Bearer <token>"}' --stream-mode stream
```

## Testing

`tests/cli/test_predict_remote.py` (31 tests, all mocked — no network): URL detection/`_resolve_data_path`/default-output/`_build_remote_kwargs` helpers (incl. Windows `C:\` is not a URL, invalid-JSON errors); provider `remote_kwargs` forwarding to the sio loaders; and end-to-end CLI routing of URL `.slp`/video with and without `--headers` (asserting the URL reaches `predict()` unmangled). Full `tests/cli/` (86) and provider suites (17) pass — no regression to local-path behavior.

## Scope

P2 of the sleap-io 0.8.0 plan, scoped to **remote-URL inputs (2.1)**. Rebases on top of #660 (P0) and #659 (P1).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)