### PR TITLE
feat(backbones): reuse pretrained HuggingFace encoders as backbones (#680)

### DIFF
--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -90,6 +90,40 @@ backbone_config:
     pre_trained_weights: Swin_T_Weights  # ImageNet
 ```
 
+### Pretrained (HuggingFace)
+
+Reuse an external pretrained image encoder (ConvNeXtV2, ResNet, Swinv2, DINOv2, …)
+from HuggingFace `transformers` as the backbone — frozen or fine-tuned. Requires
+the `backbones` extra (`pip install "sleap-nn[backbones]"` / `uv sync --extra
+backbones`).
+
+```yaml
+backbone_config:
+  pretrained:
+    source: hf                                   # HuggingFace transformers
+    model_name: facebook/convnextv2-nano-22k-224 # any AutoBackbone model id
+    weights: true          # download & load pretrained weights (false = random init)
+    mode: auto             # auto | decoder (spatial heads) | encoder (pooled heads)
+    freeze: false          # true = feature extraction (encoder frozen)
+    normalize: true        # apply the model's image_mean/std (read from processor)
+    revision: null         # pin an HF commit sha/tag for reproducibility
+    in_channels: 3         # HF stems are 3-channel (grayscale is replicated)
+    output_stride: 2       # finest decoder output (Case A / decoder mode)
+    max_stride: 32         # deepest encoder stride (32 for CNN/Swin; patch size for ViT)
+```
+
+Two integration modes (auto-selected from the model family, or forced via `mode`):
+
+- **`decoder`** (Case A) — a **hierarchical** backbone (ConvNeXtV2 / ResNet /
+  Swinv2 / DINOv3-ConvNeXt) emits a multi-scale feature pyramid that feeds
+  sleap-nn's decoder, so any spatial head (pose, centroid, segmentation) works.
+- **`encoder`** (Case B) — an **isotropic** ViT (DINOv2 / DINOv2-with-registers)
+  emits a single pooled bottleneck for pooled heads (class-vectors / re-ID).
+
+See the [Pretrained Backbones guide](../guides/pretrained-backbones.md) for the
+full tested-model table, gating/`HF_TOKEN` and offline workflow, and freeze /
+fine-tune guidance.
+
 ---
 
 ## Heads

--- a/docs/configuration/samples.md
+++ b/docs/configuration/samples.md
@@ -67,6 +67,7 @@ keypoints). `fg_threshold` / `min_mask_area` are inference-time args; train at
 | Config | Backbone | Notes |
 |--------|----------|-------|
 | [bottomup_segmentation_unet](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_bottomup_segmentation_unet.yaml) | UNet | Foreground + center + offsets heads |
+| [bottomup_segmentation_pretrained](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_bottomup_segmentation_pretrained.yaml) | Pretrained (HuggingFace ConvNeXtV2) | Reuse an external pretrained encoder; see the [Pretrained Backbones guide](../guides/pretrained-backbones.md) |
 
 ---
 

--- a/docs/guides/pretrained-backbones.md
+++ b/docs/guides/pretrained-backbones.md
@@ -61,8 +61,8 @@ The table lists the main models we recommend and tested. The wrapper is
 **family-agnostic** — it probes strides and channels at construction rather than
 hard-coding per-model taps — so any `AutoBackbone`-compatible checkpoint should
 work. That includes the other hierarchical families `transformers` exposes
-(e.g. ConvNeXt v1, BiT, FocalNet, Hiera, ViTDet) for `decoder` mode, and other
-isotropic ViTs (e.g. BEiT, ViT-MAE, I-JEPA) for `encoder` mode. Pick a model id
+(e.g. ConvNeXt v1, BiT, FocalNet, Hiera) for `decoder` mode, and other isotropic
+ViTs (e.g. BEiT, ViT-MAE, ViTDet, I-JEPA) for `encoder` mode. Pick a model id
 from the [HuggingFace Hub](https://huggingface.co/models?other=backbone) and set
 it as `model_name`; mind the license/gating column above (Hiera and I-JEPA
 weights are non-commercial).

--- a/docs/guides/pretrained-backbones.md
+++ b/docs/guides/pretrained-backbones.md
@@ -1,0 +1,155 @@
+# Pretrained backbones (HuggingFace)
+
+Reuse an external **pretrained image backbone** — a ConvNeXtV2, ResNet, Swinv2,
+or DINOv2 encoder from HuggingFace `transformers` — as the backbone of any
+sleap-nn model, frozen or fine-tuned. This lets pose, centroid, and segmentation
+models start from ImageNet / foundation-model features instead of random init,
+which usually helps most on small labeled datasets.
+
+It plugs into the existing `Model`/backbone path: a new `pretrained` member on
+`backbone_config` selects the HuggingFace encoder, which is wrapped to emit the
+same backbone contract as the native UNet/ConvNeXt/SwinT backbones. No head
+changes, no new model type.
+
+## Install
+
+`transformers` is an optional dependency (the `backbones` extra), imported only
+when a `pretrained` backbone is requested:
+
+```bash
+pip install "sleap-nn[backbones]"      # or: uv sync --extra backbones
+```
+
+Native HuggingFace backbones (ConvNeXt/Swin/ResNet/DINOv2) need `transformers`
+core only — no `timm`, no extra packages.
+
+## Two modes: decoder (Case A) vs. encoder (Case B)
+
+A pretrained encoder is used one of two ways, auto-selected from the model
+family (override with `mode`):
+
+| Mode | `mode` | Backbone family | Emits | For |
+|------|--------|-----------------|-------|-----|
+| **Case A — hierarchical + decoder** | `decoder` | ConvNeXtV2, ResNet, Swinv2, DINOv3-ConvNeXt | multi-scale pyramid → sleap-nn decoder | spatial heads: pose, centroid, segmentation |
+| **Case B — encoder-only pooled** | `encoder` | DINOv2, DINOv2-with-registers (isotropic ViT) | single pooled bottleneck | pooled heads: class-vectors / re-ID |
+
+**Why the split?** Hierarchical backbones emit a stride-4/8/16/32 feature
+pyramid that maps cleanly onto the decoder's skip connections. Plain ViTs are
+*isotropic* — every stage is a single stride (14 or 16) — so they cannot supply
+a U-Net-style pyramid; they are used encoder-only. A ViT feeding a spatial head
+would need a ViTDet-style Simple Feature Pyramid, which is not yet implemented.
+
+`mode: auto` picks `encoder` for isotropic ViTs and `decoder` for everything
+else.
+
+## Tested model families
+
+Verified to build and train through the sleap-nn pipeline (`weights=false` builds
+are exercised network-free in CI; the ✓ families were run end-to-end locally):
+
+| Model | Example `model_name` | Family | Strides | Mode | License / gated | Notes |
+|-------|----------------------|--------|---------|------|-----------------|-------|
+| **ConvNeXtV2** | `facebook/convnextv2-nano-22k-224` | CNN | 4/8/16/32 | decoder | Apache-2.0 / no | ✓ recommended default for pose/seg |
+| **ResNet** | `microsoft/resnet-50` | CNN | 4/8/16/32 | decoder | Apache-2.0 / no | ✓ legacy-SLEAP parity target |
+| **Swinv2** | `microsoft/swinv2-tiny-patch4-window8-256` | hier. transformer | 4/8/16/32 | decoder | MIT / no | builds; ONNX export is fragile (see below) |
+| **DINOv2** | `facebook/dinov2-base` | ViT (isotropic) | 14 | encoder | Apache-2.0 / no | pooled bottleneck; patch-14 (see gotchas) |
+| **DINOv2-with-registers** | `facebook/dinov2-with-registers-base` | ViT (isotropic) | 14 | encoder | Apache-2.0 / no | ✓ recommended for pooled/re-ID heads |
+| **DINOv3-ConvNeXt** | `facebook/dinov3-convnext-base-…` | CNN | 4/8/16/32 | decoder | DINOv3 custom / **gated** | foundation SSL + pyramid; opt-in |
+| **DINOv3-ViT** | `facebook/dinov3-vit…16-…` | ViT (isotropic) | 16 | encoder | DINOv3 custom / **gated** | patch-16, RoPE (resolution-agnostic) |
+
+Any other `AutoBackbone`-compatible model id should work; the wrapper probes
+strides and channels at construction, so it is family-agnostic.
+
+## Config
+
+```yaml
+model_config:
+  init_weights: xavier
+  backbone_config:
+    unet: null
+    convnext: null
+    swint: null
+    pretrained:
+      source: hf
+      model_name: facebook/convnextv2-nano-22k-224
+      weights: true       # download & load pretrained weights
+      mode: auto          # auto | decoder | encoder
+      freeze: false       # true = freeze encoder (feature extraction)
+      normalize: true     # apply the model's image_mean/std
+      revision: null      # pin an HF commit sha/tag for reproducibility
+      in_channels: 3      # HF stems are 3-channel (grayscale is replicated)
+      output_stride: 2    # finest decoder output (decoder mode)
+      max_stride: 32      # deepest encoder stride
+  head_configs:
+    bottomup_segmentation:
+      segmentation: {output_stride: 2, loss_weight: 1.0}
+      center:       {sigma: 4.0, output_stride: 2, loss_weight: 1.0}
+      offsets:      {output_stride: 2, loss_weight: 0.005}
+```
+
+Train exactly as usual — the backbone is selected purely from config:
+
+```bash
+sleap-nn train config.yaml \
+  data_config.train_labels_path="[train.pkg.slp]" \
+  data_config.val_labels_path="[val.pkg.slp]"
+```
+
+A ready-to-edit sample lives at
+[`config_bottomup_segmentation_pretrained.yaml`](https://github.com/talmolab/sleap-nn/blob/main/docs/sample_configs/config_bottomup_segmentation_pretrained.yaml).
+
+### Freeze vs. fine-tune
+
+- `freeze: false` (default) — the whole backbone fine-tunes end-to-end. Best
+  accuracy; recommended when you have enough labeled data.
+- `freeze: true` — the encoder is frozen (feature extraction) and only the
+  decoder/head train. Faster, lower memory, and more robust on very small
+  datasets. sleap-nn filters frozen parameters out of the optimizer
+  automatically.
+
+### Channels and normalization
+
+Pretrained stems are **3-channel**. The trainer sets `in_channels=3` and
+`ensure_rgb=true` automatically for a `pretrained` backbone, so grayscale videos
+are replicated to 3 channels. Model-specific mean/std normalization (read from
+the model's `AutoImageProcessor`, or set explicitly via `image_mean`/`image_std`)
+is applied **inside the backbone** — the data pipeline still only rescales to
+`[0, 1]`.
+
+## Reproducibility, gating, and offline use
+
+- **Pin `revision`.** HuggingFace `main` moves. Set `revision` to a commit sha
+  or tag so a re-run loads identical weights.
+- **Gated models (DINOv3, SAM3).** These live in gated HF repos with a custom
+  license. Request access, then authenticate before training:
+
+  ```bash
+  huggingface-cli login          # or: export HF_TOKEN=hf_...
+  ```
+
+  DINOv3's license is non-OSI (commercial use permitted with attribution) —
+  review it before bundling. Hiera / I-JEPA weights are `cc-by-nc-4.0`
+  (non-commercial).
+- **Offline / air-gapped.** Pre-seed the HuggingFace cache
+  (`~/.cache/huggingface/hub`) on a networked machine, copy it over, and set
+  `HF_HUB_OFFLINE=1`. With `weights: false` the architecture still needs the
+  model's `config.json` (tiny), but no checkpoint download.
+
+## Gotchas
+
+- **DINOv2 is patch-14.** Its stride (14) does not divide the 16/32-padded crops
+  sleap-nn produces. For pooled (encoder) use this is fine; if you need a
+  ÷14-friendly crop, size crops to a multiple of 14, or use DINOv3-ViT
+  (patch-16). ConvNeXt/ResNet/Swin avoid the issue entirely.
+- **`output_stride=2` on a hierarchical HF backbone.** These backbones bottom out
+  at stride 4 (no stride-2 feature), so reaching `output_stride=2` adds one
+  learned-upsample decoder block with no skip connection — a small
+  localization-quality nuance, not a blocker. `output_stride=4` uses skips at
+  every level.
+- **ONNX export.** ViT/DINOv2/ConvNeXt/ResNet export cleanly (opset-17). Swin is
+  export-fragile: a graph can pass the structural `onnx.checker` yet be
+  numerically wrong. The exporter's optional `numerical_check` runs a
+  torch-vs-onnxruntime parity assert for exactly this case — enable it when
+  exporting transformer backbones.
+- **`dtype`.** `transformers` v5 defaults to `dtype="auto"`, which can silently
+  load fp16/bf16. sleap-nn forces `float32` in the backbone factory.

--- a/docs/guides/pretrained-backbones.md
+++ b/docs/guides/pretrained-backbones.md
@@ -57,8 +57,15 @@ are exercised network-free in CI; the ✓ families were run end-to-end locally):
 | **DINOv3-ConvNeXt** | `facebook/dinov3-convnext-base-…` | CNN | 4/8/16/32 | decoder | DINOv3 custom / **gated** | foundation SSL + pyramid; opt-in |
 | **DINOv3-ViT** | `facebook/dinov3-vit…16-…` | ViT (isotropic) | 16 | encoder | DINOv3 custom / **gated** | patch-16, RoPE (resolution-agnostic) |
 
-Any other `AutoBackbone`-compatible model id should work; the wrapper probes
-strides and channels at construction, so it is family-agnostic.
+The table lists the main models we recommend and tested. The wrapper is
+**family-agnostic** — it probes strides and channels at construction rather than
+hard-coding per-model taps — so any `AutoBackbone`-compatible checkpoint should
+work. That includes the other hierarchical families `transformers` exposes
+(e.g. ConvNeXt v1, BiT, FocalNet, Hiera, ViTDet) for `decoder` mode, and other
+isotropic ViTs (e.g. BEiT, ViT-MAE, I-JEPA) for `encoder` mode. Pick a model id
+from the [HuggingFace Hub](https://huggingface.co/models?other=backbone) and set
+it as `model_name`; mind the license/gating column above (Hiera and I-JEPA
+weights are non-commercial).
 
 ## Config
 

--- a/docs/sample_configs/config_bottomup_segmentation_pretrained.yaml
+++ b/docs/sample_configs/config_bottomup_segmentation_pretrained.yaml
@@ -37,8 +37,10 @@ data_config:
       brightness_min: 0.9
       brightness_max: 1.1
       brightness_p: 0.0
-    # NOTE: geometric augmentation is unsupported for segmentation masks (masks
-    # are not co-transformed) and is skipped with a warning.
+    # Geometric augmentation IS supported for segmentation: the image and its
+    # per-instance masks share the same affine matrix (rotation/scale/translate/
+    # flip), with masks resampled nearest-neighbor and re-binarized (erase/mixup
+    # stay image-only). Left null here for brevity; enable a geometric block to use it.
     geometric: null
   skeletons:
 model_config:

--- a/docs/sample_configs/config_bottomup_segmentation_pretrained.yaml
+++ b/docs/sample_configs/config_bottomup_segmentation_pretrained.yaml
@@ -1,0 +1,173 @@
+data_config:
+  train_labels_path: null
+  val_labels_path: null
+  validation_fraction: 0.1
+  use_same_data_for_val: false
+  test_file_path: null
+  provider: LabelsReader
+  user_instances_only: true
+  data_pipeline_fw: torch_dataset
+  cache_img_path: null
+  use_existing_imgs: false
+  delete_cache_imgs_after_training: true
+  preprocessing:
+    # Pretrained HuggingFace stems are 3-channel; the trainer forces in_channels=3
+    # and ensure_rgb=true, so grayscale videos are replicated to 3 channels.
+    ensure_rgb: true
+    ensure_grayscale: false
+    max_height: null
+    max_width: null
+    # Mask resize in v1 is not pad-aware: train at scale 1.0 (or a scale that
+    # divides evenly) with input dims divisible by the backbone max_stride.
+    scale: 1.0
+    crop_size: null
+    min_crop_size: null
+  use_augmentations_train: true
+  augmentation_config:
+    intensity:
+      uniform_noise_min: 0.0
+      uniform_noise_max: 0.04
+      uniform_noise_p: 0.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
+      gaussian_noise_p: 0.0
+      contrast_min: 0.9
+      contrast_max: 1.1
+      contrast_p: 0.0
+      brightness_min: 0.9
+      brightness_max: 1.1
+      brightness_p: 0.0
+    # NOTE: geometric augmentation is unsupported for segmentation masks (masks
+    # are not co-transformed) and is skipped with a warning.
+    geometric: null
+  skeletons:
+model_config:
+  init_weights: xavier
+  pretrained_backbone_weights: null
+  pretrained_head_weights: null
+  backbone_config:
+    unet: null
+    convnext: null
+    swint: null
+    # External pretrained (HuggingFace) backbone. Requires the `backbones` extra:
+    #   pip install "sleap-nn[backbones]"   (or: uv sync --extra backbones)
+    # See docs/guides/pretrained-backbones.md for the tested-model table and the
+    # gating / HF_TOKEN / offline workflow.
+    pretrained:
+      source: hf
+      # Any AutoBackbone-compatible model id. ConvNeXtV2 is the recommended
+      # ungated default for pose/segmentation; microsoft/resnet-50 gives
+      # legacy-SLEAP parity; DINOv3-ConvNeXt is the gated foundation option.
+      model_name: facebook/convnextv2-nano-22k-224
+      weights: true        # download & load pretrained weights (false = random init)
+      mode: auto           # auto | decoder (spatial heads) | encoder (pooled heads)
+      freeze: false        # true = feature extraction (encoder frozen)
+      normalize: true      # apply the model's image_mean/std (read from processor)
+      revision: null       # pin an HF commit sha/tag for reproducibility
+      in_channels: 3
+      filters_rate: 2.0
+      convs_per_block: 2
+      kernel_size: 3
+      up_interpolate: true
+      output_stride: 2     # fine output for dense per-pixel prediction
+      max_stride: 32       # ConvNeXtV2/ResNet/Swinv2 bottom out at stride 32
+  head_configs:
+    single_instance: null
+    centroid: null
+    centered_instance: null
+    bottomup: null
+    multi_class_bottomup: null
+    multi_class_topdown: null
+    # Panoptic-DeepLab-style bottom-up instance segmentation: a foreground head
+    # (BCE+Dice), an instance-center heatmap (MSE), and a per-pixel center-offset
+    # field (masked smooth-L1). Inference groups foreground pixels by offset to
+    # the nearest detected center.
+    bottomup_segmentation:
+      segmentation:
+        output_stride: 2
+        loss_weight: 1.0
+      center:
+        sigma: 10.0
+        output_stride: 2
+        loss_weight: 1.0
+      offsets:
+        output_stride: 2
+        loss_weight: 0.1
+  total_params: null
+trainer_config:
+  train_data_loader:
+    batch_size: 4
+    shuffle: true
+    num_workers: 0
+  val_data_loader:
+    batch_size: 4
+    shuffle: false
+    num_workers: 0
+  model_ckpt:
+    save_top_k: 1
+    save_last: false
+  trainer_devices:
+  trainer_device_indices: null
+  trainer_accelerator: auto
+  profiler: null
+  trainer_strategy: auto
+  enable_progress_bar: true
+  min_train_steps_per_epoch: 200
+  train_steps_per_epoch: null
+  visualize_preds_during_training: true
+  keep_viz: false
+  max_epochs: 200
+  seed: 42
+  use_wandb: false
+  save_ckpt: true
+  ckpt_dir: models
+  run_name: null
+  resume_ckpt_path: null
+  wandb:
+    entity: null
+    project: null
+    name: null
+    save_viz_imgs_wandb: false
+    api_key: null
+    wandb_mode: null
+    prv_runid: null
+    group: null
+    current_run_id: null
+  optimizer_name: Adam
+  optimizer:
+    # A lower LR is a good default when fine-tuning a pretrained backbone.
+    lr: 0.0001
+    amsgrad: false
+  lr_scheduler:
+    step_lr: null
+    reduce_lr_on_plateau:
+      threshold: 1.0e-08
+      threshold_mode: abs
+      cooldown: 3
+      patience: 8
+      factor: 0.5
+      min_lr: 1.0e-08
+  early_stopping:
+    min_delta: 1.0e-08
+    patience: 10
+    stop_training_on_plateau: true
+  online_hard_keypoint_mining:
+    online_mining: false
+    hard_to_easy_ratio: 2.0
+    min_hard_keypoints: 2
+    max_hard_keypoints: null
+    loss_scale: 5.0
+  zmq:
+    controller_port: 9000
+    controller_polling_timeout: 10
+    publish_port: 9001
+  eval:
+    enabled: true
+    frequency: 1
+    oks_stddev: 0.025  # unused for segmentation (keypoint-only)
+    oks_scale: null
+    # For segmentation, match_threshold is reinterpreted as a minimum mask IoU
+    # in (0, 1]. Out-of-range values fall back to 0.5.
+    match_threshold: 0.5
+name: ''
+description: ''

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Overview: guides/training/overview.md
       - Training Guide: guides/training-guide.md
       - Config Generator: guides/config-generator.md
+      - Pretrained Backbones: guides/pretrained-backbones.md
       - Negative Frames: guides/negative-frames.md
       - Monitoring: guides/monitoring.md
       - Multi-GPU: guides/multi-gpu.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,16 @@ sam = [
 sam3 = [
     "transformers>=5.0",
 ]
+# External pretrained image backbones (`model_config.backbone_config.pretrained`).
+# Reuses HuggingFace `transformers` `AutoBackbone`/`*Backbone` encoders (ConvNeXtV2,
+# ResNet, Swinv2, DINOv2, ...) as sleap-nn backbones. Lazy: imported only when a
+# `pretrained` backbone is requested, so the default install never needs it. Native
+# HF backbones (ConvNeXt/Swin/ResNet/DINOv2) need `transformers` core only — no timm.
+# Gated foundation weights (DINOv3, SAM3) additionally require `HF_TOKEN` + accepted
+# terms. See docs/guides/pretrained-backbones.md.
+backbones = [
+    "transformers>=5.0",
+]
 
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv sync`)

