### PR TITLE
fix(infer): batch LabelsProvider frames by shape for mixed-resolution .slp

### DIFF
--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -289,10 +289,29 @@ class LabelsProvider:
         top-down with centroid model, bottom-up) skip the GT-shaped
         kwargs entirely.
         """
-        for start in range(0, len(self._labeled_frames), self.batch_size):
-            stop = min(start + self.batch_size, len(self._labeled_frames))
-            chunk = self._labeled_frames[start:stop]
-            frames = np.stack([lf.image for lf in chunk], axis=0)
+        # Group frames into chunks bounded by batch_size that ALSO share a
+        # common image shape. Frames from different videos can differ in
+        # resolution, and np.stack requires uniform shape; same-video frames
+        # share a shape, so this only shrinks a chunk at a resolution (video)
+        # boundary instead of crashing on np.stack (#mixed-resolution .slp).
+        n_frames = len(self._labeled_frames)
+        start = 0
+        while start < n_frames:
+            chunk = []
+            chunk_imgs = []
+            first_shape = None
+            idx = start
+            while idx < n_frames and len(chunk) < self.batch_size:
+                img = self._labeled_frames[idx].image
+                if first_shape is None:
+                    first_shape = img.shape
+                elif img.shape != first_shape:
+                    break
+                chunk.append(self._labeled_frames[idx])
+                chunk_imgs.append(img)
+                idx += 1
+            start = idx
+            frames = np.stack(chunk_imgs, axis=0)
 
             inst_lists = [self._frame_instances(lf) for lf in chunk]
             max_inst = max(len(insts) for insts in inst_lists)

--- a/tests/inference/test_providers.py
+++ b/tests/inference/test_providers.py
@@ -165,6 +165,48 @@ def test_labels_provider_only_suggested_frames_yields_unlabeled_suggestions():
     assert len(provider._labeled_frames[0].instances) == 0
 
 
+def test_labels_provider_mixed_resolution_batches_by_shape(tmp_path):
+    """Frames from videos of different shapes batch without crashing.
+
+    A single ``.slp`` can span videos at different resolutions, so a fixed
+    ``batch_size`` chunk can straddle a video boundary and mix ``.image``
+    shapes — which used to crash ``np.stack`` with "all input arrays must
+    have the same shape". The provider must instead close a batch at the
+    resolution boundary, never drop or reorder a frame.
+    """
+    import imageio.v3 as iio
+    import sleap_io as sio
+
+    # Two single-image videos at different resolutions.
+    p_small = tmp_path / "small.png"
+    p_large = tmp_path / "large.png"
+    iio.imwrite(p_small, np.zeros((10, 12, 3), dtype=np.uint8))
+    iio.imwrite(p_large, np.zeros((14, 16, 3), dtype=np.uint8))
+    v_small = sio.Video.from_filename(str(p_small))
+    v_large = sio.Video.from_filename(str(p_large))
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    lf_small = sio.LabeledFrame(video=v_small, frame_idx=0)
+    lf_large = sio.LabeledFrame(video=v_large, frame_idx=0)
+    labels = sio.Labels(
+        videos=[v_small, v_large],
+        skeletons=[skel],
+        labeled_frames=[lf_small, lf_large],
+    )
+
+    # batch_size=4 would put both frames in one chunk; the shape boundary
+    # must split them into two single-frame batches instead of crashing.
+    provider = LabelsProvider(labels=labels, batch_size=4, only_labeled_frames=False)
+    batches = list(provider)
+
+    # Two distinct shapes → two batches, each internally uniform.
+    assert len(batches) == 2
+    shapes = sorted(tuple(b.images.shape[1:]) for b in batches)
+    assert shapes == [(10, 12, 1), (14, 16, 1)]
+    # Every frame yielded exactly once, none reordered or dropped.
+    assert sum(b.images.shape[0] for b in batches) == 2
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # IncrementalLabelsWriter
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`LabelsProvider.__iter__` batches labeled frames with
`np.stack([lf.image for lf in chunk])` over fixed `batch_size`-sized chunks. `np.stack`
requires a uniform shape, but a single `.slp`/`.pkg.slp` can contain videos at different
resolutions. A chunk that straddles a video boundary then mixes shapes and raises:

    ValueError: all input arrays must have the same shape

This crashes both `sleap-nn predict` and the built-in post-training eval on any
mixed-resolution labels set. (Hit in practice on a 147-video set mixing 1080×1598 and
1200×1600 frames — eval could not run at all.)

## Fix

Grow each batch one frame at a time, bounded by **both** `batch_size` **and** a shared
image shape; close the batch early at a resolution boundary. Same-video frames share a
shape, so within a single-resolution video behavior is unchanged — batches only shrink at
a video/resolution boundary. No frames are dropped or reordered.

This is crash-avoidance only: `evaluation.py` (the metric math) is untouched, and per-frame
size normalization still happens downstream in the model preprocessor's per-sample
`apply_sizematcher` (`inference/layers/base.py`). The batcher's job is just to produce a
stackable batch.

## Test

Added `test_labels_provider_mixed_resolution_batches_by_shape`: a `LabelsProvider` over two
videos of different shapes now iterates without raising and yields every frame exactly once,
splitting into shape-uniform batches at the resolution boundary. All 12 provider tests pass.

## Note for reviewers — alternative design

A cleaner long-term approach would move `apply_sizematcher` *into the provider* (per frame,
before `np.stack`, like the training `Dataset.__getitem__` path), normalizing every frame to
`max_height/max_width` up front. Batches would then always pack to full `batch_size`
regardless of how resolutions interleave, and the batcher would be fully shape-agnostic. That
requires threading the per-frame `eff_scale` through the coordinate-undo ladder (the model's
downstream sizematcher would become a no-op), so it's a larger change. This PR is the minimal,
behavior-preserving fix; happy to follow up with the sizematcher-in-provider refactor if
preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)