### PR TITLE
fix(export): antialias the single-instance ONNX resize to match PyTorch inference

### DIFF
--- a/sleap_nn/export/exporters/onnx_exporter.py
+++ b/sleap_nn/export/exporters/onnx_exporter.py
@@ -47,17 +47,38 @@ def export_to_onnx(
             test_out = model(dummy_input)
         output_names = _infer_output_names(test_out)
 
-    torch.onnx.export(
-        model,
-        dummy_input,
-        save_path.as_posix(),
-        opset_version=opset_version,
+    common = dict(
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic_axes,
-        do_constant_folding=do_constant_folding,
-        dynamo=False,
     )
+    try:
+        # Default to the legacy TorchScript exporter: it is fast and exports every
+        # current wrapper (including the multi-stage top-down / multi-class ones that
+        # the torch.export-based exporter cannot trace).
+        torch.onnx.export(
+            model,
+            dummy_input,
+            save_path.as_posix(),
+            opset_version=opset_version,
+            do_constant_folding=do_constant_folding,
+            dynamo=False,
+            **common,
+        )
+    except torch.onnx.errors.UnsupportedOperatorError:
+        # A few ops have no symbolic in the legacy exporter — notably the antialiased
+        # resize (``aten::_upsample_bilinear2d_aa``) that single-instance / other
+        # downscaling wrappers use to match the PyTorch inference resize. The
+        # torch.export-based exporter supports them, so fall back to it for those
+        # models (it needs opset >= 18 for the antialias Resize attribute).
+        torch.onnx.export(
+            model,
+            dummy_input,
+            save_path.as_posix(),
+            opset_version=max(opset_version, 18),
+            dynamo=True,
+            **common,
+        )
 
     if verify:
         _verify_onnx(save_path)

--- a/sleap_nn/export/exporters/tensorrt_exporter.py
+++ b/sleap_nn/export/exporters/tensorrt_exporter.py
@@ -140,16 +140,33 @@ def _export_tensorrt_onnx(
         else:
             example_input = torch.randn(*input_shape, dtype=input_dtype, device=device)
 
-        # Export to ONNX
-        torch.onnx.export(
-            model,
-            example_input,
-            onnx_path,
-            opset_version=17,
+        # Export to ONNX. Default to the legacy exporter, falling back to the
+        # torch.export-based one for ops it cannot trace (e.g. the antialiased resize
+        # ``aten::_upsample_bilinear2d_aa`` that downscaling wrappers use) — mirroring
+        # ``export_to_onnx``.
+        onnx_kwargs = dict(
             input_names=["images"],
             dynamic_axes={"images": {0: "batch", 2: "height", 3: "width"}},
-            do_constant_folding=True,
         )
+        try:
+            torch.onnx.export(
+                model,
+                example_input,
+                onnx_path,
+                opset_version=17,
+                do_constant_folding=True,
+                dynamo=False,
+                **onnx_kwargs,
+            )
+        except torch.onnx.errors.UnsupportedOperatorError:
+            torch.onnx.export(
+                model,
+                example_input,
+                onnx_path,
+                opset_version=18,
+                dynamo=True,
+                **onnx_kwargs,
+            )
 
         if verbose:
             print(f"  ONNX export complete: {onnx_path}")

--- a/sleap_nn/export/wrappers/single_instance.py
+++ b/sleap_nn/export/wrappers/single_instance.py
@@ -61,12 +61,20 @@ class SingleInstanceONNXWrapper(BaseExportWrapper):
         # Normalize uint8 [0, 255] to float32 [0, 1]
         image = self._normalize_uint8(image)
 
-        # Apply input scaling if needed
+        # Apply input scaling if needed. ``antialias=True`` matches the PyTorch inference
+        # path, which resizes via ``torchvision.transforms.functional.resize``
+        # (antialiased by default). Without it a downscaling resize (input_scale < 1)
+        # produces visibly different pixels, which shifts confidence-map peaks and —
+        # once scaled back by ``output_stride / input_scale`` — the exported keypoints.
         if self.input_scale != 1.0:
             height = int(image.shape[-2] * self.input_scale)
             width = int(image.shape[-1] * self.input_scale)
             image = F.interpolate(
-                image, size=(height, width), mode="bilinear", align_corners=False
+                image,
+                size=(height, width),
+                mode="bilinear",
+                align_corners=False,
+                antialias=True,
             )
 
         # Run model to get confidence maps: (batch, n_nodes, height, width)

--- a/tests/export/test_export_accuracy.py
+++ b/tests/export/test_export_accuracy.py
@@ -411,15 +411,14 @@ def _collect_distances(labels_a: sio.Labels, labels_b: sio.Labels) -> np.ndarray
 class TestSingleInstanceONNXAccuracy:
     """PyTorch vs ONNX parity for single-instance models.
 
-    The single-instance ONNX wrapper bakes ``input_scale`` into the
-    TorchScript trace as a constant, which introduces small rounding
-    differences vs the PyTorch path's dynamic rescaling. Max per-keypoint
-    deviation is ~12 px on the test fixture; the threshold is set at 15 px
-    (well below the 100+ px that a real coordinate-scaling bug produces).
+    The test checkpoint runs at ``input_scale=0.5``; the ONNX wrapper resizes with
+    the same antialiased bilinear filter as the PyTorch inference path, so the
+    confidence maps (and thus the argmax peaks) match. The only residual difference
+    is sub-pixel: the wrapper takes plain argmax peaks while the PyTorch path here
+    integral-refines them, a difference well under the generic ceiling.
     """
 
-    # Wider than the generic 10 px ceiling because of traced input_scale.
-    _MAX_DIST_PX = 15.0
+    _MAX_DIST_PX = 10.0
 
     @pytest.fixture(scope="class")
     def exported_dir(self, tmp_path_factory):


### PR DESCRIPTION
## Fix single-instance ONNX export accuracy (antialiased resize parity)

`tests/export/test_export_accuracy.py::TestSingleInstanceONNXAccuracy::test_keypoint_distances_bounded`
fails on `main` (PyTorch-vs-ONNX median keypoint distance ≈ 5 px > the 3 px parity bound).

### Root cause

The two inference paths resized the input differently:

- **PyTorch** resizes via `torchvision.transforms.functional.resize` → **antialiased** bilinear
  (torchvision's default).
- The **ONNX export wrapper** resized via `F.interpolate(mode="bilinear", align_corners=False)` →
  **not antialiased**.

The test checkpoint runs at `input_scale=0.5`. For a 0.5× downscale the two resized images differ
by **up to ~47 intensity units**, which shifts one keypoint's confidence-map argmax to an adjacent
pixel. That 1-pixel shift is amplified by `output_stride / input_scale` (×8 here), so one node lands
~8 px off (the other matches exactly) → median ≈ 5 px. Confirmed: `F.interpolate(antialias=True)` is
**byte-identical** to the torchvision resize, and the diff is consistent across frames (not flaky).

### Fix

- **`single_instance` wrapper:** resize with `antialias=True`, matching the PyTorch path exactly.
- **`onnx_exporter` / `tensorrt_exporter`:** the antialiased resize op
  `aten::_upsample_bilinear2d_aa` has **no symbolic in the legacy TorchScript ONNX exporter**, so the
  export now **falls back to the `torch.export`-based exporter (`dynamo=True`, opset ≥ 18) only when
  the legacy exporter raises `UnsupportedOperatorError`**. Every other model keeps using the legacy
  exporter unchanged — the `torch.export` path cannot trace the multi-stage top-down / multi-class
  wrappers (a full dynamo migration would break ~26 export tests), so the fallback is deliberately
  scoped to just the ops the legacy exporter can't handle.
- **Test:** tighten the single-instance accuracy ceiling (`_MAX_DIST_PX` 15 → 10 px) and refresh the
  now-stale "traced input_scale rounding" docstring.

### Result

- `test_keypoint_distances_bounded`: median **5.0 px → 1.4 px** (the residual is just the wrapper's
  plain argmax vs the PyTorch integral sub-pixel; argmax-vs-argmax parity is **0.0 px**).
- Full `tests/export/` suite: **165 passed, 6 skipped, 0 failures** (was 1 failed).
- `black` + `ruff` clean.

> TensorRT export shares the same fallback for consistency (a downscaling model would otherwise hit
> the same unsupported-op error), but the TensorRT engine build is hardware-gated and not exercised
> by the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
