### PR TITLE
fix: raise instead of only logging when frame caching fails

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -76,6 +76,88 @@ from sleap_nn.config.get_config import get_aug_config
 MIN_SAMPLES_FOR_PARALLEL_CACHING = 20
 
 
+def _raise_cache_fill_error(
+    errors: List[Tuple[int, int, str]], total_samples: int, cache_type: str
+):
+    """Raise a hard error summarizing frame(s) that failed to cache.
+
+    Args:
+        errors: List of (labels_idx, lf_idx, error_message) tuples for every
+            frame that failed to read/cache.
+        total_samples: Total number of samples that were requested to cache.
+        cache_type: Either "disk" or "memory".
+
+    Raises:
+        RuntimeError: Always raised, listing up to 10 of the failures.
+    """
+    shown = "\n".join(
+        f"  labels_idx={li}, lf_idx={lf}: {err}" for li, lf, err in errors[:10]
+    )
+    more = f"\n  ... and {len(errors) - 10} more" if len(errors) > 10 else ""
+    raise RuntimeError(
+        f"Failed to cache {len(errors)}/{total_samples} frames to {cache_type}. "
+        "This usually means the source video has corrupted or unreadable "
+        "frames. Try re-encoding it, e.g.:\n"
+        "  ffmpeg -i your_video.mp4 -c:v libx264 -preset medium -crf 18 reencoded_video.mp4\n"
+        f"Errors (showing up to 10 of {len(errors)}):\n{shown}{more}"
+    )
+
+
+def _dist_failed_on_any_rank(failed: bool) -> bool:
+    """Broadcast whether any rank hit `failed=True`, so every rank agrees.
+
+    Args:
+        failed: Whether the calling rank itself hit a failure.
+
+    Returns:
+        True if any rank (including this one) reported a failure.
+    """
+    device = "cpu"
+    if dist.get_backend() == "nccl" and torch.cuda.is_available():
+        device = torch.cuda.current_device()
+    flag = torch.tensor([1 if failed else 0], dtype=torch.int64, device=device)
+    dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+    return bool(flag.item())
+
+
+def _run_cache_fill_with_dist_sync(fill_fn):
+    """Run a cache-filling callable, failing every rank together under DDP.
+
+    Without this, a rank whose cache fill raises dies immediately while
+    other ranks that succeeded proceed to the next collective op (e.g. the
+    barrier after cache creation) and hang forever waiting for the now-dead
+    rank. All ranks call this (even ranks that don't do any caching work
+    themselves, via a no-op `fill_fn`) so they all reach the same
+    synchronization point and either all proceed or all raise.
+
+    Args:
+        fill_fn: Zero-argument callable that performs this rank's share of
+            the cache fill (or nothing, for a rank that isn't responsible
+            for filling the cache).
+
+    Raises:
+        The original exception from `fill_fn` (on the rank where it failed),
+        or a RuntimeError (on ranks where it succeeded but another rank
+        failed), or nothing if every rank succeeded.
+    """
+    error = None
+    try:
+        fill_fn()
+    except Exception as e:
+        error = e
+
+    if is_distributed_initialized():
+        if _dist_failed_on_any_rank(error is not None):
+            if error is not None:
+                raise error
+            raise RuntimeError(
+                "Aborting: image caching failed on another rank. See that "
+                "rank's log for the underlying error."
+            )
+    elif error is not None:
+        raise error
+
+
 class ParallelCacheFiller:
     """Parallel implementation of image caching using thread-local video copies.
 
@@ -444,18 +526,29 @@ class BaseDataset(Dataset):
 
         if self.cache_img is not None:
             if self.cache_img == "memory":
-                self._fill_cache(
-                    labels,
-                    parallel=self.parallel_caching,
-                    num_workers=self.cache_workers,
-                )
-            elif self.cache_img == "disk" and not self.use_existing_imgs:
-                if self.rank is None or self.rank == -1 or self.rank == 0:
-                    self._fill_cache(
+                # Every rank fills its own in-memory cache independently; sync
+                # so one rank's failure aborts all ranks instead of leaving
+                # survivors to hang at a later collective op.
+                _run_cache_fill_with_dist_sync(
+                    lambda: self._fill_cache(
                         labels,
                         parallel=self.parallel_caching,
                         num_workers=self.cache_workers,
                     )
+                )
+            elif self.cache_img == "disk" and not self.use_existing_imgs:
+                is_cache_writer = self.rank is None or self.rank == -1 or self.rank == 0
+                _run_cache_fill_with_dist_sync(
+                    (
+                        lambda: self._fill_cache(
+                            labels,
+                            parallel=self.parallel_caching,
+                            num_workers=self.cache_workers,
+                        )
+                    )
+                    if is_cache_writer
+                    else (lambda: None)
+                )
                 # Synchronize all ranks after cache creation
                 if is_distributed_initialized():
                     dist.barrier()
@@ -735,19 +828,28 @@ class BaseDataset(Dataset):
             for sample in self.lf_idx_list:
                 labels_idx = sample["labels_idx"]
                 lf_idx = sample["lf_idx"]
-                if sample.get("is_negative", False):
-                    video_idx = sample["video_idx"]
-                    frame_idx = sample["frame_idx"]
-                    img = labels[labels_idx].videos[video_idx][frame_idx]
-                else:
-                    img = labels[labels_idx][lf_idx].image
-                if img.shape[-1] == 1:
-                    img = np.squeeze(img)
-                if self.cache_img == "disk":
-                    f_name = f"{self.cache_img_path}/sample_{labels_idx}_{lf_idx}.jpg"
-                    Image.fromarray(img).save(f_name, format="JPEG")
-                if self.cache_img == "memory":
-                    self.cache[(labels_idx, lf_idx)] = img
+                try:
+                    if sample.get("is_negative", False):
+                        video_idx = sample["video_idx"]
+                        frame_idx = sample["frame_idx"]
+                        img = labels[labels_idx].videos[video_idx][frame_idx]
+                    else:
+                        img = labels[labels_idx][lf_idx].image
+                    if img.shape[-1] == 1:
+                        img = np.squeeze(img)
+                    if self.cache_img == "disk":
+                        f_name = (
+                            f"{self.cache_img_path}/sample_{labels_idx}_{lf_idx}.jpg"
+                        )
+                        Image.fromarray(img).save(f_name, format="JPEG")
+                    if self.cache_img == "memory":
+                        self.cache[(labels_idx, lf_idx)] = img
+                except Exception as e:
+                    _raise_cache_fill_error(
+                        [(labels_idx, lf_idx, f"{type(e).__name__}: {e}")],
+                        total_samples,
+                        cache_type,
+                    )
                 if progress is not None:
                     progress.update(task, advance=1)
 
@@ -829,12 +931,12 @@ class BaseDataset(Dataset):
         if cache_type == "memory":
             self.cache.update(cache)
 
-        # Log any errors
+        # A frame that failed to cache is silently missing from `cache`/disk;
+        # letting training proceed means it surfaces as a confusing
+        # FileNotFoundError/KeyError in a random later DataLoader batch
+        # instead of here, where we know exactly which frame failed and why.
         if errors:
-            logger.warning(
-                f"Parallel caching completed with {len(errors)} errors. "
-                f"First error: {errors[0]}"
-            )
+            _raise_cache_fill_error(errors, total_samples, cache_type)
 
     def _apply_common_preprocessing(self, sample: Dict) -> Dict:
         """Apply common preprocessing steps shared across all dataset types.
