### PR TITLE
fix(eval): exclude PredictedInstance-linked GT masks in mask evaluation

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -217,7 +217,9 @@ def match_masks(
     )
 
 
-def _frame_masks(frame: sio.LabeledFrame) -> List[np.ndarray]:
+def _frame_masks(
+    frame: sio.LabeledFrame, drop_predicted_instances: bool = False
+) -> List[np.ndarray]:
     """Decode a frame's segmentation masks into boolean arrays on the image grid.
 
     Scale-aware: masks encoded at output-stride (non-identity ``scale``, the
@@ -226,10 +228,28 @@ def _frame_masks(frame: sio.LabeledFrame) -> List[np.ndarray]:
     ground-truth mask are compared on a common image-pixel grid. Scale-1 masks
     (legacy full-res GT/preds) take a zero-copy fast path, so existing eval
     numbers are unchanged.
+
+    ``drop_predicted_instances`` (set for the ground-truth side of
+    ``match_method="mask"`` when ``user_labels_only=True``) discards masks whose
+    linked instance is a ``PredictedInstance``. Segmentation-mask files built from
+    poses (``Instance.to_mask`` / ``Labels.convert``) attach a mask to *every*
+    instance, so any ``PredictedInstance`` carried in a labels file also gets a
+    mask; those are model output, not ground truth, and would otherwise be scored
+    as extra ground-truth instances (spurious false negatives that cap recall).
+    Masks linked to a user ``Instance``, or with no linked instance (e.g.
+    whole-frame semantic union masks), are retained -- so this is scoped to
+    per-instance mask matching and never touches the ``match_method="semantic"``
+    union path.
     """
     from sleap_nn.inference.segmentation_convert import decode_mask_to_image_res
 
     masks = getattr(frame, "masks", None) or []
+    if drop_predicted_instances:
+        masks = [
+            m
+            for m in masks
+            if not isinstance(getattr(m, "instance", None), sio.PredictedInstance)
+        ]
     return [decode_mask_to_image_res(m) for m in masks]
 
 
@@ -951,8 +971,18 @@ class Evaluator:
         user_labels_only: bool = True,
         match_method: str = "oks",
         anchor_ind: Optional[int] = None,
+        exclude_predicted_instance_masks: bool = False,
     ):
-        """Initialize the Evaluator class with ground-truth and predicted labels."""
+        """Initialize the Evaluator class with ground-truth and predicted labels.
+
+        ``exclude_predicted_instance_masks`` (``match_method="mask"`` only) drops
+        masks linked to a ``PredictedInstance`` from the ground-truth labels, so a
+        labels file that carries stray predicted instances (each of which gets a
+        mask when masks are built from poses) does not treat them as ground truth.
+        It is kept separate from ``user_labels_only`` (which controls the frame-pair
+        filter) because mask mode disables that frame filter -- see
+        :func:`run_evaluation`.
+        """
         self.ground_truth_instances = ground_truth_instances
         self.predicted_instances = predicted_instances
         self.match_threshold = match_threshold
@@ -961,6 +991,7 @@ class Evaluator:
         self.user_labels_only = user_labels_only
         self.match_method = match_method
         self.anchor_ind = anchor_ind
+        self.exclude_predicted_instance_masks = exclude_predicted_instance_masks
         # Populated only in centroid / mask mode.
         self.false_positives = []
         # Matched-pair IoUs, populated only in mask mode.
@@ -1119,7 +1150,13 @@ class Evaluator:
         self._matched_mask_pairs = []
 
         for frame_gt, frame_pr in self.frame_pairs:
-            gt_masks = _frame_masks(frame_gt)
+            # Ground-truth masks drop any PredictedInstance-linked masks when the
+            # caller asked for user-only labels; predicted-side masks are the
+            # model's output and are always kept in full.
+            gt_masks = _frame_masks(
+                frame_gt,
+                drop_predicted_instances=self.exclude_predicted_instance_masks,
+            )
             pr_masks = _frame_masks(frame_pr)
             pr_scores = _frame_pred_scores(frame_pr)
             iou_mat, inter_mat = _mask_pair_stats(pr_masks, gt_masks)
