### PR TITLE
feat(api): top-level predict/Predictor/load_models + repeatable --output_format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Configurations are managed via Hydra and can be specified in YAML files (see `do
 ### Key Entry Points
 
 - Training: `sleap_nn/train.py` - Hydra-based training entry point
-- Inference: `sleap_nn/predict.py` - Run inference on trained models
+- Inference: `sleap_nn/legacy_predict.py` - Run inference on trained models
 - CLI: `sleap_nn/cli.py` - Command-line interface (currently minimal)
 - Evaluation: `sleap_nn/evaluation.py` - Model evaluation utilities
 - Centroid-only models: first-class support — train a lone centroid head, `sleap-nn predict` auto-detects a single centroid directory (output collapses to a single-node `'centroid'` skeleton), distance-based eval (`--match_method centroid`), and standalone ONNX/TensorRT export. See `docs/guides/centroid-only-inference.md`.

--- a/docs/guides/inference-guide.md
+++ b/docs/guides/inference-guide.md
@@ -378,7 +378,7 @@ For the reusable `Predictor` class, streaming, raw `Outputs`, filtering, and
 tracking from Python, see the [Inference API guide](inference-api.md).
 
 !!! note "Legacy `run_inference`"
-    `from sleap_nn.predict import run_inference` is the older legacy-pipeline
+    `from sleap_nn.legacy_predict import run_inference` is the older legacy-pipeline
     entry point (it backs `sleap-nn track`). Prefer `sleap_nn.inference.predict`
     for new code.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -71,7 +71,7 @@ train(
 ### Basic Inference
 
 ```python
-from sleap_nn.predict import run_inference
+from sleap_nn.legacy_predict import run_inference
 
 labels = run_inference(
     data_path="video.mp4",

--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -55,4 +55,52 @@ __version__ = "0.3.0"
 # Public API
 from sleap_nn.evaluation import load_metrics
 
-__all__ = ["load_metrics", "__version__"]
+
+def load_models(model_paths, **kwargs):
+    """Load trained model(s) into a ready-to-run :class:`Predictor`.
+
+    A discoverable, top-level convenience wrapper around
+    :meth:`sleap_nn.inference.Predictor.from_model_paths`. Pass one model
+    directory (single-instance / bottom-up / centroid) or a centroid +
+    centered-instance pair (top-down); a lone centroid directory is
+    auto-detected. Accepts every keyword argument of ``from_model_paths``
+    (e.g. ``device``, ``batch_size``, ``peak_threshold``, ``tracker_config``)
+    and returns a reusable ``Predictor`` you can call ``.predict(...)`` on
+    repeatedly.
+
+    Example:
+        >>> import sleap_nn
+        >>> predictor = sleap_nn.load_models(
+        ...     ["models/centroid/", "models/centered_instance/"], device="cuda"
+        ... )
+        >>> labels = predictor.predict("video.mp4")
+
+    For a one-shot call, use :func:`sleap_nn.predict` instead.
+    """
+    from sleap_nn.inference import Predictor
+
+    return Predictor.from_model_paths(model_paths, **kwargs)
+
+
+# Lazily surface the high-level inference entry points at the top level. These
+# are resolved on first access via PEP 562 so that ``import sleap_nn`` (e.g. CLI
+# startup or a ``__version__`` check) does not eagerly import the heavy
+# inference stack (torch, the predictor/layer modules).
+_LAZY_ATTRS = {"predict": "predict", "Predictor": "Predictor"}
+
+
+def __getattr__(name):
+    """Resolve lazily-exposed inference entry points (``predict``, ``Predictor``)."""
+    if name in _LAZY_ATTRS:
+        from sleap_nn import inference
+
+        return getattr(inference, _LAZY_ATTRS[name])
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    """Include the lazily-exposed names in ``dir(sleap_nn)`` for discoverability."""
+    return sorted(set(globals()) | set(_LAZY_ATTRS))
+
+
+__all__ = ["load_metrics", "load_models", "predict", "Predictor", "__version__"]

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1023,7 +1023,7 @@ def track(**kwargs):
     This command uses the legacy ``run_inference`` pipeline. For the new
     inference pipeline, use ``sleap-nn predict``.
     """
-    from sleap_nn.predict import frame_list, run_inference
+    from sleap_nn.legacy_predict import frame_list, run_inference
 
     if "model_paths" in kwargs and kwargs["model_paths"]:
         kwargs["model_paths"] = list(kwargs["model_paths"])
@@ -1087,7 +1087,7 @@ def _run_inference_impl(**kwargs):
     ``--frames`` string into a list of int frame indices, and routes to
     the new :class:`Predictor`-based pipeline.
     """
-    from sleap_nn.predict import frame_list
+    from sleap_nn.legacy_predict import frame_list
 
     paf_workers = kwargs.pop("paf_workers", 0) or 0
     cpu_workers = kwargs.pop("cpu_workers", None)
@@ -1156,7 +1156,7 @@ def _run_inference_impl(**kwargs):
 def _resolve_device(value: object) -> str:
     """Resolve a CLI ``--device`` value to a concrete torch device string.
 
-    The legacy :func:`sleap_nn.predict.run_inference` resolves ``"auto"``
+    The legacy :func:`sleap_nn.legacy_predict.run_inference` resolves ``"auto"``
     before any checkpoint loading; the new flow needs the same so
     ``torch.load(map_location="auto")`` doesn't blow up on the legacy
     factory loader.
@@ -1235,7 +1235,7 @@ def _build_tracker_config(kwargs: dict) -> "object":
     """Build a :class:`TrackerConfig` from the CLI ``--tracking_*`` flags.
 
     Replicates the legacy ``run_inference`` edge-layer defaulting (see
-    ``sleap_nn/predict.py`` pre-#530) so the new ``predict`` flow behaves
+    ``sleap_nn/legacy_predict.py`` pre-#530) so the new ``predict`` flow behaves
     identically (#582):
 
     * ``--max_tracks`` with no ``--candidates_method`` defaults the method to
@@ -1630,7 +1630,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
             kwargs.get("output_path")
             or _default_predictions_path(source_str, src_is_url, scoped_video_name)
         ),
-        "output_format": kwargs.get("output_format") or "slp",
+        "output_format": kwargs.get("output_format") or ("slp",),
         "embed": kwargs.get("embed") or "false",
         "restore_source_videos": kwargs.get("restore_source_videos", True),
         # Bottom-up PAF grouping knobs (inert for non-bottom-up models). #583.
@@ -1821,7 +1821,7 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
     save_predictions(
         out,
         output_path,
-        output_format=kwargs.get("output_format") or "slp",
+        output_format=kwargs.get("output_format") or ("slp",),
         embed=kwargs.get("embed") or "false",
         restore_source_videos=kwargs.get("restore_source_videos", True),
     )
@@ -2011,7 +2011,7 @@ def _run_stream_to_file(
             "streaming writes each batch to disk and cannot drop empty "
             "frames after the fact. Drop --stream-to-file to use it."
         )
-    if (kwargs.get("output_format") or "slp").lower() != "slp":
+    if any(str(f).lower() != "slp" for f in (kwargs.get("output_format") or ("slp",))):
         raise click.UsageError(
             "--stream-to-file only supports --output_format slp. Drop "
             "--stream-to-file to write analysis HDF5 via the in-memory path."
@@ -2199,9 +2199,13 @@ def _common_inference_options(f):
         ),
         click.option(
             "--output_format",
-            type=click.Choice(["slp", "analysis_h5", "both"], case_sensitive=False),
-            default="slp",
-            help="Output format: 'slp' (SLEAP labels file, the default), 'analysis_h5' (SLEAP Analysis HDF5, one '.analysis.h5' per video), or 'both'.",
+            type=click.Choice(["slp", "analysis_h5"], case_sensitive=False),
+            multiple=True,
+            default=("slp",),
+            help="Output format(s); repeat the flag to write several. 'slp' "
+            "(SLEAP labels file, the default) and/or 'analysis_h5' (SLEAP "
+            "Analysis HDF5, one '.analysis.h5' per video). E.g. "
+            "'--output_format slp --output_format analysis_h5'.",
         ),
         click.option(
             "--embed",

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -28,7 +28,7 @@ Usage::
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 
 import sleap_io as sio
 from loguru import logger
@@ -171,10 +171,43 @@ def _resolve_embed(embed, labels) -> bool:
     raise ValueError(f"Invalid embed={embed!r}; expected 'auto', 'true', or 'false'.")
 
 
+def _normalize_output_formats(
+    output_format: Union[str, Sequence[str]],
+) -> List[str]:
+    """Normalize ``output_format`` (a string or sequence) to a de-duped list.
+
+    Accepts a single format (``"slp"``) or several
+    (``["slp", "analysis_h5"]``, as produced by repeating ``--output_format``).
+    Returns an order-preserving, de-duplicated list drawn from
+    ``{"slp", "analysis_h5"}``; an empty input defaults to ``["slp"]``.
+
+    Raises:
+        ValueError: If any requested format is not ``"slp"`` or ``"analysis_h5"``.
+    """
+    requested = (
+        [output_format] if isinstance(output_format, str) else list(output_format)
+    )
+    formats: List[str] = []
+    for fmt in requested:
+        fmt = str(fmt).lower()
+        if fmt not in formats:
+            formats.append(fmt)
+    if not formats:
+        formats = ["slp"]
+    valid = ("slp", "analysis_h5")
+    invalid = [f for f in formats if f not in valid]
+    if invalid:
+        raise ValueError(
+            f"Invalid output_format: {invalid!r}. Each must be one of {valid} "
+            "(pass --output_format more than once to write several)."
+        )
+    return formats
+
+
 def save_predictions(
     labels: sio.Labels,
     output_path: Union[str, Path],
-    output_format: str = "slp",
+    output_format: Union[str, Sequence[str]] = "slp",
     video_index: Optional[int] = None,
     embed: Union[str, bool] = "false",
     restore_source_videos: bool = True,
@@ -185,8 +218,9 @@ def save_predictions(
         labels: Predicted ``sio.Labels`` to save.
         output_path: Canonical ``.slp`` output path. Analysis HDF5 paths are
             derived from it.
-        output_format: One of ``"slp"`` (the default), ``"analysis_h5"``, or
-            ``"both"``.
+        output_format: One format or several — ``"slp"`` (the default),
+            ``"analysis_h5"``, or a sequence like ``["slp", "analysis_h5"]`` to
+            write both. (The CLI exposes this as a repeatable ``--output_format``.)
         video_index: Restrict the analysis HDF5 export to a single video index;
             ``None`` exports every video with predicted frames.
         embed: Image-embedding policy for the ``.slp`` output, one of
@@ -202,21 +236,15 @@ def save_predictions(
             embedding.
 
     Returns:
-        The list of analysis HDF5 paths written (empty when
-        ``output_format == "slp"``).
+        The list of analysis HDF5 paths written (empty unless ``"analysis_h5"``
+        was requested).
 
     Raises:
-        ValueError: If ``output_format`` is not one of the valid options.
+        ValueError: If any requested format is not ``"slp"`` or ``"analysis_h5"``.
     """
-    output_format = str(output_format).lower()
-    valid_output_formats = ("slp", "analysis_h5", "both")
-    if output_format not in valid_output_formats:
-        raise ValueError(
-            f"Invalid output_format: {output_format!r}. Must be one of "
-            f"{valid_output_formats}."
-        )
+    formats = _normalize_output_formats(output_format)
 
-    if output_format in ("slp", "both"):
+    if "slp" in formats:
         labels.save(
             Path(output_path).as_posix(),
             embed=_resolve_embed(embed, labels),
@@ -224,7 +252,7 @@ def save_predictions(
         )
 
     h5_paths: List[Path] = []
-    if output_format in ("analysis_h5", "both"):
+    if "analysis_h5" in formats:
         h5_paths = save_analysis_h5_files(labels, output_path, video_index=video_index)
     return h5_paths
 
@@ -297,7 +325,7 @@ def predict(
     tracker_config: Optional["TrackerConfig"] = None,
     # Output
     output_path: Optional[str] = None,
-    output_format: str = "slp",
+    output_format: Union[str, Sequence[str]] = "slp",
     embed: Union[str, bool] = "false",
     restore_source_videos: bool = True,
     clean_empty_frames: bool = False,
@@ -458,7 +486,9 @@ def predict(
         # format stores poses/tracks, not ``PredictedSegmentationMask``, so it
         # would silently drop the masks (the actual output). Reject it up front
         # rather than write a mask-less ``.h5``.
-        if output_path is not None and str(output_format).lower() != "slp":
+        if output_path is not None and any(
+            f != "slp" for f in _normalize_output_formats(output_format)
+        ):
             raise ValueError(
                 f"mask_backend output only supports output_format='slp' (got "
                 f"{output_format!r}); the SLEAP Analysis HDF5 format stores "

--- a/sleap_nn/legacy_predict.py
+++ b/sleap_nn/legacy_predict.py
@@ -329,7 +329,7 @@ def run_inference(
     import warnings
 
     warnings.warn(
-        "sleap_nn.predict.run_inference() is deprecated and will be removed "
+        "sleap_nn.legacy_predict.run_inference() is deprecated and will be removed "
         "in a future release. Use the factory functions in sleap_nn.inference — "
         "either get_predictor_from_model_paths(...).predict(...) for checkpoint "
         "inference, .predict_to_file(...) for disk-streaming, or "

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional, List, Tuple, Union
 import sleap_io as sio
 from sleap_nn.config.training_job_config import TrainingJobConfig
 from sleap_nn.training.model_trainer import ModelTrainer
-from sleap_nn.predict import run_inference as predict
+from sleap_nn.legacy_predict import run_inference as predict
 from sleap_nn.evaluation import run_evaluation
 from sleap_nn.config.get_config import (
     get_trainer_config,

--- a/tests/cli/test_aliases.py
+++ b/tests/cli/test_aliases.py
@@ -19,7 +19,7 @@ from sleap_nn.cli import cli
 def test_track_routes_to_legacy_run_inference():
     """``sleap-nn track`` routes to the legacy ``run_inference`` pipeline."""
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference", return_value=None) as mock_run:
+    with patch("sleap_nn.legacy_predict.run_inference", return_value=None) as mock_run:
         result = runner.invoke(
             cli,
             [

--- a/tests/cli/test_predict_command.py
+++ b/tests/cli/test_predict_command.py
@@ -125,7 +125,7 @@ def test_predict_simple_case_uses_predict(tmp_path):
             "sleap_nn.inference.run.predict",
             return_value=MagicMock(),
         ) as mock_predict,
-        patch("sleap_nn.predict.run_inference") as mock_run_inference,
+        patch("sleap_nn.legacy_predict.run_inference") as mock_run_inference,
     ):
         result = runner.invoke(
             cli,
@@ -164,7 +164,7 @@ def test_predict_with_tracking_uses_predict(tmp_path):
             "sleap_nn.inference.run.predict",
             return_value=MagicMock(),
         ) as mock_predict,
-        patch("sleap_nn.predict.run_inference") as mock_run,
+        patch("sleap_nn.legacy_predict.run_inference") as mock_run,
     ):
         result = runner.invoke(
             cli,
@@ -208,7 +208,7 @@ def test_predict_with_tracking_plus_filter_uses_predict(tmp_path):
             "sleap_nn.inference.run.predict",
             return_value=MagicMock(),
         ) as mock_predict,
-        patch("sleap_nn.predict.run_inference") as mock_run,
+        patch("sleap_nn.legacy_predict.run_inference") as mock_run,
     ):
         result = runner.invoke(
             cli,
@@ -312,7 +312,7 @@ def test_predict_only_suggested_frames_routes_to_predict(tmp_path):
             return_value=MagicMock(),
         ) as mock_predict,
         patch("sleap_nn.inference.providers.LabelsProvider") as mock_provider,
-        patch("sleap_nn.predict.run_inference") as mock_run,
+        patch("sleap_nn.legacy_predict.run_inference") as mock_run,
     ):
         result = runner.invoke(
             cli,
@@ -447,7 +447,7 @@ def test_predict_retrack_only_dispatches_to_predictor_retrack(tmp_path):
         patch(
             "sleap_nn.inference.predictor.Predictor.retrack", return_value=tracked
         ) as mock_retrack,
-        patch("sleap_nn.predict.run_inference") as mock_legacy,
+        patch("sleap_nn.legacy_predict.run_inference") as mock_legacy,
     ):
         result = runner.invoke(
             cli,
@@ -483,7 +483,7 @@ def test_predict_retrack_only_forwards_embed_and_restore(tmp_path):
     with (
         patch("sleap_io.load_slp", return_value=fake_labels),
         patch("sleap_nn.inference.predictor.Predictor.retrack", return_value=tracked),
-        patch("sleap_nn.predict.run_inference") as mock_legacy,
+        patch("sleap_nn.legacy_predict.run_inference") as mock_legacy,
         patch("sleap_nn.inference.run.save_predictions") as mock_save,
     ):
         result = runner.invoke(
@@ -598,7 +598,9 @@ def test_track_command_candidates_method_defaults_fixed_window():
     stay 'fixed_window', else run_inference -> Tracker.from_config(None) crashes).
     """
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference", return_value=MagicMock()) as mock_run:
+    with patch(
+        "sleap_nn.legacy_predict.run_inference", return_value=MagicMock()
+    ) as mock_run:
         result = runner.invoke(
             cli,
             [
@@ -622,7 +624,9 @@ def test_track_command_candidates_method_defaults_fixed_window():
 def test_track_gui_forwards_to_run_inference():
     """`track --gui` forwards gui=True to run_inference (no longer popped). #583."""
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference", return_value=MagicMock()) as mock_run:
+    with patch(
+        "sleap_nn.legacy_predict.run_inference", return_value=MagicMock()
+    ) as mock_run:
         result = runner.invoke(
             cli,
             [
@@ -641,7 +645,9 @@ def test_track_gui_forwards_to_run_inference():
 def test_track_no_gui_defaults_false():
     """Without --gui, track forwards gui=False."""
     runner = CliRunner()
-    with patch("sleap_nn.predict.run_inference", return_value=MagicMock()) as mock_run:
+    with patch(
+        "sleap_nn.legacy_predict.run_inference", return_value=MagicMock()
+    ) as mock_run:
         result = runner.invoke(
             cli,
             ["track", "--data_path", "/fake/x.mp4", "--model_paths", "/fake/m"],
@@ -830,7 +836,7 @@ def test_predict_retrack_only_sets_tracking_provenance(tmp_path):
 
 
 def test_predict_forwards_output_format(tmp_path):
-    """``--output_format`` propagates to ``predict()`` as the output_format kwarg."""
+    """Repeated ``--output_format`` propagates to ``predict()`` as a tuple."""
     out = tmp_path / "out.slp"
     runner = CliRunner()
     with patch(
@@ -848,12 +854,14 @@ def test_predict_forwards_output_format(tmp_path):
                 "--output_path",
                 str(out),
                 "--output_format",
-                "both",
+                "slp",
+                "--output_format",
+                "analysis_h5",
             ],
         )
     assert result.exit_code == 0, result.output
     assert mock_predict.called
-    assert mock_predict.call_args[1]["output_format"] == "both"
+    assert mock_predict.call_args[1]["output_format"] == ("slp", "analysis_h5")
 
 
 def test_predict_stream_to_file_rejects_non_slp_format(tmp_path):

--- a/tests/export/test_export_accuracy.py
+++ b/tests/export/test_export_accuracy.py
@@ -108,7 +108,7 @@ def exported_bottomup_onnx_dir(bottomup_ckpt_path, tmp_path_factory):
 @pytest.fixture(scope="session")
 def pytorch_bottomup_labels(bottomup_ckpt_path, video_path):
     """Run PyTorch inference on the test video and return Labels."""
-    from sleap_nn.predict import run_inference
+    from sleap_nn.legacy_predict import run_inference
 
     labels = run_inference(
         data_path=str(video_path),

--- a/tests/inference/sam/test_run_sam_segmentation.py
+++ b/tests/inference/sam/test_run_sam_segmentation.py
@@ -476,7 +476,7 @@ def test_predict_sam_forwards_sam3_model_id(minimal_instance, tmp_path):
     assert captured["sam3_model_id"] == "acme/custom-sam3"
 
 
-@pytest.mark.parametrize("output_format", ["analysis_h5", "both"])
+@pytest.mark.parametrize("output_format", ["analysis_h5", ["slp", "analysis_h5"]])
 def test_predict_sam_rejects_non_slp_output_format(
     minimal_instance, tmp_path, output_format
 ):

--- a/tests/inference/test_centroid_only.py
+++ b/tests/inference/test_centroid_only.py
@@ -450,7 +450,7 @@ def test_centroid_only_predict_to_file_collapses(tmp_path):
     reason="centroid ckpt / slp fixture absent",
 )
 def test_legacy_run_inference_lone_centroid_raises():
-    from sleap_nn.predict import run_inference
+    from sleap_nn.legacy_predict import run_inference
 
     with pytest.raises(ValueError, match="predict"):
         run_inference(

--- a/tests/inference/test_issue_575.py
+++ b/tests/inference/test_issue_575.py
@@ -221,7 +221,7 @@ def test_run_inference_centroid_guard_accepts_ckpt_path():
     """The lone-centroid guard in ``run_inference`` resolves a centroid best.ckpt
     path to its dir and still detects the centroid-only case (raising the
     redirect error rather than silently failing open)."""
-    from sleap_nn.predict import run_inference
+    from sleap_nn.legacy_predict import run_inference
 
     with pytest.raises(ValueError, match="Centroid-only inference is not supported"):
         run_inference(

--- a/tests/inference/test_run.py
+++ b/tests/inference/test_run.py
@@ -205,10 +205,10 @@ def test_save_predictions_invalid_format_raises():
 
 
 def test_save_predictions_both_writes_slp_and_h5(minimal_instance, tmp_path):
-    """output_format='both' writes both a .slp and an analysis .h5 that round-trip."""
+    """A multi-format request writes both a .slp and an analysis .h5 that round-trip."""
     labels = sio.load_slp(minimal_instance.as_posix())
     out = tmp_path / "preds.slp"
-    h5_written = save_predictions(labels, out, output_format="both")
+    h5_written = save_predictions(labels, out, output_format=["slp", "analysis_h5"])
     assert out.exists()
     assert h5_written == [tmp_path / "preds.analysis.h5"]
     assert h5_written[0].exists()
@@ -287,9 +287,9 @@ def test_predict_forwards_output_format(tmp_path):
             model_paths=["/m"],
             device="cpu",
             output_path=str(out),
-            output_format="both",
+            output_format=["slp", "analysis_h5"],
         )
-    assert mock_save.call_args.kwargs["output_format"] == "both"
+    assert mock_save.call_args.kwargs["output_format"] == ["slp", "analysis_h5"]
 
 
 # --- embed / restore_source_videos controls (#652) -------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 from omegaconf import OmegaConf
 import subprocess
 from click.testing import CliRunner
-from sleap_nn.predict import run_inference
+from sleap_nn.legacy_predict import run_inference
 from sleap_nn.cli import (
     cli,
     print_version,
@@ -231,7 +231,7 @@ class TestTrackCommand:
         """Test track command with empty frames string."""
         runner = CliRunner()
         # Mock run_inference to avoid actual inference
-        with patch("sleap_nn.predict.run_inference") as mock_inference:
+        with patch("sleap_nn.legacy_predict.run_inference") as mock_inference:
             mock_inference.return_value = None
             result = runner.invoke(
                 cli,
@@ -251,7 +251,7 @@ class TestTrackCommand:
     def test_track_forwards_kalman_flags(self):
         """track forwards Kalman flags (and parses --kf_node_indices) to run_inference (#572)."""
         runner = CliRunner()
-        with patch("sleap_nn.predict.run_inference") as mock_inference:
+        with patch("sleap_nn.legacy_predict.run_inference") as mock_inference:
             mock_inference.return_value = None
             result = runner.invoke(
                 cli,

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 import copy
 import torch
-from sleap_nn.predict import run_inference
+from sleap_nn.legacy_predict import run_inference
 from sleap_nn.evaluation import (
     compute_instance_area,
     compute_oks,

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -4,7 +4,7 @@ from typing import Text
 import numpy as np
 import pytest
 from omegaconf import OmegaConf
-from sleap_nn.predict import run_inference
+from sleap_nn.legacy_predict import run_inference
 from loguru import logger
 from _pytest.logging import LogCaptureFixture
 import torch

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,57 @@
+"""Top-level public API surface: ``sleap_nn.{predict, Predictor, load_models}``."""
+
+from unittest.mock import patch
+
+import pytest
+
+import sleap_nn
+
+
+def test_top_level_names_are_discoverable():
+    """The high-level entry points are advertised in ``__all__`` and ``dir()``."""
+    for name in ("predict", "Predictor", "load_models"):
+        assert name in sleap_nn.__all__
+        assert name in dir(sleap_nn)
+
+
+def test_predict_and_predictor_resolve_to_inference():
+    """``sleap_nn.predict`` / ``Predictor`` are the inference function / class."""
+    from sleap_nn import inference
+
+    assert sleap_nn.predict is inference.predict
+    assert sleap_nn.Predictor is inference.Predictor
+    assert callable(sleap_nn.predict)
+
+
+def test_predict_stays_callable_after_legacy_import():
+    """Regression: importing the legacy module must not shadow ``sleap_nn.predict``.
+
+    Before ``sleap_nn/predict.py`` was renamed to ``legacy_predict.py``,
+    importing ``sleap_nn.train`` (which pulls in the old ``sleap_nn.predict``
+    module) rebound ``sleap_nn.predict`` to the *module*, breaking
+    ``sleap_nn.predict(...)``.
+    """
+    import sleap_nn.train  # noqa: F401  (imports sleap_nn.legacy_predict)
+
+    assert callable(sleap_nn.predict)
+    from sleap_nn import inference
+
+    assert sleap_nn.predict is inference.predict
+
+
+def test_load_models_wraps_from_model_paths():
+    """``sleap_nn.load_models`` forwards to ``Predictor.from_model_paths``."""
+    sentinel = object()
+    with patch(
+        "sleap_nn.inference.Predictor.from_model_paths",
+        return_value=sentinel,
+    ) as mock_fmp:
+        result = sleap_nn.load_models(["/m1", "/m2"], device="cuda", batch_size=8)
+    assert result is sentinel
+    mock_fmp.assert_called_once_with(["/m1", "/m2"], device="cuda", batch_size=8)
+
+
+def test_unknown_attribute_raises():
+    """``__getattr__`` still raises ``AttributeError`` for unknown names."""
+    with pytest.raises(AttributeError):
+        sleap_nn.totally_made_up_name  # noqa: B018

--- a/tests/tracking/candidates/test_fixed_window.py
+++ b/tests/tracking/candidates/test_fixed_window.py
@@ -1,7 +1,7 @@
 from typing import DefaultDict, Deque, List
 import numpy as np
 import torch
-from sleap_nn.predict import run_inference
+from sleap_nn.legacy_predict import run_inference
 from sleap_nn.tracking.track_instance import TrackedInstanceFeature
 from sleap_nn.tracking.candidates.fixed_window import FixedWindowCandidates
 from sleap_nn.tracking.tracker import Tracker

--- a/tests/tracking/candidates/test_local_queues.py
+++ b/tests/tracking/candidates/test_local_queues.py
@@ -1,7 +1,7 @@
 from typing import DefaultDict, Deque
 import numpy as np
 
-from sleap_nn.predict import run_inference
+from sleap_nn.legacy_predict import run_inference
 from sleap_nn.tracking.candidates.local_queues import LocalQueueCandidates
 from sleap_nn.tracking.tracker import Tracker
 import torch

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import sleap_io as sio
-from sleap_nn.predict import run_inference
+from sleap_nn.legacy_predict import run_inference
 from sleap_nn.tracking.tracker import (
     Tracker,
     FlowShiftTracker,


### PR DESCRIPTION
Two small pre-release API-ergonomics changes for 0.3.0.

## 1. Discoverable top-level inference API
- **`sleap_nn.predict`** and **`sleap_nn.Predictor`** are now exposed at the package top level, resolved **lazily** (via module `__getattr__`) so `import sleap_nn` (CLI startup, version checks) does not eagerly import the torch/inference stack.
- **`sleap_nn.load_models(model_paths, **kwargs)`** — a findable convenience wrapper around `Predictor.from_model_paths` that returns a reusable `Predictor`:

```python
import sleap_nn

# one-shot
labels = sleap_nn.predict("video.mp4", model_paths=["models/centroid/", "models/ci/"])

# build once, reuse
predictor = sleap_nn.load_models(["models/bottomup/"], device="cuda")
labels = predictor.predict("video.mp4")
```

### Legacy module rename (to free the `predict` name)
`sleap_nn.predict` (function) collided with the legacy **`sleap_nn/predict.py` module** (`run_inference`), which `train.py` and the `track` CLI import — so `import sleap_nn.train` rebound `sleap_nn.predict` to the *module*, breaking `sleap_nn.predict(...)`. The legacy module is renamed **`sleap_nn/predict.py` → `sleap_nn/legacy_predict.py`** and all importers/patch-targets/refs updated (source, docs, ~15 test files). A regression test (`tests/test_public_api.py::test_predict_stays_callable_after_legacy_import`) guards that `sleap_nn.predict` stays the function after importing `sleap_nn.train`.

> Note: external code using `from sleap_nn.predict import run_inference` (the legacy entry point) must switch to `from sleap_nn.legacy_predict import run_inference`. The supported path is the new `sleap_nn.predict` / `sleap-nn predict`.

## 2. `--output_format` is now repeatable (no `both`)
`--output_format {slp,analysis_h5,both}` → repeatable `--output_format` drawn from `{slp, analysis_h5}`:

```bash
sleap-nn predict -m model/ -i video.mp4 -o out.slp \
  --output_format slp --output_format analysis_h5      # writes both
```

`save_predictions` / `predict` accept a `str` **or** a sequence; a shared `_normalize_output_formats` helper validates, lowercases, and de-dupes. The `both` choice is removed (it never shipped — introduced post-v0.2.0 in #613).

## Validation
- End-to-end on CUDA: `sleap_nn.predict(ndarray)` and `load_models().predict(...)` return `sio.Labels`; `--output_format slp --output_format analysis_h5` writes both `preds.slp` and `preds.analysis.h5`; `--output_format both` now errors (`'both' is not one of 'slp', 'analysis_h5'`).
- New `tests/test_public_api.py` (top-level names discoverable; `predict`/`Predictor` resolve to `inference`; `load_models` forwards to `from_model_paths`; legacy-import regression guard). Updated `output_format` tests (`test_run.py`, `test_predict_command.py`, SAM reject test) for the multi-value form.
- All ~15 rename-affected test files collect/import cleanly (207 tests); `test_aliases.py` passes against the new `legacy_predict` patch target.
- `ruff check sleap_nn/` + `black --check sleap_nn tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016siM3ZsQtDciGmp6et8n1v