### PR TITLE
feat(centroid): derive centroid targets from segmentation masks

### DIFF
--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -411,6 +411,15 @@ class DataConfig:
             partitions the training labels by the configured group key (`frame`/`video`/
             `identity`) instead of the default frame-level random `validation_fraction`
             split. *Default*: `None` (unchanged default behavior).
+        centroids_from_masks: (bool) Derive a single-node `centroid` pose from each
+            segmentation mask (`LabeledFrame.masks`) at load time, so a `centroid` model
+            can train directly on mask-only data (no keypoint skeleton). Each mask becomes
+            one `centroid` instance at its center-of-mass (or bbox midpoint), preserving
+            tracks. *Default*: `False`.
+        centroids_from_masks_centering: (str) How the mask-derived centroid is placed:
+            `com` (mask center-of-mass) or `bbox` (mask bounding-box midpoint, robust to
+            concave masks whose COM lands off the instance). Only used when
+            `centroids_from_masks` is `True`. *Default*: `com`.
     """
 
     train_labels_path: Optional[List[str]] = None
@@ -438,6 +447,8 @@ class DataConfig:
     skeletons: Optional[list] = None
     identity: Optional[IdentityConfig] = None
     split: Optional[SplitConfig] = None
+    centroids_from_masks: bool = False
+    centroids_from_masks_centering: str = "com"
 
 
 def data_mapper(legacy_config: dict) -> DataConfig:

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -2133,6 +2133,22 @@ def derive_centroids_from_masks(
         logger.error(message)
         raise ValueError(message)
 
+    # Guard the footgun: this path overwrites `lf.instances` with the synthesized
+    # single-node centroids, which would silently destroy real keypoint poses. It is
+    # for mask-only data, so refuse (atomically, before any mutation) if any frame
+    # carries BOTH masks and pre-existing instances rather than clobbering them.
+    for lf in labels:
+        if (getattr(lf, "masks", None)) and (getattr(lf, "instances", None)):
+            message = (
+                "derive_centroids_from_masks (data_config.centroids_from_masks) is for "
+                "mask-only data, but a LabeledFrame carries BOTH masks and existing "
+                "instances; synthesizing centroids from masks would overwrite the real "
+                "pose instances. Disable centroids_from_masks for data that already has "
+                "keypoint poses (the standard centroid path handles it directly)."
+            )
+            logger.error(message)
+            raise ValueError(message)
+
     skeleton = sio.Skeleton(nodes=["centroid"], name="centroid")
     n_inst = 0
     saw_mask = False

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -2125,13 +2125,16 @@ def derive_centroids_from_masks(
     Returns:
         The same ``labels`` object, with synthesized centroid instances + skeleton.
     """
-    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
-    from sleap_nn.data.segmentation_maps import _compute_mask_centroids
-
     if centering not in ("com", "bbox"):
         message = f"Unknown centering '{centering}'; choose 'com' or 'bbox'."
         logger.error(message)
         raise ValueError(message)
+    # sleap-io #531 upstreamed mask -> centroid -> pose conversion. `center_of_mass`
+    # matches the previous hand-rolled COM bit-for-bit at image resolution and handles
+    # the mask's scale/offset natively (more correct for crop-centered masks);
+    # `bbox_center` uses pixel-as-unit-area, so it sits +0.5px from the old
+    # `(min+max)/2` bbox midpoint.
+    method = "bbox_center" if centering == "bbox" else "center_of_mass"
 
     # Guard the footgun: this path overwrites `lf.instances` with the synthesized
     # single-node centroids, which would silently destroy real keypoint poses. It is