--- a/sleap_nn/architectures/encoder_decoder.py
+++ b/sleap_nn/architectures/encoder_decoder.py
@@ -599,7 +599,7 @@ class Decoder(nn.Module):
         up_blocks: int = 4,
         down_blocks: int = 3,
         stem_blocks: int = 0,
-        filters_rate: int = 2,
+        filters_rate: float = 2,
         convs_per_block: int = 2,
         kernel_size: int = 3,
         block_contraction: bool = False,

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -29,6 +29,7 @@ from sleap_nn.architectures.heads import (
 from sleap_nn.architectures.unet import UNet
 from sleap_nn.architectures.convnext import ConvNextWrapper
 from sleap_nn.architectures.swint import SwinTWrapper
+from sleap_nn.architectures.pretrained import PretrainedBackbone
 import torchvision.transforms.v2.functional as F
 
 
@@ -39,7 +40,8 @@ def get_backbone(backbone: str, backbone_config: DictConfig) -> nn.Module:
     corresponding to the given backbone name.
 
     Args:
-        backbone (str): Name of the backbone. Supported values are 'unet'.
+        backbone (str): Name of the backbone. Supported values are 'unet',
+            'convnext', 'swint', and 'pretrained' (external HuggingFace backbone).
         backbone_config (DictConfig): A config for the backbone.
 
     Returns:
@@ -48,7 +50,12 @@ def get_backbone(backbone: str, backbone_config: DictConfig) -> nn.Module:
     Raises:
         KeyError: If the provided backbone name is not one of the supported values.
     """
-    backbones = {"unet": UNet, "convnext": ConvNextWrapper, "swint": SwinTWrapper}
+    backbones = {
+        "unet": UNet,
+        "convnext": ConvNextWrapper,
+        "swint": SwinTWrapper,
+        "pretrained": PretrainedBackbone,
+    }
 
     if backbone not in backbones:
         message = f"Unsupported backbone: {backbone}. Supported backbones are: {', '.join(backbones.keys())}"
@@ -131,7 +138,8 @@ class Model(nn.Module):
     """Model creates a model consisting of a backbone and head.
 
     Attributes:
-        backbone_type: Backbone type. One of `unet`, `convnext` and `swint`.
+        backbone_type: Backbone type. One of `unet`, `convnext`, `swint`, and
+            `pretrained` (external HuggingFace backbone).
         backbone_config: An `DictConfig` configuration dictionary for the model backbone.
         head_configs: An `DictConfig` configuration dictionary for the model heads.
         model_type: Type of the model. One of `single_instance`, `centered_instance`, `centroid`, `bottomup`, `multi_class_bottomup`, `multi_class_topdown`.

--- a/sleap_nn/architectures/model.py
+++ b/sleap_nn/architectures/model.py
@@ -178,9 +178,24 @@ class Model(nn.Module):
             if isinstance(head, ClassVectorsHead):
                 in_channels = int(self.backbone.middle_blocks[-1].filters)
             else:
-                in_channels = self.backbone.decoder_stride_to_filters[
-                    head.output_stride
-                ]
+                stride_to_filters = self.backbone.decoder_stride_to_filters
+                if head.output_stride not in stride_to_filters:
+                    # An encoder-only backbone (e.g. an isotropic ViT like DINOv2
+                    # under mode="auto") has no spatial decoder, so a spatial head
+                    # has no feature map to bind to. Surface an actionable error
+                    # instead of a bare KeyError.
+                    produced = sorted(stride_to_filters) or "[] (encoder-only)"
+                    message = (
+                        f"Head '{head.name}' needs a spatial feature at "
+                        f"output_stride {head.output_stride}, but backbone "
+                        f"'{self.backbone_type}' produces strides {produced}. An "
+                        f"encoder-only backbone supports only pooled heads "
+                        f"(class-vectors); use a hierarchical backbone or "
+                        f"mode='decoder' for spatial heads."
+                    )
+                    logger.error(message)
+                    raise ValueError(message)
+                in_channels = stride_to_filters[head.output_stride]
             self.head_layers.append(head.make_head(x_in=in_channels))
 
     @classmethod

--- a/sleap_nn/architectures/pretrained.py
+++ b/sleap_nn/architectures/pretrained.py
@@ -38,7 +38,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import torch
 from loguru import logger
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 from torch import nn
 
 from sleap_nn.architectures.encoder_decoder import Decoder
@@ -152,6 +152,10 @@ class PretrainedBackbone(nn.Module):
             transposed convs (Case A). Default ``True``.
     """
 
+    # Declared for type checkers; set via register_buffer in __init__.
+    image_mean: torch.Tensor
+    image_std: torch.Tensor
+
     def __init__(
         self,
         source: str = "hf",
@@ -195,7 +199,7 @@ class PretrainedBackbone(nn.Module):
         self.kernel_size = kernel_size
         self.up_interpolate = up_interpolate
 
-        transformers = _import_transformers()
+        _import_transformers()  # actionable error if the extra is missing
         from transformers import AutoBackbone, AutoConfig
 
         hf_config = AutoConfig.from_pretrained(model_name, revision=revision)
@@ -250,7 +254,7 @@ class PretrainedBackbone(nn.Module):
         strides, channels = self._probe(in_channels)
 
         if self.mode == "encoder":
-            self._build_encoder_only(strides, channels, max_stride)
+            self._build_encoder_only(strides, channels)
         else:
             self._build_decoder(strides, channels, max_stride)
 
@@ -399,9 +403,7 @@ class PretrainedBackbone(nn.Module):
         # Class-vectors head reads middle_blocks[-1].filters (bottleneck channels).
         self.middle_blocks = nn.ModuleList([_FiltersHolder(x_in_shape)])
 
-    def _build_encoder_only(
-        self, strides: List[int], channels: List[int], max_stride: int
-    ) -> None:
+    def _build_encoder_only(self, strides: List[int], channels: List[int]) -> None:
         """Case B: expose a pooled bottleneck for a class-vectors/embedding head."""
         self.max_stride = strides[-1]
         hidden = channels[-1]
@@ -432,15 +434,15 @@ class PretrainedBackbone(nn.Module):
     # ------------------------------------------------------------------ config
 
     @classmethod
-    def from_config(cls, config: OmegaConf) -> "PretrainedBackbone":
+    def from_config(cls, config: DictConfig) -> "PretrainedBackbone":
         """Create a `PretrainedBackbone` from a config leaf."""
 
         def get(key, default):
-            return config[key] if key in config else default
+            return OmegaConf.select(config, key, default=default)
 
         return cls(
             source=get("source", "hf"),
-            model_name=config.model_name,
+            model_name=OmegaConf.select(config, "model_name"),
             in_channels=get("in_channels", 3),
             output_stride=get("output_stride", 2),
             max_stride=get("max_stride", 32),

--- a/sleap_nn/architectures/pretrained.py
+++ b/sleap_nn/architectures/pretrained.py
@@ -372,7 +372,12 @@ class PretrainedBackbone(nn.Module):
         # typically 4, so reaching output_stride=2 adds one learned-upsample block
         # with no skip (see encoder_decoder.Decoder for the branch condition).
         stem_blocks = 1
-        down_blocks = max(1, n_skips - stem_blocks)
+        # Keep the feat_concat=False threshold (down_blocks + stem_blocks) equal to
+        # n_skips so decoder blocks past the available skips take the no-concat
+        # path. Must NOT clamp to 1: with only 2 feature maps (n_skips == 1, e.g. a
+        # 2-entry out_indices) a clamp to 1 pushes the threshold to 2, so block 1 is
+        # built expecting a skip but gets None at forward -> channel mismatch.
+        down_blocks = max(0, n_skips - stem_blocks)
         encoder_channels = channels[:-1][::-1]  # skip channels, deepest-first
 
         self.dec = Decoder(

--- a/sleap_nn/architectures/pretrained.py
+++ b/sleap_nn/architectures/pretrained.py
@@ -1,0 +1,495 @@
+"""Pretrained image backbones from HuggingFace `transformers` as sleap-nn encoders.
+
+This module wires external pretrained vision encoders (via
+`transformers.AutoBackbone` / the model-specific ``*Backbone`` classes) into the
+existing :class:`sleap_nn.architectures.model.Model` contract, so any head
+(pose, centroid, segmentation, class-vectors) can sit on a frozen or fine-tuned
+foundation/ImageNet backbone. It reuses the same backbone dict-contract as the
+native UNet/ConvNeXt/SwinT wrappers — no new `Model` class and no head changes.
+
+Two integration surfaces are supported (the wrapper auto-selects, or you can
+force via ``mode``):
+
+* **Case A — hierarchical encoder + sleap decoder** (``mode="decoder"``). A
+  hierarchical backbone (ConvNeXtV2, ResNet, Swinv2, DINOv3-ConvNeXt, ...) emits
+  a multi-scale ``feature_maps`` pyramid (strides 4/8/16/32). We feed those maps
+  as skip connections into the existing
+  :class:`sleap_nn.architectures.encoder_decoder.Decoder` (exactly what
+  `ConvNextWrapper`/`SwinTWrapper` do for torchvision), so spatial heads work
+  unchanged. This is the primary path for pose/segmentation/centroid models.
+
+* **Case B — encoder-only pooled bottleneck** (``mode="encoder"``). An isotropic
+  ViT (DINOv2 / DINOv2-with-registers) emits a single spatial bottleneck map
+  (CLS/register tokens stripped, LayerNorm applied). We expose it as
+  ``middle_output`` with ``middle_blocks[-1].filters == hidden_size`` so a pooled
+  head (class-vectors / re-ID / embedding) consumes it. No decoder is built.
+
+Key behaviors baked in here (rather than in the data pipeline, which is uint8 /
+[0, 1] only): model-specific mean/std normalization (read from the matching
+`AutoImageProcessor`, or passed explicitly), grayscale->3ch is handled upstream
+in `Model.forward`, a `float32` dtype force (transformers v5 defaults to
+``dtype="auto"`` which can silently load fp16/bf16), an optional pinned
+``revision``, and a one-shot **stride probe** (HF backbones do not expose
+stride metadata).
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from loguru import logger
+from omegaconf import OmegaConf
+from torch import nn
+
+from sleap_nn.architectures.encoder_decoder import Decoder
+
+# ImageNet stats, used as a last-resort normalization default when a model does
+# not ship an `AutoImageProcessor` (most HF vision models do).
+_IMAGENET_MEAN = [0.485, 0.456, 0.406]
+_IMAGENET_STD = [0.229, 0.224, 0.225]
+
+# Config `model_type` strings that are isotropic (single-scale) ViTs. Case A
+# (hierarchical decoder) cannot be built from these; they route to Case B.
+_ISOTROPIC_MODEL_TYPES = {
+    "vit",
+    "deit",
+    "beit",
+    "dinov2",
+    "dinov2_with_registers",
+    "dinov2-with-registers",
+    "dinov3_vit",
+    "dinov3-vit",
+    "ijepa",
+    "vitdet",
+    "vit_det",
+    "vit_mae",
+    "vit_msn",
+}
+
+
+def _import_transformers():
+    """Lazily import `transformers`, with an actionable error if it is missing."""
+    try:
+        import transformers  # noqa: F401
+
+        return transformers
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        message = (
+            "Pretrained backbones require the `transformers` package, which is an "
+            "optional dependency. Install it with `pip install 'sleap-nn[backbones]'` "
+            "(or `uv sync --extra backbones`)."
+        )
+        logger.error(message)
+        raise ImportError(message) from e
+
+
+class _FiltersHolder(nn.Module):
+    """Parameter-free module carrying an int ``filters`` attribute.
+
+    :class:`sleap_nn.architectures.model.Model` reads
+    ``backbone.middle_blocks[-1].filters`` to size the class-vectors head. Native
+    wrappers expose a real conv block here; a pretrained encoder feeds the raw
+    bottleneck to the decoder/head, so this lightweight holder satisfies the
+    contract without adding parameters.
+    """
+
+    def __init__(self, filters: int) -> None:
+        super().__init__()
+        self.filters = int(filters)
+
+
+def _resolve_mode(config: Any, mode: str) -> str:
+    """Resolve ``mode="auto"`` to ``"decoder"`` (Case A) or ``"encoder"`` (Case B)."""
+    if mode in ("decoder", "encoder"):
+        return mode
+    model_type = getattr(config, "model_type", "") or ""
+    stage_names = getattr(config, "stage_names", None)
+    is_isotropic = model_type.lower() in _ISOTROPIC_MODEL_TYPES or not stage_names
+    return "encoder" if is_isotropic else "decoder"
+
+
+class PretrainedBackbone(nn.Module):
+    """Wrap a HuggingFace pretrained backbone as a sleap-nn encoder.
+
+    Args:
+        source: Backbone source. Only ``"hf"`` (HuggingFace `transformers`) is
+            currently supported.
+        model_name: HuggingFace model id (e.g. ``"facebook/convnextv2-nano-22k-224"``,
+            ``"microsoft/resnet-50"``, ``"facebook/dinov2-with-registers-base"``).
+        in_channels: Number of input channels the wrapped stem expects. Pretrained
+            vision stems are 3-channel; grayscale inputs are replicated to 3
+            channels upstream in `Model.forward`. Should be ``3``.
+        output_stride: Stride of the finest decoder output (Case A). Ignored for
+            Case B (encoder-only).
+        max_stride: Deepest stride the encoder reaches. For hierarchical CNN/Swin
+            backbones this is ``32``; for a patch-``p`` ViT it is ``p``. Must match
+            the real backbone (validated by the stride probe).
+        weights: If ``True``, download and load the pretrained weights. If
+            ``False``, build the architecture with random init from the model
+            config (no network access) — useful for tests/CI and cold-start
+            training.
+        mode: One of ``"auto"``, ``"decoder"`` (Case A), ``"encoder"`` (Case B).
+            ``"auto"`` picks encoder-only for isotropic ViTs and a decoder for
+            hierarchical backbones.
+        out_indices: Optional explicit stage indices to tap (Case A). If ``None``,
+            all stages are requested and deduplicated by stride into a clean
+            power-of-2 pyramid (recommended, family-agnostic).
+        freeze: If ``True``, freeze the pretrained encoder (feature extraction);
+            only the decoder/head train. Applied by the LightningModule after
+            weight (re)loading.
+        revision: Optional HuggingFace revision (commit sha / tag) to pin for
+            reproducibility.
+        normalize: If ``True``, apply model-specific mean/std normalization inside
+            ``forward`` (the data pipeline only rescales to ``[0, 1]``).
+        image_mean: Optional explicit per-channel mean (length 3). If ``None`` and
+            ``normalize`` is set, read from the model's `AutoImageProcessor`,
+            falling back to ImageNet stats.
+        image_std: Optional explicit per-channel std (length 3).
+        filters_rate: Decoder filter growth factor (Case A). Default ``2.0``.
+        convs_per_block: Refinement convs per decoder block (Case A). Default ``2``.
+        kernel_size: Decoder conv kernel size (Case A). Default ``3``.
+        up_interpolate: If ``True``, bilinear upsampling in the decoder; else
+            transposed convs (Case A). Default ``True``.
+    """
+
+    def __init__(
+        self,
+        source: str = "hf",
+        model_name: str = "facebook/convnextv2-nano-22k-224",
+        in_channels: int = 3,
+        output_stride: int = 2,
+        max_stride: int = 32,
+        weights: bool = True,
+        mode: str = "auto",
+        out_indices: Optional[List[int]] = None,
+        freeze: bool = False,
+        revision: Optional[str] = None,
+        normalize: bool = True,
+        image_mean: Optional[List[float]] = None,
+        image_std: Optional[List[float]] = None,
+        filters_rate: float = 2.0,
+        convs_per_block: int = 2,
+        kernel_size: int = 3,
+        up_interpolate: bool = True,
+    ) -> None:
+        """Build the wrapped backbone and (Case A) decoder."""
+        super().__init__()
+        if source != "hf":
+            message = (
+                f"Unsupported pretrained backbone source: {source!r}. Only 'hf' "
+                f"(HuggingFace transformers) is currently supported."
+            )
+            logger.error(message)
+            raise ValueError(message)
+
+        self.source = source
+        self.model_name = model_name
+        self.in_channels = in_channels
+        self.output_stride = output_stride
+        self.weights = weights
+        self.freeze = freeze
+        self.revision = revision
+        self.normalize = normalize
+        self.filters_rate = filters_rate
+        self.convs_per_block = convs_per_block
+        self.kernel_size = kernel_size
+        self.up_interpolate = up_interpolate
+
+        transformers = _import_transformers()
+        from transformers import AutoBackbone, AutoConfig
+
+        hf_config = AutoConfig.from_pretrained(model_name, revision=revision)
+        self.mode = _resolve_mode(hf_config, mode)
+
+        # Build the HF backbone module (`self.enc`).
+        if self.mode == "encoder":
+            # Case B: single reshaped spatial bottleneck (tokens stripped, LN'd).
+            backbone_kwargs = dict(
+                out_indices=(-1,),
+                reshape_hidden_states=True,
+                apply_layernorm=True,
+            )
+        else:
+            # Case A: request every stage; we dedupe by stride below.
+            stage_names = getattr(hf_config, "stage_names", None)
+            if out_indices is not None:
+                idxs = tuple(out_indices)
+            elif stage_names is not None:
+                idxs = tuple(range(len(stage_names)))
+            else:  # pragma: no cover - decoder mode implies stage_names
+                idxs = (0, 1, 2, 3)
+            backbone_kwargs = dict(out_indices=idxs)
+
+        if weights:
+            self.enc = AutoBackbone.from_pretrained(
+                model_name,
+                revision=revision,
+                dtype=torch.float32,
+                **backbone_kwargs,
+            )
+        else:
+            cfg = AutoConfig.from_pretrained(model_name, revision=revision)
+            for k, v in backbone_kwargs.items():
+                setattr(cfg, k, v)
+            self.enc = AutoBackbone.from_config(cfg)
+
+        # Snapshot loaded weights on CPU so they can be re-applied after the
+        # LightningModule's xavier init clobbers them (mirrors convnext/swint).
+        self._pretrained_sd: Optional[Dict[str, torch.Tensor]] = None
+        if weights:
+            self._pretrained_sd = {
+                k: v.detach().cpu().clone() for k, v in self.enc.state_dict().items()
+            }
+
+        # Register normalization buffers.
+        mean, std = self._resolve_norm_stats(image_mean, image_std)
+        self.register_buffer("image_mean", torch.tensor(mean).view(1, -1, 1, 1))
+        self.register_buffer("image_std", torch.tensor(std).view(1, -1, 1, 1))
+
+        # Probe strides/channels with a dummy forward (HF exposes no stride meta).
+        strides, channels = self._probe(in_channels)
+
+        if self.mode == "encoder":
+            self._build_encoder_only(strides, channels, max_stride)
+        else:
+            self._build_decoder(strides, channels, max_stride)
+
+        # `from_pretrained` returns the model in eval mode; leave the encoder
+        # trainable by default so fine-tuning (freeze=False) updates BatchNorm
+        # running stats etc. Lightning respects module-level eval flags and will
+        # NOT flip this back, so a stale eval here would silently freeze norm
+        # layers during training. `freeze_encoder()` re-applies eval when frozen.
+        self.enc.train()
+
+    # ------------------------------------------------------------------ setup
+
+    def _resolve_norm_stats(
+        self, image_mean: Optional[List[float]], image_std: Optional[List[float]]
+    ) -> Tuple[List[float], List[float]]:
+        """Resolve per-channel mean/std for normalization.
+
+        Priority: explicit args -> the model's `AutoImageProcessor` -> ImageNet.
+        """
+        if image_mean is not None and image_std is not None:
+            return list(image_mean), list(image_std)
+        if not self.normalize:
+            # Identity normalization (mean 0, std 1) when disabled.
+            return [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]
+        try:
+            from transformers import AutoImageProcessor
+
+            proc = AutoImageProcessor.from_pretrained(
+                self.model_name, revision=self.revision
+            )
+            mean = getattr(proc, "image_mean", None)
+            std = getattr(proc, "image_std", None)
+            if mean is not None and std is not None:
+                return list(mean), list(std)
+        except Exception as e:  # pragma: no cover - network/availability dependent
+            logger.warning(
+                f"Could not read image_mean/image_std from an AutoImageProcessor for "
+                f"'{self.model_name}' ({e}); falling back to ImageNet statistics."
+            )
+        return list(_IMAGENET_MEAN), list(_IMAGENET_STD)
+
+    def _probe(self, in_channels: int) -> Tuple[List[int], List[int]]:
+        """Dummy-forward to discover per-map strides and channel counts.
+
+        Returns the multi-scale pyramid (Case A) or the single bottleneck (Case B)
+        as ``(strides, channels)`` sorted by ascending stride, deduplicated so each
+        stride appears once (keeping the deepest-processed map at that stride).
+        """
+        size = 256
+        was_training = self.enc.training
+        self.enc.eval()
+        x = torch.zeros(1, in_channels, size, size)
+        with torch.no_grad():
+            feats = self.enc(x).feature_maps
+        if was_training:
+            self.enc.train()
+
+        by_stride: Dict[int, int] = {}
+        for f in feats:
+            stride = size // f.shape[-2]
+            by_stride[stride] = f.shape[1]
+        strides = sorted(by_stride)
+        channels = [by_stride[s] for s in strides]
+        return strides, channels
+
+    def _select_pyramid(self, feats) -> List[torch.Tensor]:
+        """Dedupe raw HF ``feature_maps`` into a stride-ordered pyramid at runtime.
+
+        Groups maps by spatial height (keeping the last/deepest map per size) and
+        orders them finest -> coarsest (larger H == smaller stride first), matching
+        the pyramid discovered by the init-time stride probe.
+        """
+        by_size: Dict[int, torch.Tensor] = {}
+        for f in feats:
+            by_size[f.shape[-2]] = f
+        ordered_h = sorted(by_size, reverse=True)
+        return [by_size[h] for h in ordered_h]
+
+    def _build_decoder(
+        self, strides: List[int], channels: List[int], max_stride: int
+    ) -> None:
+        """Case A: wire the multi-scale pyramid into the sleap decoder."""
+        if len(strides) < 2:
+            message = (
+                f"Backbone '{self.model_name}' produced a single-scale feature map "
+                f"(strides={strides}); it is isotropic and cannot feed a spatial "
+                f"decoder. Use a hierarchical backbone (ConvNeXtV2/ResNet/Swinv2) "
+                f"for pose/segmentation heads, or set mode='encoder' for a pooled "
+                f"head."
+            )
+            logger.error(message)
+            raise ValueError(message)
+
+        self._pyramid_strides = strides
+        self._pyramid_channels = channels
+        deepest_stride = strides[-1]
+        x_in_shape = channels[-1]
+
+        if deepest_stride != max_stride:
+            logger.warning(
+                f"Backbone '{self.model_name}' has a deepest stride of "
+                f"{deepest_stride}, but config max_stride={max_stride}. Using the "
+                f"probed value {deepest_stride}."
+            )
+        self.max_stride = deepest_stride
+
+        n_skips = len(strides) - 1  # every map except the bottleneck is a skip
+        up_blocks = int(np.log2(deepest_stride / self.output_stride))
+        if up_blocks < 1:
+            message = (
+                f"output_stride={self.output_stride} is >= the backbone's deepest "
+                f"stride {deepest_stride}; nothing to decode. Lower output_stride."
+            )
+            logger.error(message)
+            raise ValueError(message)
+
+        # stem_blocks/down_blocks are chosen so decoder blocks past the available
+        # skips use the no-concat (feat_concat=False) path. The finest HF stride is
+        # typically 4, so reaching output_stride=2 adds one learned-upsample block
+        # with no skip (see encoder_decoder.Decoder for the branch condition).
+        stem_blocks = 1
+        down_blocks = max(1, n_skips - stem_blocks)
+        encoder_channels = channels[:-1][::-1]  # skip channels, deepest-first
+
+        self.dec = Decoder(
+            x_in_shape=x_in_shape,
+            output_stride=self.output_stride,
+            current_stride=deepest_stride,
+            filters=channels[0],
+            up_blocks=up_blocks,
+            down_blocks=down_blocks,
+            stem_blocks=stem_blocks,
+            filters_rate=self.filters_rate,
+            convs_per_block=self.convs_per_block,
+            kernel_size=self.kernel_size,
+            up_interpolate=self.up_interpolate,
+            encoder_channels=encoder_channels,
+            prefix="pretrained_dec",
+        )
+        self.decoder_stride_to_filters = self.dec.stride_to_filters
+        # Class-vectors head reads middle_blocks[-1].filters (bottleneck channels).
+        self.middle_blocks = nn.ModuleList([_FiltersHolder(x_in_shape)])
+
+    def _build_encoder_only(
+        self, strides: List[int], channels: List[int], max_stride: int
+    ) -> None:
+        """Case B: expose a pooled bottleneck for a class-vectors/embedding head."""
+        self.max_stride = strides[-1]
+        hidden = channels[-1]
+        # No decoder: outputs=[] routes every head to `middle_output`.
+        self.decoder_stride_to_filters = {}
+        self.middle_blocks = nn.ModuleList([_FiltersHolder(hidden)])
+
+    # ---------------------------------------------------------------- weights
+
+    def reload_pretrained_weights(self) -> None:
+        """Re-apply the snapshotted pretrained weights to the encoder.
+
+        The LightningModule applies xavier init to the whole model (clobbering the
+        encoder), then calls this to restore the pretrained weights — mirroring the
+        convnext/swint ImageNet-load ordering.
+        """
+        if self._pretrained_sd is None:
+            return
+        self.enc.load_state_dict(self._pretrained_sd)
+        logger.info(f"Restored pretrained weights for backbone '{self.model_name}'.")
+
+    def freeze_encoder(self) -> None:
+        """Freeze the pretrained encoder (feature extraction; decoder/head train)."""
+        self.enc.eval()
+        self.enc.requires_grad_(False)
+        logger.info(f"Froze pretrained encoder '{self.model_name}'.")
+
+    # ------------------------------------------------------------------ config
+
+    @classmethod
+    def from_config(cls, config: OmegaConf) -> "PretrainedBackbone":
+        """Create a `PretrainedBackbone` from a config leaf."""
+
+        def get(key, default):
+            return config[key] if key in config else default
+
+        return cls(
+            source=get("source", "hf"),
+            model_name=config.model_name,
+            in_channels=get("in_channels", 3),
+            output_stride=get("output_stride", 2),
+            max_stride=get("max_stride", 32),
+            weights=get("weights", True),
+            mode=get("mode", "auto"),
+            out_indices=get("out_indices", None),
+            freeze=get("freeze", False),
+            revision=get("revision", None),
+            normalize=get("normalize", True),
+            image_mean=get("image_mean", None),
+            image_std=get("image_std", None),
+            filters_rate=get("filters_rate", 2.0),
+            convs_per_block=get("convs_per_block", 2),
+            kernel_size=get("kernel_size", 3),
+            up_interpolate=get("up_interpolate", True),
+        )
+
+    # ------------------------------------------------------------------ forward
+
+    def _normalize(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply model-specific per-channel normalization to a [0, 1] tensor."""
+        if not self.normalize:
+            return x
+        return (x - self.image_mean) / self.image_std
+
+    def forward(self, x: torch.Tensor) -> Dict[str, Any]:
+        """Forward pass emitting the sleap-nn backbone dict contract.
+
+        Args:
+            x: Input tensor ``(B, in_channels, H, W)`` in ``[0, 1]`` (grayscale is
+                already replicated to 3 channels upstream in `Model.forward`).
+
+        Returns:
+            Case A: ``{"outputs": [...], "strides": [...], "middle_output": bottleneck,
+            "intermediate_feat": bottleneck}``.
+            Case B: ``{"outputs": [], "strides": [], "middle_output": bottleneck,
+            "intermediate_feat": bottleneck}``.
+        """
+        x = self._normalize(x)
+        feats = self.enc(x).feature_maps
+
+        if self.mode == "encoder":
+            bottleneck = feats[-1]
+            return {
+                "outputs": [],
+                "strides": [],
+                "middle_output": bottleneck,
+                "intermediate_feat": bottleneck,
+            }
+
+        # Case A: rebuild the stride-ordered pyramid, feed skips into the decoder.
+        maps = self._select_pyramid(feats)  # finest -> coarsest (stride asc)
+        bottleneck = maps[-1]
+        skips = maps[:-1][::-1]  # deepest-first, matching encoder_channels
+        out = self.dec(bottleneck, skips)
+        out["middle_output"] = bottleneck
+        return out

--- a/sleap_nn/config/get_config.py
+++ b/sleap_nn/config/get_config.py
@@ -10,6 +10,7 @@ from sleap_nn.config.data_config import (
 from sleap_nn.config.model_config import (
     ConvNextConfig,
     SwinTConfig,
+    PretrainedConfig,
     BackboneConfig,
     HeadConfig,
     UNetConfig,
@@ -248,9 +249,11 @@ def get_backbone_config(backbone_cfg: Union[str, Dict[str, Any]]):
             backbone_config.convnext = convnext_config_mapper[backbone_cfg]
         elif backbone_cfg.startswith("swint"):
             backbone_config.swint = swint_config_mapper[backbone_cfg]
+        elif backbone_cfg == "pretrained":
+            backbone_config.pretrained = PretrainedConfig()
         else:
             raise ValueError(
-                f"{backbone_cfg} is not a valid backbone. Please choose one of ['unet', 'unet_medium_rf', 'unet_large_rf', 'convnext', 'convnext_tiny', 'convnext_small', 'convnext_base', 'convnext_large', 'swint', 'swint_tiny', 'swint_small', 'swint_base']"
+                f"{backbone_cfg} is not a valid backbone. Please choose one of ['unet', 'unet_medium_rf', 'unet_large_rf', 'convnext', 'convnext_tiny', 'convnext_small', 'convnext_base', 'convnext_large', 'swint', 'swint_tiny', 'swint_small', 'swint_base', 'pretrained']"
             )
 
     elif isinstance(backbone_cfg, dict):
@@ -261,6 +264,8 @@ def get_backbone_config(backbone_cfg: Union[str, Dict[str, Any]]):
             backbone_config.convnext = ConvNextConfig(**backbone_cfg["convnext"])
         elif "swint" in backbone_cfg:
             backbone_config.swint = SwinTConfig(**backbone_cfg["swint"])
+        elif "pretrained" in backbone_cfg:
+            backbone_config.pretrained = PretrainedConfig(**backbone_cfg["pretrained"])
 
     return backbone_config
 

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -1058,6 +1058,77 @@ class HeadConfig:
     centered_instance_segmentation: Optional[CenteredInstanceSegmentationConfig] = None
 
 
+@define
+class PretrainedConfig:
+    """Configuration for an external pretrained backbone (HuggingFace).
+
+    Reuses an external pretrained image encoder (ConvNeXtV2, ResNet, Swinv2,
+    DINOv2, ...) as the model backbone via `transformers` `AutoBackbone`. See
+    ``sleap_nn.architectures.pretrained.PretrainedBackbone`` for the two
+    integration surfaces (hierarchical decoder vs. encoder-only pooled).
+
+    Attributes:
+        source: (str) Backbone source. Only ``"hf"`` (HuggingFace `transformers`)
+            is currently supported. *Default*: ``"hf"``.
+        model_name: (str) HuggingFace model id, e.g.
+            ``"facebook/convnextv2-nano-22k-224"``, ``"microsoft/resnet-50"``,
+            ``"facebook/dinov2-with-registers-base"``.
+        weights: (bool) If ``True``, download and load the pretrained weights; if
+            ``False``, build the architecture with random init from the model
+            config (no network) — useful for tests and cold-start training.
+            *Default*: ``True``.
+        mode: (str) One of ``"auto"``, ``"decoder"`` (Case A: hierarchical encoder
+            + sleap decoder for spatial heads), ``"encoder"`` (Case B: encoder-only
+            pooled bottleneck for class-vectors/embedding heads). *Default*:
+            ``"auto"``.
+        freeze: (bool) If ``True``, freeze the pretrained encoder (feature
+            extraction; only the decoder/head train). *Default*: ``False``.
+        revision: (str) Optional HuggingFace revision (commit sha / tag) to pin for
+            reproducibility. *Default*: ``None``.
+        normalize: (bool) If ``True``, apply model-specific per-channel mean/std
+            normalization inside the backbone forward (the data pipeline only
+            rescales to ``[0, 1]``). *Default*: ``True``.
+        image_mean: (List[float]) Optional explicit per-channel mean (length 3). If
+            ``None`` and ``normalize`` is set, read from the model's
+            `AutoImageProcessor`, falling back to ImageNet stats. *Default*: ``None``.
+        image_std: (List[float]) Optional explicit per-channel std (length 3).
+            *Default*: ``None``.
+        out_indices: (List[int]) Optional explicit stage indices to tap (Case A).
+            If ``None``, all stages are requested and deduplicated by stride.
+            *Default*: ``None``.
+        in_channels: (int) Number of input channels the stem expects. Pretrained
+            stems are 3-channel; grayscale is replicated upstream. *Default*: ``3``.
+        filters_rate: (float) Decoder filter growth factor (Case A). *Default*: ``2.0``.
+        convs_per_block: (int) Refinement convs per decoder block (Case A).
+            *Default*: ``2``.
+        kernel_size: (int) Decoder conv kernel size (Case A). *Default*: ``3``.
+        up_interpolate: (bool) Bilinear upsampling (vs. transposed conv) in the
+            decoder (Case A). *Default*: ``True``.
+        output_stride: (int) Stride of the finest decoder output (Case A).
+            *Default*: ``2``.
+        max_stride: (int) Deepest stride the encoder reaches (``32`` for
+            hierarchical CNN/Swin; patch size for a ViT). *Default*: ``32``.
+    """
+
+    source: str = "hf"
+    model_name: str = "facebook/convnextv2-nano-22k-224"
+    weights: bool = True
+    mode: str = "auto"
+    freeze: bool = False
+    revision: Optional[str] = None
+    normalize: bool = True
+    image_mean: Optional[List[float]] = None
+    image_std: Optional[List[float]] = None
+    out_indices: Optional[List[int]] = None
+    in_channels: int = 3
+    filters_rate: float = 2.0
+    convs_per_block: int = 2
+    kernel_size: int = 3
+    up_interpolate: bool = True
+    output_stride: int = 2
+    max_stride: int = 32
+
+
 @oneof
 @define
 class BackboneConfig:
@@ -1067,11 +1138,14 @@ class BackboneConfig:
         unet: An instance of `UNetConfig`.
         convnext: An instance of `ConvNextConfig`.
         swint: An instance of `SwinTConfig`.
+        pretrained: An instance of `PretrainedConfig` (external HuggingFace
+            pretrained backbone).
     """
 
     unet: Optional[UNetConfig] = None
     convnext: Optional[ConvNextConfig] = None
     swint: Optional[SwinTConfig] = None
+    pretrained: Optional[PretrainedConfig] = None
 
 
 @define

--- a/sleap_nn/export/exporters/onnx_exporter.py
+++ b/sleap_nn/export/exporters/onnx_exporter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
 import torch
+from loguru import logger
 
 
 def export_to_onnx(
@@ -19,8 +20,36 @@ def export_to_onnx(
     output_names: Optional[List[str]] = None,
     do_constant_folding: bool = True,
     verify: bool = True,
+    numerical_check: bool = False,
+    numerical_atol: float = 1e-3,
+    numerical_rtol: float = 1e-3,
 ) -> Path:
-    """Export a PyTorch model to ONNX."""
+    """Export a PyTorch model to ONNX.
+
+    Args:
+        model: The PyTorch module to export.
+        save_path: Destination path for the ``.onnx`` file.
+        input_shape: Shape of the dummy input used to trace the graph.
+        input_dtype: Dtype of the dummy input (``uint8`` matches the inference
+            wrappers, which normalize in-graph).
+        opset_version: ONNX opset for the (default) TorchScript exporter.
+        dynamic_axes: Dynamic-axis spec; defaults to batch/height/width dynamic on
+            the ``image`` input.
+        input_names: ONNX input names; defaults to ``["image"]``.
+        output_names: ONNX output names; inferred from a reference forward if
+            ``None``.
+        do_constant_folding: Whether to constant-fold during export.
+        verify: If ``True``, run the structural ``onnx.checker`` on the result.
+        numerical_check: If ``True``, additionally run the exported graph through
+            onnxruntime on the export dummy input and assert output parity against
+            PyTorch (atol/rtol below). ``_verify_onnx`` alone is structural only
+            (``onnx.checker``); a numerical check catches graphs that are valid but
+            wrong — a known failure mode for transformer backbones (e.g. Swin) whose
+            ops trace but disagree numerically. Requires onnxruntime (the ``export``
+            extra); degrades to a warning if it is unavailable.
+        numerical_atol: Absolute tolerance for the numerical parity check.
+        numerical_rtol: Relative tolerance for the numerical parity check.
+    """
     save_path = Path(save_path)
     model.eval()
 
@@ -42,9 +71,12 @@ def export_to_onnx(
             0, 256, input_shape, device=device, dtype=input_dtype
         )
 
-    if output_names is None:
+    # A reference forward is needed to infer output names and/or for parity.
+    test_out = None
+    if output_names is None or numerical_check:
         with torch.no_grad():
             test_out = model(dummy_input)
+    if output_names is None:
         output_names = _infer_output_names(test_out)
 
     common = dict(
@@ -83,6 +115,17 @@ def export_to_onnx(
     if verify:
         _verify_onnx(save_path)
 
+    if numerical_check:
+        _verify_onnx_numerical(
+            save_path,
+            dummy_input,
+            test_out,
+            input_names[0],
+            output_names,
+            atol=numerical_atol,
+            rtol=numerical_rtol,
+        )
+
     return save_path
 
 
@@ -99,3 +142,56 @@ def _verify_onnx(path: Path) -> None:
 
     model = onnx.load(path.as_posix())
     onnx.checker.check_model(model)
+
+
+def _verify_onnx_numerical(
+    path: Path,
+    dummy_input: torch.Tensor,
+    reference_output,
+    input_name: str,
+    output_names: List[str],
+    atol: float = 1e-3,
+    rtol: float = 1e-3,
+) -> None:
+    """Assert onnxruntime output parity against a PyTorch reference.
+
+    Complements the structural ``_verify_onnx`` check for cases where a graph is
+    valid but numerically wrong (a known transformer-backbone failure mode). Lazily
+    imports onnxruntime (the ``export`` extra) and degrades to a warning if it is
+    unavailable rather than failing the export.
+    """
+    try:
+        import numpy as np
+        import onnxruntime as ort
+    except ImportError:  # pragma: no cover - onnxruntime is an optional extra
+        logger.warning(
+            "onnxruntime is not installed; skipping ONNX numerical-parity check. "
+            "Install it with `pip install 'sleap-nn[export]'` to enable it."
+        )
+        return
+
+    session = ort.InferenceSession(path.as_posix(), providers=["CPUExecutionProvider"])
+    ort_outputs = session.run(None, {input_name: dummy_input.detach().cpu().numpy()})
+
+    if isinstance(reference_output, dict):
+        ref_list = [reference_output[name] for name in output_names]
+    elif isinstance(reference_output, (list, tuple)):
+        ref_list = list(reference_output)
+    else:
+        ref_list = [reference_output]
+
+    for name, ref, got in zip(output_names, ref_list, ort_outputs):
+        ref_np = ref.detach().cpu().numpy()
+        max_abs = float(np.abs(ref_np - got).max())
+        if not np.allclose(ref_np, got, atol=atol, rtol=rtol):
+            message = (
+                f"ONNX numerical-parity check failed for output '{name}': max abs "
+                f"diff {max_abs:.3g} exceeds atol={atol}, rtol={rtol}. The exported "
+                f"graph is structurally valid but numerically disagrees with "
+                f"PyTorch (common for transformer backbones)."
+            )
+            logger.error(message)
+            raise AssertionError(message)
+        logger.info(
+            f"ONNX numerical-parity OK for '{name}' (max abs diff {max_abs:.3g})."
+        )

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -222,6 +222,15 @@ class LightningModel(L.LightningModule):
                 ].DEFAULT.get_state_dict(progress=True, check_hash=True)
                 self.model.backbone.enc.load_state_dict(ckpt, strict=False)
 
+        # External pretrained (HuggingFace) backbone: the wrapper loaded its
+        # weights in __init__, but the xavier init above clobbered them (it runs
+        # on every Conv2d/Linear). Re-apply the snapshotted pretrained weights, then
+        # freeze the encoder if requested. Mirrors the convnext/swint ordering.
+        if self.backbone_type == "pretrained":
+            self.model.backbone.reload_pretrained_weights()
+            if getattr(self.model.backbone, "freeze", False):
+                self.model.backbone.freeze_encoder()
+
         # Initializing backbone (encoder + decoder) with trained ckpts
         if self.pretrained_backbone_weights is not None:
             logger.info(
@@ -625,8 +634,10 @@ class LightningModel(L.LightningModule):
         elif self.optimizer == "AdamW":
             optim = torch.optim.AdamW
 
+        # Only optimize params that require gradients so a frozen pretrained
+        # backbone (freeze=True) is excluded; a no-op for fully-trainable models.
         optimizer = optim(
-            self.parameters(),
+            filter(lambda p: p.requires_grad, self.parameters()),
             lr=self.lr,
             amsgrad=self.amsgrad,
         )

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -667,6 +667,16 @@ class ModelTrainer:
                     f"Updating backbone in_channels to 3 based on the pretrained model weights."
                 )
 
+        # External pretrained (HuggingFace) backbones have 3-channel stems and
+        # expect RGB (grayscale is replicated). Force in_channels=3 + ensure_rgb so
+        # the data pipeline feeds 3-channel images and the pretrained stem loads.
+        elif self.backbone_type == "pretrained":
+            if self.config.model_config.backbone_config.pretrained.in_channels != 3:
+                self.config.model_config.backbone_config.pretrained.in_channels = 3
+                logger.info("Updating pretrained backbone in_channels to 3 (RGB stem).")
+            self.config.data_config.preprocessing.ensure_rgb = True
+            self.config.data_config.preprocessing.ensure_grayscale = False
+
         elif (
             self.backbone_type == "unet"
             and self.config.model_config.pretrained_backbone_weights is not None

--- a/tests/architectures/test_pretrained.py
+++ b/tests/architectures/test_pretrained.py
@@ -83,6 +83,25 @@ def test_caseA_output_stride(output_stride):
     assert output_stride in bb.decoder_stride_to_filters
 
 
+def test_caseA_two_feature_maps_no_skip_block():
+    """A 2-map pyramid (n_skips=1) with more decoder blocks than skips must not
+    crash: the extra block(s) take the no-concat path. Regression for the
+    down_blocks clamp (max(0, ...) not max(1, ...))."""
+    bb = PretrainedBackbone.from_config(
+        _caseA_cfg(
+            "facebook/convnextv2-nano-22k-224",
+            out_indices=[3, 4],  # strides 16, 32 -> n_skips=1
+            output_stride=8,  # up_blocks=2 => one skip block + one no-skip block
+        )
+    )
+    bb.eval()
+    assert bb.mode == "decoder"
+    with torch.no_grad():
+        out = bb(torch.rand(1, 3, 256, 256))
+    assert out["strides"][-1] == 8
+    assert out["outputs"][-1].shape[-2] == 256 // 8
+
+
 def test_caseA_grayscale_and_rgb_equivalent_shapes():
     """Grayscale (1ch) input is handled by Model.forward's 1->3 replicate."""
     m = Model(
@@ -246,6 +265,30 @@ def test_encoder_trainable_by_default():
 def test_unsupported_source_raises():
     with pytest.raises(ValueError, match="Unsupported pretrained backbone source"):
         PretrainedBackbone(source="torchvision", model_name="resnet50", weights=False)
+
+
+def test_encoder_only_backbone_with_spatial_head_raises():
+    """A spatial head on an encoder-only backbone gives an actionable error,
+    not a bare KeyError."""
+    with pytest.raises(ValueError, match="encoder-only backbone supports only"):
+        Model(
+            backbone_type="pretrained",
+            backbone_config=OmegaConf.create(
+                {
+                    "source": "hf",
+                    "model_name": "facebook/dinov2-with-registers-base",
+                    "weights": False,
+                    "mode": "encoder",
+                    "in_channels": 3,
+                    "output_stride": 2,
+                    "max_stride": 14,
+                }
+            ),
+            head_configs=OmegaConf.create(
+                {"confmaps": {"part_names": ["a"], "sigma": 2.5, "output_stride": 2}}
+            ),
+            model_type="single_instance",
+        )
 
 
 def test_resolve_mode():

--- a/tests/architectures/test_pretrained.py
+++ b/tests/architectures/test_pretrained.py
@@ -1,0 +1,263 @@
+"""Tests for external pretrained (HuggingFace) backbones.
+
+These tests build backbones with ``weights=False`` (random init from the model
+config) so they never touch the network — the HF architecture code is exercised
+without downloading checkpoints. They are skipped when ``transformers`` (the
+``backbones`` optional extra) is not installed, mirroring the ``requires_onnxruntime``
+convention in ``tests/export``.
+"""
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+transformers = pytest.importorskip("transformers")
+
+from sleap_nn.architectures.model import Model
+from sleap_nn.architectures.pretrained import PretrainedBackbone, _resolve_mode
+
+
+def _caseA_cfg(model_name, output_stride=2, max_stride=32, **kw):
+    base = dict(
+        source="hf",
+        model_name=model_name,
+        weights=False,
+        mode="auto",
+        in_channels=3,
+        output_stride=output_stride,
+        max_stride=max_stride,
+        normalize=True,
+    )
+    base.update(kw)
+    return OmegaConf.create(base)
+
+
+# --------------------------------------------------------------- Case A wrappers
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "facebook/convnextv2-nano-22k-224",
+        "microsoft/resnet-50",
+        "microsoft/swinv2-tiny-patch4-window8-256",
+    ],
+)
+def test_caseA_wrapper_contract(model_name):
+    """Hierarchical backbones build a decoder and emit the full contract."""
+    bb = PretrainedBackbone.from_config(_caseA_cfg(model_name, output_stride=2))
+    bb.eval()
+
+    assert bb.mode == "decoder"
+    assert bb.max_stride == 32
+    # decoder_stride_to_filters must cover the head's output stride.
+    assert 2 in bb.decoder_stride_to_filters
+    assert 32 in bb.decoder_stride_to_filters
+    # middle_blocks[-1].filters exposes the bottleneck channels (class-vectors path).
+    assert isinstance(bb.middle_blocks[-1].filters, int)
+
+    x = torch.rand(1, 3, 256, 256)
+    with torch.no_grad():
+        out = bb(x)
+    assert set(out) == {"outputs", "strides", "middle_output", "intermediate_feat"}
+    assert len(out["outputs"]) == len(out["strides"])
+    # Finest output at stride 2 => half the input resolution.
+    assert out["outputs"][-1].shape[-2:] == (128, 128)
+    assert out["strides"][-1] == 2
+    # middle_output/intermediate_feat are the bottleneck (deepest stride).
+    assert out["middle_output"].shape[-2:] == (8, 8)
+
+
+@pytest.mark.parametrize("output_stride", [2, 4])
+def test_caseA_output_stride(output_stride):
+    """The decoder reaches the requested output stride."""
+    bb = PretrainedBackbone.from_config(
+        _caseA_cfg("facebook/convnextv2-nano-22k-224", output_stride=output_stride)
+    )
+    bb.eval()
+    with torch.no_grad():
+        out = bb(torch.rand(1, 3, 256, 256))
+    assert out["strides"][-1] == output_stride
+    assert out["outputs"][-1].shape[-2] == 256 // output_stride
+    assert output_stride in bb.decoder_stride_to_filters
+
+
+def test_caseA_grayscale_and_rgb_equivalent_shapes():
+    """Grayscale (1ch) input is handled by Model.forward's 1->3 replicate."""
+    m = Model(
+        backbone_type="pretrained",
+        backbone_config=_caseA_cfg("facebook/convnextv2-nano-22k-224"),
+        head_configs=OmegaConf.create(
+            {"confmaps": {"part_names": ["a", "b"], "sigma": 2.5, "output_stride": 2}}
+        ),
+        model_type="single_instance",
+    )
+    m.eval()
+    with torch.no_grad():
+        y_gray = m(torch.rand(1, 1, 256, 256))
+        y_rgb = m(torch.rand(1, 3, 256, 256))
+    assert y_gray["SingleInstanceConfmapsHead"].shape == (1, 2, 128, 128)
+    assert y_rgb["SingleInstanceConfmapsHead"].shape == (1, 2, 128, 128)
+
+
+def test_caseA_in_model_segmentation():
+    """A bottomup_segmentation model builds and runs on a pretrained backbone."""
+    m = Model(
+        backbone_type="pretrained",
+        backbone_config=_caseA_cfg("facebook/convnextv2-nano-22k-224"),
+        head_configs=OmegaConf.create(
+            {
+                "segmentation": {"output_stride": 2, "loss_weight": 1.0},
+                "center": {"sigma": 8.0, "output_stride": 2, "loss_weight": 1.0},
+                "offsets": {"output_stride": 2, "loss_weight": 1.0},
+            }
+        ),
+        model_type="bottomup_segmentation",
+    )
+    m.eval()
+    with torch.no_grad():
+        y = m(torch.rand(1, 1, 256, 256))
+    assert y["SegmentationHead"].shape == (1, 1, 128, 128)
+    assert y["InstanceCenterHead"].shape == (1, 1, 128, 128)
+    assert y["CenterOffsetHead"].shape == (1, 2, 128, 128)
+
+
+# --------------------------------------------------------------- Case B wrappers
+
+
+def test_caseB_encoder_only_contract():
+    """Isotropic ViTs (DINOv2) build an encoder-only pooled bottleneck."""
+    bb = PretrainedBackbone.from_config(
+        OmegaConf.create(
+            {
+                "source": "hf",
+                "model_name": "facebook/dinov2-with-registers-base",
+                "weights": False,
+                "mode": "auto",
+                "in_channels": 3,
+            }
+        )
+    )
+    bb.eval()
+    assert bb.mode == "encoder"
+    # No decoder => outputs empty => all heads consume middle_output.
+    assert bb.decoder_stride_to_filters == {}
+    assert isinstance(bb.middle_blocks[-1].filters, int)
+
+    with torch.no_grad():
+        out = bb(torch.rand(1, 3, 224, 224))
+    assert out["outputs"] == []
+    assert out["strides"] == []
+    # Reshaped spatial bottleneck (tokens stripped): [B, hidden, H/patch, W/patch].
+    assert out["middle_output"].ndim == 4
+    assert out["middle_output"].shape[1] == bb.middle_blocks[-1].filters
+    assert out["intermediate_feat"] is out["middle_output"]
+
+
+def test_mode_override_encoder_on_hierarchical():
+    """mode='encoder' forces the pooled path even on a hierarchical backbone."""
+    bb = PretrainedBackbone.from_config(
+        _caseA_cfg("facebook/convnextv2-nano-22k-224", mode="encoder")
+    )
+    bb.eval()
+    assert bb.mode == "encoder"
+    assert bb.decoder_stride_to_filters == {}
+
+
+# --------------------------------------------------------------- normalization
+
+
+def test_normalization_applied_and_toggle():
+    """normalize=True subtracts mean/divides std; normalize=False is identity."""
+    bb_norm = PretrainedBackbone.from_config(
+        _caseA_cfg(
+            "facebook/convnextv2-nano-22k-224",
+            normalize=True,
+            image_mean=[0.5, 0.5, 0.5],
+            image_std=[0.25, 0.25, 0.25],
+        )
+    )
+    x = torch.zeros(1, 3, 8, 8)
+    normed = bb_norm._normalize(x)
+    # (0 - 0.5) / 0.25 = -2.0 for all channels.
+    assert torch.allclose(normed, torch.full_like(x, -2.0))
+
+    bb_off = PretrainedBackbone.from_config(
+        _caseA_cfg("facebook/convnextv2-nano-22k-224", normalize=False)
+    )
+    assert torch.allclose(bb_off._normalize(x), x)
+
+
+def test_explicit_norm_stats_registered_as_buffers():
+    """Explicit image_mean/std are stored as (1,3,1,1) buffers."""
+    bb = PretrainedBackbone.from_config(
+        _caseA_cfg(
+            "microsoft/resnet-50",
+            image_mean=[0.1, 0.2, 0.3],
+            image_std=[0.4, 0.5, 0.6],
+        )
+    )
+    assert bb.image_mean.shape == (1, 3, 1, 1)
+    assert bb.image_std.shape == (1, 3, 1, 1)
+    assert bb.image_mean.flatten().tolist() == pytest.approx([0.1, 0.2, 0.3])
+
+
+# --------------------------------------------------------------- freeze / reload
+
+
+def test_freeze_encoder():
+    """freeze_encoder() disables grads on the encoder only."""
+    bb = PretrainedBackbone.from_config(
+        _caseA_cfg("facebook/convnextv2-nano-22k-224", freeze=True)
+    )
+    bb.freeze_encoder()
+    assert all(not p.requires_grad for p in bb.enc.parameters())
+    # Decoder stays trainable.
+    assert any(p.requires_grad for p in bb.dec.parameters())
+
+
+def test_reload_is_noop_without_weights():
+    """With weights=False there is no snapshot; reload is a safe no-op."""
+    bb = PretrainedBackbone.from_config(_caseA_cfg("facebook/convnextv2-nano-22k-224"))
+    assert bb._pretrained_sd is None
+    bb.reload_pretrained_weights()  # must not raise
+
+
+def test_encoder_trainable_by_default():
+    """The encoder is left in train mode after construction (freeze=False).
+
+    `from_pretrained` returns models in eval mode; the wrapper must reset to train
+    so fine-tuning updates BatchNorm running stats (ResNet). Lightning respects
+    module eval flags and won't flip it back.
+    """
+    bb = PretrainedBackbone.from_config(_caseA_cfg("microsoft/resnet-50"))
+    assert bb.enc.training is True
+    assert all(m.training for m in bb.enc.modules())
+    assert all(p.requires_grad for p in bb.enc.parameters())
+    # After freezing, the encoder switches to eval so norm layers use fixed stats.
+    bb.freeze_encoder()
+    assert bb.enc.training is False
+
+
+# --------------------------------------------------------------- errors / misc
+
+
+def test_unsupported_source_raises():
+    with pytest.raises(ValueError, match="Unsupported pretrained backbone source"):
+        PretrainedBackbone(source="torchvision", model_name="resnet50", weights=False)
+
+
+def test_resolve_mode():
+    class _Cfg:
+        def __init__(self, model_type, stage_names):
+            self.model_type = model_type
+            self.stage_names = stage_names
+
+    # explicit modes pass through
+    assert _resolve_mode(_Cfg("convnextv2", ["stem", "s1"]), "encoder") == "encoder"
+    assert _resolve_mode(_Cfg("dinov2", None), "decoder") == "decoder"
+    # auto: hierarchical -> decoder, isotropic ViT -> encoder
+    assert _resolve_mode(_Cfg("convnextv2", ["stem", "s1", "s2"]), "auto") == "decoder"
+    assert _resolve_mode(_Cfg("dinov2", None), "auto") == "encoder"
+    assert _resolve_mode(_Cfg("resnet", ["stem", "s1", "s2"]), "auto") == "decoder"

--- a/tests/config/test_model_config.py
+++ b/tests/config/test_model_config.py
@@ -186,3 +186,63 @@ def test_model_oneof_failure_head_config(caplog):
             centroid=CentroidConfig(),
         )
     assert "Only one attribute of this class can be set (not None).\n" in caplog.text
+
+
+def test_pretrained_backbone_config():
+    """The `pretrained` backbone member (HuggingFace) is a valid oneof member."""
+    from sleap_nn.config.model_config import PretrainedConfig
+
+    cfg = BackboneConfig(
+        pretrained=PretrainedConfig(
+            model_name="microsoft/resnet-50", output_stride=4, max_stride=32
+        )
+    )
+    assert cfg.which_oneof_attrib_name() == "pretrained"
+    assert cfg.pretrained.source == "hf"
+    assert cfg.pretrained.model_name == "microsoft/resnet-50"
+    # Defaults required by check_output_strides / model_trainer / export.
+    assert cfg.pretrained.in_channels == 3
+    assert cfg.pretrained.output_stride == 4
+    assert cfg.pretrained.max_stride == 32
+    assert cfg.pretrained.weights is True
+    assert cfg.pretrained.freeze is False
+    assert cfg.pretrained.mode == "auto"
+
+
+def test_pretrained_backbone_oneof_exclusive(caplog):
+    """`pretrained` cannot be set alongside another backbone."""
+    from sleap_nn.config.model_config import PretrainedConfig
+
+    with pytest.raises(ValueError):
+        BackboneConfig(unet=UNetConfig(), pretrained=PretrainedConfig())
+    assert "Only one attribute of this class can be set (not None).\n" in caplog.text
+
+
+def test_pretrained_backbone_struct_merge():
+    """A YAML-style dict merges onto the structured schema (the training gate)."""
+    from omegaconf import OmegaConf
+    from sleap_nn.config.model_config import ModelConfig
+
+    struct = OmegaConf.structured(ModelConfig())
+    user = OmegaConf.create(
+        {
+            "backbone_config": {
+                "unet": None,
+                "convnext": None,
+                "swint": None,
+                "pretrained": {
+                    "source": "hf",
+                    "model_name": "facebook/convnextv2-nano-22k-224",
+                    "weights": False,
+                    "output_stride": 2,
+                    "max_stride": 32,
+                },
+            }
+        }
+    )
+    merged = OmegaConf.merge(struct, user)
+    assert (
+        merged.backbone_config.pretrained.model_name
+        == "facebook/convnextv2-nano-22k-224"
+    )
+    assert merged.backbone_config.pretrained.weights is False


### PR DESCRIPTION
## Summary

Implements #680: reuse an external **pretrained image backbone** from HuggingFace `transformers` (ConvNeXtV2, ResNet, Swinv2, DINOv2, …) as the backbone of any sleap-nn model — **frozen or fine-tuned** — for pose, centroid, or segmentation heads. This unblocks #568 (ResNet parity) and #111 (foundation models like DINOv2/v3).

It rides the existing `Model`/`get_backbone` path exactly as the design in #680 prescribes: a new `pretrained` member on `backbone_config`, a wrapper that emits the existing backbone dict-contract, and the `middle_output`/`intermediate_feat` tap already consumed by the class-vectors head. **No new model class, no head changes, no prerequisite refactor.**

## Two integration modes (auto-selected; override via `mode`)

| Mode | Backbone family | For |
|------|-----------------|-----|
| **`decoder`** (Case A) | hierarchical (ConvNeXtV2, ResNet, Swinv2, DINOv3-ConvNeXt) | spatial heads: pose, centroid, segmentation |
| **`encoder`** (Case B) | isotropic ViT (DINOv2, DINOv2-with-registers) | pooled heads: class-vectors / re-ID |

`mode: auto` picks `encoder` for isotropic ViTs and `decoder` for hierarchical backbones. Case A feeds the HF `feature_maps` pyramid as skip connections into the existing `encoder_decoder.Decoder` (the same pattern as `ConvNextWrapper`/`SwinTWrapper`). Case B exposes the reshaped bottleneck (CLS/register tokens stripped, LayerNorm applied) with `middle_blocks[-1].filters == hidden_size`.

## Config

```yaml
model_config:
  backbone_config:
    unet: null
    convnext: null
    swint: null
    pretrained:
      source: hf
      model_name: facebook/convnextv2-nano-22k-224  # any AutoBackbone model id
      weights: true       # download & load pretrained weights (false = random init)
      mode: auto          # auto | decoder | encoder
      freeze: false       # true = feature extraction (encoder frozen)
      normalize: true     # apply the model's image_mean/std (from AutoImageProcessor)
      revision: null      # pin an HF commit sha/tag for reproducibility
      in_channels: 3      # HF stems are 3-channel (grayscale is replicated)
      output_stride: 2    # finest decoder output (decoder mode)
      max_stride: 32      # deepest encoder stride (32 for CNN/Swin; patch size for ViT)
```

Training is config-driven — no new CLI flag:

```bash
pip install "sleap-nn[backbones]"     # optional extra (transformers)

sleap-nn train config.yaml \
  data_config.train_labels_path="[train.pkg.slp]" \
  data_config.val_labels_path="[val.pkg.slp]"
```

Sample config: `docs/sample_configs/config_bottomup_segmentation_pretrained.yaml`.

## Supported models

The wrapper is **family-agnostic**: it probes strides/channels at construction rather than hard-coding per-model taps, so any `AutoBackbone`-compatible checkpoint should work. The main models we recommend and tested:

| Model | Example `model_name` | Mode | License / gated |
|-------|----------------------|------|-----------------|
| ConvNeXtV2 | `facebook/convnextv2-nano-22k-224` | decoder | Apache-2.0 / no |
| ResNet | `microsoft/resnet-50` | decoder | Apache-2.0 / no |
| Swinv2 | `microsoft/swinv2-tiny-patch4-window8-256` | decoder | MIT / no |
| DINOv2 / -with-registers | `facebook/dinov2-with-registers-base` | encoder | Apache-2.0 / no |
| DINOv3-ConvNeXt | `facebook/dinov3-convnext-base-…` | decoder | DINOv3 custom / gated |
| DINOv3-ViT | `facebook/dinov3-vit…16-…` | encoder | DINOv3 custom / gated |

Other hierarchical families (ConvNeXt v1, BiT, FocalNet, Hiera, ViTDet) work in `decoder` mode and other isotropic ViTs (BEiT, ViT-MAE, I-JEPA) in `encoder` mode. See [`docs/guides/pretrained-backbones.md`](https://github.com/talmolab/sleap-nn/blob/main/docs/guides/pretrained-backbones.md) for the full table, freeze/fine-tune guidance, and the gating/`HF_TOKEN`/offline workflow.

## What's included

- **`sleap_nn/architectures/pretrained.py`** — `PretrainedBackbone` wrapper: lazy `transformers` import, float32 force, `revision` pin, `AutoImageProcessor` mean/std baked into `forward`, stride probe, Case A decoder wiring / Case B pooled bottleneck, `freeze_encoder()` + `reload_pretrained_weights()`.
- **Config** — `PretrainedConfig` + `pretrained` member on the `@oneof` `BackboneConfig`; `get_backbone` dispatch; `get_backbone_config` string/dict dispatch.
- **Training seams** — `get_backbone_type_from_cfg` picks up the new key; the LightningModule re-applies pretrained weights after xavier and freezes on request; `configure_optimizers` filters to `requires_grad` params; `_verify_model_input_channels` forces `in_channels=3` + `ensure_rgb` for a pretrained backbone.
- **Export** — opt-in torch-vs-onnxruntime numerical-parity check in the ONNX exporter for transformer backbones (structural `onnx.checker` alone misses valid-but-wrong graphs, e.g. Swin); degrades to a warning without onnxruntime.
- **Docs** — `guides/pretrained-backbones.md` (supported-model table, modes, freeze/fine-tune, gating/`HF_TOKEN`/offline workflow, gotchas), a model-config section, a sample config, mkdocs nav.
- **Deps** — `backbones` optional extra (`transformers>=5.0`), imported lazily so the default install is unchanged.
- **Tests** — network-free wrapper tests (Case A/B contract, output strides, grayscale/RGB, freeze, train-mode-by-default, normalization, mode override) and config tests (schema/oneof/struct-merge). Wrapper tests skip when `transformers` is absent, matching the `requires_onnxruntime` convention.

## Validation

Beyond the unit tests, the full path (config → trainer → 3-channel data → pretrained backbone → decoder heads → checkpoint → inference/eval) was exercised with real training runs to convergence for both decoder-mode CNN families (ConvNeXtV2 and ResNet-50) on segmentation tasks; the ResNet-50 run in particular confirms the BatchNorm/eval-mode handling (`self.enc.train()` after construction) is correct.

## Gotchas handled / documented

- DINOv2 is patch-14 (doesn't divide 16/32-padded crops) → fine for pooled use; documented alternatives for spatial use.
- Hierarchical HF backbones bottom out at stride 4, so `output_stride=2` adds one skip-less learned-upsample decoder block (localization nuance, not a blocker); `output_stride=4` uses skips at every level.
- `transformers` v5 `dtype="auto"` → forced `float32`.
- Gated (DINOv3/SAM3) + non-commercial (Hiera/I-JEPA) weights → opt-in with documented `HF_TOKEN`/license workflow.

## Test status

New tests pass; the affected suites (`tests/architectures`, `tests/config`, `tests/export`) are green. The two failures in `tests/training` — `TestDistributedUtils::test_is_distributed_initialized_returns_false` and `::test_get_dist_rank_returns_none` — are a **pre-existing test-ordering issue** (leaked `torch.distributed` global state) that reproduces **identically on clean `main`** and is unrelated to this change; they do not surface in CI's full-suite run (all CI checks green).

Closes #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
