### PR TITLE
feat: verify trainer_accelerator is available before training

### DIFF
--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -893,6 +893,48 @@ class ModelTrainer:
                             f"Updating data preprocessing to ensure_rgb to True based on the pretrained model weights."
                         )
 
+    def _verify_accelerator_config(self):
+        """Verify the configured `trainer_accelerator` is available on this machine.
+
+        A saved training config may have been created on a different machine (e.g.
+        `trainer_accelerator: mps` from a Mac, reloaded on a Linux/CUDA box). Passing an
+        unavailable accelerator straight to `lightning.Trainer` raises deep inside
+        `train()`, after dataset/ckpt setup has already run. This check runs early
+        (from `setup_config()`) and falls back to `"auto"` on a mismatch instead,
+        letting the existing device-count resolution logic pick the right backend.
+        """
+        accelerator = self.config.trainer_config.trainer_accelerator
+
+        if accelerator in ("auto", "cpu"):
+            return
+
+        if accelerator in ("gpu", "cuda"):
+            available = torch.cuda.is_available()
+        elif accelerator == "mps":
+            available = (
+                hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+            )
+        else:
+            logger.info(
+                f"Configured accelerator '{accelerator}' is not a recognized option; "
+                "changing it to 'auto' (Lightning will select the best available device)."
+            )
+            self.config.trainer_config.trainer_accelerator = "auto"
+            return
+
+        if available:
+            logger.info(
+                f"Configured accelerator '{accelerator}' is available on this machine "
+                "and will be used."
+            )
+        else:
+            logger.info(
+                f"Configured accelerator '{accelerator}' is not available on this "
+                "machine; changing it to 'auto' (Lightning will select the best "
+                "available device)."
+            )
+            self.config.trainer_config.trainer_accelerator = "auto"
+
     def setup_config(self):
         """Compute config parameters."""
         logger.info("Setting up config...")
@@ -936,6 +978,9 @@ class ModelTrainer:
         # auto-size + validate tiling geometry (no-op unless tiling.enabled)
         self._setup_tiling_config()
         self.config = check_tiling(self.config)
+
+        # verify the configured accelerator is available on this machine
+        self._verify_accelerator_config()
 
         # if trainer_devices is None, set it to "auto"
         if self.config.trainer_config.trainer_devices is None:

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -1247,6 +1247,75 @@ def test_head_config_oneof_validation_error_no_head(config, caplog):
         ModelTrainer.get_model_trainer_from_config(config_no_head)
 
 
+def test_verify_accelerator_config_noop_for_auto_and_cpu(config):
+    """Test that 'auto' and 'cpu' accelerators are always left untouched."""
+    for value in ("auto", "cpu"):
+        cfg = config.copy()
+        OmegaConf.update(cfg, "trainer_config.trainer_accelerator", value)
+        trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+        assert trainer.config.trainer_config.trainer_accelerator == value
+
+
+def test_verify_accelerator_config_keeps_available_accelerator(config, caplog):
+    """Test that a configured accelerator that IS available on this machine is kept."""
+    from unittest.mock import patch
+
+    cfg = config.copy()
+    OmegaConf.update(cfg, "trainer_config.trainer_accelerator", "mps")
+
+    with patch("torch.backends.mps.is_available", return_value=True):
+        trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+
+    assert trainer.config.trainer_config.trainer_accelerator == "mps"
+    assert "'mps' is available on this machine and will be used" in caplog.text
+
+
+def test_verify_accelerator_config_falls_back_when_mps_unavailable(config, caplog):
+    """Test that 'mps' falls back to 'auto' when MPS is not available on this machine.
+
+    Reproduces the reported bug: a config trained on a Mac (`trainer_accelerator: mps`)
+    reloaded on a Linux/CUDA (or CPU-only) machine should not crash Lightning's `Trainer`
+    with an unavailable accelerator; it should fall back to `"auto"` instead.
+    """
+    from unittest.mock import patch
+
+    cfg = config.copy()
+    OmegaConf.update(cfg, "trainer_config.trainer_accelerator", "mps")
+
+    with patch("torch.backends.mps.is_available", return_value=False):
+        trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+
+    assert trainer.config.trainer_config.trainer_accelerator == "auto"
+    assert "'mps' is not available on this machine" in caplog.text
+    assert "changing it to 'auto'" in caplog.text
+
+
+def test_verify_accelerator_config_falls_back_when_cuda_unavailable(config, caplog):
+    """Test that 'gpu'/'cuda' fall back to 'auto' when CUDA is not available."""
+    from unittest.mock import patch
+
+    for value in ("gpu", "cuda"):
+        cfg = config.copy()
+        OmegaConf.update(cfg, "trainer_config.trainer_accelerator", value)
+
+        with patch("torch.cuda.is_available", return_value=False):
+            trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+
+        assert trainer.config.trainer_config.trainer_accelerator == "auto"
+        assert f"'{value}' is not available on this machine" in caplog.text
+
+
+def test_verify_accelerator_config_unrecognized_value_falls_back(config, caplog):
+    """Test that an unrecognized accelerator string falls back to 'auto'."""
+    cfg = config.copy()
+    OmegaConf.update(cfg, "trainer_config.trainer_accelerator", "tpu")
+
+    trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+
+    assert trainer.config.trainer_config.trainer_accelerator == "auto"
+    assert "not a recognized option" in caplog.text
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("li")
     and not torch.cuda.is_available(),  # self-hosted GPUs have linux os but cuda is available, so will do test


