### PR TITLE
fix(infer): restore CPU decode / GPU inference overlap in predict pipeline

### DIFF
--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -848,7 +848,8 @@ class Predictor:
             PAF grouping stage. ``0`` (default) runs grouping inline in
             the main process — the parity path. ``>0`` is only honored
             when ``layer`` is a :class:`BottomUpLayer`; for any other
-            layer type the value is ignored.
+            layer type the value is ignored (with a logged warning, since
+            other model types have no equivalent pipelined CPU stage yet).
         tracker_config: Optional :class:`TrackerConfig`. When set,
             :meth:`predict` runs the tracker on the resulting
             ``sio.Labels`` (requires ``make_labels=True``) before
@@ -873,6 +874,24 @@ class Predictor:
     # Centroid-only output representation: "instance" (default; single-node
     # PredictedInstance), "centroid" (sio.PredictedCentroid), or "both".
     emit_centroid: str = "instance"
+
+    def __attrs_post_init__(self) -> None:
+        """Warn (once) if ``paf_workers`` was set on a layer that can't use it.
+
+        ``paf_workers > 0`` only pipelines the CPU-bound grouping stage for
+        plain bottom-up (:class:`BottomUpLayer`); every other layer type
+        (including :class:`BottomUpMultiClassLayer`, which has its own
+        CPU-bound Hungarian-matching identity step) silently ignores the
+        setting today. Without this, that's an easy-to-miss no-op — a user
+        expecting a speedup gets none, with no signal why.
+        """
+        if self.paf_workers > 0 and not self._can_pipeline():
+            logger.warning(
+                f"paf_workers={self.paf_workers} was set, but pipelined CPU "
+                f"grouping is only implemented for plain bottom-up models. "
+                f"layer={type(self.layer).__name__} will run the inline "
+                "(unpipelined) path; paf_workers has no effect here."
+            )
 
     @property
     def filter_pipeline(self) -> FilterPipeline:

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -20,6 +20,9 @@ Three concrete implementations:
 
 from __future__ import annotations
 
+import queue
+import threading
+from copy import deepcopy
 from typing import TYPE_CHECKING, Iterator, Optional, Protocol, Union
 
 import attrs
@@ -28,6 +31,25 @@ import torch
 
 if TYPE_CHECKING:
     import sleap_io as sio
