### PR TITLE
feat(data): single-source centroid targets (no user/computed mix)

### DIFF
--- a/sleap_nn/architectures/heads.py
+++ b/sleap_nn/architectures/heads.py
@@ -136,6 +136,12 @@ class CentroidConfmapsHead(Head):
     Attributes:
         anchor_part: Name of the part to use as an anchor node. If not specified, the
             bounding box centroid will be used.
+        centroid_source: Data-pipeline setting for which centroid the model is
+            trained to predict (``"user"`` / ``"computed"`` / ``None`` to infer).
+            The head output is identical regardless; it is stored here only so
+            the head can be built from the confmaps config, which co-locates it
+            with ``anchor_part``. See ``CentroidConfMapsConfig`` and
+            ``resolve_centroid_source``.
         sigma: Spread of the confidence maps.
         output_stride: Stride of the output head tensor. The input tensor is expected to
             be at the same stride.
@@ -145,6 +151,7 @@ class CentroidConfmapsHead(Head):
     def __init__(
         self,
         anchor_part: Optional[Text] = None,
+        centroid_source: Optional[Text] = None,
         sigma: float = 5.0,
         output_stride: int = 1,
         loss_weight: float = 1.0,
@@ -152,6 +159,9 @@ class CentroidConfmapsHead(Head):
         """Initialize the object with the specified attributes."""
         super().__init__(output_stride, loss_weight)
         self.anchor_part = anchor_part
+        # Data-pipeline metadata only (does not affect the head tensor); kept so
+        # the head is constructible from ``**head_config.confmaps``.
+        self.centroid_source = centroid_source
         self.sigma = sigma
 
     @property
@@ -171,6 +181,7 @@ class CentroidConfmapsHead(Head):
         """
         return cls(
             anchor_part=config.anchor_part,
+            centroid_source=config.get("centroid_source", None),
             sigma=config.sigma,
             output_stride=config.output_stride,
             loss_weight=config.loss_weight,

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -694,6 +694,19 @@ class CentroidConfMapsConfig:
             reliable anchor point can significantly improve topdown model
             accuracy as they benefit from a consistent geometry of the body parts
             relative to the center of the image. Default is None.
+        centroid_source: (str) Which centroid the model is trained to predict.
+            The centroid head must use ONE source for the whole dataset —
+            mixing user-annotated and computed centroids trains the head against
+            two conflicting definitions of "centroid". Options:
+            - ``"user"``: train on first-class ``UserCentroid`` annotations;
+              frames with pose instances but no user centroid are dropped.
+            - ``"computed"``: derive every centroid from instance keypoints
+              (the ``anchor_part`` node, else the mean of visible nodes); any
+              ``UserCentroid`` annotations are ignored.
+            - ``None`` (default): infer the source from the training labels
+              (user centroids present -> ``"user"``, else ``"computed"``) and
+              emit a loud warning, since a silently-chosen target is a training
+              footgun. Set this explicitly to silence the warning.
         sigma: (float) Spread of the Gaussian distribution of the confidence maps as a
             scalar float. Smaller values are more precise but may be difficult to learn as
             they have a lower density within the image space. Larger values are easier to
@@ -708,6 +721,7 @@ class CentroidConfMapsConfig:
     """
 
     anchor_part: Optional[str] = None
+    centroid_source: Optional[str] = None
     sigma: float = 5.0
     output_stride: int = 1
 

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -637,6 +637,12 @@ class BaseDataset(Dataset):
                         # these over instance-keypoint-derived centroids. None
                         # when the frame has no user centroids (fallback path).
                         "user_centroids": user_centroids,
+                        # Whether the frame has at least one non-empty pose
+                        # instance. Lets CentroidDataset drop pose-less
+                        # (centroid-only) frames when training on computed
+                        # centroids, the mirror of dropping centroid-less frames
+                        # when training on user centroids.
+                        "has_pose_instances": (not is_empty),
                     }
                     lf_idx_list.append(sample)
                     # This is to ensure that the labels are not passed to the multiprocessing pool (h5py objects can't be pickled)
