### PR TITLE
fix(seg): register whole-frame masks to the image grid (thread through shared preprocessing)

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -2953,6 +2953,50 @@ class _RepeatSampler:
             yield from iter(self.sampler)
 
 
+def _resize_masks_like_image(
+    mask_arrays: List[np.ndarray],
+    max_hw: Tuple[Optional[int], Optional[int]],
+    scale: float,
+    max_stride: int,
+) -> List[np.ndarray]:
+    """Transform whole-frame instance masks with the SAME geometry as the image.
+
+    The image is preprocessed by :func:`apply_sizematcher` (resize-to-fit +
+    bottom-right pad to ``max_hw``) -> :func:`apply_resizer` (``scale``) ->
+    :func:`apply_pad_to_stride` (bottom-right pad to a ``max_stride`` multiple).
+    The whole-frame foreground target must be derived from masks carried through
+    the IDENTICAL chain: a single resize straight to the final padded size
+    STRETCHES the masks across the bottom-right pad region, which displaces the
+    target from the padded image by ~pad/2 (an offset that grows toward the
+    bottom-right) — an error the model then silently learns. Mirrors the mask
+    handling in :class:`CenteredInstanceSegmentationDataset`.
+
+    Args:
+        mask_arrays: List of 2D boolean arrays at the ORIGINAL image resolution.
+        max_hw: ``(max_height, max_width)`` size-match target (``None`` per axis
+            disables size-matching on that axis).
+        scale: Input scale factor applied after size-matching.
+        max_stride: Backbone max stride the padded input must be divisible by.
+
+    Returns:
+        List of 2D boolean arrays at the preprocessed (size-matched, scaled,
+        stride-padded) image resolution, aligned pixel-for-pixel with the image.
+    """
+    if len(mask_arrays) == 0:
+        return mask_arrays
+    # Stack instance masks as channels: (1, K, H, W). The resizing helpers act on
+    # the trailing (H, W), so every mask rides the exact same transform as the image.
+    masks_t = torch.from_numpy(
+        np.stack([m.astype(np.float32) for m in mask_arrays])
+    ).unsqueeze(0)
+    masks_t, _ = apply_sizematcher(masks_t, max_height=max_hw[0], max_width=max_hw[1])
+    masks_t, _ = apply_resizer(masks_t, torch.zeros(1), scale=scale)
+    masks_t = apply_pad_to_stride(masks_t, max_stride=max_stride)
+    masks_t = masks_t[0]  # (K, H, W)
+    # Single re-binarization at the end (matches the centered-instance seg path).
+    return [masks_t[k].numpy() > 0.5 for k in range(masks_t.shape[0])]
+
+
 class BottomUpSegmentationDataset(BaseDataset):
     """Dataset class for bottom-up instance segmentation models.
 
@@ -3146,21 +3190,18 @@ class BottomUpSegmentationDataset(BaseDataset):
 
         img_hw = sample_dict["image"].shape[-2:]
 
-        # Resize masks to match preprocessed image dimensions if size changed.
+        # Resize masks to match preprocessed image dimensions if size changed. The
+        # masks are carried through the SAME size-match / scale / bottom-right
+        # stride-pad chain as the image (NOT a single stretch to the padded size,
+        # which would desync the target from the image by ~pad/2 — see
+        # ``_resize_masks_like_image``).
         if img_hw != orig_img_hw and len(mask_arrays) > 0:
-            target_h, target_w = img_hw
-            resized_masks = []
-            for m in mask_arrays:
-                # Convert mask to float tensor: (1, 1, H, W)
-                m_tensor = (
-                    torch.from_numpy(m.astype(np.float32)).unsqueeze(0).unsqueeze(0)
-                )
-                m_resized = F.interpolate(
-                    m_tensor, size=(target_h, target_w), mode="area"
-                )
-                # Threshold back to binary
-                resized_masks.append((m_resized.squeeze().numpy() > 0.5))
-            mask_arrays = resized_masks
+            mask_arrays = _resize_masks_like_image(
+                mask_arrays,
+                max_hw=self.max_hw,
+                scale=self.scale,
+                max_stride=self.max_stride,
+            )
 
         # Geometric augmentation: co-transform the per-instance masks with the SAME
         # flip/affine matrix as the image (nearest-neighbor, re-binarized). Applied
@@ -3411,21 +3452,18 @@ class SemanticSegmentationDataset(BaseDataset):
 
         img_hw = sample_dict["image"].shape[-2:]
 
-        # Resize masks to match preprocessed image dimensions if size changed.
+        # Resize masks to match preprocessed image dimensions if size changed. The
+        # masks are carried through the SAME size-match / scale / bottom-right
+        # stride-pad chain as the image (NOT a single stretch to the padded size,
+        # which would desync the target from the image by ~pad/2 — see
+        # ``_resize_masks_like_image``).
         if img_hw != orig_img_hw and len(mask_arrays) > 0:
-            target_h, target_w = img_hw
-            resized_masks = []
-            for m in mask_arrays:
-                # Convert mask to float tensor: (1, 1, H, W)
-                m_tensor = (
-                    torch.from_numpy(m.astype(np.float32)).unsqueeze(0).unsqueeze(0)
-                )
-                m_resized = F.interpolate(
-                    m_tensor, size=(target_h, target_w), mode="area"
-                )
-                # Threshold back to binary
-                resized_masks.append((m_resized.squeeze().numpy() > 0.5))
-            mask_arrays = resized_masks
+            mask_arrays = _resize_masks_like_image(
+                mask_arrays,
+                max_hw=self.max_hw,
+                scale=self.scale,
+                max_stride=self.max_stride,
+            )
 
         # Geometric augmentation: co-transform the per-instance masks with the SAME
         # flip/affine matrix as the image (nearest-neighbor, re-binarized). Applied

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -869,6 +869,22 @@ class BaseDataset(Dataset):
                 sample["instances"],
                 scale=self.scale,
             )
+
+            # Co-transform whole-frame segmentation masks (a (1, K, H, W) float
+            # tensor the seg datasets place into the sample) through the IDENTICAL
+            # size-match + scale as the image — the SAME helpers, so the mask
+            # target stays pixel-aligned with the image by construction (bilinear
+            # via ``tvf.resize``, matching the image). Non-seg samples have no
+            # ``masks`` key, so this is a no-op for them.
+            if sample.get("masks") is not None:
+                sample["masks"], _ = apply_sizematcher(
+                    sample["masks"],
+                    max_height=self.max_hw[0],
+                    max_width=self.max_hw[1],
+                )
+                sample["masks"], _ = apply_resizer(
+                    sample["masks"], torch.zeros(1), scale=self.scale
+                )
         else:
             # TILING: slice a tile IN PLACE OF the sizematcher (constant-zero pad
             # only). The incoming frame is already scaled + channel-coerced (via
@@ -898,6 +914,12 @@ class BaseDataset(Dataset):
         sample["image"] = apply_pad_to_stride(
             sample["image"], max_stride=self.max_stride
         )
+        # Pad segmentation masks to the SAME bottom-right stride multiple as the
+        # image so the whole-frame target stays registered to the padded image.
+        if sample.get("masks") is not None:
+            sample["masks"] = apply_pad_to_stride(
+                sample["masks"], max_stride=self.max_stride
+            )
 
         # apply augmentation
         if self.apply_aug:
@@ -1984,8 +2006,15 @@ class CenteredInstanceSegmentationDataset(CenteredInstanceDataset):
         )
         tgt_hw = sample["instance_image"].shape[-2:]
         if tuple(mask_t.shape[-2:]) != tuple(tgt_hw):
+            # Antialiased bilinear, matching the image's ``apply_resizer`` /
+            # ``tvf.resize`` above so the mask stays registered to the image
+            # (standardized across every seg mask-geometry resize).
             mask_t = F.interpolate(
-                mask_t, size=(int(tgt_hw[0]), int(tgt_hw[1])), mode="area"
+                mask_t,
+                size=(int(tgt_hw[0]), int(tgt_hw[1])),
+                mode="bilinear",
+                align_corners=False,
+                antialias=True,
             )
 
         # Pad both to the model's max stride (bottom-right).
@@ -2953,48 +2982,43 @@ class _RepeatSampler:
             yield from iter(self.sampler)
 
 
-def _resize_masks_like_image(
+def _masks_to_frame_canvas(
     mask_arrays: List[np.ndarray],
-    max_hw: Tuple[Optional[int], Optional[int]],
-    scale: float,
-    max_stride: int,
-) -> List[np.ndarray]:
-    """Transform whole-frame instance masks with the SAME geometry as the image.
+    orig_hw: Tuple[int, int],
+) -> torch.Tensor:
+    """Place decoded per-instance masks onto the full-frame image grid as one tensor.
 
-    The image is preprocessed by :func:`apply_sizematcher` (resize-to-fit +
-    bottom-right pad to ``max_hw``) -> :func:`apply_resizer` (``scale``) ->
-    :func:`apply_pad_to_stride` (bottom-right pad to a ``max_stride`` multiple).
-    The whole-frame foreground target must be derived from masks carried through
-    the IDENTICAL chain: a single resize straight to the final padded size
-    STRETCHES the masks across the bottom-right pad region, which displaces the
-    target from the padded image by ~pad/2 (an offset that grows toward the
-    bottom-right) — an error the model then silently learns. Mirrors the mask
-    handling in :class:`CenteredInstanceSegmentationDataset`.
+    :func:`~sleap_nn.inference.segmentation_convert.decode_mask_to_image_res`
+    returns a PARTIAL-frame array for any mask carrying a non-identity
+    scale/offset (e.g. a top-down crop-centered mask in a pseudo-label ``.slp``),
+    so the raw masks in a single frame can have DIFFERENT shapes and none may
+    match the image. Each mask is zero-placed at its absolute top-left image
+    coordinate (clamped to the frame; the decoded extent can be +/-1 px) so every
+    mask shares the image's pixel grid *before* preprocessing — mirroring the
+    single-mask placement in :class:`CenteredInstanceSegmentationDataset`.
+
+    This is what lets the masks ride the image's size-match / scale / stride-pad
+    chain in :meth:`BaseDataset._apply_common_preprocessing` and stay pixel-aligned
+    with the image by construction (rather than a hand-maintained parallel resize).
+    Uniform framing is also what makes the ``(1, K, H, W)`` stack well-defined —
+    ragged per-instance shapes would otherwise raise in :func:`numpy.stack`.
 
     Args:
-        mask_arrays: List of 2D boolean arrays at the ORIGINAL image resolution.
-        max_hw: ``(max_height, max_width)`` size-match target (``None`` per axis
-            disables size-matching on that axis).
-        scale: Input scale factor applied after size-matching.
-        max_stride: Backbone max stride the padded input must be divisible by.
+        mask_arrays: List of 2D boolean arrays at (possibly partial) image
+            resolution, one per instance. May be empty.
+        orig_hw: ``(height, width)`` of the loaded image (the target canvas).
 
     Returns:
-        List of 2D boolean arrays at the preprocessed (size-matched, scaled,
-        stride-padded) image resolution, aligned pixel-for-pixel with the image.
+        Float32 tensor of shape ``(1, K, *orig_hw)`` with each mask placed at its
+        image-space origin (``K = 0`` is allowed and yields ``(1, 0, H, W)``).
     """