+
+
+# Sentinel marking end-of-stream on a prefetch queue; a plain `object()` so it
+# can never collide with a real `Batch` or exception payload.
+_SENTINEL = object()
+
+
+class _ProducerError:
+    """Wraps an exception raised on a prefetch thread for queue delivery.
+
+    `queue.Queue` has no notion of an error channel, so an exception raised
+    while decoding on the background thread is boxed and put on the queue
+    like any other item; the consumer unwraps and re-raises it. Without this,
+    a mid-stream decode failure would look identical to a clean end-of-stream
+    (the failure mode the legacy `VideoReader`/`LabelsReader` had).
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
 
 
 @attrs.frozen
@@ -103,6 +125,16 @@ class VideoProvider:
             ``sio.load_video`` when ``video`` is a URL (e.g.
             ``{"headers": {...}, "stream_mode": "..."}``). Ignored for local
             paths and pre-loaded ``sio.Video`` instances.
+        prefetch: If ``True`` (default), decode frames on a background
+            thread into a bounded queue so CPU decode overlaps the GPU
+            forward pass on the consuming (main) thread, instead of
+            blocking on decode between batches. Set ``False`` to fall back
+            to synchronous, in-line reading (e.g. for deterministic
+            single-threaded debugging).
+        queue_maxsize: Bound on how many decoded batches may sit in the
+            prefetch queue ahead of the consumer. Kept small and explicit
+            (like ``paf_workers``' ``max_in_flight``) so a fast decoder
+            can't race far ahead of a slow GPU stage and balloon memory.
 
     Notes:
         Yields raw ``(B, H, W, C)`` frames as ``np.uint8``. The
@@ -116,6 +148,8 @@ class VideoProvider:
     dataset: Optional[str] = None
     input_format: Optional[str] = None
     remote_kwargs: Optional[dict] = None
+    prefetch: bool = True
+    queue_maxsize: int = 4
 
     _sio_video: "Optional[sio.Video]" = attrs.field(
         default=None, init=False, repr=False
@@ -143,17 +177,94 @@ class VideoProvider:
             list(self.frames) if self.frames is not None else list(range(n_frames))
         )
 
-    def __iter__(self) -> Iterator[Batch]:
-        """Read frames in batches of ``batch_size`` and yield them."""
+    def _read_batches(self, video: "sio.Video") -> Iterator[Batch]:
+        """Read frames from ``video`` in batches of ``batch_size``.
+
+        Takes the source video as a parameter (rather than always reading
+        ``self._sio_video``) so the prefetch thread in ``__iter__`` can pass
+        in its own private, thread-local copy instead of sharing a backend
+        handle with the main thread.
+        """
         for start in range(0, len(self._frame_indices), self.batch_size):
             stop = min(start + self.batch_size, len(self._frame_indices))
             chunk_inds = self._frame_indices[start:stop]
-            frames = np.stack([self._sio_video[i] for i in chunk_inds], axis=0)
+            frames = np.stack([video[i] for i in chunk_inds], axis=0)
             yield Batch(
                 images=frames,
                 frame_indices=np.asarray(chunk_inds, dtype=np.int64),
                 video_indices=np.zeros(len(chunk_inds), dtype=np.int64),
             )
+
+    def _thread_local_video(self) -> "sio.Video":
+        """Return a private ``sio.Video`` copy for the prefetch thread.
+
+        Video backends (OpenCV/ffmpeg/HDF5) cache a single stateful reader
+        handle and are not safe for concurrent seek+read from two threads —
+        sharing ``self._sio_video`` with the background thread can silently
+        return the wrong frame. Closing first drops the cached handle so
+        ``deepcopy`` clones cheap (path + config) state rather than a live
+        handle; both the original and the copy lazily reopen independent
+        handles on next access.
+        """
+        self._sio_video.close()
+        return deepcopy(self._sio_video)
+
+    def _prefetch_worker(
+        self, video: "sio.Video", q: "queue.Queue", stop_event: threading.Event
+    ) -> None:
+        """Decode batches from ``video`` onto ``q`` until exhausted or stopped."""
+        try:
+            for batch in self._read_batches(video):
+                while True:
+                    if stop_event.is_set():
+                        return
+                    try:
+                        q.put(batch, timeout=0.5)
+                        break
+                    except queue.Full:
+                        continue
+        except BaseException as exc:  # noqa: BLE001 - forwarded to the consumer
+            q.put(_ProducerError(exc))
+            return
+        q.put(_SENTINEL)
+
+    def __iter__(self) -> Iterator[Batch]:
+        """Read frames in batches of ``batch_size`` and yield them.
+
+        When ``prefetch=True`` (default), decoding happens on a background
+        thread reading from a private video copy, overlapping CPU decode of
+        the next batch with GPU inference on the current one. The thread is
+        started here (not at construction) so multi-source callers like
+        ``MultiVideoProvider`` only ever have one video being decoded ahead
+        of time, matching today's sequential, one-source-at-a-time behavior.
+        """
+        if not self.prefetch:
+            yield from self._read_batches(self._sio_video)
+            return
+
+        thread_video = self._thread_local_video()
+        q: "queue.Queue" = queue.Queue(maxsize=self.queue_maxsize)
+        stop_event = threading.Event()
+        thread = threading.Thread(
+            target=self._prefetch_worker,
+            args=(thread_video, q, stop_event),
+            daemon=True,
+        )
+        thread.start()
+        try:
+            while True:
+                item = q.get()
+                if item is _SENTINEL:
+                    return
+                if isinstance(item, _ProducerError):
+                    raise item.exc
+                yield item
+        finally:
+            # Unblock the worker if the consumer stops early (exception,
+            # break, or GeneratorExit on partial iteration) so it doesn't
+            # hang forever on a full queue with no one draining it.
+            stop_event.set()
+            thread.join(timeout=5.0)
 
     def __len__(self) -> int:
         """Number of batches; ``ceil(len(frames) / batch_size)``."""
@@ -203,6 +314,12 @@ class LabelsProvider:
             ``sio.load_slp`` when ``labels`` is a URL (e.g.
             ``{"headers": {...}, "stream_mode": "..."}``). Ignored for local
             paths and pre-loaded ``sio.Labels`` instances.
+        prefetch: If ``True`` (default), decode frame images on a background
+            thread into a bounded queue so CPU decode overlaps the GPU
+            forward pass, instead of blocking on decode between batches.
+            See :class:`VideoProvider` for the same mechanism.
+        queue_maxsize: Bound on how many decoded batches may sit in the
+            prefetch queue ahead of the consumer.
     """
 
     labels: "Union[str, sio.Labels]"
