### PR TITLE
fix: auto-switch to local_queues when max_tracks is set (sleap#2720)

### DIFF
--- a/docs/guides/inference-api.md
+++ b/docs/guides/inference-api.md
@@ -348,6 +348,12 @@ predictor = Predictor.from_model_paths(
 labels = predictor.predict("video.mp4")   # tracked
 ```
 
+!!! note "`max_tracks` auto-selects `local_queues`"
+    `max_tracks` is honored only by the `local_queues` candidate maker;
+    `fixed_window` ignores it. Setting `max_tracks` (here or anywhere a
+    `TrackerConfig`/`Tracker.from_config` is built) auto-switches the method to
+    `local_queues` (logged at INFO), overriding `candidates_method="fixed_window"`.
+
 ### Tracking existing labels with `apply_tracking`
 
 `apply_tracking` is the labels-in / labels-out tracking function. It builds a

--- a/docs/guides/tracking.md
+++ b/docs/guides/tracking.md
@@ -27,7 +27,7 @@ sleap-nn predict -i video.mp4 -m models/bottomup/ --tracking
 | `--scoring_method` | Similarity scoring method | `oks`, `cosine_sim`, `iou`, `euclidean_dist` | `oks` |
 | `--scoring_reduction` | Score reduction method | `mean`, `max`, `robust_quantile` | `mean` |
 | `--track_matching_method` | Assignment algorithm | `hungarian`, `greedy` | `hungarian` |
-| `--max_tracks` | Maximum track count | `INT` | `None` |
+| `--max_tracks` | Maximum track count (auto-selects `local_queues`) | `INT` | `None` |
 | `--use_flow` | Enable optical flow | Flag | `False` |
 | `--use_kalman` | Enable Kalman-filter tracking | Flag | `False` |
 | `--kf_init_frame_count` | Warm-up frames before EM init | `INT` | `10` |
@@ -63,6 +63,13 @@ sleap-nn predict -i video.mp4 -m models/ \
 ```
 
 **Best for**: Robust to track breaks, handles occlusions better.
+
+!!! note "`--max_tracks` requires `local_queues`"
+    `--max_tracks` (the cap on how many track IDs may be created) is honored
+    **only** by `local_queues`; `fixed_window` ignores it. Setting `--max_tracks`
+    therefore auto-selects `candidates_method local_queues` (logged at INFO),
+    overriding `fixed_window` even if you pass it explicitly. You do **not** need
+    to set `--candidates_method` yourself when capping the track count.
 
 ### Optical Flow
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -133,9 +133,15 @@ Each `--model_paths` entry may be a model **directory**, or a path to that model
 | `--tracking` | Enable tracking | Flag | `false` |
 | `--tracking_window_size` | Frames to look back | `INT` | `5` |
 | `--candidates_method` | Candidate selection method | `fixed_window`, `local_queues` | `fixed_window` |
+| `--max_tracks` | Maximum track count (auto-selects `local_queues`) | `INT` | `None` |
 | `--features` | Features for matching | `keypoints`, `centroids`, `bboxes`, `image` | `keypoints` |
 | `--scoring_method` | Similarity scoring method | `oks`, `cosine_sim`, `iou`, `euclidean_dist` | `oks` |
 | `--use_flow` | Enable optical flow | Flag | `false` |
+
+!!! note "`--max_tracks` requires `local_queues`"
+    `--max_tracks` is honored only by `local_queues`; `fixed_window` ignores it.
+    Setting it auto-selects `candidates_method local_queues` (logged at INFO),
+    so you do not need to set `--candidates_method` yourself.
 
 ### Examples
 

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1238,8 +1238,9 @@ def _build_tracker_config(kwargs: dict) -> "object":
     ``sleap_nn/legacy_predict.py`` pre-#530) so the new ``predict`` flow behaves
     identically (#582):
 
-    * ``--max_tracks`` with no ``--candidates_method`` defaults the method to
-      ``local_queues`` (``max_tracks`` is silently ignored by ``fixed_window``).
+    * ``--max_tracks`` forces ``--candidates_method local_queues`` (``max_tracks``
+      is silently ignored by ``fixed_window``), overriding even an explicit
+      ``--candidates_method fixed_window`` since that pairing is non-functional.
     * ``--post_connect_single_breaks`` / ``--tracking_pre_cull_to_target`` with
       only ``--max_instances`` (no explicit ``--tracking_target_instance_count``)
       derive the target count from ``max_instances`` instead of crashing /
@@ -1256,15 +1257,22 @@ def _build_tracker_config(kwargs: dict) -> "object":
     pcsb = kwargs.get("post_connect_single_breaks", False)
     use_kalman = kwargs.get("use_kalman", False)
 
-    # Default candidates_method to local_queues when max_tracks is set but the
-    # user did not explicitly choose a method (the click default is None).
-    # Record explicitness so apply_tracking can default mask-mode tracking to
-    # local_queues (much better identity on over-segmented masks) unless the user
-    # explicitly picked a method.
+    # max_tracks is only honored by the local_queues candidate maker; fixed_window
+    # silently ignores it. Whenever a track cap is requested, use local_queues so
+    # the cap is enforced -- even if the user explicitly passed fixed_window, since
+    # that combination is non-functional (the cap would be dropped). Logged at INFO
+    # (sleap#2720, #582). Record explicitness so apply_tracking can default
+    # mask-mode tracking to local_queues (much better identity on over-segmented
+    # masks) unless the user explicitly picked a method.
     candidates_method_explicit = kwargs.get("candidates_method") is not None
-    candidates_method = kwargs.get("candidates_method")
-    if candidates_method is None:
-        candidates_method = "local_queues" if max_tracks is not None else "fixed_window"
+    candidates_method = kwargs.get("candidates_method") or "fixed_window"
+    if max_tracks is not None and candidates_method == "fixed_window":
+        logger.info(
+            "max_tracks=%s requested; using candidates_method='local_queues' "
+            "(fixed_window ignores max_tracks).",
+            max_tracks,
+        )
+        candidates_method = "local_queues"
 
     # Legacy: post_connect_single_breaks defaults max_tracks from max_instances.
     if pcsb and max_tracks is None:

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -152,15 +152,10 @@ def apply_tracking(
         )
 
     # max_tracks is only honored by the local_queues candidate maker; the
-    # fixed_window default silently ignores it. The CLI auto-switches to
-    # local_queues, but a library caller can still hit this — warn rather than
-    # silently drop the cap (#582).
-    if config.max_tracks is not None and config.candidates_method == "fixed_window":
-        logger.warning(
-            "max_tracks=%s is set but candidates_method='fixed_window' ignores "
-            "it. Use candidates_method='local_queues' to honor max_tracks.",
-            config.max_tracks,
-        )
+    # fixed_window default silently ignores it. `Tracker.from_config` (the shared
+    # tracker constructor below) auto-switches fixed_window -> local_queues and
+    # logs an INFO when a track cap is requested, so library callers that build a
+    # TrackerConfig directly get the cap honored too (sleap#2720, #582).
 
     # Single-node (centroid) default resolution. A centroid model collapses to
     # a 1-node Skeleton(['centroid']) (#586); OKS/keypoints are degenerate on a

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -185,8 +185,10 @@ class Tracker:
                 For selecting a robust score, 0.95 is a good value.
             track_matching_method: Track matching algorithm. One of `hungarian`, `greedy.
                 Default: `hungarian`.
-            max_tracks: Meaximum number of new tracks to be created to avoid redundant tracks.
-                (only for local queues candidate) Default: None.
+            max_tracks: Maximum number of new tracks to be created to avoid redundant
+                tracks. Honored only by the `local_queues` candidate maker; setting it
+                with `candidates_method="fixed_window"` auto-switches the method to
+                `local_queues` (logged at INFO) so the cap is enforced. Default: None.
             use_flow: If True, `FlowShiftTracker` is used, where the poses are matched using
             optical flow shifts. Default: `False`.
             of_img_scale: Factor to scale the images by when computing optical flow. Decrease
@@ -233,6 +235,23 @@ class Tracker:
             tracking_pre_cull_iou_threshold: If non-zero and pre_cull_to_target also set, then use IOU threshold to remove overlapping instances over count *before* tracking. (default: 0)
 
         """
+        # `max_tracks` is enforced only by the `local_queues` candidate maker
+        # (`LocalQueueCandidates.get_new_track_id` returns `None` past the cap);
+        # `fixed_window` silently ignores it and mints unbounded track IDs. When a
+        # caller asks for a track cap under `fixed_window`, switch to `local_queues`
+        # -- the candidate method designed for a fixed identity count -- so the cap
+        # is actually honored. This is the universal safety net: every tracking
+        # entry point (CLI, `run_inference`/`run_tracker`, `apply_tracking`, direct
+        # API use) flows through `from_config` (sleap#2720, #582).
+        if max_tracks is not None and candidates_method == "fixed_window":
+            logger.info(
+                "max_tracks=%s was set with candidates_method='fixed_window', which "
+                "ignores it; switching to candidates_method='local_queues' to honor "
+                "the track cap.",
+                max_tracks,
+            )
+            candidates_method = "local_queues"
+
         if candidates_method == "fixed_window":
             candidate = FixedWindowCandidates(
                 window_size=window_size,

--- a/tests/cli/test_predict_command.py
+++ b/tests/cli/test_predict_command.py
@@ -563,8 +563,13 @@ def test_predict_max_tracks_auto_switches_to_local_queues():
         assert cfg.max_tracks == 3
 
 
-def test_predict_explicit_fixed_window_with_max_tracks_respected():
-    """An explicit `--candidates_method fixed_window` is not overridden (#582)."""
+def test_predict_explicit_fixed_window_with_max_tracks_switches_to_local_queues():
+    """`--max_tracks` overrides an explicit `--candidates_method fixed_window`.
+
+    sleap#2720: fixed_window silently ignores max_tracks, so requesting a track
+    cap always wins and switches the method to local_queues (the only maker that
+    honors the cap). This supersedes the earlier #582 escape-hatch behavior.
+    """
     runner = CliRunner()
     with patch(
         "sleap_nn.inference.run.predict", return_value=MagicMock()
@@ -586,7 +591,7 @@ def test_predict_explicit_fixed_window_with_max_tracks_respected():
         )
         assert result.exit_code == 0, result.output
         assert mock_predict.call_args[1]["tracker_config"].candidates_method == (
-            "fixed_window"
+            "local_queues"
         )
 
 

--- a/tests/inference/test_issue_582.py
+++ b/tests/inference/test_issue_582.py
@@ -529,11 +529,23 @@ def test_build_tracker_config_max_tracks_defaults_local_queues():
     assert cfg.max_tracks == 3
 
 
-def test_build_tracker_config_explicit_fixed_window_respected():
-    """An explicit candidates_method is not overridden by max_tracks (gap)."""
+def test_build_tracker_config_explicit_fixed_window_switched_for_max_tracks():
+    """max_tracks forces local_queues even over an explicit fixed_window (sleap#2720).
+
+    fixed_window silently ignores max_tracks, so the pairing is non-functional;
+    requesting a track cap always wins and switches the method to local_queues.
+    """
     from sleap_nn.cli import _build_tracker_config
 
     cfg = _build_tracker_config({"max_tracks": 3, "candidates_method": "fixed_window"})
+    assert cfg.candidates_method == "local_queues"
+
+
+def test_build_tracker_config_explicit_fixed_window_kept_without_max_tracks():
+    """An explicit fixed_window is kept when no track cap is requested."""
+    from sleap_nn.cli import _build_tracker_config
+
+    cfg = _build_tracker_config({"candidates_method": "fixed_window"})
     assert cfg.candidates_method == "fixed_window"
 
 

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -411,6 +411,61 @@ def test_tracker(
     assert "Invalid `track_matching_method` argument." in caplog.text
 
 
+def test_from_config_max_tracks_switches_to_local_queues(caplog):
+    """sleap#2720: max_tracks under fixed_window auto-switches to local_queues.
+
+    `max_tracks` is only honored by the `local_queues` candidate maker; the
+    `fixed_window` default silently ignores it. `Tracker.from_config` is the
+    universal chokepoint for every tracking entry point, so the switch (and its
+    INFO log) belongs here. The cap must reach the `local_queues` candidate maker.
+    """
+    from sleap_nn.tracking.candidates.local_queues import LocalQueueCandidates
+    from sleap_nn.tracking.candidates.fixed_window import FixedWindowCandidates
+
+    with caplog.at_level("INFO"):
+        tracker = Tracker.from_config(candidates_method="fixed_window", max_tracks=4)
+
+    assert tracker.is_local_queue
+    assert isinstance(tracker.candidate, LocalQueueCandidates)
+    assert tracker.candidate.max_tracks == 4
+    assert "switching to candidates_method='local_queues'" in caplog.text
+
+    # No max_tracks: fixed_window is left untouched (no switch, no log).
+    caplog.clear()
+    with caplog.at_level("INFO"):
+        tracker = Tracker.from_config(candidates_method="fixed_window")
+    assert not tracker.is_local_queue
+    assert isinstance(tracker.candidate, FixedWindowCandidates)
+    assert "switching to candidates_method='local_queues'" not in caplog.text
+
+
+def test_from_config_max_tracks_caps_new_tracks():
+    """The auto-switched local_queues maker enforces the max_tracks cap.
+
+    End-to-end check for sleap#2720: with the default candidate method and
+    `max_tracks=2`, no more than 2 track IDs are ever spawned even when more
+    detections appear in a frame.
+    """
+    skeleton = sio.Skeleton(["A", "B"])
+    tracker = Tracker.from_config(candidates_method="fixed_window", max_tracks=2)
+
+    # Four well-separated instances in one frame; only 2 should get tracks.
+    insts = []
+    for i in range(4):
+        insts.append(
+            sio.PredictedInstance.from_numpy(
+                points_data=np.array(
+                    [[i * 50.0, 0.0], [i * 50.0 + 10.0, 0.0]], dtype="float32"
+                ),
+                skeleton=skeleton,
+                score=0.9,
+            )
+        )
+    tracked = tracker.track(insts, 0)
+    track_names = {t.track.name for t in tracked if t.track is not None}
+    assert len(track_names) <= 2
+
+
 def test_tracker_track_objects_not_shared():
     """Regression test for #574: independent Trackers must not share `_track_objects`.
 


### PR DESCRIPTION
## Summary
- `--max_tracks` was silently ignored under the default `fixed_window` candidate method, producing far more tracks than requested (sleap#2720). It only worked if the user also passed `--candidates_method local_queues`.
- Now any tracking entry point auto-switches to `local_queues` whenever a track cap is requested, and logs the switch at **INFO**.

## Root cause
`max_tracks` is enforced only by `LocalQueueCandidates.get_new_track_id()` (returns `None` past the cap). `FixedWindowCandidates` never receives `max_tracks` and has no cap, so with the default `fixed_window` method the flag was a no-op.

`local_queues` is also the *semantically correct* method for a fixed identity count: it keeps a persistent per-track queue for **all** track IDs across the whole video, so an animal that disappears and reappears can re-bind to one of the existing N tracks. `fixed_window` only keeps the last `window_size` frames as candidates, so a gap longer than the window mints a fresh ID — which is *why* it over-produces tracks here. Simply bolting a cap onto `fixed_window` would honor the number but *drop* unmatched detections instead of re-identifying them, so switching the method is the right fix.

## Changes Made
- **`Tracker.from_config`** (`sleap_nn/tracking/tracker.py`): the universal chokepoint — when `max_tracks` is set with `candidates_method="fixed_window"`, switch to `local_queues` and log at INFO. Covers the CLI, `run_inference`/`run_tracker`, `apply_tracking`, and direct API use. Docstring updated.
- **CLI `_build_tracker_config`** (`sleap_nn/cli.py`): mirror the switch so the resolved `TrackerConfig` reflects the choice, with the INFO log.
- **`apply_tracking`** (`sleap_nn/inference/tracking.py`): removed the now-redundant warning (the shared constructor performs the switch + log).

## API / Behavior Changes
- `--max_tracks N` (or the equivalent API arg) now **forces** `local_queues`, **overriding even an explicit `--candidates_method fixed_window`**. That pairing was non-functional (the cap was dropped), so this is strictly an improvement. This supersedes the earlier #582 escape-hatch behavior where an explicit `fixed_window` was preserved.
- No change when `max_tracks` is unset: `fixed_window` remains the default.

## Example Usage
The command from the issue now yields ≤ 4 tracks without needing `--candidates_method`:
```bash
sleap-nn track -i my_id_predictions.slp --tracking --max_tracks 4 --max_instances 4 -o my_retrack.slp
# INFO: max_tracks=4 ... switching to candidates_method='local_queues' to honor the track cap.
```

## Testing
- `tests/tracking/test_tracker.py`: new `test_from_config_max_tracks_switches_to_local_queues` (switch + INFO log; no switch/log without `max_tracks`) and `test_from_config_max_tracks_caps_new_tracks` (end-to-end: ≤ N track IDs spawned).
- `tests/inference/test_issue_582.py`: updated the explicit-`fixed_window` case to assert the new switch behavior; added a no-`max_tracks` case that keeps `fixed_window`.
- `tests/cli/test_predict_command.py`: updated the explicit-`fixed_window` CLI test to assert the switch to `local_queues`.
- Full `tests/tracking/`, `tests/inference/test_tracking.py`, `tests/inference/test_issue_582.py`, `tests/cli/test_predict_command.py` suites pass; `black`/`ruff` clean.

## Design Decisions
- Put the canonical switch in `Tracker.from_config` rather than only in the CLI so **any** caller (including `sleap track` via `run_inference`, the exact path in the issue) honors `max_tracks`.
- Made it unconditional (overrides explicit `fixed_window`) because `fixed_window` + `max_tracks` has no valid use — the cap is simply ignored.

## Related Issues
talmolab/sleap#2720

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)