-    if len(mask_arrays) == 0:
-        return mask_arrays
-    # Stack instance masks as channels: (1, K, H, W). The resizing helpers act on
-    # the trailing (H, W), so every mask rides the exact same transform as the image.
-    masks_t = torch.from_numpy(
-        np.stack([m.astype(np.float32) for m in mask_arrays])
-    ).unsqueeze(0)
-    masks_t, _ = apply_sizematcher(masks_t, max_height=max_hw[0], max_width=max_hw[1])
-    masks_t, _ = apply_resizer(masks_t, torch.zeros(1), scale=scale)
-    masks_t = apply_pad_to_stride(masks_t, max_stride=max_stride)
-    masks_t = masks_t[0]  # (K, H, W)
-    # Single re-binarization at the end (matches the centered-instance seg path).
-    return [masks_t[k].numpy() > 0.5 for k in range(masks_t.shape[0])]
+    h, w = int(orig_hw[0]), int(orig_hw[1])
+    canvas = np.zeros((len(mask_arrays), h, w), dtype=np.float32)
+    for k, m in enumerate(mask_arrays):
+        mh, mw = m.shape[:2]
+        h0, w0 = min(mh, h), min(mw, w)
+        canvas[k, :h0, :w0] = m[:h0, :w0]
+    return torch.from_numpy(canvas).unsqueeze(0)  # (1, K, H, W)
 
 
 class BottomUpSegmentationDataset(BaseDataset):
