### PR TITLE
feat(train): centroid model trains on pure-centroid frames (no pose instance)

### DIFF
--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -84,14 +84,21 @@ def _run_centroid_split_eval(
     if match_threshold is None:
         match_threshold = 50.0
 
-    metrics = run_evaluation(
-        ground_truth_path=path,
-        predicted_path=pred_path.as_posix(),
-        match_method="centroid",
-        anchor_part=anchor_part,
-        match_threshold=match_threshold,
-        save_metrics=metrics_path.as_posix(),
-    )
+    try:
+        metrics = run_evaluation(
+            ground_truth_path=path,
+            predicted_path=pred_path.as_posix(),
+            match_method="centroid",
+            anchor_part=anchor_part,
+            match_threshold=match_threshold,
+            save_metrics=metrics_path.as_posix(),
+        )
+    except Exception as e:  # noqa: BLE001 — eval is best-effort post-training.
+        # e.g. "Empty Frame Pairs" when GT and predictions don't pair (a weak
+        # model, or centroid-only GT the matcher can't align). Don't abort a
+        # training run that already produced a checkpoint.
+        logger.warning(f"Skipping centroid eval on `{d_name}`: {e}")
+        return None
 
     # Centroid metrics: detection_metrics + distance_metrics only. Guard every
     # key access (no oks_voc.* / mOKS / pck / visibility keys exist here).

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -229,14 +229,29 @@ class ModelTrainer:
                 trainer_devices = 1
         return trainer_devices
 
+    def _is_training_frame(self, lf: "sio.LabeledFrame") -> bool:
+        """Whether a frame carries a usable training target.
+
+        Normally that means user instances. The centroid model can additionally
+        train on frames that carry only user centroid annotations
+        (``frame.centroids``) with no pose instance — the pure-centroid seeding
+        case (label a body-center per animal before any keypoints exist).
+        """
+        if lf.has_user_instances:
+            return True
+        if self.model_type == "centroid":
+            return any(not c.is_predicted for c in lf.centroids)
+        return False
+
     def _count_labeled_frames(
         self, labels_list: List[sio.Labels], user_only: bool = True
     ) -> int:
-        """Count labeled frames, optionally filtering to user-labeled only.
+        """Count labeled frames, optionally filtering to trainable frames only.
 
         Args:
             labels_list: List of Labels objects to count frames from.
-            user_only: If True, count only frames with user instances.
+            user_only: If True, count only frames with a training target
+                (user instances, or — for the centroid model — user centroids).
 
         Returns:
             Total count of labeled frames.
@@ -244,24 +259,25 @@ class ModelTrainer:
         total = 0
         for label in labels_list:
             if user_only:
-                total += sum(1 for lf in label if lf.has_user_instances)
+                total += sum(1 for lf in label if self._is_training_frame(lf))
             else:
                 total += len(label)
         return total
 
     def _filter_to_user_labeled(self, labels: sio.Labels) -> sio.Labels:
-        """Filter a Labels object to only include user-labeled frames.
+        """Filter a Labels object to only include trainable frames.
 
         Args:
             labels: Labels object to filter.
 
         Returns:
-            New Labels object containing only frames with user instances.
+            New Labels object containing only frames with a training target
+            (user instances, or user centroids for the centroid model).
         """
-        # Filter labeled frames to only those with user instances
-        user_lfs = [lf for lf in labels if lf.has_user_instances]
+        # Filter labeled frames to only trainable ones
+        user_lfs = [lf for lf in labels if self._is_training_frame(lf)]
 
-        # Set instances to user instances only
+        # Set instances to user instances only (empty for centroid-only frames)
         for lf in user_lfs:
             lf.instances = lf.user_instances
 
@@ -274,6 +290,42 @@ class ModelTrainer:
             suggestions=labels.suggestions,
             provenance=labels.provenance,
         )
+
+    def _split_centroid_labels(
+        self, label: sio.Labels, val_fraction: float, seed: Optional[int]
+    ):
+        """Train/val split for the centroid model that keeps centroid-only frames.
+
+        `sio.Labels.make_training_splits` returns only frames with user
+        instances, so it would drop pure-centroid frames. This reimplements a
+        deterministic fractional split over frames with a centroid training
+        target (user instances OR user centroids).
+        """
+        frames = [lf for lf in label if self._is_training_frame(lf)]
+        for lf in frames:
+            lf.instances = lf.user_instances
+
+        def mk(selected):
+            return sio.Labels(
+                labeled_frames=selected,
+                videos=label.videos,
+                skeletons=label.skeletons,
+                tracks=label.tracks,
+                suggestions=label.suggestions,
+                provenance=label.provenance,
+            )
+
+        n = len(frames)
+        if n <= 1:
+            # Too few to hold out a val frame; use the same frame for both so
+            # training still runs (mirrors small-dataset behavior elsewhere).
+            return mk(list(frames)), mk(list(frames))
+        rng = np.random.default_rng(seed)
+        order = rng.permutation(n)
+        n_val = max(1, int(round(n * val_fraction)))
+        val_sel = [frames[i] for i in order[:n_val]]
+        train_sel = [frames[i] for i in order[n_val:]]
+        return mk(train_sel), mk(val_sel)
 
     def _setup_train_val_labels(
         self,
@@ -355,12 +407,18 @@ class ModelTrainer:
                         f"training run to avoid data leakage."
                     )
             for label in labels:
-                train_split, val_split = label.make_training_splits(
-                    n_train=1 - val_fraction, n_val=val_fraction, seed=seed
-                )
+                if self.model_type == "centroid":
+                    # Centroid-aware split keeps pure-centroid frames that
+                    # make_training_splits would drop (no user instances).
+                    train_split, val_split = self._split_centroid_labels(
+                        label, val_fraction, seed
+                    )
+                else:
+                    train_split, val_split = label.make_training_splits(
+                        n_train=1 - val_fraction, n_val=val_fraction, seed=seed
+                    )
                 self.train_labels.append(train_split)
                 self.val_labels.append(val_split)
-                # make_training_splits returns only user-labeled frames
                 total_train_lfs += len(train_split)
                 total_val_lfs += len(val_split)
         else:

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -639,6 +639,48 @@ def test_model_trainer_centroid(config, tmp_path):
     ).exists()
 
 
+def test_centroid_split_keeps_centroid_only_frames(config, minimal_instance, tmp_path):
+    """The centroid model's train/val split must keep frames carrying only user
+    centroids (no pose instance) — the pure-centroid seeding case. Regression:
+    make_training_splits filters to has_user_instances, which dropped them (0
+    training frames); _split_centroid_labels keeps them.
+    """
+    from sleap_io.model.centroid import UserCentroid
+
+    base = sio.load_slp(minimal_instance)
+    video = base.videos[0]
+    skel = base.skeletons[0]
+    # Six frames with ONLY a user centroid each (no pose instance).
+    frames = [
+        sio.LabeledFrame(
+            video=video, frame_idx=i, centroids=[UserCentroid(x=5.0 + i, y=6.0 + i)]
+        )
+        for i in range(6)
+    ]
+    labels = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=frames)
+
+    centroid_config = config.copy()
+    head_config = centroid_config.model_config.head_configs.centered_instance
+    OmegaConf.update(centroid_config, "model_config.head_configs.centroid", head_config)
+    del centroid_config.model_config.head_configs.centered_instance
+    del centroid_config.model_config.head_configs.centroid["confmaps"].part_names
+    OmegaConf.update(centroid_config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(centroid_config, "data_config.validation_fraction", 0.25)
+
+    trainer = ModelTrainer.get_model_trainer_from_config(centroid_config)
+    assert trainer.model_type == "centroid"
+
+    # get_model_trainer_from_config already split the config's labels; reset and
+    # re-split on our pure-centroid labels in isolation.
+    trainer.train_labels = []
+    trainer.val_labels = []
+    trainer._setup_train_val_labels([labels])
+    n_train = sum(len(lb) for lb in trainer.train_labels)
+    n_val = sum(len(lb) for lb in trainer.val_labels)
+    assert n_train + n_val == 6, f"pure-centroid frames were dropped: {n_train}+{n_val}"
+    assert n_train >= 1 and n_val >= 1
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("li")
     and not torch.cuda.is_available(),  # self-hosted GPUs have linux os but cuda is available, so will do test


### PR DESCRIPTION
Follow-up to #702.

## Problem
Training a centroid model from `UserCentroid` annotations still failed for the **pure-centroid seeding** case — a frame that carries a `UserCentroid` but **no pose instance** (the Phase-1 active-learning workflow: click one centroid per animal before any keypoint labelling). #702 taught `CentroidDataset` to read `frame.centroids`, but the **train/val split runs first** and filters to `has_user_instances` (`make_training_splits` / `_filter_to_user_labeled`), so those frames were dropped before the dataset saw them → **0 training frames**. (#702's unit test exercised `CentroidDataset` directly, bypassing the split.)

## Changes
- **`model_trainer.py`** — centroid-aware split. `_is_training_frame` treats a frame as trainable if it has user instances **or** (for the centroid model) a user centroid. `_split_centroid_labels` does a deterministic fractional split over those frames (instead of `make_training_splits`, which drops centroid-only frames). `_filter_to_user_labeled` / `_count_labeled_frames` use the same predicate. All scoped to `model_type == "centroid"` — every other model behaves exactly as before.
- **`train.py`** — the centroid post-train eval now has the same best-effort `try/except` the segmentation eval already has, so an `"Empty Frame Pairs"` match failure on centroid-only GT logs-and-skips instead of aborting a run that already wrote a checkpoint.
- **test** — `test_centroid_split_keeps_centroid_only_frames`: six pure-centroid frames survive the split (regression for the 0-frames drop).

## Verification
End to end on a sleap-io.js-written `.slp` of 12 pure-centroid frames: the split now yields 11 train / 1 val frames, the model trains to a checkpoint, and predicting with it detects **24/24** seeded centroids within **2.2px** (as `PredictedCentroid`s on `frame.centroids`). Centroid dataset + this split test pass; other models' split behaviour is unchanged.