@@ -212,6 +329,8 @@ class LabelsProvider:
     exclude_user_labeled: bool = False
     only_predicted_frames: bool = False
     remote_kwargs: Optional[dict] = None
+    prefetch: bool = True
+    queue_maxsize: int = 4
 
     _sio_labels: "Optional[sio.Labels]" = attrs.field(
         default=None, init=False, repr=False
@@ -290,7 +409,7 @@ class LabelsProvider:
                 )
         return out
 
-    def __iter__(self) -> Iterator[Batch]:
+    def _read_batches(self, image_fn=None) -> Iterator[Batch]:
         """Yield batches; each ``Batch.instances`` carries GT keypoints.
 
         For frames with no instances (e.g. ``only_suggested_frames``
@@ -298,7 +417,17 @@ class LabelsProvider:
         downstream layers that don't need GT (single-instance,
         top-down with centroid model, bottom-up) skip the GT-shaped
         kwargs entirely.
+
+        Args:
+            image_fn: Optional ``(LabeledFrame) -> np.ndarray`` override for
+                pixel access, used by the prefetch thread to read through a
+                thread-local video copy instead of ``lf.image`` (which would
+                share a backend handle with whatever the main thread touches).
+                Defaults to ``lambda lf: lf.image``.
         """
+        if image_fn is None:
+            image_fn = lambda lf: lf.image  # noqa: E731
+
         # Group frames into chunks bounded by batch_size that ALSO share a
         # common image shape. Frames from different videos can differ in
         # resolution, and np.stack requires uniform shape; same-video frames
@@ -312,7 +441,7 @@ class LabelsProvider:
             first_shape = None
             idx = start
             while idx < n_frames and len(chunk) < self.batch_size:
-                img = self._labeled_frames[idx].image
+                img = image_fn(self._labeled_frames[idx])
                 if first_shape is None:
                     first_shape = img.shape
                 elif img.shape != first_shape:
@@ -357,6 +486,74 @@ class LabelsProvider:
                 video_indices=video_idxs,
                 instances=instances,
             )
+
+    def _thread_local_video_map(self) -> dict:
+        """Map ``id(original video)`` -> private deep copy for the prefetch thread.
+
+        Mirrors :meth:`VideoProvider._thread_local_video`: closing first drops
+        each video's cached backend handle so ``deepcopy`` clones cheap
+        (path + config) state rather than a live, non-thread-safe handle.
+        """
+        mapping = {}
+        for video in self._sio_labels.videos:
+            video.close()
+            mapping[id(video)] = deepcopy(video)
+        return mapping
+
+    def _prefetch_worker(
+        self, video_map: dict, q: "queue.Queue", stop_event: threading.Event
+    ) -> None:
+        """Decode batches via ``video_map`` onto ``q`` until exhausted or stopped."""
+
+        def image_fn(lf):
+            return video_map[id(lf.video)][lf.frame_idx]
+
+        try:
+            for batch in self._read_batches(image_fn):
+                while True:
+                    if stop_event.is_set():
+                        return
+                    try:
+                        q.put(batch, timeout=0.5)
+                        break
+                    except queue.Full:
+                        continue
+        except BaseException as exc:  # noqa: BLE001 - forwarded to the consumer
+            q.put(_ProducerError(exc))
+            return
+        q.put(_SENTINEL)
+
+    def __iter__(self) -> Iterator[Batch]:
+        """Yield batches, prefetching frame decode on a background thread.
+
+        See :meth:`VideoProvider.__iter__` for the rationale and shutdown
+        semantics (lazy thread start, bounded queue, exception propagation,
+        stop-on-early-exit).
+        """
+        if not self.prefetch:
+            yield from self._read_batches()
+            return
+
+        video_map = self._thread_local_video_map()
+        q: "queue.Queue" = queue.Queue(maxsize=self.queue_maxsize)
+        stop_event = threading.Event()
+        thread = threading.Thread(
+            target=self._prefetch_worker,
+            args=(video_map, q, stop_event),
+            daemon=True,
+        )
+        thread.start()
+        try:
+            while True:
+                item = q.get()
+                if item is _SENTINEL:
+                    return
+                if isinstance(item, _ProducerError):
+                    raise item.exc
+                yield item
+        finally:
+            stop_event.set()
+            thread.join(timeout=5.0)
 
     def __len__(self) -> int:
         """Number of batches over the (filtered) labeled-frame list."""

