### PR TITLE
Filter out-of-bounds points before training (#571)

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -36,6 +36,7 @@ from sleap_nn.data.normalization import (
     convert_to_rgb,
 )
 from sleap_nn.data.providers import (
+    filter_oob_points,
     get_max_instances,
     get_max_height_width,
     process_lf,
@@ -1393,6 +1394,10 @@ class CenteredInstanceDataset(BaseDataset):
 
         img_hw = sample["instance_image"].shape[-2:]
 
+        # Drop keypoints pushed outside the crop by augmentation so their target
+        # confidence map is empty rather than a partial blob at the crop edge.
+        sample["instance"] = filter_oob_points(sample["instance"], img_hw[0], img_hw[1])
+
         # Generate confidence maps
         confidence_maps = generate_confmaps(
             sample["instance"],
@@ -2064,6 +2069,10 @@ class TopDownCenteredInstanceMultiClassDataset(CenteredInstanceDataset):
         )
 
         img_hw = sample["instance_image"].shape[-2:]
+
+        # Drop keypoints pushed outside the crop by augmentation so their target
+        # confidence map is empty rather than a partial blob at the crop edge.
+        sample["instance"] = filter_oob_points(sample["instance"], img_hw[0], img_hw[1])
 
         # Generate confidence maps
         confidence_maps = generate_confmaps(

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -2414,6 +2414,12 @@ class SingleInstanceDataset(BaseDataset):
 
         img_hw = sample["image"].shape[-2:]
 
+        # Drop keypoints pushed outside the image by augmentation so their target
+        # confidence map is empty rather than a partial blob at the image edge.
+        sample["instances"] = filter_oob_points(
+            sample["instances"], img_hw[0], img_hw[1]
+        )
+
         # Generate confidence maps
         confidence_maps = generate_confmaps(
             sample["instances"],

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -1,6 +1,6 @@
 """This module implements pipeline blocks for reading input data such as labels."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import sleap_io as sio
@@ -36,31 +36,36 @@ def get_max_height_width(labels: sio.Labels) -> Tuple[int, int]:
 
 
 def filter_oob_points(
-    points: np.ndarray, img_height: int, img_width: int
-) -> np.ndarray:
+    points: Union[np.ndarray, torch.Tensor], img_height: int, img_width: int
+) -> Union[np.ndarray, torch.Tensor]:
     """Set out-of-bounds (OOB) keypoints to NaN.
 
-    A keypoint is OOB if it has a negative coordinate or falls outside the original
-    image frame (``x >= img_width`` or ``y >= img_height``). Such points are typically
-    annotation errors that cannot be supervised correctly during training (they would
-    bleed a partial confidence-map blob onto the image edge), so they are set to NaN —
-    the missing-point representation used throughout the data pipeline.
+    A keypoint is OOB if it has a negative coordinate or falls outside the frame /
+    crop of size ``img_height`` x ``img_width`` (``x >= img_width`` or
+    ``y >= img_height``; upper bound exclusive). Such points cannot be supervised
+    correctly during training — they would bleed a partial confidence-map blob onto
+    the edge — so they are set to NaN, the missing-point representation used
+    throughout the data pipeline. This is used both to drop annotation errors against
+    the original image frame (in `process_lf`) and to drop keypoints pushed outside a
+    crop by augmentation (before confidence-map generation).
+
+    Works on both NumPy arrays and torch tensors, and on any leading batch/instance
+    dimensions; the last axis must be ``(x, y)``.
 
     Args:
-        points: Keypoints array of shape ``(num_nodes, 2)`` with ``(x, y)`` pixel
-            coordinates in the original image frame. May already contain NaNs for
-            missing points.
-        img_height: Height of the original image frame.
-        img_width: Width of the original image frame.
+        points: Keypoints of shape ``(..., num_nodes, 2)`` with ``(x, y)`` pixel
+            coordinates. May already contain NaNs for missing points.
+        img_height: Height of the frame / crop.
+        img_width: Width of the frame / crop.
 
     Returns:
-        A copy of ``points`` with OOB keypoints set to NaN.
+        A copy of ``points`` (same type as the input) with OOB keypoints set to NaN.
     """
-    points = points.copy()
-    x = points[:, 0]
-    y = points[:, 1]
+    points = points.clone() if isinstance(points, torch.Tensor) else points.copy()
+    x = points[..., 0]
+    y = points[..., 1]
     oob = (x < 0) | (x >= img_width) | (y < 0) | (y >= img_height)
-    points[oob] = np.nan
+    points[oob] = float("nan")
     return points
 
 

--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -35,6 +35,35 @@ def get_max_height_width(labels: sio.Labels) -> Tuple[int, int]:
     )
 
 
+def filter_oob_points(
+    points: np.ndarray, img_height: int, img_width: int
+) -> np.ndarray:
+    """Set out-of-bounds (OOB) keypoints to NaN.
+
+    A keypoint is OOB if it has a negative coordinate or falls outside the original
+    image frame (``x >= img_width`` or ``y >= img_height``). Such points are typically
+    annotation errors that cannot be supervised correctly during training (they would
+    bleed a partial confidence-map blob onto the image edge), so they are set to NaN —
+    the missing-point representation used throughout the data pipeline.
+
+    Args:
+        points: Keypoints array of shape ``(num_nodes, 2)`` with ``(x, y)`` pixel
+            coordinates in the original image frame. May already contain NaNs for
+            missing points.
+        img_height: Height of the original image frame.
+        img_width: Width of the original image frame.
+
+    Returns:
+        A copy of ``points`` with OOB keypoints set to NaN.
+    """
+    points = points.copy()
+    x = points[:, 0]
+    y = points[:, 1]
+    oob = (x < 0) | (x >= img_width) | (y < 0) | (y >= img_height)
+    points[oob] = np.nan
+    return points
+
+
 def process_lf(
     instances_list: List[sio.Instance],
     img: np.ndarray,
@@ -66,11 +95,18 @@ def process_lf(
             instances_list = user_instances
 
     image = np.transpose(img, (2, 0, 1))  # HWC -> CHW
+    img_height, img_width = image.shape[-2:]
 
     instances = []
     for inst in instances_list:
-        if not inst.is_empty:
-            instances.append(inst.numpy())
+        if inst.is_empty:
+            continue
+        # Sanity check: set out-of-bounds keypoints (annotation errors) to NaN and
+        # drop instances that fall entirely outside the original image frame.
+        pts = filter_oob_points(inst.numpy(), img_height, img_width)
+        if np.isnan(pts).all():
+            continue
+        instances.append(pts)
     if len(instances) == 0:
         return None
     instances = np.stack(instances, axis=0)
@@ -84,7 +120,6 @@ def process_lf(
     instances = torch.from_numpy(instances.astype("float32"))
 
     num_instances, nodes = instances.shape[1:3]
-    img_height, img_width = image.shape[-2:]
 
     # append with nans for broadcasting
     if max_instances != 1:

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -671,6 +671,43 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
     assert sample["confidence_maps"].shape == (1, 2, 104, 104)
 
 
+def test_single_instance_dataset_filters_out_of_frame(minimal_instance):
+    """Nodes pushed off-frame by augmentation get an empty confmap."""
+    labels = sio.load_slp(minimal_instance)
+    for lf in labels:
+        lf.instances = lf.instances[:1]
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+
+    # Deterministic 4x zoom about the image center pushes the off-center node
+    # outside the 384x384 frame; all other augmentations are disabled.
+    geometric_aug = {
+        "scale_min": 4.0,
+        "scale_max": 4.0,
+        "scale_p": 1.0,
+    }
+    dataset = SingleInstanceDataset(
+        max_stride=8,
+        scale=1.0,
+        confmap_head_config=confmap_head,
+        labels=[labels],
+        apply_aug=True,
+        geometric_aug=geometric_aug,
+        cache_img="memory",
+    )
+    dataset._fill_cache([labels])
+    sample = next(iter(dataset))
+
+    instances = sample["instances"][0]  # (n_instances, n_nodes, 2)
+    cms = sample["confidence_maps"][0]  # (n_nodes, h, w)
+
+    oob = torch.isnan(instances[0]).any(dim=-1)  # single instance
+    assert oob.any()  # at least one node was pushed off-frame and masked
+    for n in range(oob.shape[0]):
+        if oob[n]:
+            assert cms[n].sum() == 0  # empty target for off-frame node
+
+
 def test_centered_instance_dataset_filters_out_of_crop(minimal_instance):
     """Nodes outside the crop get an empty confmap; in-crop nodes are preserved."""
     confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": None})

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -671,6 +671,43 @@ def test_centered_instance_dataset(minimal_instance, tmp_path):
     assert sample["confidence_maps"].shape == (1, 2, 104, 104)
 
 
+def test_centered_instance_dataset_filters_out_of_crop(minimal_instance):
+    """Nodes outside the crop get an empty confmap; in-crop nodes are preserved."""
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": None})
+
+    def build(crop_size):
+        dataset = CenteredInstanceDataset(
+            max_stride=2,
+            scale=1.0,
+            confmap_head_config=confmap_head,
+            crop_size=crop_size,
+            labels=[sio.load_slp(minimal_instance)],
+            apply_aug=False,
+            cache_img="memory",
+        )
+        dataset._fill_cache([sio.load_slp(minimal_instance)])
+        return next(iter(dataset))
+
+    # Tiny crop: both nodes (~30px from the centroid) fall outside the crop, so they
+    # are masked to NaN and their confidence maps are empty (all-zero).
+    small = build(20)
+    inst_s = small["instance"][0]  # (n_nodes, 2)
+    cms_s = small["confidence_maps"][0]  # (n_nodes, h, w)
+    oob = torch.isnan(inst_s).any(dim=-1)
+    assert oob.any()
+    for n in range(inst_s.shape[0]):
+        if oob[n]:
+            assert cms_s[n].sum() == 0
+
+    # Large crop: both nodes stay inside, so nothing is masked and every node has a
+    # non-empty confidence map.
+    large = build(160)
+    inst_l = large["instance"][0]
+    cms_l = large["confidence_maps"][0]
+    assert not torch.isnan(inst_l).any()
+    assert (cms_l.sum(dim=(-1, -2)) > 0).all()
+
+
 def test_centered_multiclass_dataset(minimal_instance, tmp_path):
     """Test the TopDownCenteredInstanceMultiClassDataset."""
     tracked_labels = sio.load_slp(minimal_instance)

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -288,6 +288,21 @@ def test_filter_oob_points():
         assert np.isnan(out[i]).all()
 
 
+def test_filter_oob_points_torch_batched():
+    """`filter_oob_points` works on batched torch tensors without mutating the input."""
+    pts = torch.tensor(
+        [[[10.0, 20.0], [200.0, 5.0], [-1.0, 3.0], [5.0, 5.0]]]  # (1, 4, 2)
+    )
+    out = filter_oob_points(pts, img_height=100, img_width=100)
+
+    assert isinstance(out, torch.Tensor)
+    assert not torch.isnan(pts).any()  # input untouched
+    assert torch.allclose(out[0, 0], torch.tensor([10.0, 20.0]))  # in bounds
+    assert torch.isnan(out[0, 1]).all()  # x >= width
+    assert torch.isnan(out[0, 2]).all()  # negative x
+    assert torch.allclose(out[0, 3], torch.tensor([5.0, 5.0]))  # in bounds
+
+
 def test_filter_oob_points_boundary():
     """Upper bound is exclusive: a coord equal to the size is OOB."""
     pts = np.array([[99.0, 99.0], [100.0, 50.0], [50.0, 100.0]])

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -3,6 +3,7 @@ import torch
 from sleap_nn.data.providers import (
     LabelsReader,
     VideoReader,
+    filter_oob_points,
     process_lf,
 )
 from queue import Queue
@@ -262,6 +263,107 @@ def test_process_lf(minimal_instance):
     assert ex["instances"].shape == torch.Size([1, 4, 2, 2])
     assert torch.isnan(ex["instances"][:, 2:, :, :]).all()
     assert not torch.is_floating_point(ex["image"])
+
+
+def test_filter_oob_points():
+    """`filter_oob_points` sets OOB keypoints to NaN without mutating the input."""
+    pts = np.array(
+        [
+            [10.0, 20.0],  # in bounds
+            [-1.0, 5.0],  # negative x
+            [5.0, -2.0],  # negative y
+            [100.0, 5.0],  # x >= width
+            [5.0, 100.0],  # y >= height
+            [np.nan, np.nan],  # already missing
+        ]
+    )
+    out = filter_oob_points(pts, img_height=100, img_width=100)
+
+    # Input is not mutated.
+    assert pts[1, 0] == -1.0
+
+    # In-bounds point is preserved; OOB and missing points are NaN.
+    assert np.array_equal(out[0], [10.0, 20.0])
+    for i in range(1, 6):
+        assert np.isnan(out[i]).all()
+
+
+def test_filter_oob_points_boundary():
+    """Upper bound is exclusive: a coord equal to the size is OOB."""
+    pts = np.array([[99.0, 99.0], [100.0, 50.0], [50.0, 100.0]])
+    out = filter_oob_points(pts, img_height=100, img_width=100)
+    assert np.array_equal(out[0], [99.0, 99.0])  # width-1 / height-1 in bounds
+    assert np.isnan(out[1]).all()  # x == width
+    assert np.isnan(out[2]).all()  # y == height
+
+
+def test_process_lf_filters_oob(minimal_instance):
+    """`process_lf` sets off-frame keypoints to NaN while keeping in-bounds nodes."""
+    labels = sio.load_slp(minimal_instance)
+    skeleton = labels.skeletons[0]
+    img = labels[0].image
+    h, w = img.shape[:2]
+
+    partial = sio.Instance.from_numpy(
+        np.array([[10.0, 20.0], [w + 50.0, 30.0]]), skeleton=skeleton
+    )
+    ex = process_lf(
+        instances_list=[partial],
+        img=img,
+        frame_idx=0,
+        video_idx=0,
+        max_instances=1,
+    )
+    inst = ex["instances"][0, 0]  # (num_nodes, 2)
+    assert torch.allclose(inst[0], torch.tensor([10.0, 20.0]))
+    assert torch.isnan(inst[1]).all()
+
+
+def test_process_lf_drops_fully_oob_instance(minimal_instance):
+    """An instance entirely out-of-bounds is dropped; valid instances remain."""
+    labels = sio.load_slp(minimal_instance)
+    skeleton = labels.skeletons[0]
+    img = labels[0].image
+    h, w = img.shape[:2]
+
+    in_bounds = sio.Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0]]), skeleton=skeleton
+    )
+    fully_oob = sio.Instance.from_numpy(
+        np.array([[-5.0, -5.0], [w + 10.0, h + 10.0]]), skeleton=skeleton
+    )
+    ex = process_lf(
+        instances_list=[in_bounds, fully_oob],
+        img=img,
+        frame_idx=0,
+        video_idx=0,
+        max_instances=4,
+    )
+    assert ex["num_instances"] == 1
+    assert torch.allclose(
+        ex["instances"][0, 0], torch.tensor([[10.0, 20.0], [30.0, 40.0]])
+    )
+    assert torch.isnan(ex["instances"][0, 1:]).all()
+
+
+def test_process_lf_all_oob_returns_none(minimal_instance):
+    """If every instance is fully out-of-bounds, `process_lf` returns None."""
+    labels = sio.load_slp(minimal_instance)
+    skeleton = labels.skeletons[0]
+    img = labels[0].image
+    h, w = img.shape[:2]
+
+    fully_oob = sio.Instance.from_numpy(
+        np.array([[-5.0, -5.0], [w + 10.0, h + 10.0]]), skeleton=skeleton
+    )
+    ex = process_lf(
+        instances_list=[fully_oob],
+        img=img,
+        frame_idx=0,
+        video_idx=0,
+        max_instances=1,
+    )
+    assert ex is None
 
 
 def test_exclude_user_labeled(minimal_instance):


### PR DESCRIPTION
## Summary
Out-of-bounds (OOB) keypoints — points that can't actually be located in the supervised image — currently get a phantom Gaussian blob at the image/crop edge instead of an empty target, because `make_confmaps` evaluates over the grid for any finite point. This PR sets such points to NaN (→ empty target via the existing `nan_to_num`) at three places, all reusing one helper (`filter_oob_points`):

1. **Annotation errors vs the original frame** — at load time in `process_lf` (issue #571's direct scope).
2. **Keypoints pushed outside the crop by augmentation** — top-down centered-instance datasets.
3. **Keypoints pushed off the frame by augmentation** — single-instance dataset.

## Problem
A keypoint that isn't in the supervised image still produces a partial blob hugging the edge → the model is taught a phantom peak at the border for a node it can never actually localize there.

- **(1)** Annotation data can contain negative / off-frame coordinates (issue #571, from [talmolab/sleap#1901](https://github.com/talmolab/sleap/discussions/1901)).
- **(2)** Top-down crops are augmented *after* cropping (rotation about the crop center), so a node near a crop corner can rotate outside the crop. The crop is taken ~√2 larger to preserve image content, but that doesn't keep keypoints inside the final crop box. Worst case: a user sets a tight `crop_size`, which returns early in `find_instance_crop_size` and **bypasses the rotation-aware padding** entirely — nodes then fall outside the crop *every epoch, even with augmentation off*.
- **(3)** Single-instance trains on the full frame; rotation/scale can push an in-frame node off the image.

## Changes Made
- `sleap_nn/data/providers.py`:
  - `filter_oob_points(points, img_height, img_width)` — returns a copy with OOB nodes (negative, or `>=` size; upper bound exclusive) set to NaN. Accepts **NumPy arrays or torch tensors** and any leading batch/instance dims.
  - `process_lf` applies it per instance against the **original frame** dims and drops instances that go fully NaN.
- `sleap_nn/data/custom_datasets.py`: apply `filter_oob_points` against the relevant grid `img_hw`, right before confmap generation, in `CenteredInstanceDataset`, `TopDownCenteredInstanceMultiClassDataset`, and `SingleInstanceDataset`.
- Tests in `tests/data/test_providers.py` and `tests/data/test_custom_datasets.py`.

## Scope / what's intentionally NOT changed
- **Bottom-up** is left for a follow-up. Its PAF/edge-map targets make node-level OOB handling a larger, separate decision (an edge with one off-frame endpoint is more involved than a single keypoint), and it already has an instance-level guard (drops instances where *all* nodes are off-frame).
- The legacy TensorFlow SLEAP keeps off-frame points only because dropping them would break a fixed-shape array `reshape` (`remove_invisible=False` is a structural necessity, not an intentional "supervise off-frame points" design). sleap-nn is the current backend, so this is treated as a bug to fix rather than behavior to preserve.

## API Changes
- New public function `filter_oob_points` in `sleap_nn.data.providers` (numpy or torch). No config or other signature changes.

## Design Decisions
- **One helper, NaN semantics:** OOB → NaN matches the missing-point convention the pipeline already honors (`nan_to_num` in confmaps, `isnan` masks in centroids, `nanmin/nanmax` in cropping), so an OOB node yields an empty (all-zero) target with no downstream changes.
- **Right bounds at each stage:** original-frame dims at load; crop / full-frame `img_hw` right before confmaps — the exact grid the target is drawn on.
- **No config flag:** OOB points are never valid supervision.
- **Negligible cost:** ~3 µs (numpy, `process_lf`) / ~15 µs (torch, per crop/frame sample) on tiny keypoint arrays — well under 1% of a sample's image-resize/crop/augment/confmap cost.

## Testing
- `filter_oob_points`: numpy + torch paths, exclusive boundary, already-missing points, no input mutation.
- `process_lf`: partial-OOB instance keeps valid nodes; fully-OOB instance dropped; all-OOB frame → `None`.
- `CenteredInstanceDataset`: tiny crop → nodes masked + confmaps empty; large crop → nodes kept + confmaps non-empty.
- `SingleInstanceDataset`: deterministic 4× zoom pushes a node off-frame → masked + empty confmap.
- Full data suite green (`tests/data/` — 143 passed). `black` + `ruff` clean.

## Related Issues
Closes #571

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)