### PR TITLE
fix: honor predict-time --max_instances override in CentroidLayer

### DIFF
--- a/sleap_nn/inference/layers/centroid.py
+++ b/sleap_nn/inference/layers/centroid.py
@@ -148,8 +148,13 @@ class CentroidLayer(InferenceLayer):
             torch.ones((B, n_valid), device=device),
         )
 
-        # Honor ``self.max_instances`` cap; pad-with-NaN or truncate to it.
-        max_inst = self.max_instances or n_valid
+        # Honor max_instances cap; pad-with-NaN or truncate to it.
+        # Prefer predict-time override (postprocess_config) over build-time value.
+        max_inst = (
+            getattr(self.postprocess_config, "max_instances", None)
+            or self.max_instances
+            or n_valid
+        )
         if max_inst > n_valid:
             pad_n = max_inst - n_valid
             centroids = torch.cat(
@@ -212,7 +217,11 @@ class CentroidLayer(InferenceLayer):
         # Batch size from confmaps shape (always available on the torch path).
         B = int(confmaps.shape[0])
 
-        max_instances = self.max_instances or self._infer_max_instances(sample_inds)
+        max_instances = (
+            getattr(self.postprocess_config, "max_instances", None)
+            or self.max_instances
+            or self._infer_max_instances(sample_inds)
+        )
         if max_instances == 0:
             max_instances = 1  # always emit at least one slot for shape stability
 

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -550,6 +550,10 @@ def predict(
             build_kwargs["preprocess_config"] = preprocess_config
         if anchor_part is not None:
             build_kwargs["anchor_part"] = anchor_part
+        if peak_threshold is not None:
+            build_kwargs["peak_threshold"] = peak_threshold
+        if max_instances is not None:
+            build_kwargs["max_instances"] = max_instances
         if centroid_only:
             build_kwargs["centroid_only"] = True
         if emit_centroid != "instance":

--- a/tests/inference/layers/test_centroid.py
+++ b/tests/inference/layers/test_centroid.py
@@ -42,6 +42,19 @@ DATA_ROOT = Path(__file__).resolve().parents[3] / "tests" / "assets" / "datasets
 PARITY_ATOL = 1e-4
 PARITY_RTOL = 1e-5
 
+
+class _StubBackend:
+    """Minimal stub satisfying the ``ModelBackend`` runtime protocol."""
+
+    device = "cpu"
+    does_baked_postproc = False
+
+    def __call__(self, x):
+        return {}
+
+    def warmup(self, input_shape):
+        return None
+
 NEUTRAL_PREPROCESS = OmegaConf.create(
     {
         "ensure_rgb": None,
@@ -197,3 +210,100 @@ def test_return_confmaps_true_populates_field():
     out = layer.predict(np.zeros((1, 1, 384, 384), dtype=np.float32))
     assert out.pred_confmaps is not None
     assert out.pred_confmaps.ndim == 4  # (B, N, H, W)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 6. Predict-time max_instances override (sleap#2831)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_postprocess_config_max_instances_override():
+    """A predict-time max_instances override on postprocess_config is honored.
+
+    Regression test for talmolab/sleap#2831: CentroidLayer.postprocess()
+    read ``self.max_instances`` (frozen at __init__) instead of
+    ``self.postprocess_config.max_instances`` (set by _postprocess_overrides),
+    so predict-time --max_instances had no effect.
+    """
+    layer = CentroidLayer(
+        backend=_StubBackend(),
+        output_stride=1,
+        max_instances=None,
+        postprocess_config=PostprocessConfig(max_instances=None),
+    )
+
+    # Simulate 5 raw detections across 1 frame by calling postprocess directly.
+    B, n_peaks = 1, 5
+    device = torch.device("cpu")
+    raw_peaks = torch.rand(n_peaks, 2, device=device)
+    raw_vals = torch.rand(n_peaks, device=device)
+    sample_inds = torch.zeros(n_peaks, dtype=torch.long, device=device)
+
+    # Monkey-patch _extract_confmaps and find_local_peaks to inject detections.
+    import sleap_nn.inference.layers.centroid as centroid_mod
+    from sleap_nn.inference.preprocess_info import PreprocInfo
+
+    original_find = centroid_mod.find_local_peaks
+
+    def fake_find(confmaps, threshold, refinement, integral_patch_size):
+        channel_inds = torch.zeros(n_peaks, dtype=torch.long)
+        return raw_peaks, raw_vals, sample_inds, channel_inds
+
+    centroid_mod.find_local_peaks = fake_find
+    layer._extract_confmaps = lambda raw_out: torch.zeros(B, 1, 8, 8)
+
+    info = PreprocInfo(
+        original_size=(8, 8),
+        processed_size=(8, 8),
+        eff_scale=torch.ones(B),
+        input_scale=1.0,
+        output_stride=1,
+    )
+
+    try:
+        # Without override: all 5 detections survive.
+        out_all = layer.postprocess({}, info)
+        assert out_all.pred_centroids.shape[1] == n_peaks
+
+        # Apply predict-time override to cap at 2.
+        import attrs
+
+        layer.postprocess_config = attrs.evolve(
+            layer.postprocess_config, max_instances=2
+        )
+        out_capped = layer.postprocess({}, info)
+        assert out_capped.pred_centroids.shape[1] == 2
+    finally:
+        centroid_mod.find_local_peaks = original_find
+
+
+def test_predict_from_gt_respects_postprocess_config_max_instances():
+    """_predict_from_gt honors postprocess_config.max_instances override.
+
+    Same root cause as the postprocess path (sleap#2831): the GT path
+    read ``self.max_instances`` instead of ``self.postprocess_config``.
+    """
+    layer = CentroidLayer(
+        backend=_StubBackend(),
+        output_stride=1,
+        max_instances=None,
+        use_gt_centroids=True,
+        postprocess_config=PostprocessConfig(max_instances=None),
+    )
+
+    # 1 frame, 4 GT instances, 2 nodes each.
+    instances = torch.rand(1, 4, 2, 2)
+    image = torch.zeros(1, 1, 8, 8)
+
+    # Without override: all 4 GT centroids survive.
+    out_all = layer.predict(image, instances=instances)
+    assert out_all.pred_centroids.shape[1] == 4
+
+    # Apply predict-time override to cap at 2.
+    import attrs
+
+    layer.postprocess_config = attrs.evolve(
+        layer.postprocess_config, max_instances=2
+    )
+    out_capped = layer.predict(image, instances=instances)
+    assert out_capped.pred_centroids.shape[1] == 2

--- a/tests/inference/layers/test_centroid.py
+++ b/tests/inference/layers/test_centroid.py
@@ -55,6 +55,7 @@ class _StubBackend:
     def warmup(self, input_shape):
         return None
 
+
 NEUTRAL_PREPROCESS = OmegaConf.create(
     {
         "ensure_rgb": None,
@@ -302,8 +303,6 @@ def test_predict_from_gt_respects_postprocess_config_max_instances():
     # Apply predict-time override to cap at 2.
     import attrs
 
-    layer.postprocess_config = attrs.evolve(
-        layer.postprocess_config, max_instances=2
-    )
+    layer.postprocess_config = attrs.evolve(layer.postprocess_config, max_instances=2)
     out_capped = layer.predict(image, instances=instances)
     assert out_capped.pred_centroids.shape[1] == 2


### PR DESCRIPTION
## Summary

Fixes talmolab/sleap#2831

`--max_instances` / `-n` passed to `sleap-nn predict` had no effect on centroid-only or top-down models. The root cause was that `CentroidLayer.postprocess()` and `_predict_from_gt()` read `self.max_instances` (frozen at `__init__`) instead of `self.postprocess_config.max_instances` (which is what `Predictor._postprocess_overrides` sets at predict time). This is the same bug that was fixed in `BottomUpLayer` and `BottomUpMultiClassLayer` in #582, but `CentroidLayer` was missed.

### Changes

- **`sleap_nn/inference/layers/centroid.py`**: Both `postprocess()` and `_predict_from_gt()` now read `self.postprocess_config.max_instances` first, falling back to `self.max_instances`, matching the pattern already used in `BottomUpLayer`, `BottomUpMultiClassLayer`, and `SegmentationLayer`.
- **`sleap_nn/inference/run.py`**: Forward `peak_threshold` and `max_instances` into `build_kwargs` for the checkpoint (`model_paths`) branch, so the "Loaded inference model" startup log reflects the actual user-specified values instead of always printing defaults.
- **`tests/inference/layers/test_centroid.py`**: Two regression tests verifying the override is honored on both the model path (`postprocess()`) and the GT path (`_predict_from_gt()`).

## Test plan

- [x] `test_postprocess_config_max_instances_override` — builds a `CentroidLayer` with `max_instances=None`, injects 5 detections, applies a predict-time override of `max_instances=2`, asserts output is capped at 2
- [x] `test_predict_from_gt_respects_postprocess_config_max_instances` — same pattern for the GT-centroids path with 4 GT instances capped to 2
- [x] All 8 existing centroid layer tests pass
- [x] All 28 `test_run.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)