--- a/tests/inference/test_provider_prefetch.py
+++ b/tests/inference/test_provider_prefetch.py
@@ -1,0 +1,310 @@
+"""Tests for background-thread frame prefetching in the inference providers.
+
+Restores the legacy ``VideoReader``/``LabelsReader`` producer-consumer
+pattern (``sleap_nn/data/providers.py``) that overlapped CPU frame decode
+with the GPU forward pass, which was dropped in the inference-pipeline
+refactor (#508/#530). Covers: output parity with/without prefetch, real
+wall-clock overlap (not just correctness), exception propagation from the
+background thread to the consumer, no thread leak on early iterator
+exit, ``MultiVideoProvider`` still decoding only one source ahead of
+time, and the ``paf_workers``-on-unsupported-layer warning.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import pytest
+from _pytest.logging import LogCaptureFixture
+from loguru import logger
+
+from sleap_nn.inference.predictor import Predictor
+from sleap_nn.inference.providers import (
+    LabelsProvider,
+    MultiVideoProvider,
+    VideoProvider,
+)
+
+DATA_ROOT = Path(__file__).resolve().parents[1] / "assets" / "datasets"
+VIDEO = DATA_ROOT / "small_robot.mp4"
+LABELS = DATA_ROOT / "minimal_instance.pkg.slp"
+
+
+@pytest.fixture
+def caplog(caplog: LogCaptureFixture):
+    """Route loguru records into pytest's ``caplog`` (project convention)."""
+    handler_id = logger.add(
+        caplog.handler,
+        format="{message}",
+        level=0,
+        filter=lambda record: record["level"].no >= caplog.handler.level,
+        enqueue=False,
+    )
+    yield caplog
+    logger.remove(handler_id)
+
+
+def _active_thread_count() -> int:
+    return threading.active_count()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# VideoProvider
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_video_provider_prefetch_matches_synchronous_output():
+    """prefetch=True yields byte-identical batches to prefetch=False."""
+    frames = list(range(20))
+    sync_batches = list(
+        VideoProvider(str(VIDEO), batch_size=4, frames=frames, prefetch=False)
+    )
+    pre_batches = list(
+        VideoProvider(str(VIDEO), batch_size=4, frames=frames, prefetch=True)
+    )
+    assert len(sync_batches) == len(pre_batches)
+    for a, b in zip(sync_batches, pre_batches):
+        np.testing.assert_array_equal(a.images, b.images)
+        np.testing.assert_array_equal(a.frame_indices, b.frame_indices)
+        np.testing.assert_array_equal(a.video_indices, b.video_indices)
+
+
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_video_provider_prefetch_overlaps_decode_with_consumer_work():
+    """Prefetch must actually overlap decode with consumer work, not just be correct.
+
+    Wraps frame access with an artificial per-frame delay (standing in for a
+    slow decode) and times the full iterate-and-consume loop (with an
+    artificial per-batch consumer delay, standing in for a GPU forward pass)
+    against the synchronous baseline. True overlap makes the prefetching
+    version meaningfully faster; without it, this is just a no-op wrapper.
+    """
+    decode_delay = 0.03
+    consumer_delay = 0.03
+    n_batches = 5
+
+    class SlowVideo:
+        def __init__(self, video):
+            self._video = video
+
+        def __getitem__(self, i):
+            time.sleep(decode_delay / 4)
+            return self._video[i]
+
+        def __len__(self):
+            return len(self._video)
+
+        def close(self):
+            return self._video.close()
+
+        def __deepcopy__(self, memo):
+            return SlowVideo(deepcopy(self._video, memo))
+
+    def timed_run(prefetch: bool) -> float:
+        provider = VideoProvider(
+            str(VIDEO),
+            batch_size=4,
+            frames=list(range(n_batches * 4)),
+            prefetch=prefetch,
+        )
+        provider._sio_video = SlowVideo(provider._sio_video)
+        t0 = time.monotonic()
+        for _ in provider:
+            time.sleep(consumer_delay)
+        return time.monotonic() - t0
+
+    elapsed_prefetch = timed_run(True)
+    elapsed_sync = timed_run(False)
+    assert elapsed_prefetch < elapsed_sync - 0.05, (
+        f"expected prefetch to overlap decode with consumer work: "
+        f"prefetch={elapsed_prefetch:.3f}s, sync={elapsed_sync:.3f}s"
+    )
+
+
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_video_provider_prefetch_propagates_decode_exception():
+    """A mid-stream decode failure must raise on the consumer.
+
+    Not be swallowed as a silent (legacy-bug) end-of-stream.
+    """
+    provider = VideoProvider(str(VIDEO), batch_size=4, frames=list(range(20)))
+    real_video = provider._sio_video
+
+    class FlakyVideo:
+        def __init__(self, video):
+            self._video = video
+
+        def __getitem__(self, i):
+            if i == 8:
+                raise RuntimeError("simulated decode failure")
+            return self._video[i]
+
+        def __len__(self):
+            return len(self._video)
+
+        def close(self):
+            return self._video.close()
+
+        def __deepcopy__(self, memo):
+            return FlakyVideo(deepcopy(self._video, memo))
+
+    provider._sio_video = FlakyVideo(real_video)
+
+    seen = 0
+    with pytest.raises(RuntimeError, match="simulated decode failure"):
+        for _ in provider:
+            seen += 1
+    assert seen == 2  # batches [0-3], [4-7] succeed before frame 8 fails
+
+
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_video_provider_prefetch_fills_queue_and_retries_on_full():
+    """A stalled consumer forces the producer's ``queue.Full`` retry loop.
+
+    The producer's ``q.put(batch, timeout=0.5)`` only raises ``Full`` (and
+    loops back to retry) once that 0.5s window actually elapses with the
+    queue still full, so the consumer must stall past it at least once.
+    """
+    provider = VideoProvider(
+        str(VIDEO), batch_size=1, frames=list(range(4)), queue_maxsize=1
+    )
+    it = iter(provider)
+    next(it)  # producer fills the size-1 queue with the next batch, then blocks
+    time.sleep(0.6)  # outlast the 0.5s put timeout at least once
+    rest = list(it)
+    assert len(rest) == 3
+
+
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_video_provider_prefetch_no_thread_leak_on_early_exit():
+    """Breaking out of iteration early must not leak the background thread."""
+    before = _active_thread_count()
+    provider = VideoProvider(
+        str(VIDEO), batch_size=2, frames=list(range(40)), queue_maxsize=1
+    )
+    it = iter(provider)
+    next(it)
+    it.close()
+    time.sleep(0.2)
+    assert _active_thread_count() <= before
+
+
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_multivideo_provider_prefetches_one_source_at_a_time():
+    """Only one sub-provider's prefetch thread is alive at once.
+
+    Preserves today's sequential, one-source-at-a-time decode behavior.
+    """
+    p1 = VideoProvider(str(VIDEO), batch_size=2, frames=list(range(6)))
+    p2 = VideoProvider(str(VIDEO), batch_size=2, frames=list(range(6)))
+    mv = MultiVideoProvider(providers=[p1, p2])
+
+    before = _active_thread_count()
+    max_extra = 0
+    for _ in mv:
+        max_extra = max(max_extra, _active_thread_count() - before)
+    time.sleep(0.2)
+    assert (
+        max_extra == 1
+    ), f"expected exactly 1 concurrent prefetch thread, saw {max_extra}"
+    assert _active_thread_count() == before
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# LabelsProvider
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not LABELS.exists(), reason="test labels file not present")
+def test_labels_provider_prefetch_matches_synchronous_output():
+    """prefetch=True yields byte-identical batches to prefetch=False."""
+    kwargs = dict(labels=str(LABELS), batch_size=2, only_labeled_frames=False)
+    sync_batches = list(LabelsProvider(**kwargs, prefetch=False))
+    pre_batches = list(LabelsProvider(**kwargs, prefetch=True))
+    assert len(sync_batches) == len(pre_batches)
+    for a, b in zip(sync_batches, pre_batches):
+        np.testing.assert_array_equal(a.images, b.images)
+        np.testing.assert_array_equal(a.frame_indices, b.frame_indices)
+        np.testing.assert_array_equal(a.video_indices, b.video_indices)
+        if a.instances is None:
+            assert b.instances is None
+        else:
+            np.testing.assert_allclose(a.instances, b.instances, equal_nan=True)
+
+
+@pytest.mark.skipif(not LABELS.exists(), reason="test labels file not present")
+def test_labels_provider_prefetch_propagates_decode_exception():
+    """A mid-stream decode failure raises on the consumer, not a silent stop."""
+    provider = LabelsProvider(
+        labels=str(LABELS), batch_size=2, only_labeled_frames=False
+    )
+    real_video = provider._sio_labels.videos[0]
+
+    class FlakyVideo:
+        def __init__(self, video):
+            self._video = video
+
+        def __getitem__(self, i):
+            raise RuntimeError("simulated decode failure")
+
+        def close(self):
+            return self._video.close()
+
+        def __deepcopy__(self, memo):
+            return FlakyVideo(deepcopy(self._video, memo))
+
+    # attrs(slots=True) instances forbid ad hoc attributes; patch the class
+    # method for the duration of the test instead.
+    orig_map = type(provider)._thread_local_video_map
+
+    def patched_map(self):
+        return {k: FlakyVideo(v) for k, v in orig_map(self).items()}
+
+    type(provider)._thread_local_video_map = patched_map
+    try:
+        with pytest.raises(RuntimeError, match="simulated decode failure"):
+            list(provider)
+    finally:
+        type(provider)._thread_local_video_map = orig_map
+
+
+@pytest.mark.skipif(not LABELS.exists(), reason="test labels file not present")
+def test_labels_provider_prefetch_no_thread_leak_on_early_exit():
+    """Breaking out of iteration early must not leak the background thread."""
+    before = _active_thread_count()
+    provider = LabelsProvider(
+        labels=str(LABELS), batch_size=1, only_labeled_frames=False, queue_maxsize=1
+    )
+    it = iter(provider)
+    next(it)
+    it.close()
+    time.sleep(0.2)
+    assert _active_thread_count() <= before
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Predictor: paf_workers on an unsupported layer warns instead of silently
+# no-op'ing.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _FakeLayer:
+    """Stand-in for any non-``BottomUpLayer`` layer."""
+
+
+def test_predictor_warns_when_paf_workers_set_on_unsupported_layer(caplog):
+    """paf_workers>0 on a non-BottomUpLayer warns instead of silently no-op'ing."""
+    Predictor(layer=_FakeLayer(), paf_workers=4)
+    assert "paf_workers=4" in caplog.text
+    assert "_FakeLayer" in caplog.text
+
+
+def test_predictor_no_warning_when_paf_workers_zero(caplog):
+    """The default paf_workers=0 emits no warning."""
+    Predictor(layer=_FakeLayer(), paf_workers=0)
+    assert "paf_workers" not in caplog.text