@@ -3180,52 +3204,48 @@ class BottomUpSegmentationDataset(BaseDataset):
         }
 
         # Masks captured at index-build time (decoded bool arrays at orig res).
+        # Place them on the full-frame image grid as one float (1, K, H, W) tensor
+        # so they ride the IDENTICAL size-match / scale / stride-pad chain as the
+        # image inside ``_apply_common_preprocessing`` (kept as a float tensor
+        # end-to-end and binarized ONCE just before target generation). This is
+        # what keeps the whole-frame target registered to the padded image and
+        # makes ragged/offset-carrying decoded masks well-defined (see
+        # ``_masks_to_frame_canvas``).
         mask_arrays = [np.asarray(m, dtype=bool) for m in sample["masks"]]
-
-        # Record original image size before preprocessing
         orig_img_hw = (image.shape[-2], image.shape[-1])
+        sample_dict["masks"] = _masks_to_frame_canvas(mask_arrays, orig_img_hw)
 
-        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding)
+        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding).
+        # Co-transforms ``sample_dict["masks"]`` with the same geometry as the image.
         sample_dict = self._apply_common_preprocessing(sample_dict)
 
         img_hw = sample_dict["image"].shape[-2:]
 
-        # Resize masks to match preprocessed image dimensions if size changed. The
-        # masks are carried through the SAME size-match / scale / bottom-right
-        # stride-pad chain as the image (NOT a single stretch to the padded size,
-        # which would desync the target from the image by ~pad/2 — see
-        # ``_resize_masks_like_image``).
-        if img_hw != orig_img_hw and len(mask_arrays) > 0:
-            mask_arrays = _resize_masks_like_image(
-                mask_arrays,
-                max_hw=self.max_hw,
-                scale=self.scale,
-                max_stride=self.max_stride,
-            )
-
         # Geometric augmentation: co-transform the per-instance masks with the SAME
-        # flip/affine matrix as the image (nearest-neighbor, re-binarized). Applied
-        # here (post size-match / resize / pad) so the image and masks share a
-        # resolution, and BEFORE centroid/heatmap/offset generation so those targets
-        # are derived from the augmented masks. Bottom-up has no keypoints, so a dummy
-        # instances tensor rides along; erase/mixup stay image-only.
-        if self.apply_aug and self.geometric_aug is not None and len(mask_arrays) > 0:
-            masks_t = torch.from_numpy(
-                np.stack([m.astype(np.float32) for m in mask_arrays])
-            ).unsqueeze(
-                0
-            )  # (1, K, H, W)
+        # flip/affine matrix as the image (nearest-neighbor). Applied here (post
+        # size-match / resize / pad) so image and masks share a resolution, and
+        # BEFORE centroid/heatmap/offset generation so those targets are derived
+        # from the augmented masks. Bottom-up has no keypoints, so a dummy instances
+        # tensor rides along; erase/mixup stay image-only.
+        if (
+            self.apply_aug
+            and self.geometric_aug is not None
+            and sample_dict["masks"].shape[1] > 0
+        ):
             (
                 sample_dict["image"],
                 _,
-                masks_t,
+                sample_dict["masks"],
             ) = apply_geometric_augmentation(
                 sample_dict["image"],
                 torch.zeros((1, 1, 1, 2), dtype=torch.float32),
-                masks=masks_t,
+                masks=sample_dict["masks"],
                 **self.geometric_aug,
             )
