### PR TITLE
fix(data): clear error on empty dataset instead of cryptic IndexError

### DIFF
--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -521,6 +521,22 @@ class BaseDataset(Dataset):
 
         self.lf_idx_list = self._get_lf_idx_list(labels)
 
+        # Fail fast with an actionable message when no frame yields a training
+        # sample. Otherwise the empty dataset surfaces much later as a cryptic
+        # ``IndexError: list index out of range`` the first time ``dataset[0]``
+        # is accessed (e.g. the trainer's "Input image shape" log line).
+        if not self.lf_idx_list:
+            n_frames = sum(len(label) for label in labels)
+            raise ValueError(
+                f"{type(self).__name__} has no training samples: none of the "
+                f"{n_frames} labeled frame(s) in the provided labels contain "
+                "user-labeled data usable by this model. Predicted instances "
+                "and suggestion frames are not used as training targets (nor "
+                "are standalone centroid annotations, except by centroid "
+                "models). Verify that the .slp file passed for training "
+                "contains user-labeled instances."
+            )
+
         self.labels_list = None
         # this is to ensure that the labels are not passed to the multiprocessing pool when caching is enabled
         # (h5py objects can't be pickled error with num_workers > 0) in mac and windows

--- a/tests/data/test_custom_datasets.py
+++ b/tests/data/test_custom_datasets.py
@@ -1771,3 +1771,32 @@ def test_flip_augmentation_warns_without_symmetries(minimal_instance):
 
     assert dataset.symmetric_inds == []
     assert any("no symmetries" in m for m in messages)
+
+
+def test_empty_dataset_raises_clear_error(minimal_instance):
+    """Building a dataset with no usable samples raises a clear ValueError.
+
+    Regression: a labels file with no user-labeled instances (e.g. only
+    predictions, suggestions, or standalone centroid annotations) produced an
+    empty ``lf_idx_list``. Training then crashed with a cryptic
+    ``IndexError: list index out of range`` the first time ``train_dataset[0]``
+    was accessed (the trainer's "Input image shape" log line). Construction now
+    fails fast with an actionable message instead.
+    """
+    labels = sio.load_slp(minimal_instance)
+    # Drop every user instance so no frame yields a training sample.
+    for lf in labels:
+        lf.instances = []
+
+    confmap_head = DictConfig({"sigma": 1.5, "output_stride": 2})
+    pafs_head = DictConfig({"sigma": 4, "output_stride": 4})
+
+    with pytest.raises(ValueError, match="no training samples"):
+        BottomUpDataset(
+            max_stride=32,
+            scale=1.0,
+            confmap_head_config=confmap_head,
+            pafs_head_config=pafs_head,
+            labels=[labels],
+            apply_aug=False,
+        )


### PR DESCRIPTION
Fixes #705

## Problem

When a training dataset has **zero samples** (`lf_idx_list == []`), training crashes with a bare `IndexError: list index out of range` — the first `dataset[0]` access is the trainer's `Input image shape` log line (`model_trainer.py:1619`). Nothing tells the user the real cause: the `.slp` has no user-labeled instances.

Real-world trigger: a `.slp` with **1000 labeled frames, 223 user centroid annotations, and 0 user pose instances**, trained as a centroid model on `0.3.0` (where `CentroidDataset` builds `lf_idx_list` from user instances). `main` (#704) added centroid-only training, but the empty-dataset crash is still latent for any labels with no usable user-labeled data.

## Fix

Fail fast in `BaseDataset.__init__` when `lf_idx_list` is empty, with an actionable message. Covers every dataset type (all subclass via `BaseDataset.__init__`), and turns the cryptic `IndexError` into:

> `<Dataset> has no training samples: none of the N labeled frame(s) in the provided labels contain user-labeled data usable by this model. Predicted instances and suggestion frames are not used as training targets (nor are standalone centroid annotations, except by centroid models). Verify that the .slp file passed for training contains user-labeled instances.`

## Test

Adds `test_empty_dataset_raises_clear_error`: strips user instances from `minimal_instance` and asserts `BottomUpDataset(...)` raises `ValueError` (not `IndexError`). Verified locally against the real failing `.slp` and the fixture; a control (unmodified labels) still builds a non-empty dataset, so the guard doesn't false-positive.

## Scope note

This is the robustness fix only. Enabling centroid **model** training directly from first-class `frame.centroids` (the deeper reason the reporter's centroid-only `.slp` couldn't train) is separate feature work already begun on `main` (#704).