### PR TITLE
fix(infer): attach provider source videos so predict output is saveable (#699)

### DIFF
--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1233,7 +1233,15 @@ class Predictor:
             )
 
         if hasattr(source, "__iter__"):
-            return source, None
+            # A pre-built Provider. Recover its source videos (when it exposes
+            # them) so predicted frames reference the real Video, matching the
+            # str/sio.Video/sio.Labels branches above (#530). Without this the
+            # output Labels carries a None-placeholder video and sio.Labels.save
+            # crashes walking video.backend — hit whenever the CLI wraps the
+            # input in a LabelsProvider for --only_suggested_frames /
+            # --exclude_user_labeled / --video_index etc. (#699).
+            provider_videos = getattr(source, "videos", None)
+            return source, (list(provider_videos) if provider_videos else None)
 
         raise TypeError(
             f"Unsupported source type: {type(source).__name__}. "

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -157,6 +157,16 @@ class VideoProvider:
         """Total number of frames this provider will yield."""
         return len(self._frame_indices)
 
+    @property
+    def videos(self) -> "list[sio.Video]":
+        """The source ``sio.Video``(s), for packaging the output ``Labels``.
+
+        Lets ``Predictor._make_provider`` attach the real video to predicted
+        frames when a pre-built provider is passed as the source, instead of a
+        ``None`` placeholder that later crashes ``sio.Labels.save`` (#699).
+        """
+        return [self._sio_video] if self._sio_video is not None else []
+
 
 @attrs.define
 class LabelsProvider:
@@ -324,6 +334,18 @@ class LabelsProvider:
         """Total number of frames over the (filtered) labeled-frame list."""
         return len(self._labeled_frames)
 
+    @property
+    def videos(self) -> "list[sio.Video]":
+        """Source videos of the underlying ``Labels``, for output packaging.
+
+        Frame filtering (``only_suggested_frames`` etc.) narrows which frames
+        are yielded, not the video list — predicted frames still reference these
+        real videos. Used by ``Predictor._make_provider`` so a pre-built
+        provider source doesn't yield a ``None``-video ``Labels`` that crashes
+        ``sio.Labels.save`` (#699).
+        """
+        return list(self._sio_labels.videos)
+
 
 @attrs.define
 class MultiVideoProvider:
@@ -388,6 +410,14 @@ class MultiVideoProvider:
                 return -1
             total += n
         return total
+
+    @property
+    def videos(self) -> list:
+        """Merged source videos across sub-providers, in offset order (#699)."""
+        merged: list = []
+        for provider in self.providers:
+            merged.extend(getattr(provider, "videos", None) or [])
+        return merged
 
 
 @attrs.define

--- a/tests/inference/test_centroid_only.py
+++ b/tests/inference/test_centroid_only.py
@@ -398,6 +398,43 @@ def test_centroid_only_predict_collapses_to_single_node():
     not (CENTROID_CKPT.exists() and SLP_FIXTURE.exists()),
     reason="centroid ckpt / slp fixture absent",
 )