### PR DESCRIPTION
## Summary

- Restores frame-decode/GPU-inference overlap in `sleap-nn predict` that the inference-pipeline refactor (#508/#530) silently dropped when it replaced the legacy thread+queue readers with synchronous generators.
- Adds a warning (instead of a silent no-op) when `paf_workers>0` is set on a layer that can't use the pipelined CPU-grouping path.

## Problem

Before the refactor, `sleap-nn track` read video/`.slp` frames via `VideoReader`/`LabelsReader` (`sleap_nn/data/providers.py`) — `threading.Thread` subclasses that decoded frames into a bounded `queue.Queue` on a background thread, so CPU decode of the *next* batch overlapped the GPU forward pass on the *current* one.

The new `sleap-nn predict` pipeline's `VideoProvider`/`LabelsProvider` (`sleap_nn/inference/providers.py`) are plain synchronous generators: `for batch in provider: ... layer.predict(...)`, a strict `read → forward → read → forward` loop with no overlap. Checked the refactor's own performance doc (`docs/guides/inference-performance.md`) and design notes — no evidence this was a deliberate tradeoff; it reads as dropped during the provider rewrite and never benchmarked against (the refactor's benchmarks use a tiny 320×560 fixture where decode is cheap enough not to show up).

This mainly matters on long/high-res production videos where decode time is non-trivial relative to a fast GPU forward pass.

## Changes Made

**`sleap_nn/inference/providers.py`**
- `VideoProvider`: new `prefetch: bool = True` / `queue_maxsize: int = 4` fields. `__iter__` now spawns a lazily-started background thread (started on iteration, not construction) that decodes through a **private, thread-local `sio.Video` copy** — video backends (OpenCV/ffmpeg/HDF5) cache a single seek+read handle and aren't safe for concurrent access from two threads, so sharing one risks silently returning the wrong frame.
- `LabelsProvider`: same mechanism, with a `dict[id(video) -> thread-local copy]` since a `.slp` can reference multiple source videos.
- Both propagate exceptions raised on the background thread to the consumer (boxed via `_ProducerError`) instead of the legacy bug where a mid-stream decode failure was indistinguishable from a clean end-of-stream.
- A `stop_event` + real `daemon=True` thread ensure an early consumer exit (`break`, exception, `GeneratorExit`) doesn't leak the thread — the legacy reader had a dead `self._daemonic` attribute that didn't actually daemonize anything.
- The thread starts inside `__iter__` (not `__attrs_post_init__`) so `MultiVideoProvider` — which iterates sub-providers strictly sequentially — never has more than one video being decoded ahead of time, matching today's behavior.

**`sleap_nn/inference/predictor.py`**
- `Predictor.__attrs_post_init__` now logs a warning if `paf_workers > 0` but `layer` isn't a `BottomUpLayer` (the only layer type `_can_pipeline()` supports), so setting it on e.g. a topdown/multiclass/segmentation model doesn't silently do nothing.

## Testing

New `tests/inference/test_provider_prefetch.py` (11 tests, all passing), verifying properties beyond what unit correctness alone would catch:
- **Parity**: `prefetch=True` vs `prefetch=False` yield byte-identical batches, same order.
- **Real overlap** (not just correctness): with simulated slow decode + slow "GPU" consumer work, prefetch is measurably faster than synchronous — proves actual overlap happens.
- **Exception propagation**: a simulated mid-stream decode failure raises on the consumer instead of truncating silently.
- **No thread leak on early exit**: breaking iteration early returns `threading.active_count()` to baseline.
- **`queue.Full` retry branch**: a stalled consumer forces the producer's backpressure retry loop.
- **`MultiVideoProvider` sequencing**: exactly one prefetch thread alive at a time across multiple video sources, no leak after full exhaustion.
- **`paf_workers` warning**: fires for unsupported layers, silent when `paf_workers=0`.

Full suite: `tests/inference/` — 821 passed, 81 skipped, 1 xfailed (up from 810/81/1 pre-change; no regressions, +11 new tests). `black`/`ruff` clean on all changed files.

## Design Decisions

- **Thread-local video copies over sharing one handle**: mirrors the legacy `VideoReader`/`LabelsReader` pattern (`video.close()` to drop the cached handle so `deepcopy` clones cheap path/config state, not a live handle) but fixes two real bugs found in that legacy code along the way: exceptions silently swallowed as end-of-stream, and a dead `_daemonic` attribute that never actually made threads daemons.
- **Lazy thread start, bounded queue (`queue_maxsize=4`)**: keeps `MultiVideoProvider`'s one-source-at-a-time decode behavior intact, and avoids reintroducing the double-buffering memory bug that `#583` already had to fix once for the PAF-grouping worker pool.
- **`LabelsProvider` scope**: also fixed (not just `VideoProvider`) — the legacy `LabelsReader` had the identical thread+queue pattern, so this was the same regression on the `.slp` GT-fallback path.
- **`paf_workers` warning, not a fix**: investigated extending the pipelined CPU/GPU-overlap path (`_predict_streaming_pipelined`, currently bottom-up-only via `_can_pipeline()`) to `multi_class_bottomup`. It's architecturally plausible — `BottomUpMultiClassLayer` has its own CPU-bound bottleneck (`classify_peaks_from_maps` → `scipy.linear_sum_assignment` Hungarian matching) — but needs a new picklable value type, a new pure grouping function, and a new worker-pool path, comparable in scope to the original `PafGroupingPool` PR (#517). Out of scope here; this PR only closes the "silent no-op" gap so the limitation is visible instead of surprising.

## Related Investigation Notes

- Confirmed `predict_streaming()` works for **every** model type (including topdown) via the plain `_batch_iter` path — verified against the existing `test_e2e_video.py::test_predict_streaming_cpu[topdown]` e2e test plus a manual run producing real keypoints. Only the *pipelined* CPU/GPU-overlap optimization (`paf_workers`) is bottom-up-only; `predict_streaming` itself is not.

## Future Considerations

- Full pipelined-streaming support for `multi_class_bottomup` (new value type + grouping function + worker pool + parity tests) — real feature work, not scoped here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)