@@ -2469,6 +2475,15 @@ class CentroidDataset(BaseDataset):
             divisible by.
         anchor_ind: Index of the node to use as the anchor point, based on its index in the
             ordered list of skeleton nodes.
+        use_user_centroids: Selects the single dataset-wide centroid source.
+            `True` trains on user-annotated centroids (``UserCentroid``); `False`
+            computes every centroid from instance keypoints (``anchor_ind`` node,
+            else mean of visible nodes). Frames that cannot supply a target in
+            the chosen mode are dropped so the head never sees a per-frame mix of
+            the two sources. If `None`, the mode is inferred from the labels
+            (user centroids present -> `True`) and a warning is emitted; callers
+            that care about train/val consistency should pass it explicitly
+            (``get_train_val_datasets`` does, via ``centroid_source``).
         user_instances_only: `True` if only user labeled instances should be used for training. If `False`,
             both user labeled and predicted instances would be used.
         ensure_rgb: (bool) True if the input image should have 3 channels (RGB image). If input has only one
@@ -2515,6 +2530,7 @@ class CentroidDataset(BaseDataset):
         confmap_head_config: DictConfig,
         max_stride: int,
         anchor_ind: Optional[int] = None,
+        use_user_centroids: Optional[bool] = None,
         user_instances_only: bool = True,
         ensure_rgb: bool = False,
         ensure_grayscale: bool = False,
@@ -2553,6 +2569,64 @@ class CentroidDataset(BaseDataset):
         )
         self.anchor_ind = anchor_ind
         self.confmap_head_config = confmap_head_config
+
+        # Resolve ONE centroid source for the whole dataset so the head is never
+        # trained against a per-frame mix of user-annotated and computed
+        # centroids. ``get_train_val_datasets`` resolves this (respecting the
+        # ``centroid_source`` config and sharing the decision across splits) and
+        # passes an explicit bool. When constructed directly (e.g. in tests)
+        # without it, infer from this dataset's frames and warn loudly — a
+        # silently-chosen target is a subtle training footgun.
+        if use_user_centroids is None:
+            self.use_user_centroids = any(
+                entry.get("user_centroids") for entry in self.lf_idx_list
+            )
+            src = "user-annotated" if self.use_user_centroids else "computed"
+            logger.warning(
+                "CentroidDataset: centroid source not specified; inferred "
+                "'%s' centroids from the labels for ALL frames. Pass "
+                "use_user_centroids explicitly (or set centroid_source in the "
+                "config) to silence this.",
+                src,
+            )
+        else:
+            self.use_user_centroids = bool(use_user_centroids)
+
+        # Enforce the resolved mode by dropping frames that cannot supply a
+        # target in that mode (keeping them would force the per-frame fallback,
+        # i.e. the mix we are eliminating). The two modes are mirror images:
+        #   - user mode:     keep frames with a user centroid (+ negatives);
+        #                    drop pose-only frames that have no user centroid.
+        #   - computed mode: keep frames with a pose instance (+ negatives);
+        #                    drop centroid-only frames that have no pose.
+        # Negative frames (empty target) are valid in both modes.
+        def _keeps(entry: Dict) -> bool:
+            if entry.get("is_negative"):
+                return True
+            if self.use_user_centroids:
+                return bool(entry.get("user_centroids"))
+            return bool(entry.get("has_pose_instances"))
+
+        n_before = len(self.lf_idx_list)
+        self.lf_idx_list = [e for e in self.lf_idx_list if _keeps(e)]
+        n_dropped = n_before - len(self.lf_idx_list)
+        if n_dropped:
+            if self.use_user_centroids:
+                reason = (
+                    "have pose instances but no UserCentroid annotation; annotate "
+                    "centroids on them or set centroid_source='computed'"
+                )
+            else:
+                reason = (
+                    "have UserCentroid annotations but no pose instance; add pose "
+                    "labels or set centroid_source='user'"
+                )
+            logger.warning(
+                "CentroidDataset: dropped %d/%d frame(s) that %s.",
+                n_dropped,
+                n_before,
+                reason,
+            )
 
         # First-class centroid annotations may outnumber the pose instances in a
         # frame. The per-sample centroid target must have a fixed slot count so