+def test_centroid_only_predict_provider_source_is_saveable(tmp_path):
+    """Regression #699: predicting from a pre-built ``Provider`` must attach the
+    real source video to the output ``Labels``.
+
+    The CLI wraps the input in a ``LabelsProvider`` whenever a frame-selection
+    flag is set (``--only_suggested_frames``, ``--exclude_user_labeled``,
+    ``--video_index`` …). Previously ``Predictor._make_provider`` dropped the
+    videos for a pre-built provider (returned ``videos=None``), so the output
+    ``Labels`` got a ``None`` placeholder video and ``sio.Labels.save`` crashed
+    with ``AttributeError: 'NoneType' object has no attribute 'backend'``.
+    """
+    from sleap_nn.inference.providers import LabelsProvider
+
+    labels_in = sio.load_slp(str(SLP_FIXTURE))
+    provider = LabelsProvider(labels=labels_in, batch_size=4)
+    # The provider surfaces its source videos for output packaging.
+    assert provider.videos == list(labels_in.videos)
+    assert provider.videos and all(v is not None for v in provider.videos)
+
+    pred = Predictor.from_model_paths([str(CENTROID_CKPT)], device="cpu")
+    labels = pred.predict(provider, make_labels=True)
+
+    # Output references the real video, not a None placeholder.
+    assert labels.videos and all(v is not None for v in labels.videos)
+
+    # The crash was inside Labels.save (it walks each video's backend); saving
+    # and reloading must now succeed.
+    out = tmp_path / "preds.slp"
+    labels.save(str(out), embed=False)
+    reloaded = sio.load_slp(str(out))
+    assert reloaded.videos and all(v is not None for v in reloaded.videos)
+
+
+@pytest.mark.skipif(
+    not (CENTROID_CKPT.exists() and SLP_FIXTURE.exists()),
+    reason="centroid ckpt / slp fixture absent",
+)
 def test_centroid_only_predict_emit_both():
     pred = Predictor.from_model_paths(
         [str(CENTROID_CKPT)], device="cpu", emit_centroid="both"


### PR DESCRIPTION
## Summary

Closes #699.

`sleap-nn predict` completed inference but **crashed while saving** whenever the source was a pre-built `Provider` — which the CLI creates for every frame-selection flag (`--only_suggested_frames`, `--only_labeled_frames`, `--only_predicted_frames`, `--exclude_user_labeled`, `--video_index`):

```
save_predictions → labels.save → sleap_io/model/labels.py
  hasattr(video.backend, "has_embedded_images")
AttributeError: 'NoneType' object has no attribute 'backend'
```

## Root cause

`Predictor._make_provider` attaches the real source videos to the returned `(provider, videos)` tuple for the `str` / `sio.Video` / `sio.Labels` / `list` branches — this is the #530 fix ("predicted frames must reference the source video, not be dropped"). But the **already-a-Provider** fall-through dropped them:

```python
if hasattr(source, "__iter__"):
    return source, None          # <-- videos lost
```

With `videos=None`, `to_labels()` falls back to `videos = [None]`, so the packaged `Labels` ends up with a `None` video, and `sio.Labels.save()` trips over it while walking `video.backend` for its self-referential-embedded-video check.

Inference itself was fine — passing the same `sio.Labels` directly (not a provider) always produced a clean, saveable result. The gap was confined to the provider path.

## Fix

- Add a `videos` accessor to the providers — `LabelsProvider` (`self._sio_labels.videos`), `VideoProvider` (`[self._sio_video]`), `MultiVideoProvider` (merged, in offset order).
- Use it in `_make_provider`'s Provider fall-through:

```python
if hasattr(source, "__iter__"):
    provider_videos = getattr(source, "videos", None)
    return source, (list(provider_videos) if provider_videos else None)
```

This mirrors the other `_make_provider` branches; a provider that doesn't expose `videos` still degrades to `None` (unchanged behavior).

## Test

`tests/inference/test_centroid_only.py::test_centroid_only_predict_provider_source_is_saveable` — predicting from a pre-built `LabelsProvider` now yields a `Labels` whose videos are non-`None`, and `save(embed=False)` + reload round-trips.

Verified end-to-end against a real project: `sleap-nn predict --centroid_output instance --only_suggested_frames --exclude_user_labeled` now runs to completion and writes the output `.slp` (previously crashed at save).

- `pytest tests/inference/test_centroid_only.py tests/inference/test_providers.py tests/inference/test_run.py` → all pass (68).
- `ruff check sleap_nn/` + `black --check` clean.

## Repro (before this PR)

```
sleap-nn predict --data_path project.slp --model_paths models/centroid_run/ \
  --output_path out.slp --centroid_output instance \
  --only_suggested_frames --exclude_user_labeled --device cpu
# inference completes, then AttributeError: 'NoneType' object has no attribute 'backend'
```

With the help of Claude.