@@ -2030,7 +2067,13 @@ def run_evaluation(
             distance for centroid mode. In centroid mode, if the caller leaves
             the OKS default of ``0.0`` it is bumped to ``50.0`` px.
         user_labels_only: If False, predicted instances in the GT frame may be
-            matched.
+            matched. For ``match_method="mask"`` (default True), this additionally
+            drops masks linked to a ``PredictedInstance`` from the ground-truth
+            labels, so stray predicted instances (each of which gets a mask when
+            masks are built per-instance from poses) are not treated as ground
+            truth. Pass ``False`` when the GT is intentionally built from predicted
+            poses (pseudo-mask GT). The whole-frame ``match_method="semantic"`` union is
+            unaffected either way.
         save_metrics: Optional ``.npz`` path to save metrics to.
         match_method: ``"oks"``, ``"centroid"``, ``"mask"``, ``"semantic"``, or
             ``"auto"``. ``"mask"`` matches predicted vs GT segmentation masks by
@@ -2094,7 +2137,14 @@ def run_evaluation(
     # ``user_labels_only`` frame filter (find_frame_pairs) keeps only frames with
     # USER keypoint instances, which silently drops EVERY frame when the GT was
     # built from predicted poses (e.g. pseudo-mask GT from predicted skeletons),
-    # raising "Empty Frame Pairs". Mask mode therefore never applies that filter.
+    # raising "Empty Frame Pairs". Mask mode therefore never applies that FRAME
+    # filter. The caller's ``user_labels_only`` intent is preserved separately to
+    # govern the ground-truth MASK filter: a labels file with stray
+    # PredictedInstances gives each a mask (masks are built per-instance), and under
+    # user-only labels those must not be treated as ground truth (they would be
+    # spurious false negatives that cap recall). Callers evaluating pseudo-mask GT
+    # pass ``user_labels_only=False``.
+    exclude_predicted_instance_masks = user_labels_only
     if match_method in ("mask", "semantic"):
         user_labels_only = False
 
@@ -2115,6 +2165,7 @@ def run_evaluation(
         user_labels_only=user_labels_only,
         match_method=match_method,
         anchor_ind=anchor_ind,
+        exclude_predicted_instance_masks=exclude_predicted_instance_masks,
     )
     logger.info(
         f"  Frame pairs: {len(evaluator.frame_pairs)}, "

--- a/tests/test_segmentation_eval.py
+++ b/tests/test_segmentation_eval.py
@@ -266,6 +266,71 @@ def test_run_evaluation_mask_partial_recall(tmp_path):
     assert abs(m["mask_metrics"]["mean_iou"] - 1.0) < 1e-9
 
 
+def test_run_evaluation_mask_excludes_predicted_instance_masks(tmp_path):
+    """Masks linked to a ``PredictedInstance`` are not treated as ground truth.
+
+    Segmentation-mask files built from poses (``Instance.to_mask`` /
+    ``Labels.convert``) attach a mask to *every* instance, so any
+    ``PredictedInstance`` carried in the labels also gets a mask. Under
+    ``user_labels_only=True`` (the default) those must be dropped from the
+    ground-truth labels for ``match_method="mask"`` -- otherwise they inflate the
+    ground-truth count as spurious false negatives that cap recall. With
+    ``user_labels_only=False`` they are kept (opt-out), which pins the exact
+    behavior the fix changes.
+    """
+    skel = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    video = sio.Video.from_filename(FNAME)
+    user_mask = _disk(H, W, 14, 14, 8)
+    pred_mask = _disk(H, W, 34, 34, 8)
+
+    user_inst = sio.Instance.from_numpy(
+        np.array([[14, 14], [15, 15]], dtype="float64"), skeleton=skel
+    )
+    pred_inst = sio.PredictedInstance.from_numpy(
+        np.array([[34, 34], [35, 35]], dtype="float64"), skeleton=skel, score=0.9
+    )
+    gt_user_mask = sio.UserSegmentationMask.from_numpy(user_mask)
+    gt_user_mask.instance = user_inst
+    gt_pred_mask = sio.UserSegmentationMask.from_numpy(pred_mask)
+    gt_pred_mask.instance = pred_inst  # a mask on a predicted instance -> not GT
+    gt_lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[user_inst, pred_inst],
+        masks=[gt_user_mask, gt_pred_mask],
+    )
+    gt = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[gt_lf])
+
+    # Prediction perfectly recovers ONLY the user-instance mask.
+    pred = _make_pred([user_mask])
+
+    gt_path = tmp_path / "gt.slp"
+    pr_path = tmp_path / "pr.slp"
+    gt.save(gt_path.as_posix())
+    pred.save(pr_path.as_posix())
+
+    # Default (user_labels_only=True): the predicted-instance mask is excluded,
+    # so the single user mask is a perfect match -> recall 1.0, no false negative.
+    det = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+    )["detection_metrics"]
+    assert det["n_tp"] == 1 and det["n_fp"] == 0 and det["n_fn"] == 0
+    assert det["recall"] == 1.0 and det["precision"] == 1.0 and det["f1"] == 1.0
+
+    # Opt-out (user_labels_only=False): the predicted-instance mask is kept and
+    # counts as an unmatched GT -> a spurious false negative (recall 0.5).
+    det_all = run_evaluation(
+        ground_truth_path=gt_path.as_posix(),
+        predicted_path=pr_path.as_posix(),
+        match_method="mask",
+        user_labels_only=False,
+    )["detection_metrics"]
+    assert det_all["n_tp"] == 1 and det_all["n_fp"] == 0 and det_all["n_fn"] == 1
+    assert det_all["recall"] == 0.5
+
+
 def test_run_evaluation_mask_panoptic_quality_perfect(tmp_path):
     """Perfect match -> PQ = SQ = RQ = 1.0 and miss-penalized IoU = 1.0."""
     masks = [_disk(H, W, 14, 14, 8), _disk(H, W, 34, 34, 8)]