@@ -4353,6 +4455,44 @@ class SemanticSegmentationTiledDataset(BaseDataset):
         }
 
 
+def _validate_existing_disk_cache_complete(
+    dataset: "BaseDataset", cache_path: Path, split_name: str
+):
+    """Validate that a reused disk cache actually has every frame it needs.
+
+    `get_train_val_datasets(..., use_existing_imgs=True)` skips re-caching
+    and trusts the on-disk `.jpg` files are already there. If a prior
+    caching run partially failed (see `_raise_cache_fill_error`) or the
+    directory is simply stale/wrong, that gap would otherwise only surface
+    as a `FileNotFoundError` deep in a later `DataLoader` batch.
+
+    Args:
+        dataset: The constructed dataset whose `lf_idx_list` defines exactly
+            which `sample_{labels_idx}_{lf_idx}.jpg` files are required.
+        cache_path: Directory expected to contain the cached `.jpg` files.
+        split_name: Either "train" or "val", used only for the error message.
+
+    Raises:
+        RuntimeError: If any required cached image is missing.
+    """
+    missing = [
+        (labels_idx, lf_idx)
+        for sample in dataset.lf_idx_list
+        for labels_idx, lf_idx in [(sample["labels_idx"], sample["lf_idx"])]
+        if not (cache_path / f"sample_{labels_idx}_{lf_idx}.jpg").exists()
+    ]
+    if missing:
+        shown = ", ".join(f"({li}, {lf})" for li, lf in missing[:10])
+        more = f", ... and {len(missing) - 10} more" if len(missing) > 10 else ""
+        raise RuntimeError(
+            f"use_existing_imgs=True but the {split_name} disk cache at "
+            f"{cache_path} is missing {len(missing)}/{len(dataset.lf_idx_list)} "
+            f"required images (labels_idx, lf_idx): {shown}{more}. The cache is "
+            "incomplete or stale. Set use_existing_imgs=False to regenerate it, "
+            "or check that cache_img_path points at the right directory."
+        )
+
+
 def get_train_val_datasets(
     train_labels: List[sio.Labels],
     val_labels: List[sio.Labels],
@@ -5219,6 +5359,12 @@ def get_train_val_datasets(
                 cache_workers=cache_workers,
                 use_negative_frames=use_negative_frames,
             )
+
+    if cache_imgs == "disk" and use_existing_imgs:
+        _validate_existing_disk_cache_complete(
+            train_dataset, train_cache_img_path, "train"
+        )
+        _validate_existing_disk_cache_complete(val_dataset, val_cache_img_path, "val")
 
     # If using caching, close the videos to prevent `h5py objects can't be pickled error` when num_workers > 0.
     if "cache_img" in config.data_config.data_pipeline_fw:

--- a/tests/test_parallel_caching.py
+++ b/tests/test_parallel_caching.py
@@ -15,6 +15,9 @@ from sleap_nn.data.custom_datasets import (
     ParallelCacheFiller,
     BaseDataset,
     SingleInstanceDataset,
+    _dist_failed_on_any_rank,
+    _run_cache_fill_with_dist_sync,
+    _validate_existing_disk_cache_complete,
 )
 
 
@@ -345,3 +348,245 @@ class TestMinSamplesThreshold:
     def test_min_samples_reasonable_value(self):
         """Test that threshold is reasonable (between 10 and 100)."""
         assert 10 <= MIN_SAMPLES_FOR_PARALLEL_CACHING <= 100
+
+
+def _confmap_config(labels):
+    """Build a minimal confmap head config for SingleInstanceDataset tests."""
+    from omegaconf import DictConfig
+
+    return DictConfig(
+        {
+            "sigma": 1.5,
+            "output_stride": 2,
+            "part_names": [n.name for n in labels.skeletons[0].nodes],
+        }
+    )
+
+
+class TestCacheFillHardRaise:
+    """Regression tests for talmolab/sleap#2777: a frame that fails to cache
+    must raise instead of only being logged, so training can't silently
+    proceed with a missing/incomplete cache.
+    """
+
+    def test_fill_cache_parallel_raises_on_error(self, minimal_labels):
+        """`_fill_cache_parallel` raises when `ParallelCacheFiller` reports errors."""
+        dataset = SingleInstanceDataset(
+            labels=[minimal_labels],
+            confmap_head_config=_confmap_config(minimal_labels),
+            max_stride=32,
+            cache_img=None,
+        )
+        fake_errors = [(0, 0, "IndexError: Failed to read frame index 5.")]
+        with patch(
+            "sleap_nn.data.custom_datasets.ParallelCacheFiller.fill_cache",
+            return_value=({}, fake_errors),
+        ):
+            with pytest.raises(RuntimeError, match=r"Failed to cache 1/1 frames"):
+                dataset._fill_cache_parallel(
+                    labels=[minimal_labels],
+                    total_samples=1,
+                    cache_type="memory",
+                    use_progress=False,
+                )
+
+    def test_fill_cache_parallel_no_errors_does_not_raise(self, minimal_labels):
+        """Sanity check: the happy path is untouched by the raise."""
+        dataset = SingleInstanceDataset(
+            labels=[minimal_labels],
+            confmap_head_config=_confmap_config(minimal_labels),
+            max_stride=32,
+            cache_img=None,
+        )
+        with patch(
+            "sleap_nn.data.custom_datasets.ParallelCacheFiller.fill_cache",
+            return_value=({(0, 0): np.zeros((2, 2))}, []),
+        ):
+            dataset._fill_cache_parallel(
+                labels=[minimal_labels],
+                total_samples=1,
+                cache_type="memory",
+                use_progress=False,
+            )
+        assert (0, 0) in dataset.cache
+
+    def test_disk_cache_parallel_write_failure_raises(self, minimal_labels):
+        """End-to-end: a real disk-write failure during parallel caching raises."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "sleap_nn.data.custom_datasets.Image.fromarray",
+                side_effect=OSError("disk full"),
+            ):
+                with pytest.raises(RuntimeError, match="Failed to cache"):
+                    SingleInstanceDataset(
+                        labels=[minimal_labels],
+                        confmap_head_config=_confmap_config(minimal_labels),
+                        max_stride=32,
+                        cache_img="disk",
+                        cache_img_path=tmpdir,
+                        parallel_caching=True,
+                        cache_workers=2,
+                    )
+
+    def test_disk_cache_sequential_write_failure_raises(self, minimal_labels):
+        """End-to-end: a real disk-write failure during sequential caching raises."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "sleap_nn.data.custom_datasets.Image.fromarray",
+                side_effect=OSError("disk full"),
+            ):
+                with pytest.raises(RuntimeError, match="Failed to cache"):
+                    SingleInstanceDataset(
+                        labels=[minimal_labels],
+                        confmap_head_config=_confmap_config(minimal_labels),
+                        max_stride=32,
+                        cache_img="disk",
+                        cache_img_path=tmpdir,
+                        parallel_caching=False,
+                    )
+
+
+class TestDistSyncCacheFill:
+    """Tests for the DDP failure-broadcast helper around cache filling.
+
+    Without this broadcast, a rank whose cache fill fails would raise and
+    die immediately while surviving ranks proceed to the next collective op
+    (e.g. `dist.barrier()` right after cache creation in `BaseDataset.__init__`)
+    and hang forever waiting for the now-dead rank.
+    """
+
+    @staticmethod
+    def _raise_boom():
+        raise ValueError("boom")
+
+    def test_no_distributed_propagates_local_error(self):
+        with patch(
+            "sleap_nn.data.custom_datasets.is_distributed_initialized",
+            return_value=False,
+        ):
+            with pytest.raises(ValueError, match="boom"):
+                _run_cache_fill_with_dist_sync(self._raise_boom)
+
+    def test_no_distributed_success_is_noop(self):
+        called = []
+        with patch(
+            "sleap_nn.data.custom_datasets.is_distributed_initialized",
+            return_value=False,
+        ):
+            _run_cache_fill_with_dist_sync(lambda: called.append(True))
+        assert called == [True]
+
+    def test_distributed_local_failure_raises_original_error(self):
+        def fake_all_reduce(tensor, op=None):
+            tensor.fill_(1)  # simulate: this rank's failure is seen by the group
+
+        with (
+            patch(
+                "sleap_nn.data.custom_datasets.is_distributed_initialized",
+                return_value=True,
+            ),
+            patch(
+                "sleap_nn.data.custom_datasets.dist.get_backend", return_value="gloo"
+            ),
+            patch(
+                "sleap_nn.data.custom_datasets.dist.all_reduce",
+                side_effect=fake_all_reduce,
+            ),
+        ):
+            with pytest.raises(ValueError, match="boom"):
+                _run_cache_fill_with_dist_sync(self._raise_boom)
+
+    def test_distributed_remote_failure_raises_generic_error(self):
+        def fake_all_reduce(tensor, op=None):
+            tensor.fill_(1)  # simulate: another rank failed, we succeeded locally
+
+        called = []
+        with (
+            patch(
+                "sleap_nn.data.custom_datasets.is_distributed_initialized",
+                return_value=True,
+            ),
+            patch(
+                "sleap_nn.data.custom_datasets.dist.get_backend", return_value="gloo"
+            ),
+            patch(
+                "sleap_nn.data.custom_datasets.dist.all_reduce",
+                side_effect=fake_all_reduce,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="failed on another rank"):
+                _run_cache_fill_with_dist_sync(lambda: called.append(True))
+        assert called == [True]
+
+    def test_distributed_all_succeed_is_noop(self):
+        def fake_all_reduce(tensor, op=None):
+            pass  # simulate: nobody failed, flag stays 0
+
+        called = []
+        with (
+            patch(
+                "sleap_nn.data.custom_datasets.is_distributed_initialized",
+                return_value=True,
+            ),
+            patch(
+                "sleap_nn.data.custom_datasets.dist.get_backend", return_value="gloo"
+            ),
+            patch(
+                "sleap_nn.data.custom_datasets.dist.all_reduce",
+                side_effect=fake_all_reduce,
+            ),
+        ):
+            _run_cache_fill_with_dist_sync(lambda: called.append(True))
+        assert called == [True]
+
+    def test_dist_failed_on_any_rank_uses_cpu_when_no_cuda(self):
+        """nccl backend without CUDA available must not try to allocate a CUDA tensor."""
+        with (
+            patch(
+                "sleap_nn.data.custom_datasets.dist.get_backend", return_value="nccl"
+            ),
+            patch(
+                "sleap_nn.data.custom_datasets.torch.cuda.is_available",
+                return_value=False,
+            ),
+            patch("sleap_nn.data.custom_datasets.dist.all_reduce") as mock_all_reduce,
+        ):
+            result = _dist_failed_on_any_rank(True)
+
+        assert result is True
+        tensor_arg = mock_all_reduce.call_args[0][0]
+        assert tensor_arg.device.type == "cpu"
+
+
+class TestValidateExistingDiskCache:
+    """Tests for the use_existing_imgs=True disk cache completeness check."""
+
+    def test_raises_when_files_missing(self, minimal_labels, tmp_path):
+        cache_dir = tmp_path / "train_imgs"
+        cache_dir.mkdir()
+
+        dataset = SingleInstanceDataset(
+            labels=[minimal_labels],
+            confmap_head_config=_confmap_config(minimal_labels),
+            max_stride=32,
+            cache_img=None,
+        )
+
+        with pytest.raises(RuntimeError, match="missing"):
+            _validate_existing_disk_cache_complete(dataset, cache_dir, "train")
+
+    def test_passes_when_all_files_present(self, minimal_labels, tmp_path):
+        cache_dir = tmp_path / "train_imgs"
+        cache_dir.mkdir()
+
+        dataset = SingleInstanceDataset(
+            labels=[minimal_labels],
+            confmap_head_config=_confmap_config(minimal_labels),
+            max_stride=32,
+            cache_img=None,
+        )
+        for sample in dataset.lf_idx_list:
+            fname = f"sample_{sample['labels_idx']}_{sample['lf_idx']}.jpg"
+            (cache_dir / fname).touch()
+
+        _validate_existing_disk_cache_complete(dataset, cache_dir, "train")


### PR DESCRIPTION
## Summary

- A frame that failed to read/cache before training (e.g. a corrupt source video, disk-full) was only logged as a warning — training then proceeded with an incomplete cache and crashed much later with a confusing `FileNotFoundError`/`KeyError` in a random `DataLoader` batch.
- The caching step now raises immediately, naming the exact failing frame(s) and suggesting a re-encode, so the failure surfaces before a single training batch runs instead of epochs in.
- Also fixes a related multi-GPU (DDP) risk this change introduces if left unhandled, and tightens a related validation gap in the disk-cache reuse path.

## Changes Made

`sleap_nn/data/custom_datasets.py`:
- `_raise_cache_fill_error(errors, total_samples, cache_type)`: new shared helper that raises `RuntimeError` listing up to 10 failing `(labels_idx, lf_idx, error)` entries plus a `ffmpeg -c:v libx264 -crf 18` re-encode hint.
- `_fill_cache_parallel`: now calls this instead of `logger.warning(...)` when `ParallelCacheFiller` reports errors.
- `_fill_cache_sequential`: previously had **no** error handling at all (failed fast, but with a raw/unhelpful exception). Now wraps the per-sample body and raises the same clear message for consistency.
- `_dist_failed_on_any_rank` / `_run_cache_fill_with_dist_sync`: new DDP-safe helpers. Without these, if the caching-writer rank (rank 0 for disk cache, or any rank for the independent memory cache) raises, it never reaches the `dist.barrier()` right after cache creation, and every other rank hangs indefinitely. These broadcast a failure flag via `dist.all_reduce` so every rank learns about the failure and raises together instead.
- `_validate_existing_disk_cache_complete`: new helper wired into `get_train_val_datasets` for the `use_existing_imgs=True` reuse path. The previous check only verified the cache directory contained *any* `.jpg` file; this checks every `sample_{labels_idx}_{lf_idx}.jpg` the dataset's `lf_idx_list` actually needs is present.

## Testing

Added to `tests/test_parallel_caching.py` (27/27 passing, 12 new):
- `TestCacheFillHardRaise`: mocked-error unit test for `_fill_cache_parallel`, plus real disk-write-failure integration tests (via a patched `Image.fromarray`) for both the parallel and sequential caching paths.
- `TestDistSyncCacheFill`: 5 tests covering no-DDP passthrough, local-rank-failure, remote-rank-failure (broadcasted), all-succeed, and the nccl-without-cuda device-selection edge case for the broadcast tensor.
- `TestValidateExistingDiskCache`: missing-files raises, complete-cache passes.

Also verified no regressions:
- `tests/data/test_custom_datasets.py`: 15/15 passed.
- `tests/training/test_model_trainer.py`: 28/28 passed, including `test_reuse_cache_img_files` which exercises the `use_existing_imgs` path touched here.
- Full `pytest tests`: 2120 passed, 138 skipped, 4 xfailed, 0 failed.
- `black`/`ruff check sleap_nn/` clean.

## Design Decisions

- Raise unconditionally on any caching error (no tolerance threshold) — a dropped frame silently changes the effective training set, so any failure should stop training rather than being tolerated up to some count.
- The DDP broadcast is deliberately included in this PR rather than deferred, since making rank 0 (or any rank) raise without it would turn a previously-recoverable-but-wrong situation (train proceeds, crashes later) into a straightforward multi-GPU hang.

## Future Considerations

- The inference-side `sleap_nn/data/providers.py` `VideoReader`/`LabelsReader` have an analogous swallow-and-continue pattern (a read failure is logged and treated as end-of-stream rather than raised), but that's a separate, predict-time code path and is intentionally left out of scope here.

## Related Issues
Closes talmolab/sleap#2777

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)