-            mask_arrays = [masks_t[0, k].numpy() > 0.5 for k in range(masks_t.shape[1])]
+
+        # Single re-binarization to bool arrays right before target generation.
+        masks_t = sample_dict.pop("masks")
+        mask_arrays = [masks_t[0, k].numpy() > 0.5 for k in range(masks_t.shape[1])]
 
         # Pre-compute mask centroids once for both center heatmap and offset heads
         centers = _compute_mask_centroids(mask_arrays) if len(mask_arrays) > 0 else []
@@ -3442,52 +3462,48 @@ class SemanticSegmentationDataset(BaseDataset):
         }
 
         # Masks captured at index-build time (decoded bool arrays at orig res).
+        # Place them on the full-frame image grid as one float (1, K, H, W) tensor
+        # so they ride the IDENTICAL size-match / scale / stride-pad chain as the
+        # image inside ``_apply_common_preprocessing`` (kept as a float tensor
+        # end-to-end and binarized ONCE just before target generation). This is
+        # what keeps the whole-frame target registered to the padded image and
+        # makes ragged/offset-carrying decoded masks well-defined (see
+        # ``_masks_to_frame_canvas``).
         mask_arrays = [np.asarray(m, dtype=bool) for m in sample["masks"]]
-
-        # Record original image size before preprocessing
         orig_img_hw = (image.shape[-2], image.shape[-1])
+        sample_dict["masks"] = _masks_to_frame_canvas(mask_arrays, orig_img_hw)
 
-        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding)
+        # Apply common preprocessing (RGB/grayscale, size matching, scaling, padding).
+        # Co-transforms ``sample_dict["masks"]`` with the same geometry as the image.
         sample_dict = self._apply_common_preprocessing(sample_dict)
 
         img_hw = sample_dict["image"].shape[-2:]
 
-        # Resize masks to match preprocessed image dimensions if size changed. The
-        # masks are carried through the SAME size-match / scale / bottom-right
-        # stride-pad chain as the image (NOT a single stretch to the padded size,
-        # which would desync the target from the image by ~pad/2 — see
-        # ``_resize_masks_like_image``).
-        if img_hw != orig_img_hw and len(mask_arrays) > 0:
-            mask_arrays = _resize_masks_like_image(
-                mask_arrays,
-                max_hw=self.max_hw,
-                scale=self.scale,
-                max_stride=self.max_stride,
-            )
-
         # Geometric augmentation: co-transform the per-instance masks with the SAME
-        # flip/affine matrix as the image (nearest-neighbor, re-binarized). Applied
-        # here (post size-match / resize / pad) so the image and masks share a
-        # resolution, and BEFORE the foreground mask is generated so it is derived
-        # from the augmented masks. Semantic segmentation has no keypoints, so a dummy
-        # instances tensor rides along; erase/mixup stay image-only.
-        if self.apply_aug and self.geometric_aug is not None and len(mask_arrays) > 0:
-            masks_t = torch.from_numpy(
-                np.stack([m.astype(np.float32) for m in mask_arrays])
-            ).unsqueeze(
-                0
-            )  # (1, K, H, W)
+        # flip/affine matrix as the image (nearest-neighbor). Applied here (post
+        # size-match / resize / pad) so image and masks share a resolution, and
+        # BEFORE the foreground mask is generated so it is derived from the augmented
+        # masks. Semantic segmentation has no keypoints, so a dummy instances tensor
+        # rides along; erase/mixup stay image-only.
+        if (
+            self.apply_aug
+            and self.geometric_aug is not None
+            and sample_dict["masks"].shape[1] > 0
+        ):
             (
                 sample_dict["image"],
                 _,
-                masks_t,
+                sample_dict["masks"],
             ) = apply_geometric_augmentation(
                 sample_dict["image"],
                 torch.zeros((1, 1, 1, 2), dtype=torch.float32),
-                masks=masks_t,
+                masks=sample_dict["masks"],
                 **self.geometric_aug,
             )
-            mask_arrays = [masks_t[0, k].numpy() > 0.5 for k in range(masks_t.shape[1])]
+
+        # Single re-binarization to bool arrays right before target generation.
+        masks_t = sample_dict.pop("masks")
+        mask_arrays = [masks_t[0, k].numpy() > 0.5 for k in range(masks_t.shape[1])]
 
         # Generate the single whole-frame foreground mask (union of all instance
         # masks, area-downsampled + re-binarized to the seg head's output stride).
@@ -3734,8 +3750,9 @@ class BottomUpSegmentationTiledDataset(BaseDataset):
         mask_arrays = [np.asarray(m, dtype=bool) for m in d["masks"]]
         sized_hw = (image.shape[-2], image.shape[-1])
         if (sized_hw != orig_hw) and len(mask_arrays) > 0:
