### PR TITLE
feat(viz): add trainer_config.viz_img_format (png|jpg) for local viz images

### DIFF
--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -335,6 +335,7 @@ class TrainerConfig:
         train_steps_per_epoch: (int) Number of minibatches (steps) to train for in an epoch. If set to `None`, this is set to the number of batches in the training data or `min_train_steps_per_epoch`, whichever is largest. *Default*: `None`. **Note**: In a multi-gpu training setup, the effective steps during training would be the `trainer_steps_per_epoch` / `trainer_devices`.
         visualize_preds_during_training: (bool) If set to `True`, sample predictions (keypoints + confidence maps) are saved to `viz` folder in the ckpt dir and in wandb table. *Default*: `False`.
         keep_viz: (bool) If set to `True`, the `viz` folder will be kept after training. If `False`, the `viz` folder will be deleted after training. Only applies when `visualize_preds_during_training` is `True`. *Default*: `False`.
+        viz_img_format: (str) Image format for the visualization figures saved to the local `viz` folder, one of `"png"` or `"jpg"`. `"jpg"` produces much smaller files, which helps when training a battery of models on the same dataset (#644). Only applies when `visualize_preds_during_training` is `True`. *Default*: `"png"`.
         max_epochs: (int) Maximum number of epochs to run. *Default*: `100`.
         seed: (int) Seed value for the current experiment. This ensures deterministic train/val splits across runs, which is critical for safe checkpoint resume. *Default*: `42`.
         use_wandb: (bool) True to enable wandb logging. *Default*: `False`.
@@ -366,6 +367,7 @@ class TrainerConfig:
     train_steps_per_epoch: Optional[int] = None
     visualize_preds_during_training: bool = False
     keep_viz: bool = False
+    viz_img_format: str = "png"
     max_epochs: int = 100
     seed: Optional[int] = 42
     use_wandb: bool = False

--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -480,6 +480,18 @@ class WandBVizCallbackWithPAFs(WandBVizCallback):
         trainer.strategy.barrier()
 
 
+def _resolve_viz_img_format(img_format: str):
+    """Resolve a viz image-format string to ``(extension, savefig_format, kwargs)``.
+
+    ``"jpg"`` / ``"jpeg"`` (case-insensitive) map to JPEG at quality 90, which
+    yields much smaller files when training a battery of models on the same
+    dataset (#644). Any other value falls back to ``"png"``.
+    """
+    if str(img_format).lower() in ("jpg", "jpeg"):
+        return "jpg", "jpg", {"pil_kwargs": {"quality": 90}}
+    return "png", "png", {}
+
+
 class UnifiedVizCallback(Callback):
     """Unified callback for all visualization outputs during training.
 
@@ -522,6 +534,7 @@ class UnifiedVizCallback(Callback):
         wandb_box_size: float = 5.0,
         wandb_confmap_threshold: float = 0.1,
         log_wandb_table: bool = False,
+        img_format: str = "png",
     ):
         """Initialize the unified visualization callback.
 
@@ -537,6 +550,9 @@ class UnifiedVizCallback(Callback):
             wandb_box_size: Size of keypoint boxes in pixels.
             wandb_confmap_threshold: Threshold for confidence map masks.
             log_wandb_table: If True, also log to a wandb.Table.
+            img_format: Image format for figures saved to ``local_save_dir`` --
+                ``"png"`` (default) or ``"jpg"`` (smaller files; #644). Unknown
+                values fall back to ``"png"``.
         """
         super().__init__()
         from itertools import cycle
@@ -549,6 +565,11 @@ class UnifiedVizCallback(Callback):
         # Local disk config
         self.save_local = save_local
         self.local_save_dir = local_save_dir
+        # Local viz image format: jpg yields much smaller files for batteries of
+        # models on the same dataset (#644); png is the default.
+        self._viz_ext, self._viz_fmt, self._viz_savefig_kwargs = (
+            _resolve_viz_img_format(img_format)
+        )
 
         # WandB config
         self.log_wandb = log_wandb
@@ -637,50 +658,65 @@ class UnifiedVizCallback(Callback):
 
         # Confmaps visualization
         fig = self._mpl_renderer.render(data)
-        fig_path = self.local_save_dir / f"{prefix}.{epoch:04d}.png"
-        fig.savefig(fig_path, format="png")
+        fig_path = self.local_save_dir / f"{prefix}.{epoch:04d}.{self._viz_ext}"
+        fig.savefig(fig_path, format=self._viz_fmt, **self._viz_savefig_kwargs)
         plt.close(fig)
 
         # PAFs visualization (for bottomup models)
         if self.viz_pafs and data.pred_pafs is not None:
             fig = self._mpl_renderer.render_pafs(data)
-            fig_path = self.local_save_dir / f"{prefix}.pafs_magnitude.{epoch:04d}.png"
-            fig.savefig(fig_path, format="png")
+            fig_path = (
+                self.local_save_dir
+                / f"{prefix}.pafs_magnitude.{epoch:04d}.{self._viz_ext}"
+            )
+            fig.savefig(fig_path, format=self._viz_fmt, **self._viz_savefig_kwargs)
             plt.close(fig)
 
         # Class maps visualization (for multi_class_bottomup models)
         if self.viz_class_maps and data.pred_class_maps is not None:
             fig = self._render_class_maps(data)
-            fig_path = self.local_save_dir / f"{prefix}.class_maps.{epoch:04d}.png"
-            fig.savefig(fig_path, format="png")
+            fig_path = (
+                self.local_save_dir / f"{prefix}.class_maps.{epoch:04d}.{self._viz_ext}"
+            )
+            fig.savefig(fig_path, format=self._viz_fmt, **self._viz_savefig_kwargs)
             plt.close(fig)
 
         # Center heatmap visualization (for segmentation models)
         if self.viz_center_heatmap and data.pred_center_heatmap is not None:
             fig = self._render_center_heatmap(data)
-            fig_path = self.local_save_dir / f"{prefix}.center_heatmap.{epoch:04d}.png"
-            fig.savefig(fig_path, format="png")
+            fig_path = (
+                self.local_save_dir
+                / f"{prefix}.center_heatmap.{epoch:04d}.{self._viz_ext}"
+            )
+            fig.savefig(fig_path, format=self._viz_fmt, **self._viz_savefig_kwargs)
             plt.close(fig)
 
         # Center-offset field visualization (for segmentation models)
         if self.viz_offsets and data.pred_offsets is not None:
             fig = self._mpl_renderer.render_offsets(data)
-            fig_path = self.local_save_dir / f"{prefix}.offsets.{epoch:04d}.png"
-            fig.savefig(fig_path, format="png")
+            fig_path = (
+                self.local_save_dir / f"{prefix}.offsets.{epoch:04d}.{self._viz_ext}"
+            )
+            fig.savefig(fig_path, format=self._viz_fmt, **self._viz_savefig_kwargs)
             plt.close(fig)
 
         # GT-vs-prediction foreground mask overlay (for segmentation models)
         if self.viz_gt_mask and data.gt_mask is not None:
             fig = self._mpl_renderer.render_gt_mask(data)
-            fig_path = self.local_save_dir / f"{prefix}.gt_mask.{epoch:04d}.png"
-            fig.savefig(fig_path, format="png")
+            fig_path = (
+                self.local_save_dir / f"{prefix}.gt_mask.{epoch:04d}.{self._viz_ext}"
+            )
+            fig.savefig(fig_path, format=self._viz_fmt, **self._viz_savefig_kwargs)
             plt.close(fig)
 
         # Colored grouped per-instance mask overlay (bottom-up segmentation)
         if self.viz_instance_masks and data.instance_masks is not None:
             fig = self._mpl_renderer.render_instance_masks(data)
-            fig_path = self.local_save_dir / f"{prefix}.instance_masks.{epoch:04d}.png"
-            fig.savefig(fig_path, format="png")
+            fig_path = (
+                self.local_save_dir
+                / f"{prefix}.instance_masks.{epoch:04d}.{self._viz_ext}"
+            )
+            fig.savefig(fig_path, format=self._viz_fmt, **self._viz_savefig_kwargs)
             plt.close(fig)
 
     def _render_class_maps(self, data):

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -1220,6 +1220,11 @@ class ModelTrainer:
                     log_wandb_table=OmegaConf.select(
                         self.config, "trainer_config.wandb.log_viz_table", default=False
                     ),
+                    img_format=OmegaConf.select(
+                        self.config,
+                        "trainer_config.viz_img_format",
+                        default="png",
+                    ),
                 )
             )
 

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -2524,3 +2524,69 @@ class TestCentroidEvaluationCallback:
         # Non-NaN values should be present
         assert log_dict["eval/val/centroid_precision"] == 0.0
         assert log_dict["eval/val/centroid_recall"] == 0.0
+
+
+class TestUnifiedVizImgFormat:
+    """Local viz image format (`viz_img_format` / `_resolve_viz_img_format`, #644)."""
+
+    @pytest.mark.parametrize(
+        "value,exp_ext,exp_fmt",
+        [
+            ("png", "png", "png"),
+            ("jpg", "jpg", "jpg"),
+            ("jpeg", "jpg", "jpg"),
+            ("JPG", "jpg", "jpg"),
+            ("tiff", "png", "png"),
+            (None, "png", "png"),
+        ],
+    )
+    def test_resolve_viz_img_format(self, value, exp_ext, exp_fmt):
+        """`jpg`/`jpeg` (any case) -> jpg@q90; anything else -> png."""
+        from sleap_nn.training.callbacks import _resolve_viz_img_format
+
+        ext, fmt, kwargs = _resolve_viz_img_format(value)
+        assert (ext, fmt) == (exp_ext, exp_fmt)
+        assert kwargs == ({"pil_kwargs": {"quality": 90}} if exp_ext == "jpg" else {})
+
+    def test_callback_stores_requested_format(self):
+        """`img_format` flows into the callback's resolved ext/fmt."""
+        cb = UnifiedVizCallback(
+            model_trainer=MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="single_instance",
+            save_local=False,
+            img_format="jpg",
+        )
+        assert (cb._viz_ext, cb._viz_fmt) == ("jpg", "jpg")
+
+    def test_callback_defaults_to_png(self):
+        """Omitting `img_format` keeps the png default."""
+        cb = UnifiedVizCallback(
+            model_trainer=MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="single_instance",
+            save_local=False,
+        )
+        assert cb._viz_ext == "png"
+
+    def test_save_local_viz_writes_jpg(self, tmp_path):
+        """End-to-end: `_save_local_viz` writes a real `.jpg` (not `.png`)."""
+        import matplotlib.pyplot as plt
+
+        cb = UnifiedVizCallback(
+            model_trainer=MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="single_instance",
+            save_local=True,
+            local_save_dir=tmp_path,
+            img_format="jpg",
+        )
+        # Stub the renderer so we exercise the real savefig path with a tiny fig.
+        cb._mpl_renderer = MagicMock()
+        cb._mpl_renderer.render.return_value = plt.figure()
+        cb._save_local_viz(MagicMock(), "train", 3)
+        assert (tmp_path / "train.0003.jpg").exists()
+        assert not (tmp_path / "train.0003.png").exists()


### PR DESCRIPTION
Closes #644.

## Problem
Training visualization figures saved to the local `viz/` folder are hard-coded to **PNG**. When training a battery of models on the same dataset, each run's `viz/` folder accumulates 200+ PNGs and gets large fast. (Requested by Stefan via talmolab/sleap discussion #2737.)

## Change
Add a **`trainer_config.viz_img_format`** option — `"png"` (default) or `"jpg"` — controlling the format/extension of the local viz images written by `UnifiedVizCallback._save_local_viz`. `jpg` is written at quality 90 (`pil_kwargs={"quality": 90}`); unknown values fall back to `png`.

```yaml
trainer_config:
  visualize_preds_during_training: true
  viz_img_format: jpg   # smaller viz/ folder
```

- Threaded through the only active local-disk saver (`UnifiedVizCallback`, instantiated in `model_trainer.py`); applies to all 7 saved figure kinds (confmaps, PAFs, class maps, center heatmap, offsets, GT mask, instance masks).
- The **wandb** logging path renders to in-memory buffers and is unaffected; the deprecated `WandBPredImageLogger`/`MatplotlibSaver` callbacks are not instantiated, so no local-file reader breaks.
- Default stays `png` — fully backward-compatible.

## Tests
New `TestUnifiedVizImgFormat`: a `_resolve_viz_img_format` resolution table (png/jpg/jpeg/case/unknown/None), callback wiring (`img_format` → resolved ext/fmt; png default), and an **end-to-end** `_save_local_viz` write asserting a real `.jpg` (and no `.png`) lands on disk. Config round-trips (default `png`, settable to `jpg`). `ruff check sleap_nn/` + `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016siM3ZsQtDciGmp6et8n1v