### PR DESCRIPTION
## Problem

`run_evaluation(match_method="mask")` counts **every** mask in `frame.masks` as ground truth — including masks linked to a `PredictedInstance`. Segmentation-mask files built from poses (`Instance.to_mask` / `Labels.convert`) attach a mask to *every* instance, so any stray predicted instance carried in a labels file also gets a mask and was scored as extra GT. That imposes a fixed, unreachable false-negative floor that silently caps recall/F1.

Measured on real plant-root instance val files:

| file | user inst | predicted inst | total `frame.masks` | recall floor |
|---|--:|--:|--:|--:|
| soy_lateral | 772 | 26 | 798 | 0.967 |
| rice | 323 | 240 | 563 | **0.574** |
| wheat / cyl | 143 / 25 | 0 | 143 / 25 | 1.000 |

Any model evaluated against the rice file could never exceed recall 0.574, independent of quality.

## Root cause

`run_evaluation` force-sets `user_labels_only=False` for `mask`/`semantic` mode to dodge an **unrelated** footgun: the frame-pair filter in `find_frame_pairs` drops frames that lack user *keypoint* instances, which would drop every frame of a pseudo-mask GT (built from predicted poses) and raise `Empty Frame Pairs`. That blanket force also discarded the caller's intent for the GT-*mask* filter.

## Fix

Decouple the two concerns:

- The **frame-pair filter** stays off for mask/semantic (no behavior change, no `Empty Frame Pairs` regression).
- The caller's `user_labels_only` (default `True`) now drives a new `exclude_predicted_instance_masks` flag that drops `PredictedInstance`-linked masks from the ground-truth labels in `match_method="mask"` only. `_frame_masks` gains an opt-in `drop_predicted_instances` param. **Predicted-side masks (the model's output) are always kept in full.**
- Whole-frame `match_method="semantic"` is untouched — its per-frame union mask may legitimately be attached to any instance, so instance-type filtering doesn't apply there.
- Callers evaluating pseudo-mask GT (predicted-pose-derived masks used intentionally as GT) opt out with `user_labels_only=False`.

## Test

`test_run_evaluation_mask_excludes_predicted_instance_gt`: a GT frame with one user mask + one `PredictedInstance`-linked mask, prediction recovering only the user mask →
- default (`user_labels_only=True`): predicted-instance GT excluded → `n_fn=0`, recall `1.0`.
- `user_labels_only=False`: retained → `n_fn=1`, recall `0.5`.

All `tests/test_segmentation_eval.py` (31) and `tests/test_evaluation.py` (19) pass; `black` clean; no new `ruff`/`ty` findings.

## Discovery

Found via a GT-representation ceiling sanity check on a plant-root segmentation campaign (decode each task's *training target* through the same inference + eval → the score a perfect model would get). The top-down ceiling recall plateaued at exactly `772/798`, which traced to this GT-set mismatch rather than any representation limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHp77mBbzqE19uiLdyYnea
