### PR TITLE
fix(infer): route np.ndarray / torch.Tensor predict() source to NumpyProvider

### DIFF
--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1149,11 +1149,29 @@ class Predictor:
 
         from sleap_nn.inference.providers import (
             LabelsProvider,
+            NumpyProvider,
             VideoProvider,
         )
 
-        if isinstance(source, (str, np.ndarray)):
-            if isinstance(source, str) and source.endswith(".slp"):
+        if isinstance(source, (np.ndarray, torch.Tensor)):
+            # In-memory frame stack ``(N, H, W, C)`` — the batch-oriented analog
+            # of the realtime ``layer.predict`` path. Route to ``NumpyProvider``;
+            # a raw array is not a video file, so ``VideoProvider`` raised
+            # "Unknown video file type", and a bare tensor would otherwise be
+            # mistaken for a ``Provider`` by the ``__iter__`` branch below.
+            # ``frames`` (if given) labels the per-frame indices on the output.
+            provider = NumpyProvider(
+                images=source,
+                batch_size=self.batch_size,
+                frame_indices=(
+                    np.asarray(frames, dtype=np.int64) if frames is not None else None
+                ),
+                **provider_kwargs,
+            )
+            return provider, None
+
+        if isinstance(source, str):
+            if source.endswith(".slp"):
                 # Load once so we can both build the provider AND attach the
                 # real videos to the output Labels — legacy parity: predicted
                 # frames must reference the source video, not be dropped
@@ -1168,15 +1186,14 @@ class Predictor:
                     **provider_kwargs,
                 )
                 return provider, (list(labels.videos) if labels.videos else None)
-            video = sio.Video(source) if isinstance(source, str) else None
+            video = sio.Video(source)
             provider = VideoProvider(
                 video=source,
                 batch_size=self.batch_size,
                 frames=frames,
                 **provider_kwargs,
             )
-            videos = [video] if video is not None else None
-            return provider, videos
+            return provider, [video]
 
         if isinstance(source, sio.Video):
             provider = VideoProvider(

--- a/tests/inference/test_predictor_new.py
+++ b/tests/inference/test_predictor_new.py
@@ -147,6 +147,52 @@ def test_metadata_propagates_from_provider():
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# 5b. A bare np.ndarray / torch.Tensor source auto-wraps a NumpyProvider
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_predict_accepts_numpy_array_source():
+    """A bare ``np.ndarray`` source is wrapped in a ``NumpyProvider``.
+
+    Regression: it previously routed to ``VideoProvider(video=ndarray)`` and
+    raised ``ValueError: Unknown video file type``. ``predict(ndarray)`` must
+    match ``predict(NumpyProvider(images=ndarray))``.
+    """
+    images = np.zeros((6, 1, 8, 8), dtype=np.float32)
+    predictor = Predictor(layer=_StubLayer())
+    out_arr = predictor.predict(images, make_labels=False)
+    out_provider = predictor.predict(
+        NumpyProvider(images=images, batch_size=predictor.batch_size),
+        make_labels=False,
+    )
+    n_arr = sum(o.pred_keypoints.shape[0] for o in out_arr)
+    assert n_arr == 6
+    assert n_arr == sum(o.pred_keypoints.shape[0] for o in out_provider)
+
+
+def test_predict_accepts_torch_tensor_source():
+    """A bare ``torch.Tensor`` source is wrapped too.
+
+    Regression: a raw tensor previously fell through to the ``__iter__``
+    branch and was mistaken for a ``Provider`` (iterating yields rows, not
+    ``Batch`` objects), failing downstream.
+    """
+    images = torch.zeros((4, 1, 8, 8))
+    predictor = Predictor(layer=_StubLayer())
+    out = predictor.predict(images, make_labels=False)
+    assert sum(o.pred_keypoints.shape[0] for o in out) == 4
+
+
+def test_predict_numpy_array_source_frame_indices():
+    """``frames`` labels the per-frame indices for an in-memory source."""
+    images = np.zeros((3, 1, 8, 8), dtype=np.float32)
+    predictor = Predictor(layer=_StubLayer())
+    outs = predictor.predict(images, frames=[10, 11, 12], make_labels=False)
+    fi = torch.cat([o.frame_indices for o in outs]).tolist()
+    assert sorted(fi) == [10, 11, 12]
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # 6. make_labels requires skeleton
 # ─────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes the `predict(np.ndarray)` bug surfaced in the 0.3.0 preflight review (`inference-api-1`).

## Problem
`Predictor._make_provider` branched on `isinstance(source, (str, np.ndarray))` — clearly intending to accept in-memory frames — but then built `VideoProvider(video=source)` for the non-`.slp` case, so a numpy array hit `sio.load_video(str(ndarray))` and raised:

```
ValueError: Unknown video file type: [[[[0 0 0] ...
```

A bare `torch.Tensor` was silently worse: it skipped every `isinstance` branch and fell into the trailing `hasattr(source, "__iter__")` branch, where it was mistaken for a `Provider` (iterating a tensor yields rows, not `Batch` objects) and failed downstream.

## Fix
Dispatch an in-memory frame stack `(N, H, W, C)` to **`NumpyProvider`** — the batch-oriented analog of the realtime `layer.predict` path — for both `np.ndarray` and `torch.Tensor` (which `NumpyProvider` already supports). The `str` branch (`.slp` → `LabelsProvider`, otherwise `VideoProvider`) is split out and otherwise unchanged. `frames=` (if given) labels the per-frame indices on the output.

```python
# now works (previously raised "Unknown video file type"):
labels = predict(frames, model_paths=[...])          # frames: np.ndarray (N, H, W, C)
labels = Predictor.from_model_paths([...]).predict(frames)
```

This makes the high-level API accept in-memory frames directly — a realtime/notebook ergonomic win — matching `predict(NumpyProvider(images=frames))`.

## Validation
- New unit tests (`test_predictor_new.py`): ndarray and tensor sources produce the same result as an explicit `NumpyProvider`, and `frames=` propagates to per-frame indices.
- End-to-end on a real model: 5 in-memory frames from `centered_pair_small.mp4` → `sio.Labels` with 2 instances/frame (previously a crash).
- Existing `test_run.py` / `test_predictors.py` / `test_providers.py` pass (51); the file/`.slp`/`sio.Video`/`sio.Labels` source paths are unchanged.
- `ruff check sleap_nn/` and `black --check sleap_nn tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016siM3ZsQtDciGmp6et8n1v