-            # Resize masks to the sized image resolution (mirrors
-            # BottomUpSegmentationDataset's scale-change branch).
+            # Resize masks to the sized image resolution with antialiased bilinear,
+            # matching the image's ``apply_resizer`` / ``tvf.resize`` above
+            # (standardized across every seg mask-geometry resize).
             target_h, target_w = sized_hw
             resized = []
             for m in mask_arrays:
@@ -3743,7 +3760,11 @@ class BottomUpSegmentationTiledDataset(BaseDataset):
                     torch.from_numpy(m.astype(np.float32)).unsqueeze(0).unsqueeze(0)
                 )
                 m_resized = F.interpolate(
-                    m_tensor, size=(target_h, target_w), mode="area"
+                    m_tensor,
+                    size=(target_h, target_w),
+                    mode="bilinear",
+                    align_corners=False,
+                    antialias=True,
                 )
                 resized.append(m_resized.squeeze().numpy() > 0.5)
             mask_arrays = resized
@@ -4151,8 +4172,9 @@ class SemanticSegmentationTiledDataset(BaseDataset):
         mask_arrays = [np.asarray(m, dtype=bool) for m in d["masks"]]
         sized_hw = (image.shape[-2], image.shape[-1])
         if (sized_hw != orig_hw) and len(mask_arrays) > 0:
-            # Resize masks to the sized image resolution (mirrors
-            # SemanticSegmentationDataset's scale-change branch).
+            # Resize masks to the sized image resolution with antialiased bilinear,
+            # matching the image's ``apply_resizer`` / ``tvf.resize`` above
+            # (standardized across every seg mask-geometry resize).
             target_h, target_w = sized_hw
             resized = []
             for m in mask_arrays:
@@ -4160,7 +4182,11 @@ class SemanticSegmentationTiledDataset(BaseDataset):
                     torch.from_numpy(m.astype(np.float32)).unsqueeze(0).unsqueeze(0)
                 )
                 m_resized = F.interpolate(
-                    m_tensor, size=(target_h, target_w), mode="area"
+                    m_tensor,
+                    size=(target_h, target_w),
+                    mode="bilinear",
+                    align_corners=False,
+                    antialias=True,
                 )
                 resized.append(m_resized.squeeze().numpy() > 0.5)
             mask_arrays = resized

--- a/tests/test_semantic_segmentation.py
+++ b/tests/test_semantic_segmentation.py
@@ -185,6 +185,104 @@ def test_semantic_tiled_dataset_fg_only(minimal_instance):
     assert saw_fg
 
 
+@pytest.mark.parametrize("dataset_cls", ["semantic", "bottomup"])
+def test_seg_target_registers_under_padding(minimal_instance, dataset_cls):
+    """Whole-frame fg target must register to the image grid when the frame is padded.
+
+    Regression for the ~half-pad offset: when the input H/W are not multiples of
+    ``max_stride`` the image is padded bottom-right, but the pre-fix code resized the
+    GT masks with a single ``F.interpolate`` straight to the PADDED size — stretching
+    them across the pad region and displacing the foreground target from the image by
+    ~pad/2 (worse toward the bottom-right). The masks must instead be carried through
+    the SAME bottom-right pad as the image. ``max_stride=40`` is not a divisor of the
+    384x384 frame, so it pads to 400x400 (pad 16), exactly the arabidopsis/soy
+    ``pad_to_stride`` scenario.
+    """
+    import torch.nn.functional as F
+    from sleap_nn.data.custom_datasets import (
+        BottomUpSegmentationDataset,
+        SemanticSegmentationDataset,
+    )
+    from sleap_nn.data.resizing import apply_pad_to_stride
+    from sleap_nn.data.segmentation_maps import generate_foreground_mask
+
+    labels = _seg_labels(minimal_instance)
+    max_stride = 40  # 384 % 40 == 24 -> bottom-right pad of 16 px (400x400)
+    seg_head = OmegaConf.create({"output_stride": 1})  # no downsample: crispest check
+    if dataset_cls == "semantic":
+        ds = SemanticSegmentationDataset(
+            labels=[labels],
+            seg_head_config=seg_head,
+            max_stride=max_stride,
+            ensure_grayscale=True,
+        )
+    else:
+        ds = BottomUpSegmentationDataset(
+            labels=[labels],
+            seg_head_config=seg_head,
+            center_head_config=OmegaConf.create({"output_stride": 1, "sigma": 4.0}),
+            offset_head_config=OmegaConf.create({"output_stride": 1}),
+            max_stride=max_stride,
+            ensure_grayscale=True,
+        )
+
+    sample = ds[0]
+    got = sample["foreground_mask"][0, 0].numpy() > 0.5
+    assert got.shape == (400, 400)  # padded, not the raw 384x384
+
+    # Masks captured at index-build (original resolution, pre-preprocessing).
+    mask_arrays = [np.asarray(m, dtype=bool) for m in ds.lf_idx_list[0]["masks"]]
+
+    # Correct reference: pad each mask bottom-right the SAME way as the image.
+    correct = (
+        generate_foreground_mask(
+            [
+                apply_pad_to_stride(
+                    torch.from_numpy(m.astype(np.float32))[None, None],
+                    max_stride=max_stride,
+                )
+                .squeeze()
+                .numpy()
+                > 0.5
+                for m in mask_arrays
+            ],
+            img_hw=got.shape,
+            output_stride=1,
+        )[0, 0].numpy()
+        > 0.5
+    )
+    # Buggy reference: STRETCH each mask straight to the padded size (pre-fix path).
+    stretched = (
+        generate_foreground_mask(
+            [
+                F.interpolate(
+                    torch.from_numpy(m.astype(np.float32))[None, None],
+                    size=got.shape,
+                    mode="area",
+                )
+                .squeeze()
+                .numpy()
+                > 0.5
+                for m in mask_arrays
+            ],
+            img_hw=got.shape,
+            output_stride=1,
+        )[0, 0].numpy()
+        > 0.5
+    )
+
+    def _iou(a, b):
+        union = (a | b).sum()
+        return float((a & b).sum() / union) if union else 1.0
+
+    # The two references genuinely differ (the pad shift is real) -> test is non-trivial.
+    assert _iou(correct, stretched) < 0.7
+    # After the fix the target equals the pad-correct reference exactly...
+    assert np.array_equal(got, correct)
+    # ...and is clearly NOT the stretched (pre-fix) target.
+    assert _iou(got, stretched) < 0.7
+
+
 # --------------------------------------------------------------------------- #
 # LightningModule — sigmoid-dict forward + val/fg_iou
 # --------------------------------------------------------------------------- #