@@ -2691,11 +2765,12 @@ class CentroidDataset(BaseDataset):
             scale=self.scale,
         )
 
-        # Prefer first-class user-annotated centroids as the target. These are
-        # annotated points that need not be pose nodes. Fall back to deriving
-        # the centroid from instance keypoints (anchor node, else mean of
-        # visible nodes) only when the frame has no user centroids.
-        if user_centroids:
+        # Build the centroid target from the single dataset-wide source resolved
+        # in ``__init__`` (``self.use_user_centroids``) — never a per-frame mix.
+        # In user mode every kept non-negative frame carries a user centroid
+        # (frame filtering guarantees it); negative frames have none and fall to
+        # the computed path, which yields an all-NaN (empty) target as intended.
+        if self.use_user_centroids and user_centroids:
             # Raw annotation coords -> preprocessed frame: instances were scaled
             # by ``eff_scale`` then by ``self.scale`` (apply_resizer) above.
             centroids = self._build_user_centroid_target(
@@ -4646,6 +4721,88 @@ def _validate_existing_disk_cache_complete(
         )
 
 
+# Valid values for ``CentroidConfMapsConfig.centroid_source`` and the resolved
+# dataset-wide centroid mode.
+CENTROID_SOURCE_USER = "user"
+CENTROID_SOURCE_COMPUTED = "computed"
+
+
+def labels_have_user_centroids(labels: List[sio.Labels]) -> bool:
+    """Return True if any labeled frame carries a usable ``UserCentroid``.
+
+    Mirrors the per-frame extraction used to build the centroid sample list
+    (``BaseDataset._extract_user_centroid_xy``): predicted centroids and NaN
+    coordinates do not count, and an installed sleap-io without first-class
+    centroids yields False.
+    """
+    for label in labels:
+        for lf in label:
+            if BaseDataset._extract_user_centroid_xy(lf):
+                return True
+    return False
+
+
+def resolve_centroid_source(
+    centroid_source: Optional[str], train_labels: List[sio.Labels]
+) -> bool:
+    """Resolve the centroid target source to one dataset-wide mode.
+
+    Returns ``True`` to train on user-annotated centroids, ``False`` to compute
+    centroids from instance keypoints (the anchor node, else the mean of
+    visible nodes). The centroid model must use ONE source for the whole
+    dataset; mixing the two trains the head against two different definitions of
+    "centroid".
+
+    ``centroid_source`` (from ``CentroidConfMapsConfig``) selects the mode
+    explicitly — ``"user"`` or ``"computed"`` (``"anchor"`` is accepted as an
+    alias for ``"computed"``). When it is ``None`` the mode is INFERRED from the
+    training labels and a loud warning is emitted, because a silently-chosen
+    target is a subtle training footgun.
+
+    Raises:
+        ValueError: if ``centroid_source`` is a non-empty unrecognized string.
+    """
+    if centroid_source is not None:
+        source = str(centroid_source).strip().lower()
+        if source == CENTROID_SOURCE_USER:
+            logger.info(
+                "Centroid target source: user-annotated centroids "
+                "(centroid_source='user')."
+            )
+            return True
+        if source in (CENTROID_SOURCE_COMPUTED, "anchor"):
+            logger.info(
+                "Centroid target source: computed from instance keypoints "
+                "(centroid_source='computed')."
+            )
+            return False
+        raise ValueError(
+            f"Invalid centroid_source={centroid_source!r}. Expected 'user', "
+            f"'computed', or None (infer from the training labels)."
+        )
+
+    has_user = labels_have_user_centroids(train_labels)
+    chosen = (
+        "user-annotated centroids (UserCentroid)"
+        if has_user
+        else "computed centroids (anchor node / mean of visible nodes)"
+    )
+    bar = "=" * 76
+    logger.warning(
+        "\n%s\n"
+        "centroid_source is NOT set: INFERRING the centroid target from the "
+        "training labels.\n"
+        "  -> Training on %s for ALL frames.\n"
+        "Set model_config.head_configs.centroid.confmaps.centroid_source to "
+        "'user' or\n'computed' to make this explicit and silence this warning.\n"
+        "%s",
+        bar,
+        chosen,
+        bar,
+    )
+    return has_user
+
+
 def get_train_val_datasets(
     train_labels: List[sio.Labels],
     val_labels: List[sio.Labels],
@@ -4990,9 +5147,20 @@ def get_train_val_datasets(
             if anchor_part is not None and anchor_part in nodes
             else None
         )
+        # Resolve ONE centroid source for the whole run (no per-frame mix of
+        # user-annotated and computed centroids). Inference (when unset) reads
+        # the TRAIN labels and the same decision is applied to both splits so
+        # train and val can never disagree on the centroid definition.
+        centroid_source = OmegaConf.select(
+            config,
+            "model_config.head_configs.centroid.confmaps.centroid_source",
+            default=None,
+        )
+        use_user_centroids = resolve_centroid_source(centroid_source, train_labels)
         train_dataset = CentroidDataset(
             labels=train_labels,
             confmap_head_config=config.model_config.head_configs.centroid.confmaps,
+            use_user_centroids=use_user_centroids,
             max_stride=config.model_config.backbone_config[f"{backbone_type}"][
                 "max_stride"
             ],
@@ -5027,6 +5195,7 @@ def get_train_val_datasets(
         val_dataset = CentroidDataset(
             labels=val_labels,
             confmap_head_config=config.model_config.head_configs.centroid.confmaps,
+            use_user_centroids=use_user_centroids,
             max_stride=config.model_config.backbone_config[f"{backbone_type}"][
                 "max_stride"
             ],

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -1,6 +1,7 @@
 from omegaconf import DictConfig, OmegaConf
 import sleap_io as sio
 import torch
+import pytest
 from sleap_nn.data.custom_datasets import (
     BottomUpDataset,
     BottomUpMultiClassDataset,
@@ -10,6 +11,8 @@ from sleap_nn.data.custom_datasets import (
     SingleInstanceDataset,
     InfiniteDataLoader,
     get_steps_per_epoch,
+    labels_have_user_centroids,
+    resolve_centroid_source,
 )
 from sleap_nn.data.instance_centroids import generate_centroids
 
@@ -1294,6 +1297,128 @@ def test_centroid_dataset_centroid_only_frame(minimal_instance):
         r = int(round(cy / output_stride))
         c = int(round(cx / output_stride))
         assert cmap[r, c] > 0.9
+
+
+def test_resolve_centroid_source(minimal_instance):
+    """The centroid source resolves to ONE dataset-wide mode; unset -> inferred."""
+    labels_plain = sio.load_slp(minimal_instance)  # no user centroids
+    labels_user = sio.load_slp(minimal_instance)
+    labels_user[0].centroids = [sio.UserCentroid(x=10.0, y=20.0)]
+
+    # Explicit config wins regardless of what the labels contain.
+    assert resolve_centroid_source("user", [labels_plain]) is True
+    assert resolve_centroid_source("computed", [labels_user]) is False
+    assert resolve_centroid_source("anchor", [labels_user]) is False  # alias
+    assert resolve_centroid_source(" User ", [labels_plain]) is True  # normalized
+
+    # Unset -> inferred from the (train) labels.
+    assert resolve_centroid_source(None, [labels_user]) is True
+    assert resolve_centroid_source(None, [labels_plain]) is False
+
+    # A non-empty unrecognized value is a hard error, not a silent fallback.
+    with pytest.raises(ValueError):
+        resolve_centroid_source("centroid", [labels_plain])
+
+    # Detection helper agrees.
+    assert labels_have_user_centroids([labels_user]) is True
+    assert labels_have_user_centroids([labels_plain]) is False
+
+
+def test_centroid_dataset_source_overrides_per_frame(minimal_instance):
+    """The dataset-wide source wins over any per-frame user centroid.
+
+    A frame carrying ``UserCentroid`` annotations must still produce the
+    COMPUTED target in computed mode (no per-frame preference) and the user
+    target in user mode.
+    """
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": None})
+    user_xy = [[50.0, 60.0], [300.0, 320.0]]
+
+    def _labels_with_user_centroids():
+        lbls = sio.load_slp(minimal_instance)
+        lbls[0].centroids = [
+            sio.UserCentroid(x=user_xy[0][0], y=user_xy[0][1]),
+            sio.UserCentroid(x=user_xy[1][0], y=user_xy[1][1]),
+        ]
+        return lbls
+
+    common = dict(
+        max_stride=32,
+        ensure_rgb=True,
+        scale=1.0,
+        confmap_head_config=confmap_head,
+        apply_aug=False,
+    )
+
+    # Computed mode ignores the user centroids -> target is the keypoint-derived
+    # centroid, NOT the annotated one.
+    ds_computed = CentroidDataset(
+        labels=[_labels_with_user_centroids()], use_user_centroids=False, **common
+    )
+    assert ds_computed.use_user_centroids is False
+    s = next(iter(ds_computed))
+    fb = generate_centroids(s["instances"], anchor_ind=None)
+    assert torch.allclose(s["centroids"], fb, atol=1e-4, equal_nan=True)
+    user_target = torch.tensor(user_xy, dtype=torch.float32) * float(s["eff_scale"])
+    assert not torch.allclose(s["centroids"][0, :2], user_target, atol=5.0)
+
+    # User mode -> target sits at the annotated centroids.
+    ds_user = CentroidDataset(
+        labels=[_labels_with_user_centroids()], use_user_centroids=True, **common
+    )
+    assert ds_user.use_user_centroids is True
+    s2 = next(iter(ds_user))
+    user_target2 = torch.tensor(user_xy, dtype=torch.float32) * float(s2["eff_scale"])
+    assert torch.allclose(s2["centroids"][0, :2], user_target2, atol=1e-4)
+
+
+def test_centroid_dataset_no_mix_frame_dropping(minimal_instance):
+    """No mix-and-match: frames that can't supply the chosen target are dropped.
+
+    Two single-frame Labels (each an embedded-image copy of the fixture) let us
+    control which frames carry user centroids vs. only pose instances.
+    """
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2, "anchor_part": None})
+
+    def _pose_only():
+        return sio.load_slp(minimal_instance)  # 2 pose instances, no centroids
+
+    def _with_centroids():
+        lbls = sio.load_slp(minimal_instance)  # pose instances + a user centroid
+        lbls[0].centroids = [sio.UserCentroid(x=50.0, y=60.0)]
+        return lbls
+
+    def _centroid_only():
+        lbls = sio.load_slp(minimal_instance)  # user centroid, no pose instance
+        for lf in lbls:
+            lf.instances = []
+        lbls[0].centroids = [sio.UserCentroid(x=50.0, y=60.0)]
+        return lbls
+
+    common = dict(
+        max_stride=32,
+        ensure_rgb=True,
+        scale=1.0,
+        confmap_head_config=confmap_head,
+        apply_aug=False,
+    )
+
+    # User mode: the pose-only frame (no user centroid) is dropped.
+    ds_user = CentroidDataset(
+        labels=[_with_centroids(), _pose_only()], use_user_centroids=True, **common
+    )
+    assert len(ds_user.lf_idx_list) == 1
+    assert all(e.get("user_centroids") for e in ds_user.lf_idx_list)
+
+    # Computed mode: the centroid-only frame (no pose) is dropped, and the
+    # surviving frame's user centroid is ignored in favor of a computed target.
+    ds_computed = CentroidDataset(
+        labels=[_with_centroids(), _centroid_only()], use_user_centroids=False, **common
+    )
+    assert len(ds_computed.lf_idx_list) == 1
+    assert all(e.get("has_pose_instances") for e in ds_computed.lf_idx_list)
+    s = next(iter(ds_computed))
+    assert not torch.isnan(s["centroids"][0, :2]).all()
 
 
 def test_single_instance_dataset(minimal_instance, tmp_path):


### PR DESCRIPTION
## Problem

The centroid training dataloader chose its target **per frame**: it used a first-class `UserCentroid` annotation if the frame had one, otherwise it computed a centroid from the anchor node / mean of visible keypoints (`CentroidDataset.__getitem__`). In a dataset where the user annotated centroids on only *some* frames, the centroid head was trained against **two different definitions of "centroid"** — user-clicked points on some frames, keypoint-derived points on others. That mix is a silent training footgun.

## Change

Pick **one** centroid source for the whole run, never a per-frame mix.

- **New config field** `model_config.head_configs.centroid.confmaps.centroid_source`:
  - `"user"` — train on `UserCentroid` annotations; pose-only frames (no user centroid) are dropped.
  - `"computed"` — derive every centroid from instance keypoints (anchor node, else mean of visible nodes); any `UserCentroid` annotations are ignored.
  - `None` (default) — **infer** from the training labels (user centroids present → `"user"`, else `"computed"`) and emit a **loud warning**, since a silently-chosen target is easy to miss. Set it explicitly to silence the warning.
- The source is resolved **once** in `get_train_val_datasets` (`resolve_centroid_source`) and the same decision is passed to **both** the train and val datasets, so the splits can never disagree on the centroid definition.
- `CentroidDataset` **drops frames that cannot supply the chosen target** instead of falling back per frame — pose-only frames in user mode, centroid-only frames in computed mode (mirror images). Negative frames are kept in both modes. A warning reports how many frames were dropped and why.
- `CentroidConfmapsHead` accepts and ignores `centroid_source` (data-pipeline metadata, exactly like `anchor_part`) so the head stays constructible from `**head_config.confmaps`.

## Tests

- `test_resolve_centroid_source` — explicit modes + `"anchor"` alias + case/whitespace normalization, inference both ways, and a hard `ValueError` on an unrecognized value.
- `test_centroid_dataset_source_overrides_per_frame` — a frame with user centroids yields the *computed* target in computed mode and the *user* target in user mode (the dataset mode wins; no per-frame preference).
- `test_centroid_dataset_no_mix_frame_dropping` — user mode drops pose-only frames; computed mode drops centroid-only frames.

All passing locally (`.venv`, sleap-io 0.8.0): `tests/data/test_custom_datasets.py`, `tests/data/test_negative_frames.py`, `tests/architectures/test_heads.py`, `tests/config`, `tests/inference/test_centroid_only.py`, and `tests/training/test_model_trainer.py::test_model_trainer_centroid`. `black` clean; `ruff` clean on changed source (the pre-existing f-string lint errors in the test file are untouched).

## Follow-up (out of scope)

Centroid-matching **evaluation** (`evaluation.py::compute_gt_centroids`) always derives GT centroids from keypoints. For consistent metrics in `"user"` mode it should mirror the training source; noting here rather than expanding this PR.

## Notes

Branched off `main` in an isolated worktree; the `tom/centroid-only-split-eval` working copy is untouched.