### PR TITLE
fix: unbound corrected_lfs when combining tracking_clean_instance_count with post_connect_single_breaks

### DIFF
--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -330,21 +330,24 @@ def apply_tracking(
             progress_callback(i + 1, n_frames)
 
     # Cull/connect cleanups are pose-only (and rejected above for mask mode).
-    if not is_mask_mode and config.tracking_clean_instance_count > 0:
-        tracked_lfs = cull_instances(
-            tracked_lfs,
-            config.tracking_clean_instance_count,
-            config.tracking_clean_iou_threshold,
-        )
-        if not config.post_connect_single_breaks:
-            tracked_lfs = connect_single_breaks(
-                tracked_lfs, config.tracking_clean_instance_count
+    if not tracked_lfs:
+        logger.info("0 frames to track; skipping tracking post-processing.")
+    else:
+        if not is_mask_mode and config.tracking_clean_instance_count > 0:
+            tracked_lfs = cull_instances(
+                tracked_lfs,
+                config.tracking_clean_instance_count,
+                config.tracking_clean_iou_threshold,
             )
+            if not config.post_connect_single_breaks:
+                tracked_lfs = connect_single_breaks(
+                    tracked_lfs, config.tracking_clean_instance_count
+                )
 
-    if not is_mask_mode and config.post_connect_single_breaks:
-        tracked_lfs = connect_single_breaks(
-            tracked_lfs, max_instances=config.tracking_target_instance_count
-        )
+        if not is_mask_mode and config.post_connect_single_breaks:
+            tracked_lfs = connect_single_breaks(
+                tracked_lfs, max_instances=config.tracking_target_instance_count
+            )
 
     return sio.Labels(
         labeled_frames=tracked_lfs,

--- a/sleap_nn/legacy_predict.py
+++ b/sleap_nn/legacy_predict.py
@@ -862,16 +862,14 @@ def run_inference(
                     lfs, tracking_clean_instance_count, tracking_clean_iou_threshold
                 )
                 if not post_connect_single_breaks:
-                    corrected_lfs = connect_single_breaks(
-                        lfs, tracking_clean_instance_count
-                    )
-            elif post_connect_single_breaks:
+                    lfs = connect_single_breaks(lfs, tracking_clean_instance_count)
+            if post_connect_single_breaks:
                 start_final_pass_time = time()
                 start_fp_timestamp = str(datetime.now())
                 logger.info(
                     f"Started final-pass (connecting single breaks) at: {start_fp_timestamp}"
                 )
-                corrected_lfs = connect_single_breaks(
+                lfs = connect_single_breaks(
                     lfs, max_instances=tracking_target_instance_count
                 )
                 finish_fp_timestamp = str(datetime.now())
@@ -880,11 +878,9 @@ def run_inference(
                     f"Finished final-pass (connecting single breaks) at: {finish_fp_timestamp}"
                 )
                 logger.info(f"Total runtime: {total_fp_elapsed} secs")
-            else:
-                corrected_lfs = lfs
 
             output = sio.Labels(
-                labeled_frames=corrected_lfs,
+                labeled_frames=lfs,
                 videos=output.videos,
                 skeletons=output.skeletons,
             )

--- a/sleap_nn/legacy_predict.py
+++ b/sleap_nn/legacy_predict.py
@@ -857,27 +857,30 @@ def run_inference(
 
         if tracking:
             lfs = [x for x in output]
-            if tracking_clean_instance_count > 0:
-                lfs = cull_instances(
-                    lfs, tracking_clean_instance_count, tracking_clean_iou_threshold
-                )
-                if not post_connect_single_breaks:
-                    lfs = connect_single_breaks(lfs, tracking_clean_instance_count)
-            if post_connect_single_breaks:
-                start_final_pass_time = time()
-                start_fp_timestamp = str(datetime.now())
-                logger.info(
-                    f"Started final-pass (connecting single breaks) at: {start_fp_timestamp}"
-                )
-                lfs = connect_single_breaks(
-                    lfs, max_instances=tracking_target_instance_count
-                )
-                finish_fp_timestamp = str(datetime.now())
-                total_fp_elapsed = time() - start_final_pass_time
-                logger.info(
-                    f"Finished final-pass (connecting single breaks) at: {finish_fp_timestamp}"
-                )
-                logger.info(f"Total runtime: {total_fp_elapsed} secs")
+            if not lfs:
+                logger.info("0 frames to track; skipping tracking post-processing.")
+            else:
+                if tracking_clean_instance_count > 0:
+                    lfs = cull_instances(
+                        lfs, tracking_clean_instance_count, tracking_clean_iou_threshold
+                    )
+                    if not post_connect_single_breaks:
+                        lfs = connect_single_breaks(lfs, tracking_clean_instance_count)
+                if post_connect_single_breaks:
+                    start_final_pass_time = time()
+                    start_fp_timestamp = str(datetime.now())
+                    logger.info(
+                        f"Started final-pass (connecting single breaks) at: {start_fp_timestamp}"
+                    )
+                    lfs = connect_single_breaks(
+                        lfs, max_instances=tracking_target_instance_count
+                    )
+                    finish_fp_timestamp = str(datetime.now())
+                    total_fp_elapsed = time() - start_final_pass_time
+                    logger.info(
+                        f"Finished final-pass (connecting single breaks) at: {finish_fp_timestamp}"
+                    )
+                    logger.info(f"Total runtime: {total_fp_elapsed} secs")
 
             output = sio.Labels(
                 labeled_frames=lfs,

--- a/sleap_nn/tracking/tracker.py
+++ b/sleap_nn/tracking/tracker.py
@@ -1757,6 +1757,10 @@ def run_tracker(
         logger.info("Tracking interrupted by user")
         raise KeyboardInterrupt
 
+    if not tracked_lfs:
+        logger.info("0 frames to track; skipping tracking post-processing.")
+        return tracked_lfs
+
     if tracking_clean_instance_count > 0:
         logger.info("Post-processing: Culling instances...")
         tracked_lfs = cull_instances(

--- a/sleap_nn/tracking/utils.py
+++ b/sleap_nn/tracking/utils.py
@@ -356,10 +356,10 @@ def cull_instances(
             only use score to determine which instances to remove.
 
     Returns:
-        None; modifies frames in place.
+        The (possibly empty) input `frames`, also modified in place.
     """
     if not frames:
-        return
+        return frames
 
     frames.sort(key=lambda lf: lf.frame_idx)
 

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -123,6 +123,31 @@ def test_apply_tracking_post_connect_requires_target_count(skeleton, video):
         apply_tracking(labels, cfg)
 
 
+def test_apply_tracking_zero_frames_with_clean_instance_count_does_not_crash(
+    skeleton, video
+):
+    """Regression: an empty ``labels.labeled_frames`` combined with
+    ``tracking_clean_instance_count`` used to reach ``cull_instances([])``,
+    which returned ``None`` instead of ``[]``, propagating into
+    ``sio.Labels(labeled_frames=None, ...)`` and crashing. ``apply_tracking``
+    should just skip post-processing and hand back an empty ``Labels``."""
+    labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[])
+    out = apply_tracking(labels, TrackerConfig(tracking_clean_instance_count=2))
+    assert isinstance(out, sio.Labels)
+    assert len(out.labeled_frames) == 0
+
+
+def test_apply_tracking_zero_frames_post_connect_requires_target_count_still_raises(
+    skeleton, video
+):
+    """Config validation happens before the frame-count check, so it must
+    still fire even when there happen to be 0 frames."""
+    labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[])
+    cfg = TrackerConfig(post_connect_single_breaks=True)
+    with pytest.raises(ValueError, match="tracking_target_instance_count"):
+        apply_tracking(labels, cfg)
+
+
 def test_apply_tracking_preserves_videos_and_skeletons(skeleton, video):
     labels = _make_labels(skeleton, video, frames=2, instances_per_frame=1)
     out = apply_tracking(labels, TrackerConfig())

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1433,6 +1433,61 @@ def test_topdown_predictor_with_tracking_cleaning(
     assert len(labels) < 10
 
 
+def test_tracking_clean_instance_count_with_post_connect_single_breaks(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_centered_instance_ckpt,
+    centered_instance_video,
+    tmp_path,
+):
+    """Regression test for corrected_lfs UnboundLocalError (sleap discussion #2820).
+
+    Combining `tracking_clean_instance_count` with `post_connect_single_breaks`
+    previously left `corrected_lfs` unassigned in `run_inference`'s tracking
+    cleanup block (the `elif post_connect_single_breaks` branch was never
+    reached because the outer `if tracking_clean_instance_count > 0` had
+    already matched), raising an UnboundLocalError. Both flags are meant to
+    compose (cull to target count, then repair single-frame track breaks).
+    """
+    # Both flags combined in a single inference + tracking call (the exact
+    # combination reported as crashing).
+    labels = run_inference(
+        model_paths=[
+            minimal_instance_centroid_ckpt,
+            minimal_instance_centered_instance_ckpt,
+        ],
+        data_path=centered_instance_video.as_posix(),
+        make_labels=True,
+        output_path=tmp_path / "test.slp",
+        max_instances=2,
+        peak_threshold=0.1,
+        frames=[x for x in range(0, 10)],
+        integral_refinement="integral",
+        tracking=True,
+        tracking_clean_instance_count=2,
+        post_connect_single_breaks=True,
+        tracking_target_instance_count=2,
+        device="cpu" if torch.backends.mps.is_available() else "auto",
+    )
+    for lf in labels:
+        assert len(lf.instances) <= 2
+
+    # Same combination in the track-only (retrack an existing .slp) path.
+    labels.save(f"{tmp_path}/preds.slp")
+    tracked_labels = run_inference(
+        data_path=f"{tmp_path}/preds.slp",
+        tracking=True,
+        tracking_clean_instance_count=2,
+        post_connect_single_breaks=True,
+        tracking_target_instance_count=2,
+        max_instances=2,
+        integral_refinement=None,
+        device="cpu" if torch.backends.mps.is_available() else "auto",
+    )
+    assert len(tracked_labels) == 10
+    for lf in tracked_labels:
+        assert len(lf.instances) <= 2
+
+
 def test_video_index_output_path(
     minimal_instance,
     minimal_instance_centered_instance_ckpt,

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1488,6 +1488,34 @@ def test_tracking_clean_instance_count_with_post_connect_single_breaks(
         assert len(lf.instances) <= 2
 
 
+def test_tracking_zero_frames_with_clean_instance_count_does_not_crash(
+    minimal_instance, tmp_path
+):
+    """Regression: 0 predicted frames reaching the tracking block combined
+    with `tracking_clean_instance_count` used to reach `cull_instances([])`,
+    which returned `None` instead of `[]`, propagating into
+    `sio.Labels(labeled_frames=None, ...)` and raising a `TypeError`.
+    `run_inference` should just skip tracking post-processing and return an
+    empty `sio.Labels`.
+    """
+    base = sio.load_slp(minimal_instance.as_posix())
+    empty_labels = sio.Labels(
+        labeled_frames=[], videos=base.videos, skeletons=base.skeletons
+    )
+
+    out = run_inference(
+        input_labels=empty_labels,
+        tracking=True,
+        tracking_clean_instance_count=1,
+        integral_refinement=None,
+        device="cpu" if torch.backends.mps.is_available() else "auto",
+        make_labels=True,
+        output_path=tmp_path / "test.slp",
+    )
+    assert isinstance(out, sio.Labels)
+    assert len(out) == 0
+
+
 def test_video_index_output_path(
     minimal_instance,
     minimal_instance_centered_instance_ckpt,

--- a/tests/tracking/test_tracker.py
+++ b/tests/tracking/test_tracker.py
@@ -709,6 +709,21 @@ def test_post_clean_up(
     assert len(tracked_lfs[0].instances) == 1
 
 
+def test_run_tracker_zero_frames_with_clean_instance_count_returns_empty_list():
+    """Regression: an empty ``untracked_frames`` combined with
+    ``tracking_clean_instance_count`` used to reach ``cull_instances([])``,
+    which returned ``None`` instead of ``[]`` -- silently propagated through
+    (no crash, but ``run_tracker`` returned ``None`` instead of a list).
+    ``run_tracker`` should just skip post-processing and return ``[]``."""
+    tracked_lfs = run_tracker(
+        untracked_frames=[],
+        max_tracks=2,
+        candidates_method="local_queues",
+        tracking_clean_instance_count=1,
+    )
+    assert tracked_lfs == []
+
+
 def test_get_scores_robust_quantile_honors_best_instance():
     """`robust_quantile` reduction must use the per-instance `robust_best_instance`.
 


### PR DESCRIPTION
## Summary

- Fixes an `UnboundLocalError: cannot access local variable 'corrected_lfs'` in `sleap_nn/legacy_predict.py`'s `run_inference`, reported in [talmolab/sleap discussion #2820](https://github.com/talmolab/sleap/discussions/2820).
- Triggered by combining `--tracking_clean_instance_count N` (N > 0) with `--post_connect_single_breaks` — a legitimate combination (cull to target instance count, then repair single-frame track breaks caused by e.g. an occluded anchor node), not user error.
- Still live on `main` today: `sleap-nn track` (and the `sleap` frontend's `sleap track`, which shells out to it) always uses this legacy pipeline.
- **Also fixes a related, separately-discovered bug**: tracking on an empty frame list (e.g. `--frames`/filters that resolve to 0 frames) combined with `tracking_clean_instance_count` crashed (or, in one case, silently returned `None`) instead of just skipping tracking. See "Second fix" below.

## Root cause (corrected_lfs)

The tracking-cleanup block in `run_inference` used an `if`/`elif`/`else` chain to assign `corrected_lfs`:

```python
if tracking_clean_instance_count > 0:
    lfs = cull_instances(...)
    if not post_connect_single_breaks:
        corrected_lfs = connect_single_breaks(lfs, tracking_clean_instance_count)
elif post_connect_single_breaks:
    corrected_lfs = connect_single_breaks(lfs, max_instances=tracking_target_instance_count)
else:
    corrected_lfs = lfs

output = sio.Labels(labeled_frames=corrected_lfs, ...)  # crashes here
```

Of the 4 possible combinations of `(tracking_clean_instance_count > 0, post_connect_single_breaks)`, exactly one falls through every branch without assigning `corrected_lfs`: both `True`. The outer `if` claims the branch (since `tracking_clean_instance_count > 0`), the inner `if not post_connect_single_breaks` guard skips its assignment (since `post_connect_single_breaks` is `True`), and the `elif` — the only branch that assigns `corrected_lfs` for `post_connect_single_breaks=True` — is never reached because the outer `if` already matched.

This is purely an implementation bug, not a misuse of flags. Proof: the newer, already-fixed pipeline (`sleap_nn/inference/tracking.py::apply_tracking`, introduced in the #508/#530 inference-refactor) implements the identical cleanup using two **independent** `if` statements instead of `if`/`elif`, reassigning a single `tracked_lfs` variable throughout — and `sleap_nn/tracking/tracker.py::run_tracker` (a third, independent call site) already used the same correct pattern too. So it was 2-for-3 correct in the codebase; this PR makes it 3-for-3.

That fix was never backported to `legacy_predict.py`, which is still what `sleap-nn track`'s CLI command uses unconditionally (`sleap_nn/cli.py`'s `track` command is explicitly documented as "legacy pipeline").

## Fix (corrected_lfs)

- `sleap_nn/legacy_predict.py`: mirrored the `apply_tracking` pattern — changed `elif post_connect_single_breaks:` to an independent `if post_connect_single_breaks:`, and replaced the separate `corrected_lfs` variable with in-place reassignments of `lfs` (dropping the now-redundant `else: corrected_lfs = lfs`). Purely a control-flow fix; no change to `cull_instances`/`connect_single_breaks` themselves.

## Second fix: 0-frame tracking crash/silent-`None`

While verifying edge cases around the fix above, found that none of the three call sites that compose `cull_instances` + `connect_single_breaks` (`legacy_predict.run_inference`, `inference/tracking.apply_tracking`, `tracking/tracker.run_tracker`) guard against an **empty frame list** reaching the cleanup block. `cull_instances` returns `None` (not `[]`) for empty input (its own `if not frames: return` bug), which then:
- propagates through `connect_single_breaks` (which correctly returns `[]` unchanged for empty input, but passes through an existing `None` untouched), and
- crashes downstream reconstructing `sio.Labels(labeled_frames=None, ...)` → `TypeError: 'NoneType' object is not iterable` (in `legacy_predict.py` and `apply_tracking`), or
- in `run_tracker`, doesn't crash at all — it silently **returns `None` instead of `[]`**, a worse "silent data corruption" version of the same bug (any caller that expects a list and does `len(...)` on it downstream would break somewhere else, with no clear link back to the cause).

This is reachable whenever inference/filtering produces 0 frames but `tracking=True` still runs (e.g. `--frames` resolving to no matching indices, or filter flags like `--only_predicted_frames` zeroing out every frame) combined with `tracking_clean_instance_count > 0`. Unrelated to the `post_connect_single_breaks` combination above — this hits regardless of that flag.

Fix: added an explicit `if not lfs: log a note; skip cleanup` guard at the top of the cleanup block in all three call sites, and fixed `cull_instances`'s own empty-list branch to `return frames` instead of an implicit `None`, as defense in depth for any other caller. Where `post_connect_single_breaks`'s config validation (`ValueError` if `tracking_target_instance_count` isn't set) happens *inside* the same block (`run_tracker`), the guard was placed to only skip the actual cull/connect *work*, not the eager config validation — confirmed with a dedicated test that the `ValueError` still fires even with 0 frames.

## Testing

- Added `tests/test_predict.py::test_tracking_clean_instance_count_with_post_connect_single_breaks`, exercising the exact previously-crashing `corrected_lfs` combination in both a single full inference + tracking call and the track-only (retrack an existing `.slp`) path.
- Added three 0-frames regression tests, one per call site:
  - `tests/test_predict.py::test_tracking_zero_frames_with_clean_instance_count_does_not_crash`
  - `tests/tracking/test_tracker.py::test_run_tracker_zero_frames_with_clean_instance_count_returns_empty_list`
  - `tests/inference/test_tracking.py::test_apply_tracking_zero_frames_with_clean_instance_count_does_not_crash`
  - plus `tests/inference/test_tracking.py::test_apply_tracking_zero_frames_post_connect_requires_target_count_still_raises` (confirms the eager validation ordering wasn't disturbed).
- Verified every new test is a *real* regression guard, not a false positive: isolated each fix via `git stash` on just the source files, confirmed each test fails with the exact reported/expected error against the pre-fix code (including confirming `run_tracker` silently returned `None` pre-fix, not just "didn't crash"), then passes once patched.
- Went a step further on the `corrected_lfs` fix: built a synthetic scenario that triggers both cleanup effects at once (a spurious low-score instance to cull + a genuine single-frame track break to repair), confirmed both actually applied in the correct order, and confirmed the output is byte-for-byte identical to independently running the same scenario through `run_tracker`'s already-shipped equivalent logic.
- Ran the full existing `tests/test_predict.py`, `tests/tracking/`, and `tests/inference/test_tracking.py` suites (covering all previously-working flag combinations) to confirm no behavior change there.
- Ran `tests/test_cli.py` + `tests/cli/` + `tests/inference/` (950 tests) and the full project suite (`pytest tests/`): **2131 passed, 138 skipped, 4 xfailed, 0 failed**.
- `black`/`ruff` clean on all changed source files (pre-existing, unrelated docstring lint issues in `tests/test_predict.py` confirmed present on `main` too, via diffing against the unpatched file).

## Related

- Discussion: https://github.com/talmolab/sleap/discussions/2820 (the reporter's exact quoted flags, `--tracking_target_instance_count 2 --tracking_clean_instance_count 2`, don't alone trigger the `corrected_lfs` crash — `--post_connect_single_breaks` must also be set, most likely present in their real command and dropped from the paraphrase, since reconnecting single-frame track breaks is exactly what they need to recover instances lost to anchor-node occlusion, the main subject of their post).
- Not in scope: the same discussion also flags `--use_flow` tracking running CPU-only; not investigated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)