### PR TITLE
fix(ci): disable MPS on mac CI to stop hangs + MPS-OOM failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,23 @@ jobs:
         run: uv run --frozen --no-group gpu --extra torch-cpu ruff check sleap_nn/
 
   tests:
-    # Windows runs ~29 min on this matrix (slow VMs + torch-on-Windows).
-    # 30 was right at the edge and timed out mid-pytest-summary; 45
-    # gives headroom for normal CI load variance without masking real
-    # hangs (which would still saturate the budget).
-    timeout-minutes: 45
+    # Windows is the slowest job at ~11-13 min (slow VMs + torch-on-Windows);
+    # ubuntu ~4 min, mac ~7 min. 20 gives comfortable headroom for load
+    # variance while still catching genuine hangs. (The mac job used to blow
+    # past 45 min because MPS compute intermittently hangs / OOMs on the
+    # virtualized macos-14 runner; that is now neutralized by
+    # SLEAP_NN_DISABLE_MPS below.)
+    timeout-minutes: 20
     env:
       CUDA_VISIBLE_DEVICES: ""
       USE_CUDA: "0"
       UV_FROZEN: "1"
+      # Disable Apple Metal (MPS): the macos-14 runner reports MPS available
+      # but real MPS compute intermittently hangs / raises "MPS backend out of
+      # memory". Set here at the job level so both pytest and the `sleap-nn`
+      # CLI subprocesses it spawns inherit it (honored in sleap_nn/__init__.py).
+      # No-op on ubuntu/windows (no MPS).
+      SLEAP_NN_DISABLE_MPS: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -8,6 +8,28 @@ from loguru import logger
 RANK = int(os.environ.get("LOCAL_RANK", -1))
 
 
+# Force-disable Apple Metal (MPS) acceleration when ``SLEAP_NN_DISABLE_MPS=1``.
+#
+# MPS on Apple Silicon has known driver bugs. On the GitHub ``macos-14`` CI
+# runner in particular, real MPS compute intermittently *hangs* or raises
+# ``RuntimeError: MPS backend out of memory`` even for tiny allocations.
+# Setting this env var makes torch report MPS as unavailable, so torch itself,
+# Lightning's ``accelerator="auto"`` selection, and every ``--device auto``
+# resolution in this package all fall back to CPU.
+#
+# Applied here at package import (rather than in a pytest fixture) so it also
+# takes effect inside ``sleap-nn`` CLI *subprocesses* spawned by the tests —
+# those inherit the env var but not any in-process patching. torch is imported
+# only when the flag is set, keeping normal CLI startup lean. No-op otherwise.
+if os.environ.get("SLEAP_NN_DISABLE_MPS") == "1":
+    import torch
+
+    if hasattr(torch.backends, "mps"):
+        torch.backends.mps.is_available = lambda: False
+    if hasattr(torch, "mps") and hasattr(torch.mps, "is_available"):
+        torch.mps.is_available = lambda: False
+
+
 # Configure loguru for distributed training
 def _should_log(record):
     """Filter function to control logging based on rank."""


### PR DESCRIPTION
## Summary
- The macOS test job intermittently **hung until its 45-min timeout**; once it ran to completion it also **failed 4 CLI tests** with `RuntimeError: MPS backend out of memory`.
- **Root cause:** GitHub's virtualized `macos-14` M1 GPU reports MPS *available* and passes a trivial probe, but real MPS compute intermittently **hangs or OOMs**. ubuntu/windows (no MPS) pass in minutes.
- **Fix:** an opt-in `SLEAP_NN_DISABLE_MPS=1` env var (honored in `sleap_nn/__init__.py`) that forces the CPU path, set at the CI job level so **pytest and its `sleap-nn` CLI subprocesses** both inherit it. Timeout ceiling dropped `45 → 20` min.

## Why the failures happened
Two categories of MPS work run only on the mac runner:
1. **In-process** MPS unit tests — `TorchBackend.warmup` (conv forward + `torch.mps.synchronize()`) and `system_info.test_gpu_operations` (`torch.mm` on MPS). These *hang*.
2. **Subprocess** CLI tests — `test_main_cli`, `test_train_cli_*`, `test_predict_main` spawn `uv run … sleap-nn …` with `--device auto`, which auto-selects MPS and *OOMs*.

Both were previously **masked by the 45-min timeout** (the job never completed). An in-process pytest patch can't reach the CLI subprocesses — which is why the fix lives in the package itself and is toggled by an inherited env var.

Why it never reproduced locally: real dev Macs have working MPS, so the full suite runs in ~3.5 min and the subprocess CLI runs happily on MPS. The bug needs the runner's broken/virtualized GPU.

## Changes Made
- **`sleap_nn/__init__.py`**: when `SLEAP_NN_DISABLE_MPS=1`, patch `torch.backends.mps.is_available` / `torch.mps.is_available` → `False` at package import. This one hook covers **torch**, **Lightning's `accelerator="auto"`**, and every **`--device auto`** resolution (all call the same function). Applied at import so it also takes effect in CLI subprocesses. `torch` is imported **only** when the flag is set, so normal lazy CLI startup is preserved. Doubles as a user escape hatch for MPS driver bugs.
- **`.github/workflows/ci.yml`**: add `SLEAP_NN_DISABLE_MPS: "1"` to the tests job `env` (inherited by pytest + subprocesses; no-op on ubuntu/windows), `timeout-minutes: 45 → 20`, refreshed comments.

## API Changes
- New env var **`SLEAP_NN_DISABLE_MPS`** (`"1"` to force-disable Apple Metal). Unset = unchanged behavior. No code API changes.

## Testing
- Mechanism (with flag set): `torch.backends.mps.is_available()` → `False`, `torch.mps.is_available()` → `False`, `cli._resolve_device("auto")` → `"cpu"`, Lightning `MPSAccelerator.is_available()` → `False`.
- The **4 previously-failing** CLI subprocess tests now pass (children inherit the env → CPU); the MPS unit tests self-skip.
- Flag **unset**: MPS stays available on Apple Silicon and `torch` is **not** eagerly imported (startup optimization intact).
- Prior CI run on this branch (in-process-only version) already confirmed the **hang is gone** — mac finished in **8m9s** (was 45-min timeout) — surfacing exactly these subprocess failures, which this revision fixes.
- `black`/`ruff` clean; `ci.yml` valid YAML.

## Design Decisions
- **Patch `is_available` once, at import, gated by env** — over threading a helper through the 8 device-resolution call sites. A helper can't intercept **Lightning's** internal auto-selection (used by the `train` subprocess); patching the function torch/Lightning both call does, and covers every site at once.
- **Env var over `CI=true`** — decouples "disable MPS" (a real, reusable capability) from "in CI", and is the only thing that reaches subprocesses.
- **Timeout 20, not lower** — headroom over the ~13-min Windows worst case while still catching genuine hangs.

## Future Considerations
- If a self-hosted mac runner with reliable MPS is added, simply don't set the env var there to keep real MPS coverage.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)