### PR TITLE
release: 0.3.0 version bump + seed-config fix + docs-correctness sweep

### DIFF
--- a/docs/guides/centroid-only-inference.md
+++ b/docs/guides/centroid-only-inference.md
@@ -98,14 +98,14 @@ from sleap_nn.inference.run import predict
 
 # Auto-detect a lone centroid directory.
 labels = predict(
-    data_path="video.mp4",
+    source="video.mp4",
     model_paths=["models/centroid/"],
     output_path="centroids.slp",
 )
 
 # Explicit override on a two-model setup, emitting PredictedCentroid objects.
 labels = predict(
-    data_path="video.mp4",
+    source="video.mp4",
     model_paths=["models/centroid/", "models/centered_instance/"],
     centroid_only=True,
     emit_centroid="centroid",

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -20,8 +20,11 @@ sleap-nn eval \
 | `-g` / `--ground_truth_path` | Ground truth labels file | Required |
 | `-p` / `--predicted_path` | Predicted labels file | Required |
 | `-s` / `--save_metrics` | Save metrics to .npz file | None |
-| `--oks_stddev` | OKS standard deviation | `0.05` |
-| `--user_labels_only` | Only evaluate user-labeled frames | `False` |
+| `--oks_stddev` | OKS standard deviation | `0.025` |
+| `--oks_scale` | Scale factor for OKS calculation | None |
+| `--match_method` | Instance matcher: `oks`, `centroid`, `mask`, or `auto` (centroid when the prediction skeleton is single-node) | `auto` |
+| `--anchor_part` | GT node for centroid-mode ground-truth centroids (defaults to mean of visible nodes) | None |
+| `--user_labels_only` / `--no-user_labels_only` | Only evaluate user-labeled frames | `True` |
 
 ---
 
@@ -45,16 +48,12 @@ metrics = evaluator.evaluate()
 ```python
 # Overall metrics
 print(f"OKS mAP: {metrics['voc_metrics']['oks_voc.mAP']:.3f}")
-print(f"mOKS: {metrics['mOKS']:.3f}")
+print(f"mOKS: {metrics['mOKS']['mOKS']:.3f}")
 
 # Distance errors
-print(f"Mean error: {metrics['distance_metrics']['mean']:.2f} px")
+print(f"Mean error: {metrics['distance_metrics']['avg']:.2f} px")
 print(f"Median error: {metrics['distance_metrics']['p50']:.2f} px")
 print(f"90th %ile error: {metrics['distance_metrics']['p90']:.2f} px")
-
-# Per-node metrics
-for node, oks in metrics['per_node_oks'].items():
-    print(f"  {node}: {oks:.3f}")
 ```
 
 ---
@@ -69,10 +68,10 @@ Measures pose similarity accounting for keypoint visibility and scale:
 
 | Metric | Description | Range |
 |--------|-------------|-------|
-| `mOKS` | Mean OKS across all instances | 0-1 |
-| `oks_voc.mAP` | COCO-style mean Average Precision | 0-1 |
-| `oks_voc.AP@0.5` | AP at OKS threshold 0.5 | 0-1 |
-| `oks_voc.AP@0.75` | AP at OKS threshold 0.75 | 0-1 |
+| `mOKS` | Mean OKS across all instances (access via `metrics['mOKS']['mOKS']`) | 0-1 |
+| `oks_voc.mAP` | COCO-style mean Average Precision (mean over OKS thresholds) | 0-1 |
+| `oks_voc.mAR` | COCO-style mean Average Recall | 0-1 |
+| `oks_voc.AP` / `oks_voc.AR` | Per-OKS-threshold AP / AR arrays | 0-1 |
 
 Higher is better. mAP > 0.7 is generally good.
 
@@ -82,25 +81,15 @@ Euclidean distance between predicted and ground truth keypoints (in pixels):
 
 | Metric | Description |
 |--------|-------------|
-| `mean` | Mean error |
-| `std` | Standard deviation |
+| `avg` | Mean error |
 | `p50` | Median (50th percentile) |
+| `p75` | 75th percentile |
 | `p90` | 90th percentile |
 | `p95` | 95th percentile |
 | `p99` | 99th percentile |
 
-Lower is better. Values depend on image resolution and animal size.
-
-### Per-Node Metrics
-
-OKS computed separately for each body part:
-
-```python
-for node, oks in metrics['per_node_oks'].items():
-    print(f"{node}: {oks:.3f}")
-```
-
-Useful for identifying which keypoints are harder to predict.
+Lower is better. Values depend on image resolution and animal size. The raw
+per-pair distances are also available under `metrics['distance_metrics']['dists']`.
 
 ---
 

--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -79,11 +79,11 @@ sleap-nn export MODEL_PATH [options]
 
 | Option | Description | Values | Default |
 |--------|-------------|--------|---------|
-| `-o`, `--output-dir` | Output directory | `PATH` | Required |
+| `-o`, `--output` | Output directory | `PATH` | Required |
 | `-f`, `--format` | Export format | `onnx`, `tensorrt`, `both` | `onnx` |
-| `--precision` | TensorRT precision | `fp32`, `fp16` | `fp16` |
-| `-n`, `--max-instances` | Max instances per frame | `INT` | `20` |
-| `-b`, `--max-batch-size` | Max batch size | `INT` | `8` |
+| `--precision` | TensorRT precision | `fp32`, `fp16`, `tf32` | `fp16` |
+| `--max-instances` | Max instances per frame | `INT` | `20` |
+| `--max-batch-size` | Max batch size | `INT` | `8` |
 
 ---
 
@@ -209,14 +209,17 @@ export_to_tensorrt(model, "model.trt", input_shape=(1, 1, 192, 192))
 
 ### Inference
 
-```python
-from sleap_nn.export.predictors import ONNXPredictor
-import numpy as np
+Run an exported model through the unified pipeline by pointing a `Predictor` at
+the export directory written by `sleap-nn export` (it contains `export_metadata.json`):
 
-predictor = ONNXPredictor("model.onnx")
-frames = np.random.randint(0, 256, (4, 1, 192, 192), dtype=np.uint8)
-outputs = predictor.predict(frames)
+```python
+from sleap_nn.inference import Predictor
+
+predictor = Predictor.from_export_dir("exports/my_model", runtime="onnx")
+labels = predictor.predict("video.mp4")
 ```
+
+The CLI equivalent is `sleap-nn predict -m exports/my_model --runtime onnx -i video.mp4`.
 
 ---
 
@@ -225,7 +228,7 @@ outputs = predictor.predict(frames)
 ```
 exports/my_model/
 ├── model.onnx
-├── model.onnx.metadata.json
+├── export_metadata.json
 ├── model.trt                   # If TensorRT
 └── model.trt.metadata.json     # If TensorRT
 ```

--- a/docs/guides/topdown-segmentation.md
+++ b/docs/guides/topdown-segmentation.md
@@ -75,7 +75,7 @@ Top-down seg needs **two model dirs** — a `centroid` model and the
 `centered_instance_segmentation` model — composed via repeated `--model_paths`:
 
 ```bash
-sleap-nn predict video.mp4 \
+sleap-nn predict -i video.mp4 \
   --model_paths centroid_model_dir \
   --model_paths centered_instance_segmentation_model_dir \
   --fg_threshold 0.5 -o predictions.slp
@@ -107,7 +107,7 @@ GT instance. This is what post-training evaluation uses, and is handy for scorin
 the segmentation model in isolation:
 
 ```bash
-sleap-nn predict labeled.pkg.slp --model_paths centered_instance_segmentation_model_dir
+sleap-nn predict -i labeled.pkg.slp --model_paths centered_instance_segmentation_model_dir
 ```
 
 ## Evaluation

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -68,7 +68,7 @@ SLEAP-NN uses PyTorch, so it runs on any system where PyTorch is supported. This
 
     Tips for limited VRAM:
 
-    - Reduce batch size: `trainer_config.train_batch_size: 2`
+    - Reduce batch size: `trainer_config.train_data_loader.batch_size: 2`
     - Scale down images: `data_config.preprocessing.scale: 0.5`
     - Use smaller backbones: `model_config.backbone_config.unet.filters: 16`
 
@@ -166,10 +166,10 @@ SLEAP-NN uses PyTorch, so it runs on any system where PyTorch is supported. This
 ??? question "Out of GPU memory (CUDA OOM)"
     Common solutions:
 
-    1. **Reduce batch size**: `trainer_config.train_batch_size: 2`
+    1. **Reduce batch size**: `trainer_config.train_data_loader.batch_size: 2`
     2. **Scale down images**: `data_config.preprocessing.scale: 0.5`
     3. **Limit instances during inference**: `--max_instances 5`
-    4. **Use disk caching**: `data_config.data_pipeline_fw: torch_dataset`
+    4. **Use disk caching**: `data_config.data_pipeline_fw: torch_dataset_cache_img_disk`
     5. **Close other GPU applications**
 
     Check current GPU memory usage:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -129,7 +129,7 @@ metrics = evaluator.evaluate()
 
 # Access results
 print(f"OKS mAP: {metrics['voc_metrics']['oks_voc.mAP']:.3f}")
-print(f"Mean OKS: {metrics['mOKS']:.3f}")
+print(f"Mean OKS: {metrics['mOKS']['mOKS']:.3f}")
 print(f"Distance 90th %ile: {metrics['distance_metrics']['p90']:.2f} px")
 ```
 
@@ -140,13 +140,16 @@ print(f"Distance 90th %ile: {metrics['distance_metrics']['p90']:.2f} px")
 ### To ONNX
 
 ```python
+import torch
 from sleap_nn.export import export_to_onnx
 
+# ``model`` is a trained ``torch.nn.Module``. Most users export via the CLI
+# (``sleap-nn export``) instead — see "Inference with Exported Model" below.
 export_to_onnx(
     model,
-    output_path="model.onnx",
+    save_path="model.onnx",
     input_shape=(1, 1, 192, 192),
-    input_dtype="uint8",
+    input_dtype=torch.uint8,
 )
 ```
 
@@ -157,7 +160,7 @@ from sleap_nn.export import export_to_tensorrt
 
 export_to_tensorrt(
     model,
-    output_path="model.trt",
+    save_path="model.trt",
     input_shape=(1, 1, 192, 192),
     precision="fp16",
 )
@@ -165,20 +168,25 @@ export_to_tensorrt(
 
 ### Inference with Exported Model
 
-```python
-from sleap_nn.export.predictors import ONNXPredictor
-import numpy as np
+Exported ONNX/TensorRT models run through the same unified pipeline as
+checkpoints. From the CLI, point `sleap-nn predict` at the export directory and
+choose the runtime:
 
-predictor = ONNXPredictor("model.onnx")
-
-# Prepare frames (uint8, NCHW format)
-frames = np.random.randint(0, 256, (4, 1, 192, 192), dtype=np.uint8)
-
-# Predict
-outputs = predictor.predict(frames)
-peaks = outputs["peaks"]      # (B, N_nodes, 2)
-peak_vals = outputs["peak_vals"]  # (B, N_nodes)
+```bash
+sleap-nn predict -m exported_model/ -i video.mp4 -o predictions.slp --runtime onnx
 ```
+
+From Python, build a `Predictor` from the export directory:
+
+```python
+from sleap_nn.inference import Predictor
+
+predictor = Predictor.from_export_dir("exported_model/", runtime="onnx")
+labels = predictor.predict("video.mp4")
+```
+
+`exported_model/` is the directory written by `sleap-nn export` (it contains the
+`model.onnx`/`model.trt` plus an `export_metadata.json`).
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -209,9 +209,12 @@ sleap-nn eval --ground_truth_path GT --predicted_path PRED [OPTIONS]
 | `--ground_truth_path` | `-g` | Ground truth labels | `PATH` | Required |
 | `--predicted_path` | `-p` | Predicted labels | `PATH` | Required |
 | `--save_metrics` | `-s` | Save metrics to .npz | `PATH` | None |
-| `--oks_stddev` | | OKS standard deviation | `FLOAT` | `0.05` |
+| `--oks_stddev` | | OKS standard deviation | `FLOAT` | `0.025` |
+| `--oks_scale` | | Scale factor for OKS calculation | `FLOAT` | None |
 | `--match_threshold` | | Instance matching threshold | `FLOAT` | `0.0` |
-| `--user_labels_only` | | Only evaluate user-labeled | Flag | `false` |
+| `--match_method` | | Matcher: `oks`, `centroid`, `mask`, `auto` | `CHOICE` | `auto` |
+| `--anchor_part` | | GT node for centroid-mode GT centroids | `STR` | None |
+| `--user_labels_only` / `--no-user_labels_only` | | Only evaluate user-labeled | Flag | `True` |
 
 ### Example
 

--- a/docs/sample_configs/config_bottomup_convnext.yaml
+++ b/docs/sample_configs/config_bottomup_convnext.yaml
@@ -109,7 +109,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 40
-  seed:
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_bottomup_segmentation_unet.yaml
+++ b/docs/sample_configs/config_bottomup_segmentation_unet.yaml
@@ -123,7 +123,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_bottomup_unet_large_rf.yaml
+++ b/docs/sample_configs/config_bottomup_unet_large_rf.yaml
@@ -110,7 +110,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_bottomup_unet_medium_rf.yaml
+++ b/docs/sample_configs/config_bottomup_unet_medium_rf.yaml
@@ -110,7 +110,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_centroid_swint.yaml
+++ b/docs/sample_configs/config_centroid_swint.yaml
@@ -104,7 +104,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 30
-  seed:
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_centroid_unet.yaml
+++ b/docs/sample_configs/config_centroid_unet.yaml
@@ -104,7 +104,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_centroid_unet_standalone.yaml
+++ b/docs/sample_configs/config_centroid_unet_standalone.yaml
@@ -140,7 +140,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_multi_class_bottomup_unet.yaml
+++ b/docs/sample_configs/config_multi_class_bottomup_unet.yaml
@@ -109,7 +109,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 40
-  seed:
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/docs/sample_configs/config_single_instance_unet_large_rf.yaml
+++ b/docs/sample_configs/config_single_instance_unet_large_rf.yaml
@@ -104,7 +104,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_single_instance_unet_medium_rf.yaml
+++ b/docs/sample_configs/config_single_instance_unet_medium_rf.yaml
@@ -104,7 +104,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_topdown_centered_instance_segmentation_unet.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_segmentation_unet.yaml
@@ -106,7 +106,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_topdown_centered_instance_unet_large_rf.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet_large_rf.yaml
@@ -107,7 +107,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_topdown_centered_instance_unet_medium_rf.yaml
+++ b/docs/sample_configs/config_topdown_centered_instance_unet_medium_rf.yaml
@@ -107,7 +107,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 200
-  seed: null
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir: models

--- a/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
+++ b/docs/sample_configs/config_topdown_multi_class_centered_instance_unet.yaml
@@ -112,7 +112,7 @@ trainer_config:
   visualize_preds_during_training: true
   keep_viz: false
   max_epochs: 30
-  seed:
+  seed: 42
   use_wandb: false
   save_ckpt: true
   ckpt_dir:

--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -50,7 +50,7 @@ logger.add(
     colorize=False,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 # Public API
 from sleap_nn.evaluation import load_metrics


### PR DESCRIPTION
Preflight fixes ahead of the **0.3.0** release, from the comprehensive review of everything that landed since `v0.2.0` (inference refactor #508, centroid-only models, the segmentation/SAM stack, the `infer`→`predict` rename, the sleap-io 0.8.0 pin). Every fix below was verified against `HEAD`.

## What's in this PR (all low-risk: version string + config scalar + docs)

### 1. Version bump (release gate)
`sleap_nn/__init__.py` still reported `0.2.0`; `pyproject.toml` derives the dist version from `sleap_nn.__version__`, so tagging without this ships a **mislabeled artifact**. Bumped to `0.3.0`.

### 2. Seed-config regression (config correctness)
All 14 `docs/sample_configs/*.yaml` pinned `seed: null` (or a blank `seed:`), which **overrides the new `seed=42` default** and silently defeats the deterministic-split / resume-data-leakage guard added in #579/#600 (PR 600 regenerated test goldens but missed the user-facing onboarding configs). Set all 14 to `seed: 42`.

### 3. Docs-correctness sweep (broken copy-paste examples + wrong facts)
Confirmed-broken examples that raise on copy-paste, plus factually wrong CLI defaults/config keys:

- **`api.md` / `export.md`** — removed the import of the **non-existent** `sleap_nn.export.predictors.ONNXPredictor`; exported inference now points at `Predictor.from_export_dir(...)` / `sleap-nn predict --runtime onnx`. `export_to_onnx`/`export_to_tensorrt` now use `save_path=` (real kwarg; `output_path=` is a `TypeError`) and `input_dtype=torch.uint8` (the string `"uint8"` crashes — the exporter calls `input_dtype.is_floating_point`). `metrics['mOKS']` is a dict → `metrics['mOKS']['mOKS']`. Export metadata file is `export_metadata.json` (not `model.onnx.metadata.json`). Export options table: `--output` (not `--output-dir`), dropped the fake `-n`/`-b` shorts, added `tf32`.
- **`evaluation.md` / `cli.md`** — fixed metric access (`mOKS` dict; `distance_metrics['avg']` not `'mean'`); removed the **fabricated `per_node_oks`** section (no such key is returned); corrected the OKS/distance reference tables; fixed eval defaults (`--oks_stddev` `0.025`, `--user_labels_only` default `True`) and added the missing `--match_method`/`--oks_scale`/`--anchor_part`.
- **`centroid-only-inference.md`** — `predict(source=...)` (the kwarg is `source`; `data_path=` is a `TypeError`).
- **`topdown-segmentation.md`** — `sleap-nn predict -i <path>` (predict has no positional argument; a bare path errors).
- **`faq.md`** — `trainer_config.train_data_loader.batch_size` (not `train_batch_size`); disk caching value is `torch_dataset_cache_img_disk`.

## Validation
- `import sleap_nn; sleap_nn.__version__ == "0.3.0"` ✓
- All 14 sample configs parse via OmegaConf with `seed == 42` ✓
- Every documented import/signature resolves: `Predictor.from_export_dir(runtime=...)`, `export_to_onnx/tensorrt(save_path=, input_dtype=torch.uint8)` ✓
- Every documented metric-access path resolves against a **real** `Evaluator` run (GT `minimal_instance.pkg.slp` vs a fresh bottom-up prediction: mOKS 0.91, oks_voc.mAP 0.85, distance avg/p50/p75/p90/p95/p99 all present; `per_node_oks` confirmed absent) ✓
- `black --check` + `ruff check` clean ✓

## Context (not in this PR)
The other open release gate — the unverified cu130 channel-mismatch crash from #563 — was **separately cleared** by a GPU smoke run on this hardware (TITAN RTX / CUDA 13.0 / torch 2.9.1+cu130): centroid / bottom-up / top-down `predict` on off-dimension + RGB video, in-memory **and** streaming, **8/8 pass**, no crash. No code change required.

Out of scope (tracked for follow-up): additive docs (new `predict` flags in `cli.md`, a bottom-up-seg training guide), the `inference-guide.md` track-only-filter claim, the bare-`np.ndarray` source routing bug, and the inference-API ergonomics (model-surgery accessor + realtime `warmup()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016siM3ZsQtDciGmp6et8n1v