--- a/tests/test_semantic_segmentation.py
+++ b/tests/test_semantic_segmentation.py
@@ -271,16 +271,188 @@ def test_seg_target_registers_under_padding(minimal_instance, dataset_cls):
         > 0.5
     )
 
-    def _iou(a, b):
-        union = (a | b).sum()
-        return float((a & b).sum() / union) if union else 1.0
-
-    # The two references genuinely differ (the pad shift is real) -> test is non-trivial.
-    assert _iou(correct, stretched) < 0.7
+    # The two references genuinely differ (the pad shift is real) -> test is
+    # non-trivial. Use an exact set difference rather than an IoU threshold so the
+    # assertion does not depend on fixture geometry / radius / max_stride.
+    assert not np.array_equal(correct, stretched)
     # After the fix the target equals the pad-correct reference exactly...
     assert np.array_equal(got, correct)
     # ...and is clearly NOT the stretched (pre-fix) target.
-    assert _iou(got, stretched) < 0.7
+    assert not np.array_equal(got, stretched)
+
+
+def _chain_reference(mask_arrays, max_hw, scale, max_stride, output_stride):
+    """Foreground target from masks carried through the PUBLIC image chain.
+
+    Mirrors :meth:`BaseDataset._apply_common_preprocessing` for the whole-frame
+    masks: size-match -> scale -> stride-pad (the exact helpers the image rides),
+    binarized once, then reduced to the union foreground. Any dataset that skips,
+    reorders, or re-implements a leg (e.g. the pre-fix single stretch-to-padded)
+    diverges from this reference.
+    """
+    from sleap_nn.data.resizing import (
+        apply_pad_to_stride,
+        apply_resizer,
+        apply_sizematcher,
+    )
+    from sleap_nn.data.segmentation_maps import generate_foreground_mask
+
+    mt = torch.from_numpy(
+        np.stack([m.astype(np.float32) for m in mask_arrays])
+    ).unsqueeze(0)
+    mt, _ = apply_sizematcher(mt, max_height=max_hw[0], max_width=max_hw[1])
+    mt, _ = apply_resizer(mt, torch.zeros(1), scale=scale)
+    mt = apply_pad_to_stride(mt, max_stride=max_stride)
+    masks = [mt[0, k].numpy() > 0.5 for k in range(mt.shape[1])]
+    img_hw = (int(mt.shape[-2]), int(mt.shape[-1]))
+    return (
+        generate_foreground_mask(masks, img_hw=img_hw, output_stride=output_stride)[
+            0, 0
+        ].numpy()
+        > 0.5
+    )
+
+
+@pytest.mark.parametrize("dataset_cls", ["semantic", "bottomup"])
+@pytest.mark.parametrize(
+    "leg, max_stride, scale, max_hw",
+    [
+        ("pad", 40, 1.0, (None, None)),  # bottom-right stride pad only (384->400)
+        ("scale", 1, 0.5, (None, None)),  # scale/resizer only (384->192)
+        ("sizematch", 1, 1.0, (256, 256)),  # size-matcher only (384->256)
+        ("sizematch_nonsquare", 1, 1.0, (300, 500)),  # aspect-preserving + asym. pad
+        ("combo", 32, 0.5, (320, 320)),  # all three legs at once
+    ],
+)
+def test_seg_target_matches_full_preprocessing_chain(
+    minimal_instance, dataset_cls, leg, max_stride, scale, max_hw
+):
+    """The fg target must ride the FULL size-match / scale / stride-pad chain.
+
+    The prior regression test only padded (max_stride, scale=1, max_hw=None), so the
+    size-matcher and scale legs were never exercised — a dataset that dropped or
+    re-implemented either leg would still pass. Each parametrization here makes a
+    DIFFERENT leg the one that changes the resolution, and the target is checked
+    against a reference carried through the identical public helpers.
+    """
+    from sleap_nn.data.custom_datasets import (
+        BottomUpSegmentationDataset,
+        SemanticSegmentationDataset,
+    )
+
+    labels = _seg_labels(minimal_instance)
+    seg_head = OmegaConf.create({"output_stride": 1})  # crispest check
+    common = dict(
+        labels=[labels],
+        seg_head_config=seg_head,
+        max_stride=max_stride,
+        scale=scale,
+        max_hw=max_hw,
+        ensure_grayscale=True,
+    )
+    if dataset_cls == "semantic":
+        ds = SemanticSegmentationDataset(**common)
+    else:
+        ds = BottomUpSegmentationDataset(
+            center_head_config=OmegaConf.create({"output_stride": 1, "sigma": 4.0}),
+            offset_head_config=OmegaConf.create({"output_stride": 1}),
+            **common,
+        )
+
+    got = ds[0]["foreground_mask"][0, 0].numpy() > 0.5
+
+    # Masks captured at index-build (original resolution, full-frame).
+    mask_arrays = [np.asarray(m, dtype=bool) for m in ds.lf_idx_list[0]["masks"]]
+    correct = _chain_reference(mask_arrays, max_hw, scale, max_stride, output_stride=1)
+
+    assert got.shape == correct.shape
+    assert np.array_equal(got, correct), f"target diverges from full chain on leg={leg}"
+
+
+@pytest.mark.parametrize("dataset_cls", ["semantic", "bottomup"])
+def test_seg_heterogeneous_mask_shapes_register_without_crash(
+    minimal_instance, dataset_cls
+):
+    """Ragged (offset-carrying) decoded masks must place correctly, not crash.
+
+    ``decode_mask_to_image_res`` top-left-pads an offset mask to a per-instance
+    shape, so a frame's decoded masks can have DIFFERENT (H, W) and none may match
+    the frame. The pre-fix code, whenever preprocessing changed the size, ran the
+    masks through ``_resize_masks_like_image`` -> ``np.stack`` and raised
+    ``ValueError: all input arrays must have the same shape``; the fix canvases each
+    mask onto the full-frame grid at its absolute (top-left-anchored) origin first.
+
+    ``max_stride=40`` forces a bottom-right pad (384 -> 400), which is exactly the
+    condition that made the pre-fix ``np.stack`` fire — so this test discriminates
+    the fix from the old code (a no-size-change config would NOT, since
+    ``generate_foreground_mask`` clips ragged masks itself and never stacks). The
+    placed masks sit well inside 384, so the bottom-right pad only extends the
+    canvas; the fg target must equal the exact union at 400x400.
+    """
+    from sleap_nn.data.custom_datasets import (
+        BottomUpSegmentationDataset,
+        SemanticSegmentationDataset,
+    )
+
+    labels = _seg_labels(minimal_instance)
+    common = dict(
+        labels=[labels],
+        seg_head_config=OmegaConf.create({"output_stride": 1}),
+        max_stride=40,  # 384 -> 400 pad: the size change that fires the pre-fix stack
+        ensure_grayscale=True,
+    )
+    if dataset_cls == "semantic":
+        ds = SemanticSegmentationDataset(**common)
+    else:
+        ds = BottomUpSegmentationDataset(
+            center_head_config=OmegaConf.create({"output_stride": 1, "sigma": 4.0}),
+            offset_head_config=OmegaConf.create({"output_stride": 1}),
+            **common,
+        )
+
+    # Simulate offset-decoded masks: differently-shaped, top-left-anchored arrays.
+    m1 = np.zeros((40, 50), dtype=bool)
+    m1[10:20, 12:22] = True
+    m2 = np.zeros((150, 300), dtype=bool)
+    m2[120:140, 250:280] = True
+    ds.lf_idx_list[0]["masks"] = [m1, m2]
+
+    sample = ds[0]  # pre-fix: raised ValueError in _resize_masks_like_image's np.stack
+    fg = sample["foreground_mask"][0, 0].numpy() > 0.5
+    assert fg.shape == (
+        400,
+        400,
+    )  # padded (proves the size change that fired the stack)
+
+    expected = np.zeros((400, 400), dtype=bool)
+    expected[10:20, 12:22] = True
+    expected[120:140, 250:280] = True
+    assert np.array_equal(fg, expected)
+
+
+def test_masks_to_frame_canvas_handles_ragged_shapes():
+    """``_masks_to_frame_canvas`` unifies ragged masks onto the frame grid."""
+    from sleap_nn.data.custom_datasets import _masks_to_frame_canvas
+
+    m1 = np.zeros((40, 50), dtype=bool)
+    m1[5:8, 5:8] = True
+    m2 = np.zeros((120, 200), dtype=bool)
+    m2[100:110, 150:160] = True
+
+    t = _masks_to_frame_canvas([m1, m2], (384, 384))
+    assert t.shape == (1, 2, 384, 384)
+    assert t.dtype == torch.float32
+    b = t[0].numpy() > 0.5
+    assert b[0, 5:8, 5:8].all() and b[1, 100:110, 150:160].all()
+    assert int(b[0].sum()) == 9 and int(b[1].sum()) == 100
+
+    # Oversized mask (decoded extent can exceed the frame) is clamped, not an error.
+    big = np.ones((500, 500), dtype=bool)
+    t2 = _masks_to_frame_canvas([big], (384, 384))
+    assert t2.shape == (1, 1, 384, 384) and (t2[0, 0].numpy() > 0.5).all()
+
+    # Empty list -> a well-formed (1, 0, H, W) tensor (no instances).
+    assert _masks_to_frame_canvas([], (10, 12)).shape == (1, 0, 10, 12)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

