### PR TITLE
fix: don't crash ModelCheckpoint when a monitored seg metric is NaN

### DIFF
--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -1733,6 +1733,9 @@ class SegmentationEvaluationCallback(Callback):
         # ModelCheckpoint save in on_validation_end), so the value is available.
         # Set on rank 0 only (this callback computes there); single-GPU. Under DDP,
         # checkpoint-on-clDice would need an all-rank broadcast of these values.
+        # ALWAYS populate the key (0.0 for NaN/missing) so a run that monitors it does
+        # not crash ModelCheckpoint on an epoch with no valid metric; these are all
+        # in [0, 1] and higher-is-better, so 0.0 is the correct worst value.
         for src_key, ck_key in (
             ("fg_mean_iou", "eval/val/fg_mean_iou"),
             ("fg_mean_cldice", "eval/val/fg_mean_cldice"),
@@ -1740,8 +1743,8 @@ class SegmentationEvaluationCallback(Callback):
             ("fg_frame_recall", "eval/val/fg_frame_recall"),
         ):
             v = metrics.get(src_key)
-            if v is not None and not np.isnan(v):
-                trainer.callback_metrics[ck_key] = torch.as_tensor(float(v))
+            fv = 0.0 if (v is None or np.isnan(v)) else float(v)
+            trainer.callback_metrics[ck_key] = torch.as_tensor(fv)
 
         wandb_logger = None
         for log in trainer.loggers:
@@ -1781,7 +1784,11 @@ class SegmentationEvaluationCallback(Callback):
         # Expose per-instance mask metrics to ModelCheckpoint/EarlyStopping via
         # callback_metrics so instance-seg runs can select best.ckpt on
         # eval/val/mask_mean_iou (mode="max") instead of val/loss. See the
-        # foreground variant above for the rank/DDP caveat.
+        # foreground variant above for the rank/DDP caveat. ALWAYS populate the key
+        # (0.0 for NaN/missing): mask_mean_iou is NaN on epochs with no matched
+        # instances (common early in training / on sparse-instance datasets), and a
+        # missing monitored key crashes ModelCheckpoint. These metrics are in [0, 1]
+        # higher-is-better, so 0.0 is the correct worst value.
         for src_key, ck_key in (
             ("mask_mean_iou", "eval/val/mask_mean_iou"),
             ("mask_mean_iou_all_gt", "eval/val/mask_mean_iou_all_gt"),
@@ -1791,8 +1798,12 @@ class SegmentationEvaluationCallback(Callback):
             ("f1", "eval/val/mask_f1"),
         ):
             v = metrics.get(src_key)
-            if v is not None and not (isinstance(v, float) and np.isnan(v)):
-                trainer.callback_metrics[ck_key] = torch.as_tensor(float(v))
+            fv = (
+                0.0
+                if (v is None or (isinstance(v, float) and np.isnan(v)))
+                else float(v)
+            )
+            trainer.callback_metrics[ck_key] = torch.as_tensor(fv)
 
         wandb_logger = None
         for log in trainer.loggers:

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -537,7 +537,9 @@ class TestSegmentationEvalCallbackCheckpointMetrics:
         ) == pytest.approx(0.55)
         assert "eval/val/mask_mean_cldice" in trainer.callback_metrics
 
-    def test_nan_metric_is_not_pushed(self):
+    def test_nan_metric_pushed_as_zero(self):
+        """A NaN metric is still populated (as 0.0) so a run monitoring it does not
+        crash ModelCheckpoint with a missing-key error."""
         cb = SegmentationEvaluationCallback(foreground=True)
         trainer = self._trainer()
         cb._log_metrics_foreground(
@@ -551,8 +553,35 @@ class TestSegmentationEvalCallbackCheckpointMetrics:
             },
             epoch=1,
         )
-        assert "eval/val/fg_mean_iou" not in trainer.callback_metrics
-        assert "eval/val/fg_mean_cldice" in trainer.callback_metrics
+        assert "eval/val/fg_mean_iou" in trainer.callback_metrics
+        assert float(trainer.callback_metrics["eval/val/fg_mean_iou"]) == 0.0
+        assert float(
+            trainer.callback_metrics["eval/val/fg_mean_cldice"]
+        ) == pytest.approx(0.6)
+
+    def test_nan_mask_iou_pushed_as_zero(self):
+        """Regression: mask_mean_iou is NaN on epochs with no matched instances;
+        the monitored key must still be present (0.0) so ModelCheckpoint(
+        monitor="eval/val/mask_mean_iou") does not raise."""
+        cb = SegmentationEvaluationCallback(foreground=False)
+        trainer = self._trainer()
+        cb._log_metrics(
+            trainer,
+            {
+                "mask_mean_iou": float("nan"),
+                "mask_mean_iou_all_gt": 0.0,
+                "mask_mean_cldice": float("nan"),
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "n_tp": 0,
+                "n_fp": 3,
+                "n_fn": 5,
+            },
+            epoch=0,
+        )
+        assert "eval/val/mask_mean_iou" in trainer.callback_metrics
+        assert float(trainer.callback_metrics["eval/val/mask_mean_iou"]) == 0.0
 
 
 class TestUnifiedVizCallbackSegmentation:


### PR DESCRIPTION
## Summary
Follow-up to #691. Segmentation runs that select `best.ckpt` on `eval/val/mask_mean_iou` (instance) or `eval/val/fg_mean_cldice` (semantic) could crash with `MisconfigurationException: ModelCheckpoint(monitor=...) could not find the monitored key`.

## Root cause
#691 mirrors the seg eval metrics into `trainer.callback_metrics` but **skipped NaN values**. `mask_mean_iou` is `NaN` on validation epochs with **no matched instances** — common early in training and on sparse-instance datasets (e.g. a primary-root set with ~1–3 instances/frame). When it was NaN the monitored key was absent, and Lightning's `ModelCheckpoint` raises rather than warns → the run dies. (Top-down/dense-instance runs happened to always have a match, so they survived — the crash was intermittent.)

## Fix
Always populate the key, using `0.0` when the metric is NaN/missing. These metrics are all in `[0, 1]` and higher-is-better, so `0.0` is the correct worst value for a no-match epoch (that epoch simply won't be selected as best).

## Testing
- New regression tests: `test_nan_metric_pushed_as_zero` (foreground) and `test_nan_mask_iou_pushed_as_zero` (the exact instance-seg crash case) assert the monitored key is present as `0.0`.
- Full `TestSegmentationEvalCallbackCheckpointMetrics` + `TestUnifiedVizCallbackSegmentation` + `test_trainer_config.py` pass (25 tests).

## Related
Follow-up to #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