### PR DESCRIPTION
## Summary
- A saved training config may have been created on a different machine (e.g. `trainer_accelerator: mps` from a Mac), then reloaded and re-run on a Linux+CUDA or CPU-only box. Today that stale value is passed straight to `lightning.Trainer(accelerator=...)` with zero validation, raising a `MisconfigurationException` deep inside `ModelTrainer.train()` — *after* dataset setup, ckpt dir creation, and viz dataset setup have already run.
- Adds `ModelTrainer._verify_accelerator_config()`, called early from `setup_config()`, which checks the configured accelerator against real device availability and either confirms it or falls back to `"auto"` with a log note, so the existing "auto" device-count resolution logic (unchanged) picks the right backend downstream.

## Changes Made
- `sleap_nn/training/model_trainer.py`:
  - New `ModelTrainer._verify_accelerator_config()`:
    - `"auto"` / `"cpu"` always pass through unchanged (no-op).
    - `"gpu"` / `"cuda"` require `torch.cuda.is_available()`.
    - `"mps"` requires `torch.backends.mps.is_available()`.
    - Any other/unrecognized string is treated as invalid.
    - If available: logs an info line confirming it will be used.
    - If not available: mutates `self.config.trainer_config.trainer_accelerator = "auto"` and logs an info line noting the fallback.
  - Wired into `setup_config()` right before the existing `trainer_devices` `None` → `"auto"` normalization step.
- `tests/training/test_model_trainer.py`: 5 new tests —
  - `test_verify_accelerator_config_noop_for_auto_and_cpu`
  - `test_verify_accelerator_config_keeps_available_accelerator`
  - `test_verify_accelerator_config_falls_back_when_mps_unavailable` (reproduces the reported bug directly)
  - `test_verify_accelerator_config_falls_back_when_cuda_unavailable`
  - `test_verify_accelerator_config_unrecognized_value_falls_back`

## Example Usage
No API change — this runs automatically as part of `ModelTrainer.get_model_trainer_from_config()` / `setup_config()`, which every training entry point (`sleap-nn train` CLI, `sleap_nn.train.train()`, GUI-launched subprocess training) already goes through.

Example log output when a Mac-trained config (`trainer_accelerator: mps`) is reloaded on a Linux+CUDA machine:
```
Configured accelerator 'mps' is not available on this machine; changing it to 'auto' (Lightning will select the best available device).
```
And when the configured accelerator is valid:
```
Configured accelerator 'cuda' is available on this machine and will be used.
```

## Design Decisions
- Placed the check in `setup_config()` (not directly before `L.Trainer(...)` construction) so it runs as early as possible — before ckpt dir creation and dataset setup — following the same "silently correct + `logger.info()`" pattern already used by `_verify_model_input_channels()` in this file.
- Falls back to `"auto"` rather than raising, per the request: this is meant to keep training running smoothly across machines rather than hard-failing on a stale config field.
- Does not touch `trainer_devices`/`trainer_device_indices` — those already have their own "auto" normalization/validation, which correctly branches on real CUDA/MPS availability today.
- Reuses real-time `torch.cuda.is_available()`/`torch.backends.mps.is_available()` checks (same primitives already used elsewhere in this file and in `sleap_nn/system_info.py`) rather than introducing a new detection utility.

## Testing
- `uv run pytest tests/training/test_model_trainer.py -q` → 33 passed.
- `uv run pytest tests/training/ -q` → 246 passed.
- `uv run black --check sleap_nn tests` / `uv run ruff check sleap_nn/` → clean (scoped to changed files).

## Related
Companion GUI-side fix: [talmolab/sleap#2830](https://github.com/talmolab/sleap/pull/2830), which stops `TrainingEditorWidget._load_config` from carrying a stale `trainer_accelerator` value into the dropdown when reloading a saved profile on a different machine. This PR is the backend guard that protects every training path (GUI subprocess, direct CLI usage, scripts) regardless of what the GUI does.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)