Whole-frame segmentation (`semantic_segmentation`, `bottomup_segmentation`) trains a foreground target derived from the GT masks. When the input H/W are not multiples of `max_stride` the image is padded bottom-right, but the original code resized the masks with a single `F.interpolate` straight to the **padded** size — stretching them across the pad region and displacing the target from the image by ~pad/2 (worse toward the bottom-right). The model then silently learns the offset.

The first fix (previous commit) carried the masks through the same size-match/scale/stride-pad chain via a private helper `_resize_masks_like_image`. An `xhigh` code review surfaced that the helper was a fragile band-aid:

- **Crash on ragged masks** — the helper's `np.stack` raised `ValueError: all input arrays must have the same shape` when a frame's decoded masks had different shapes. `decode_mask_to_image_res` top-left-pads offset-carrying masks (top-down crop-centered / pseudo-label `.slp`) to a **per-instance** shape, and `generate_foreground_mask` already defensively clips ragged masks — so heterogeneous shapes are an anticipated input the old per-mask loop tolerated and the helper regressed.
- **Silent desync** — the helper size-matched off each mask's own H×W instead of first placing it on the image's full-frame canvas (as `CenteredInstanceSegmentationDataset` does), so a mask whose decoded shape ≠ image shape mis-registers.
- **Wrong altitude** — image and mask geometry were defined in two places (a hand-maintained parallel copy), aligned only by convention.
- **Interpolation inconsistency** — the new helper used bilinear while the "mirror" it cited (and the tiled seg datasets) used `area`.
- **Thin tests** — the regression test only exercised the pad leg (size-match/scale legs untested) and gated non-triviality on a fixture-dependent `IoU < 0.7` magic threshold (actual 0.626, ~0.07 margin).