@@ -2159,21 +2162,14 @@ def derive_centroids_from_masks(
         saw_mask = True
         instances = []
         for mask in masks:
-            mask_bool = np.asarray(decode_mask_to_image_res(mask)) > 0.5
-            if not mask_bool.any():
+            if mask.is_empty:
                 # An empty/degenerate mask (filtered or thresholding artifact) has no
-                # location; skip it rather than planting a spurious center-of-frame
+                # location; skip it rather than planting a spurious NaN / center-of-frame
                 # centroid as a training target.
                 continue
-            if centering == "bbox":
-                cx, cy = _mask_bbox_midpoint(mask_bool)
-            else:
-                cx, cy = _compute_mask_centroids([mask_bool])[0]
-            inst = sio.Instance.from_numpy(
-                np.array([[cx, cy]], dtype="float64"),
-                skeleton=skeleton,
-                track=getattr(mask, "track", None),
-            )
+            # Full-image centroid pose via the upstream conversion; the mask's track /
+            # identity propagate onto the derived single-node pose.
+            inst = mask.to_centroid(method=method).to_pose(skeleton=skeleton)
             instances.append(inst)
             mask.instance = inst
             n_inst += 1

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -2099,6 +2099,79 @@ def _mask_bbox_midpoint(mask_bool: np.ndarray) -> Tuple[float, float]:
     return cx, cy
 
 
+def derive_centroids_from_masks(
+    labels: "sio.Labels", centering: str = "com"
+) -> "sio.Labels":
+    """Attach a single-node ``centroid`` pose derived from each segmentation mask.
+
+    Mask-only data (e.g. instance segmentation) carries no keypoint skeleton, so the
+    standard ``centroid`` training path (which reads ``lf.instances`` and reduces them
+    via :func:`generate_centroids`) has nothing to train on. This synthesizes that input
+    natively — without an offline preprocessing step — by adding, for every
+    ``LabeledFrame.masks`` entry, a one-node ``"centroid"`` :class:`sio.Instance` at the
+    mask's center-of-mass (``centering="com"``) or bounding-box midpoint
+    (``centering="bbox"``), in full-image coordinates. The instance carries the mask's
+    track and is back-linked via ``mask.instance``, so the rest of the pipeline (head
+    config, dataset, eval, inference) sees a normal single-node centroid pose model.
+
+    Mutates ``labels`` in place (sets ``lf.instances`` and ``labels.skeletons``) and
+    returns it. A no-op (returns ``labels`` unchanged) when no frame has masks.
+
+    Args:
+        labels: The labels to transform (typically mask-only).
+        centering: ``"com"`` (mask center-of-mass) or ``"bbox"`` (mask bounding-box
+            midpoint, robust to concave masks whose COM lands off the instance).
+
+    Returns:
+        The same ``labels`` object, with synthesized centroid instances + skeleton.
+    """
+    from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+    from sleap_nn.data.segmentation_maps import _compute_mask_centroids
+
+    if centering not in ("com", "bbox"):
+        message = f"Unknown centering '{centering}'; choose 'com' or 'bbox'."
+        logger.error(message)
+        raise ValueError(message)
+
+    skeleton = sio.Skeleton(nodes=["centroid"], name="centroid")
+    n_inst = 0
+    saw_mask = False
+    for lf in labels:
+        masks = getattr(lf, "masks", None) or []
+        if not masks:
+            continue
+        saw_mask = True
+        instances = []
+        for mask in masks:
+            mask_bool = np.asarray(decode_mask_to_image_res(mask)) > 0.5
+            if not mask_bool.any():
+                # An empty/degenerate mask (filtered or thresholding artifact) has no
+                # location; skip it rather than planting a spurious center-of-frame
+                # centroid as a training target.
+                continue
+            if centering == "bbox":
+                cx, cy = _mask_bbox_midpoint(mask_bool)
+            else:
+                cx, cy = _compute_mask_centroids([mask_bool])[0]
+            inst = sio.Instance.from_numpy(
+                np.array([[cx, cy]], dtype="float64"),
+                skeleton=skeleton,
+                track=getattr(mask, "track", None),
+            )
+            instances.append(inst)
+            mask.instance = inst
+            n_inst += 1
+        lf.instances = instances
+
+    if saw_mask:
+        labels.skeletons = [skeleton]
+        logger.info(
+            f"Derived {n_inst} '{centering}' centroid instance(s) from masks "
+            f"(single-node 'centroid' skeleton)."
+        )
+    return labels
+
+
 class EmbeddingDataset(BaseDataset):
     """Dataset for the ``embedding`` (crop -> vector, re-ID) model type.
 

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -288,6 +288,34 @@ class ModelTrainer:
         logger.info(f"Creating train-val split...")
         total_train_lfs = 0
         total_val_lfs = 0
+
+        # Derive single-node `centroid` poses from segmentation masks so a centroid model
+        # can train directly on mask-only data (no keypoint skeleton). Runs before the
+        # skeleton is read so the synthesized `centroid` skeleton flows through head-config
+        # setup, the dataset, eval and inference unchanged.
+        if OmegaConf.select(
+            self.config, "data_config.centroids_from_masks", default=False
+        ):
+            from sleap_nn.data.custom_datasets import derive_centroids_from_masks
+
+            centering = OmegaConf.select(
+                self.config, "data_config.centroids_from_masks_centering", default="com"
+            )
+            labels = [derive_centroids_from_masks(lb, centering) for lb in labels]
+            if val_labels:
+                val_labels = [
+                    derive_centroids_from_masks(lb, centering) for lb in val_labels
+                ]
+            # labels[0] may be maskless (e.g. an empty/negative-only first file), so it
+            # would carry no synthesized skeleton. Share the `centroid` skeleton from the
+            # first file that has one onto every (train + val) object so downstream
+            # `labels[0].skeletons` and head-config setup are consistent.
+            centroid_skel = next((lb.skeletons for lb in labels if lb.skeletons), None)
+            if centroid_skel is not None:
+                for lb in [*labels, *(val_labels or [])]:
+                    if not lb.skeletons:
+                        lb.skeletons = list(centroid_skel)
+
         self.skeletons = labels[0].skeletons
 
         # Check if we should count only user-labeled frames

--- a/tests/training/test_centroids_from_masks.py
+++ b/tests/training/test_centroids_from_masks.py
@@ -17,8 +17,17 @@ from tests.fixtures.datasets import make_seg_labels_from_slp
 
 @pytest.fixture
 def seg_labels(minimal_instance):
-    """Mask-bearing labels (circular blobs around each instance)."""
-    return make_seg_labels_from_slp(str(minimal_instance))
+    """Mask-only labels (circular blobs around each instance).
+
+    ``make_seg_labels_from_slp`` retains the source keypoint instances alongside the
+    masks; this path is for mask-only data, so strip them (matching the real use case —
+    and the fail-fast guard against clobbering real poses).
+    """
+    labels = make_seg_labels_from_slp(str(minimal_instance))
+    for lf in labels:
+        lf.instances = []
+    labels.skeletons = []
+    return labels
 
 
 class TestDeriveCentroidsFromMasks:
@@ -113,6 +122,22 @@ class TestDeriveCentroidsFromMasks:
     def test_invalid_centering_raises(self, seg_labels):
         with pytest.raises(ValueError, match="centering"):
             derive_centroids_from_masks(seg_labels, centering="diagonal")
+
+    def test_mixed_pose_and_mask_frame_raises(self, seg_labels):
+        # A frame carrying BOTH masks and real keypoint instances must fail fast — the
+        # synthesized centroids would otherwise silently clobber the real poses. This
+        # path is mask-only; mixed data should use the standard centroid path.
+        pose_skel = sio.Skeleton(nodes=["a", "b"], name="pose")
+        seg_labels[0].instances = [
+            sio.Instance.from_numpy(
+                np.array([[1.0, 2.0], [3.0, 4.0]]), skeleton=pose_skel
+            )
+        ]
+        original = seg_labels[0].instances
+        with pytest.raises(ValueError, match="mask-only"):
+            derive_centroids_from_masks(seg_labels, centering="com")
+        # Atomic: the real instances are untouched (guard runs before any mutation).
+        assert seg_labels[0].instances is original
 
 
 class TestTrainerWiring:

--- a/tests/training/test_centroids_from_masks.py
+++ b/tests/training/test_centroids_from_masks.py
@@ -96,8 +96,10 @@ class TestDeriveCentroidsFromMasks:
 
         com = _one("com")
         bbox = _one("bbox")
-        # bbox midpoint = ((4+35)/2, (4+35)/2) = (19.5, 19.5).
-        assert abs(bbox[0] - 19.5) < 1e-6 and abs(bbox[1] - 19.5) < 1e-6
+        # bbox_center (upstream sleap-io #531) treats a pixel as a unit area, so the
+        # midpoint of occupied columns/rows [4, 35] is (4 + 35 + 1) / 2 = 20.0 (the old
+        # hand-rolled `(min+max)/2` gave 19.5; this is the deliberate +0.5px shift).
+        assert abs(bbox[0] - 20.0) < 1e-6 and abs(bbox[1] - 20.0) < 1e-6
         # The COM is pulled off the bbox center by the asymmetric mass.
         assert abs(com[0] - bbox[0]) + abs(com[1] - bbox[1]) > 2.0
 

--- a/tests/training/test_centroids_from_masks.py
+++ b/tests/training/test_centroids_from_masks.py
@@ -1,0 +1,163 @@
+"""Tests for the native centroid-from-masks path.
+
+Covers ``derive_centroids_from_masks`` (synthesize a single-node ``centroid`` pose from
+each segmentation mask) and its wiring into ``ModelTrainer._setup_train_val_labels`` via
+``data_config.centroids_from_masks`` — so a ``centroid`` model can train on mask-only
+data with no offline preprocessing.
+"""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from omegaconf import OmegaConf
+
+from sleap_nn.data.custom_datasets import derive_centroids_from_masks
+from tests.fixtures.datasets import make_seg_labels_from_slp
+
+
+@pytest.fixture
+def seg_labels(minimal_instance):
+    """Mask-bearing labels (circular blobs around each instance)."""
+    return make_seg_labels_from_slp(str(minimal_instance))
+
+
+class TestDeriveCentroidsFromMasks:
+    def test_adds_single_node_centroid_skeleton(self, seg_labels):
+        n_masks = sum(len(lf.masks) for lf in seg_labels)
+        assert n_masks > 0
+
+        out = derive_centroids_from_masks(seg_labels, centering="com")
+
+        assert [s.name for s in out.skeletons] == ["centroid"]
+        assert [n.name for n in out.skeletons[0].nodes] == ["centroid"]
+        n_inst = sum(len(lf.instances) for lf in out)
+        assert n_inst == n_masks
+        # One single-node instance per mask, back-linked.
+        for lf in out:
+            assert len(lf.instances) == len(lf.masks)
+            for mask, inst in zip(lf.masks, lf.instances):
+                assert inst.numpy().shape == (1, 2)
+                assert mask.instance is inst
+
+    def test_com_matches_blob_center(self, seg_labels):
+        """The COM of a circular blob is its center (within ~1px)."""
+        lf = seg_labels[0]
+        from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
+
+        expected = []
+        for mask in lf.masks:
+            mb = np.asarray(decode_mask_to_image_res(mask)) > 0.5
+            ys, xs = np.where(mb)
+            expected.append((xs.mean(), ys.mean()))
+
+        derive_centroids_from_masks(seg_labels, centering="com")
+        for (ex, ey), inst in zip(expected, seg_labels[0].instances):
+            cx, cy = inst.numpy()[0]
+            assert abs(cx - ex) < 1e-3 and abs(cy - ey) < 1e-3
+            # Centroid lies inside the image.
+            h, w = seg_labels.videos[0].shape[1:3]
+            assert 0 <= cx < w and 0 <= cy < h
+
+    def test_bbox_centering_routes_concave_mask_to_bbox_midpoint(self):
+        """For a concave (L-shaped) mask, bbox midpoint != center-of-mass.
+
+        Validates the ``centering='bbox'`` branch INSIDE derive_centroids_from_masks
+        (not just the primitive), and that COM and bbox genuinely diverge.
+        """
+        video = sio.Video.from_filename("v.mp4")
+        # L-shape: a tall left bar + a bottom bar. COM is pulled toward the mass; the
+        # bbox midpoint is the center of the (full) bounding box.
+        blob = np.zeros((40, 40), dtype=bool)
+        blob[4:36, 4:10] = True  # tall left bar
+        blob[30:36, 4:36] = True  # bottom bar
+
+        def _one(centering):
+            labels = sio.Labels(
+                videos=[video],
+                labeled_frames=[
+                    sio.LabeledFrame(
+                        video=video,
+                        frame_idx=0,
+                        masks=[sio.UserSegmentationMask.from_numpy(blob)],
+                    )
+                ],
+            )
+            derive_centroids_from_masks(labels, centering=centering)
+            return labels[0].instances[0].numpy()[0]
+
+        com = _one("com")
+        bbox = _one("bbox")
+        # bbox midpoint = ((4+35)/2, (4+35)/2) = (19.5, 19.5).
+        assert abs(bbox[0] - 19.5) < 1e-6 and abs(bbox[1] - 19.5) < 1e-6
+        # The COM is pulled off the bbox center by the asymmetric mass.
+        assert abs(com[0] - bbox[0]) + abs(com[1] - bbox[1]) > 2.0
+
+    def test_preserves_tracks(self, seg_labels):
+        # Attach tracks to the masks, then confirm they ride onto the centroids.
+        track = sio.Track(name="animal0")
+        for lf in seg_labels:
+            for mask in lf.masks:
+                mask.track = track
+        derive_centroids_from_masks(seg_labels, centering="com")
+        for lf in seg_labels:
+            for inst in lf.instances:
+                assert inst.track is track
+
+    def test_no_masks_is_noop(self, minimal_instance):
+        labels = sio.load_slp(str(minimal_instance))  # keypoint-only, no masks
+        orig_skel = labels.skeletons
+        out = derive_centroids_from_masks(labels, centering="com")
+        # Unchanged: no masks -> no synthesis.
+        assert out.skeletons is orig_skel
+
+    def test_invalid_centering_raises(self, seg_labels):
+        with pytest.raises(ValueError, match="centering"):
+            derive_centroids_from_masks(seg_labels, centering="diagonal")
+
+
+class TestTrainerWiring:
+    """data_config.centroids_from_masks drives the synthesis in the trainer."""
+
+    @staticmethod
+    def _cfg(enabled, centering="com"):
+        return OmegaConf.create(
+            {
+                "data_config": {
+                    "centroids_from_masks": enabled,
+                    "centroids_from_masks_centering": centering,
+                    "user_instances_only": True,
+                    "use_same_data_for_val": False,
+                    "val_labels_path": ["dummy"],  # val provided -> no internal split
+                    "split": None,
+                }
+            }
+        )
+
+    def _run(self, cfg, minimal_instance, mask_only=False):
+        from sleap_nn.training.model_trainer import ModelTrainer
+
+        # Independent train/val objects (the trainer mutates labels in place).
+        train = make_seg_labels_from_slp(str(minimal_instance))
+        val = make_seg_labels_from_slp(str(minimal_instance))
+        if mask_only:
+            for labels in (train, val):
+                for lf in labels:
+                    lf.instances = []
+                labels.skeletons = []
+        mt = ModelTrainer.__new__(ModelTrainer)
+        mt.config = cfg
+        mt.model_type = "centroid"
+        mt._setup_train_val_labels(labels=[train], val_labels=[val])
+        return mt
+
+    def test_enabled_synthesizes_centroids(self, minimal_instance):
+        mt = self._run(self._cfg(True), minimal_instance, mask_only=True)
+        assert [s.name for s in mt.skeletons] == ["centroid"]
+        assert sum(len(lf.instances) for lf in mt.train_labels[0]) == sum(
+            len(lf.masks) for lf in mt.train_labels[0]
+        )
+
+    def test_disabled_leaves_mask_only_data_skeletonless(self, minimal_instance):
+        # Mask-only labels (no retained pose) stay skeleton-less when the flag is off.
+        mt = self._run(self._cfg(False), minimal_instance, mask_only=True)
+        assert not mt.skeletons


### PR DESCRIPTION
## Centroid targets from segmentation masks

> **Stacked on #671** (the `embedding` model type). Base branch is `embedding-model-port`; review/merge #671 first. The diff against `embedding-model-port` is a single commit.

### What & why
Adds a native path to train **`centroid` models directly on mask‑only data** (instance segmentation with no keypoint skeleton — e.g. the gerbils) by deriving the centroid target from each segmentation mask at load time. Previously `CentroidDataset` only read centroids from `lf.instances` (keypoint poses) via `generate_centroids`, so mask‑only data had nothing to train on; the only workaround was an offline mask→pose preprocessing script. This makes it a first‑class, in‑pipeline option.

### How
- **`derive_centroids_from_masks(labels, centering)`** (`data/custom_datasets.py`) — synthesizes a single‑node `"centroid"` `sio.Instance` per mask at its **center‑of‑mass** (`com`) or **bounding‑box midpoint** (`bbox`), in full‑image coordinates, preserving tracks and back‑linking `mask.instance`; sets a single‑node `centroid` skeleton. Reuses `decode_mask_to_image_res` + `_compute_mask_centroids` / `_mask_bbox_midpoint`.
- **Config:** `data_config.centroids_from_masks` (bool) + `data_config.centroids_from_masks_centering` (`com` | `bbox`).
- **Wiring:** called at the top of `ModelTrainer._setup_train_val_labels` when the flag is set, *before* the skeleton is read — so the synthesized `centroid` skeleton flows through head‑config setup, the dataset, eval, and inference **unchanged**. The whole pipeline just sees a standard single‑node centroid model.

### Usage
```yaml
data_config:
  train_labels_path: [gerbils_train.pkg.slp]   # raw mask-only data, no preprocessing
  centroids_from_masks: true
  centroids_from_masks_centering: com          # or "bbox"
model_config:
  head_configs: { centroid: { confmaps: { sigma: 5.0, output_stride: 2 } } }
```

### Tests
`tests/training/test_centroids_from_masks.py` (8): the helper (COM/bbox centering, image‑coord correctness, track preservation, no‑mask no‑op, invalid‑centering guard) + the trainer wiring (flag on → synthesizes; flag off → mask‑only data stays skeleton‑less).

### Validation (gerbils, cross‑session held‑out `gerbils_valid`, raw masks)
Trained end‑to‑end with `centroids_from_masks=true`, logged to [`centroid-from-masks-gerbils`](https://wandb.ai/talmolab/centroid-from-masks-gerbils):

| backbone | centering | σ | median dist | p95 | precision | recall |
|---|---|---|---|---|---|---|
| **ConvNeXt‑T (ImageNet)** | com | 5 | **1.52 px** | 4.20 | 0.981 | **1.000** |
| Swin‑T (ImageNet) | com | 5 | 1.81 px | 4.88 | 0.981 | 0.995 |
| unet (scratch) | com | 5 | 3.23 px | 12.2 | 0.958 | 0.962 |
| unet (scratch) | bbox | 5 | 5.26 px | 15.3 | 0.93 | 0.915 |

Sub‑2px median centroid localization with ~perfect recall on a held‑out session, training straight from the masks. **COM beats bbox** centering (the mask center‑of‑mass is a more stable target than the bbox midpoint); ImageNet backbones roughly halve the unet median distance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAv4xbUdzioQ9tTzit9qNm
