### PR TITLE
fix: keep full-frame max_height/width off centered-instance (crop-based) configs (#2748)

### DIFF
--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -302,20 +302,36 @@ def data_mapper(legacy_config: dict) -> DataConfig:
         preprocessing_args["ensure_grayscale"] = legacy_config_data["preprocessing"][
             "ensure_grayscale"
         ]
-    if (
-        legacy_config_data.get("preprocessing", {}).get("target_height", None)
-        is not None
-    ):
-        preprocessing_args["max_height"] = legacy_config_data["preprocessing"][
-            "target_height"
-        ]
-    if (
-        legacy_config_data.get("preprocessing", {}).get("target_width", None)
-        is not None
-    ):
-        preprocessing_args["max_width"] = legacy_config_data["preprocessing"][
-            "target_width"
-        ]
+    # Centered-instance / top-down models run on fixed-size crops around the
+    # anchor part (governed by ``crop_size``), not on the full frame. They must
+    # therefore NOT inherit a full-frame ``max_height``/``max_width``: a legacy
+    # ``target_height``/``target_width`` (set when ``resize_and_pad_to_target``
+    # was enabled) would downscale the whole frame before cropping, shrinking the
+    # animal inside the crop and clustering predicted nodes near the anchor
+    # (talmolab/sleap#2748). Detect the active legacy head and skip the
+    # target -> max mapping for these crop-based models.
+    legacy_heads = legacy_config.get("model", {}).get("heads", {}) or {}
+    is_crop_based_model = any(
+        legacy_heads.get(head) is not None
+        for head in ("centered_instance", "multi_class_topdown")
+    )
+
+    target_height = legacy_config_data.get("preprocessing", {}).get(
+        "target_height", None
+    )
+    target_width = legacy_config_data.get("preprocessing", {}).get("target_width", None)
+    if is_crop_based_model and (target_height is not None or target_width is not None):
+        logger.info(
+            "Ignoring legacy target_height/target_width "
+            f"({target_height}x{target_width}) for a centered-instance / top-down "
+            "model: crop-based models are sized by crop_size, not a full-frame "
+            "max_height/max_width."
+        )
+    if not is_crop_based_model:
+        if target_height is not None:
+            preprocessing_args["max_height"] = target_height
+        if target_width is not None:
+            preprocessing_args["max_width"] = target_width
     if (
         legacy_config_data.get("preprocessing", {}).get("input_scaling", None)
         is not None

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -507,8 +507,15 @@ class ModelTrainer:
                     if crop_sz > max_crop_size:
                         max_crop_size = crop_sz
 
-        # if preprocessing params were None, replace with computed params
-        if max_height is None or max_width is None:
+        # if preprocessing params were None, replace with computed params.
+        # Crop-based (top-down) models are sized by `crop_size`, not by a
+        # full-frame max_height/max_width; auto-filling those would make the
+        # inference pipeline resize frames before cropping (talmolab/sleap#2748).
+        if (max_height is None or max_width is None) and self.model_type not in (
+            "centered_instance",
+            "multi_class_topdown",
+            "centered_instance_segmentation",
+        ):
             self.config.data_config.preprocessing.max_height = max_h
             self.config.data_config.preprocessing.max_width = max_w
 

--- a/tests/config/test_data_config.py
+++ b/tests/config/test_data_config.py
@@ -231,6 +231,90 @@ def test_data_mapper():
     assert config.skeletons == None
 
 
+def test_data_mapper_centered_instance_drops_max_hw(caplog):
+    """Centered-instance configs must not inherit full-frame max_height/width.
+
+    Legacy top-down (centered-instance) configs set ``target_height``/
+    ``target_width`` when ``resize_and_pad_to_target`` was enabled. Mapping those
+    to ``max_height``/``max_width`` would downscale the whole frame before the
+    fixed-size crop is taken, shrinking the animal inside the crop and clustering
+    predicted nodes near the anchor (talmolab/sleap#2748). The importer must drop
+    them and keep only ``crop_size``.
+    """
+    legacy_config = {
+        "data": {
+            "preprocessing": {
+                "target_height": 384,
+                "target_width": 384,
+                "input_scaling": 0.5,
+            },
+            "instance_cropping": {"crop_size": 96, "center_on_part": "thorax"},
+        },
+        "model": {
+            "heads": {
+                "single_instance": None,
+                "centroid": None,
+                "centered_instance": {"anchor_part": "thorax", "output_stride": 2},
+                "multi_instance": None,
+            }
+        },
+    }
+
+    config = data_mapper(legacy_config)
+
+    # Full-frame resize params must be left unset for crop-based models...
+    assert config.preprocessing.max_height is None
+    assert config.preprocessing.max_width is None
+    # ...but crop_size and scale should still come through.
+    assert config.preprocessing.crop_size == 96
+    assert config.preprocessing.scale == 0.5
+    # A note should be logged so the dropped values aren't silently discarded.
+    assert "Ignoring legacy target_height/target_width" in caplog.text
+
+
+def test_data_mapper_multi_class_topdown_drops_max_hw():
+    """multi_class_topdown is crop-based too, so max_height/width are dropped."""
+    legacy_config = {
+        "data": {
+            "preprocessing": {"target_height": 512, "target_width": 512},
+            "instance_cropping": {"crop_size": 128},
+        },
+        "model": {
+            "heads": {
+                "centered_instance": None,
+                "multi_class_topdown": {"confmaps": {"anchor_part": "thorax"}},
+            }
+        },
+    }
+
+    config = data_mapper(legacy_config)
+
+    assert config.preprocessing.max_height is None
+    assert config.preprocessing.max_width is None
+    assert config.preprocessing.crop_size == 128
+
+
+def test_data_mapper_centroid_keeps_max_hw():
+    """Full-frame heads (e.g. centroid) still map target_height/width -> max_*."""
+    legacy_config = {
+        "data": {
+            "preprocessing": {"target_height": 384, "target_width": 384},
+        },
+        "model": {
+            "heads": {
+                "centroid": {"anchor_part": "thorax", "output_stride": 2},
+                "centered_instance": None,
+            }
+        },
+    }
+
+    config = data_mapper(legacy_config)
+
+    assert config.preprocessing.max_height == 384
+    assert config.preprocessing.max_width == 384
+    assert config.preprocessing.crop_size is None
+
+
 def test_validate_test_file_path():
     """Test the validate_test_file_path validator function."""
     # Test with None (should pass)

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -1548,3 +1548,53 @@ def test_multi_gpu_no_cache_auto_generates_run_name(config, tmp_path, minimal_in
 
         assert trainer.config.trainer_config.run_name is not None
         assert re.match(r"\d{6}_\d{6}\.", trainer.config.trainer_config.run_name)
+
+
+def test_setup_preprocessing_config_crop_based_skips_max_hw(
+    pytestconfig, minimal_instance
+):
+    """Crop-based models must not auto-fill max_height/max_width (#2748).
+
+    Top-down / crop-based models (``centered_instance``, ``multi_class_topdown``,
+    ``centered_instance_segmentation``) are sized by ``crop_size``. A stray
+    full-frame ``max_height``/``max_width`` makes the inference pipeline resize
+    frames before cropping, which clusters predictions (talmolab/sleap#2748).
+    ``_setup_preprocessing_config`` must therefore leave ``max_height`` /
+    ``max_width`` as configured (``None``) for crop-based models while still
+    auto-computing ``crop_size``. Full-frame models (e.g. ``centroid``) must
+    still get ``max_height``/``max_width`` auto-filled from the video dims.
+    """
+    configs_dir = Path(pytestconfig.rootdir) / "tests/assets/generated_configs"
+    labels = sio.load_slp(minimal_instance)  # 384 x 384
+
+    # Crop-based model: max_height/max_width must stay None, crop_size computed.
+    ci_cfg = OmegaConf.load(configs_dir / "centered_instance.yaml")
+    ci_cfg.data_config.preprocessing.max_height = None
+    ci_cfg.data_config.preprocessing.max_width = None
+    ci_cfg.data_config.preprocessing.crop_size = None
+
+    ci_trainer = ModelTrainer(config=ci_cfg)
+    ci_trainer.model_type = "centered_instance"
+    ci_trainer.backbone_type = "unet"
+    ci_trainer.train_labels = [labels]
+    ci_trainer._setup_preprocessing_config()
+
+    ci_pp = ci_trainer.config.data_config.preprocessing
+    assert ci_pp.max_height is None
+    assert ci_pp.max_width is None
+    assert ci_pp.crop_size is not None
+
+    # Full-frame model: max_height/max_width must be auto-filled from video dims.
+    centroid_cfg = OmegaConf.load(configs_dir / "centroid.yaml")
+    centroid_cfg.data_config.preprocessing.max_height = None
+    centroid_cfg.data_config.preprocessing.max_width = None
+
+    centroid_trainer = ModelTrainer(config=centroid_cfg)
+    centroid_trainer.model_type = "centroid"
+    centroid_trainer.backbone_type = "unet"
+    centroid_trainer.train_labels = [labels]
+    centroid_trainer._setup_preprocessing_config()
+
+    centroid_pp = centroid_trainer.config.data_config.preprocessing
+    assert centroid_pp.max_height == 384
+    assert centroid_pp.max_width == 384


### PR DESCRIPTION
## Problem

Surfaced by talmolab/sleap#2748: a top-down (centered-instance) model predicts the centroid/anchor accurately, but the other nodes come out **compressed/clustered toward the anchor** on videos whose resolution differs from training. Setting `max_height: null` / `max_width: null` in the model's `training_config.yaml` fixes it.

## Root cause

A centered-instance / top-down model runs on fixed-size crops around the anchor (sized by `crop_size`), **not** the full frame. But it could end up with a full-frame `max_height`/`max_width` via **two independent paths**, neither guarded:

1. **Training** — `model_trainer._setup_preprocessing_config` auto-fills `max_height`/`max_width` from the training video's dimensions for *every* model type and saves them into the run's `training_config.yaml`. This affects current (1.5/1.6) GUI training; it is **not** specific to legacy configs.
2. **Legacy import** — `data_mapper` maps legacy `target_height`/`target_width` → `max_height`/`max_width` for every model type when importing ≤1.4.x configs.

With `max_height`/`max_width` set, inference (`predictors.py` → `apply_sizematcher`) resizes each frame to those dims **before** cropping. On a video whose resolution differs from training, the animal is rescaled inside the fixed crop → out-of-training-scale → confidence maps collapse/merge → nodes cluster toward the anchor. Validation frames match training resolution, so they look fine — exactly the #2748 report.

The native sleap-nn config generator confirms intent: crop-based configs carry only `crop_size`; full-frame configs (centroid, single-instance, bottom-up) carry `max_height`/`max_width`.

## Fix

Add the same model-type guard to both paths: skip setting `max_height`/`max_width` for `centered_instance` / `multi_class_topdown` / `centered_instance_segmentation`. `crop_size` logic unchanged; full-frame models unchanged.

## Verification — reproduced end-to-end (two models)

Predicted A–B segment length as % of ground truth vs. inference/training resolution ratio (pretrained centered-instance ckpt, no scale-aug):

| ratio (inf/train) | BAKED max_hw (bug) | NULL max_hw (fix) |
|---|---|---|
| 0.67× | 81% | 100% |
| 1.0×  | 100% | 100% |
| 1.5×  | instances dropped | 99% |
| 2.0×  | 7% (collapsed onto anchor) | 100% |
| 3.0×  | 14% | 99% |

NULL holds ~97–100% at every resolution; BAKED is correct only at 1.0× and collapses with mismatch (worst on downscale). A freshly-trained, scale-augmented model degrades more gently (~67–82% at mismatch) but is still clearly broken.

- Regression tests on both paths (`tests/config/test_data_config.py`, `tests/training/test_model_trainer.py`); config + generator suites green.

Refs: talmolab/sleap#2748