## Fix (this PR)

Thread the masks through the **shared** `BaseDataset._apply_common_preprocessing` the image already rides, so image↔mask alignment holds **by construction**:

- **`_masks_to_frame_canvas`** — zero-places each decoded mask onto the full `(orig_h, orig_w)` grid at its absolute top-left origin (clamped), mirroring `CenteredInstanceSegmentationDataset`. Fixes the `np.stack` crash **and** the desync in one move (uniform framing makes the `(1,K,H,W)` stack well-defined and starts the mask on the image's grid).
- **`_apply_common_preprocessing`** now co-transforms `sample["masks"]` through the identical `apply_sizematcher → apply_resizer → apply_pad_to_stride` as the image (gated on `sample.get("masks")`; non-seg samples have no `masks` key, so it's inert). The seg datasets keep masks as a float tensor end-to-end and binarize **once** just before target generation — removing the triplicated pack/unpack + wasted re-binarize.
- **Standardize interpolation to antialiased bilinear** across every per-instance mask-geometry resize (matching the image's `tvf.resize`): the whole-frame path inherits it via threading; `CenteredInstanceSegmentationDataset` and both `Tiled*SegmentationDataset` switch `F.interpolate(mode="area")` → `mode="bilinear", align_corners=False, antialias=True`.
- Delete `_resize_masks_like_image`.

## Tests

- **Full-chain coverage** — `test_seg_target_matches_full_preprocessing_chain` parametrized over `pad / scale / sizematch (square + non-square, aspect-preserving) / combo` × `{semantic, bottomup}`; each config isolates a different leg and is checked against a reference carried through the identical public helpers.
- **Ragged-mask regression** — `test_seg_heterogeneous_mask_shapes_register_without_crash` feeds differently-shaped (offset-style) masks with `max_stride=40` (the size change that fired the pre-fix `np.stack`) and asserts correct absolute placement, no crash.
- **Canvas unit test** — placement, oversize clamping, empty list.
- **De-fragilized** the pad-offset test: exact set-difference assertions replace the `IoU < 0.7` magic threshold.

## Verification

- All affected suites green: `test_semantic_segmentation`, `test_segmentation`, `test_segmentation_eval`, `test_tiling_bottomup_seg`, `test_topdown_segmentation_inference`, `test_callbacks`, full `tests/data/` (**324** data + **257** seg-focused, all pass). `black` + `ruff` clean.
- An adversarial multi-agent verification pass over the refactor confirmed geometry parity, the sample-dict contract (`masks` is popped before return; no downstream consumer), the base-preprocessing blast radius (inert for all pose datasets and tiled seg datasets), and the bilinear standardization; its one finding (the ragged-mask test didn't originally force a size change, so it didn't reproduce the crash) is fixed above.

## Note

Models trained before the original fix must be **retrained** — the offset was baked into the learned weights. This PR does not change inference geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeyRpA39YfQvTqRBCFu1jj
