### PR TITLE
Configurable best-checkpoint metric + segmentation viz cleanup (#690)

### DIFF
--- a/sleap_nn/config/trainer_config.py
+++ b/sleap_nn/config/trainer_config.py
@@ -62,10 +62,14 @@ class ModelCkptConfig:
     Attributes:
         save_top_k: (int) If save_top_k == k, the best k models according to the quantity monitored will be saved. If save_top_k == 0, no models are saved. If save_top_k == -1, all models are saved. Please note that the monitors are checked every every_n_epochs epochs. if save_top_k >= 2 and the callback is called multiple times inside an epoch, the name of the saved file will be appended with a version count starting with v1 unless enable_version_counter is set to False. *Default*: `1`.
         save_last: (bool) When True, saves a last.ckpt whenever a checkpoint file gets saved. On a local filesystem, this will be a symbolic link, and otherwise a copy of the checkpoint file. This allows accessing the latest checkpoint in a deterministic manner. *Default*: `None`.
+        monitor: (str) Metric name the checkpoint tracks to pick the "best" model. Any key present in ``trainer.callback_metrics`` — e.g. ``"val/loss"`` (default), or, for segmentation runs with ``eval.enabled``, a full-resolution quality metric such as ``"eval/val/fg_mean_cldice"`` (semantic) or ``"eval/val/mask_mean_iou"`` (instance) logged by ``SegmentationEvaluationCallback``. *Default*: `"val/loss"`.
+        mode: (str) ``"min"`` (default) or ``"max"`` — direction of improvement for ``monitor`` (use ``"max"`` for IoU/clDice metrics). *Default*: `"min"`.
     """
 
     save_top_k: int = 1
     save_last: Optional[bool] = None
+    monitor: str = "val/loss"
+    mode: str = "min"
 
 
 @define

--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -787,11 +787,28 @@ class UnifiedVizCallback(Callback):
 
         log_dict = {}
 
-        # Render confmaps for each enabled mode
-        for mode_name, renderer in self._wandb_renderers.items():
-            suffix = "" if mode_name == "direct" else f"_{mode_name}"
-            img = renderer.render(data, caption=f"{prefix.title()} Epoch {epoch}")
-            log_dict[f"viz/{prefix}/predictions{suffix}"] = img
+        # Predictions panel. For segmentation models this IS the GT-vs-prediction
+        # foreground overlay (issue #690): it is strictly more informative than the
+        # bare prediction, and the confmap "masks" mode ("predictions_masks") does
+        # not render for seg. So for seg we log ONLY that overlay under the standard
+        # "predictions" key and skip the confmap modes and the separate "gt_mask"
+        # key. Non-seg models keep the per-mode confmap renderers as before.
+        if self.viz_gt_mask and data.gt_mask is not None:
+            gt_mask_fig = self._mpl_renderer.render_gt_mask(data)
+            buf = BytesIO()
+            gt_mask_fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+            buf.seek(0)
+            plt.close(gt_mask_fig)
+            gt_mask_pil = PILImage.open(buf)
+            log_dict[f"viz/{prefix}/predictions"] = wandb.Image(
+                gt_mask_pil, caption=f"{prefix.title()} GT vs Pred Mask Epoch {epoch}"
+            )
+        else:
+            # Render confmaps for each enabled mode
+            for mode_name, renderer in self._wandb_renderers.items():
+                suffix = "" if mode_name == "direct" else f"_{mode_name}"
+                img = renderer.render(data, caption=f"{prefix.title()} Epoch {epoch}")
+                log_dict[f"viz/{prefix}/predictions{suffix}"] = img
 
         # PAFs visualization (for bottomup models)
         if self.viz_pafs and data.pred_pafs is not None:
@@ -843,18 +860,8 @@ class UnifiedVizCallback(Callback):
                 caption=f"{prefix.title()} Offset Direction Epoch {epoch}",
             )
 
-        # GT-vs-prediction foreground mask overlay (for segmentation models)
-        if self.viz_gt_mask and data.gt_mask is not None:
-            gt_mask_fig = self._mpl_renderer.render_gt_mask(data)
-            buf = BytesIO()
-            gt_mask_fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
-            buf.seek(0)
-            plt.close(gt_mask_fig)
-            gt_mask_pil = PILImage.open(buf)
-            log_dict[f"viz/{prefix}/gt_mask"] = wandb.Image(
-                gt_mask_pil,
-                caption=f"{prefix.title()} GT vs Pred Mask Epoch {epoch}",
-            )
+        # (issue #690) The GT-vs-prediction overlay is now logged above under the
+        # "predictions" key for segmentation models — no separate "gt_mask" panel.
 
         # Colored grouped per-instance mask overlay (bottom-up segmentation)
         if self.viz_instance_masks and data.instance_masks is not None:
@@ -897,9 +904,8 @@ class UnifiedVizCallback(Callback):
                 columns.append(f"{prefix.title()} Offsets")
                 table_data[0].append(log_dict.get(f"viz/{prefix}/offsets"))
 
-            if self.viz_gt_mask and data.gt_mask is not None:
-                columns.append(f"{prefix.title()} GT Mask")
-                table_data[0].append(log_dict.get(f"viz/{prefix}/gt_mask"))
+            # (issue #690) gt_mask is now the "predictions" panel for seg; no
+            # separate GT Mask table column.
 
             if self.viz_instance_masks and data.instance_masks is not None:
                 columns.append(f"{prefix.title()} Instance Masks")
@@ -1717,7 +1723,25 @@ class SegmentationEvaluationCallback(Callback):
     def _log_metrics_foreground(self, trainer, metrics: dict, epoch: int):
         """Log whole-frame foreground (semantic) metrics to WandB."""
         import numpy as np
+        import torch
         from lightning.pytorch.loggers import WandbLogger
+
+        # Expose the full-eval metrics to ModelCheckpoint/EarlyStopping via
+        # callback_metrics, so a run can select best.ckpt on quality
+        # (model_ckpt.monitor="eval/val/fg_mean_cldice", mode="max") instead of the
+        # coarse val/loss. This runs in on_validation_epoch_end (before the
+        # ModelCheckpoint save in on_validation_end), so the value is available.
+        # Set on rank 0 only (this callback computes there); single-GPU. Under DDP,
+        # checkpoint-on-clDice would need an all-rank broadcast of these values.
+        for src_key, ck_key in (
+            ("fg_mean_iou", "eval/val/fg_mean_iou"),
+            ("fg_mean_cldice", "eval/val/fg_mean_cldice"),
+            ("fg_mean_boundary_iou", "eval/val/fg_mean_boundary_iou"),
+            ("fg_frame_recall", "eval/val/fg_frame_recall"),
+        ):
+            v = metrics.get(src_key)
+            if v is not None and not np.isnan(v):
+                trainer.callback_metrics[ck_key] = torch.as_tensor(float(v))
 
         wandb_logger = None
         for log in trainer.loggers:
@@ -1751,7 +1775,24 @@ class SegmentationEvaluationCallback(Callback):
     def _log_metrics(self, trainer, metrics: dict, epoch: int):
         """Log mask evaluation metrics to WandB."""
         import numpy as np
+        import torch
         from lightning.pytorch.loggers import WandbLogger
+
+        # Expose per-instance mask metrics to ModelCheckpoint/EarlyStopping via
+        # callback_metrics so instance-seg runs can select best.ckpt on
+        # eval/val/mask_mean_iou (mode="max") instead of val/loss. See the
+        # foreground variant above for the rank/DDP caveat.
+        for src_key, ck_key in (
+            ("mask_mean_iou", "eval/val/mask_mean_iou"),
+            ("mask_mean_iou_all_gt", "eval/val/mask_mean_iou_all_gt"),
+            ("mask_mean_cldice", "eval/val/mask_mean_cldice"),
+            ("precision", "eval/val/mask_precision"),
+            ("recall", "eval/val/mask_recall"),
+            ("f1", "eval/val/mask_f1"),
+        ):
+            v = metrics.get(src_key)
+            if v is not None and not (isinstance(v, float) and np.isnan(v)):
+                trainer.callback_metrics[ck_key] = torch.as_tensor(float(v))
 
         wandb_logger = None
         for log in trainer.loggers:

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -1131,8 +1131,8 @@ class ModelTrainer:
                     / self.config.trainer_config.run_name
                 ).as_posix(),
                 filename="best",
-                monitor="val/loss",
-                mode="min",
+                monitor=self.config.trainer_config.model_ckpt.monitor,
+                mode=self.config.trainer_config.model_ckpt.mode,
             )
             callbacks.append(checkpoint_callback)
 

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -93,15 +93,26 @@ def test_model_ckpt_config():
 
     Check default values and customization
     """
-    # Check default values
+    # Check default values (defaults keep the historical val/loss selection)
     conf = OmegaConf.structured(ModelCkptConfig)
     assert conf.save_top_k == 1
     assert conf.save_last is None
+    assert conf.monitor == "val/loss"
+    assert conf.mode == "min"
 
-    # Test customization
-    custom_conf = OmegaConf.structured(ModelCkptConfig(save_top_k=5, save_last=True))
+    # Test customization (e.g. select best.ckpt on a full-eval quality metric)
+    custom_conf = OmegaConf.structured(
+        ModelCkptConfig(
+            save_top_k=5,
+            save_last=True,
+            monitor="eval/val/fg_mean_cldice",
+            mode="max",
+        )
+    )
     assert custom_conf.save_top_k == 5
     assert custom_conf.save_last is True
+    assert custom_conf.monitor == "eval/val/fg_mean_cldice"
+    assert custom_conf.mode == "max"
 
 
 def test_wandb_config():

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -20,6 +20,7 @@ from sleap_nn.training.callbacks import (
     CentroidEvaluationCallback,
     match_centroids,
     UnifiedVizCallback,
+    SegmentationEvaluationCallback,
 )
 from sleap_nn.training.utils import VisualizationData
 
@@ -482,6 +483,78 @@ class TestWandBVizCallbackWithPAFs:
             mock_get_logger.assert_not_called()
 
 
+class TestSegmentationEvalCallbackCheckpointMetrics:
+    """The seg eval callback exposes its metrics via ``trainer.callback_metrics`` so
+    ModelCheckpoint can select best.ckpt on quality (clDice / mask-IoU) not val/loss."""
+
+    def _trainer(self):
+        trainer = MagicMock()
+        trainer.callback_metrics = {}
+        trainer.loggers = (
+            []
+        )  # no wandb -> returns right after the callback_metrics push
+        return trainer
+
+    def test_foreground_metrics_pushed_to_callback_metrics(self):
+        cb = SegmentationEvaluationCallback(foreground=True)
+        trainer = self._trainer()
+        cb._log_metrics_foreground(
+            trainer,
+            {
+                "fg_mean_iou": 0.4,
+                "fg_mean_cldice": 0.75,
+                "fg_mean_boundary_iou": 0.4,
+                "fg_frame_recall": 1.0,
+                "n_frames": 10,
+            },
+            epoch=2,
+        )
+        assert float(
+            trainer.callback_metrics["eval/val/fg_mean_cldice"]
+        ) == pytest.approx(0.75)
+        assert "eval/val/fg_mean_iou" in trainer.callback_metrics
+
+    def test_mask_metrics_pushed_to_callback_metrics(self):
+        cb = SegmentationEvaluationCallback(foreground=False)
+        trainer = self._trainer()
+        cb._log_metrics(
+            trainer,
+            {
+                "mask_mean_iou": 0.55,
+                "mask_mean_iou_all_gt": 0.5,
+                "mask_mean_cldice": 0.7,
+                "precision": 0.8,
+                "recall": 0.7,
+                "f1": 0.75,
+                "n_tp": 5,
+                "n_fp": 1,
+                "n_fn": 2,
+            },
+            epoch=2,
+        )
+        assert float(
+            trainer.callback_metrics["eval/val/mask_mean_iou"]
+        ) == pytest.approx(0.55)
+        assert "eval/val/mask_mean_cldice" in trainer.callback_metrics
+
+    def test_nan_metric_is_not_pushed(self):
+        cb = SegmentationEvaluationCallback(foreground=True)
+        trainer = self._trainer()
+        cb._log_metrics_foreground(
+            trainer,
+            {
+                "fg_mean_iou": float("nan"),
+                "fg_mean_cldice": 0.6,
+                "fg_mean_boundary_iou": 0.5,
+                "fg_frame_recall": 1.0,
+                "n_frames": 3,
+            },
+            epoch=1,
+        )
+        assert "eval/val/fg_mean_iou" not in trainer.callback_metrics
+        assert "eval/val/fg_mean_cldice" in trainer.callback_metrics
+
+
 class TestUnifiedVizCallbackSegmentation:
     """Segmentation-specific visualization wiring for UnifiedVizCallback."""
 
@@ -511,6 +584,61 @@ class TestUnifiedVizCallbackSegmentation:
         _, kwargs = mt.lightning_model.get_visualization_data.call_args
         assert kwargs.get("include_center_heatmap") is True
         assert kwargs.get("include_offsets") is True
+
+    def _seg_viz_data(self):
+        from sleap_nn.training.utils import VisualizationData
+
+        return VisualizationData(
+            image=np.random.rand(64, 64, 3).astype(np.float32),
+            pred_confmaps=np.random.rand(64, 64, 1).astype(np.float32),
+            pred_peaks=np.zeros((0, 1, 2)),
+            pred_peak_values=np.zeros((0,)),
+            gt_instances=np.zeros((0, 1, 2)),
+            output_scale=1.0,
+            gt_mask=(np.random.rand(64, 64) > 0.5),
+        )
+
+    def test_seg_predictions_panel_is_gt_mask_overlay(self):
+        """#690: for seg models the ``viz/{prefix}/predictions`` panel IS the
+        GT-vs-pred overlay; the broken ``predictions_masks`` mode and the separate
+        ``gt_mask`` key are dropped."""
+        cb = UnifiedVizCallback(
+            model_trainer=MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="semantic_segmentation",
+            log_wandb=True,
+            wandb_modes=["direct", "masks"],  # "masks" would add predictions_masks
+            save_local=False,
+        )
+        mock_logger = MagicMock()
+        cb._log_wandb_viz(self._seg_viz_data(), "val", 3, mock_logger)
+
+        mock_logger.experiment.log.assert_called_once()
+        log_dict = mock_logger.experiment.log.call_args[0][0]
+        assert "viz/val/predictions" in log_dict
+        assert "viz/val/predictions_masks" not in log_dict
+        assert "viz/val/gt_mask" not in log_dict
+
+    def test_nonseg_predictions_keep_confmap_modes(self):
+        """Non-seg models are unchanged: per-mode confmap predictions incl. _masks."""
+        cb = UnifiedVizCallback(
+            model_trainer=MagicMock(),
+            train_dataset=[{}],
+            val_dataset=[{}],
+            model_type="single_instance",
+            log_wandb=True,
+            wandb_modes=["direct", "masks"],
+            save_local=False,
+        )
+        assert cb.viz_gt_mask is False
+        for r in cb._wandb_renderers.values():
+            r.render = MagicMock(return_value="img")
+        mock_logger = MagicMock()
+        cb._log_wandb_viz(self._seg_viz_data(), "val", 1, mock_logger)
+        log_dict = mock_logger.experiment.log.call_args[0][0]
+        assert "viz/val/predictions" in log_dict
+        assert "viz/val/predictions_masks" in log_dict
 
     def test_render_offsets_produces_figure(self):
         """``render_offsets`` renders an offset-magnitude figure from (H, W, 2)."""


### PR DESCRIPTION
## Summary
- Select `best.ckpt` on the honest full-eval quality metric (clDice / mask-IoU) instead of the coarse `val/loss`, via a configurable `ModelCkptConfig.monitor`/`mode` plus the segmentation eval callback mirroring its metrics into `trainer.callback_metrics`.
- **Fixes #690**: for segmentation models, `viz/{split}/predictions` is now the GT-vs-pred overlay; the non-rendering `predictions_masks` panel and the redundant separate `gt_mask` key are dropped.

## Changes Made
- `config/trainer_config.py`: `ModelCkptConfig` gains `monitor` (default `"val/loss"`) and `mode` (default `"min"`).
- `training/model_trainer.py`: `ModelCheckpoint(monitor=…, mode=…)` now read from `model_ckpt`.
- `training/callbacks.py`:
  - `SegmentationEvaluationCallback._log_metrics_foreground` / `_log_metrics` push their metrics into `trainer.callback_metrics` (`eval/val/fg_mean_cldice`, `eval/val/mask_mean_iou`, …) so `ModelCheckpoint`/`EarlyStopping` can monitor them.
  - `UnifiedVizCallback._log_wandb_viz`: for seg the `predictions` panel is the `render_gt_mask` overlay; removed the `predictions_masks` mode and the separate `gt_mask` key (+ its wandb-table column).

## Why
The per-epoch seg eval (`val/fg_iou` and the callback clDice) is scored on the model's output-stride grid, which reads optimistically high vs the post-training full-resolution eval that unions `frame.masks`. Selecting `best.ckpt` on `val/loss` therefore picks a model tuned to the coarse/eroded target. Separately (#690), the `predictions_masks` wandb panel does not render for seg, while the GT-vs-pred overlay is the panel users actually read.

## Example Usage
```yaml
trainer_config:
  model_ckpt:
    monitor: eval/val/fg_mean_cldice   # or eval/val/mask_mean_iou for instance seg
    mode: max
  eval:
    enabled: true
```

## API Changes
- New `ModelCkptConfig.monitor: str = "val/loss"` and `mode: str = "min"` (backward-compatible defaults — existing configs unchanged).
- Seg training now exposes `eval/val/*` keys in `trainer.callback_metrics`.
- Seg wandb viz: `viz/{split}/predictions` is the GT overlay; `viz/{split}/predictions_masks` and `viz/{split}/gt_mask` are removed for seg (non-seg viz unchanged).

## Testing
- `tests/config/test_trainer_config.py`: `monitor`/`mode` defaults + customization.
- `tests/training/test_callbacks.py`: callback_metrics push (foreground + mask + NaN-skip) and the seg predictions-panel-is-GT-overlay behavior (+ non-seg unchanged).
- 137 tests pass across the two touched test files.
- Manual: a semantic smoke selected `best.ckpt` on `eval/val/fg_mean_cldice` (`best_model_score` 0.751 — a clDice, not a loss), zero "monitor not found" warnings, no crash.
- Did not run the GPU training suite (GPUs were in use); CI will.

## Design Decisions
- Metrics are mirrored into `callback_metrics` from the eval callback's `on_validation_epoch_end` (before `ModelCheckpoint`'s `on_validation_end`), on rank 0 (single-GPU). A DDP checkpoint-on-clDice would need an all-rank broadcast — noted inline.
- Defaults keep `val/loss` / `min`, so nothing changes unless a run opts in.

## Related Issues
Fixes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)
