### PR TITLE
fix(infer): predict-pipeline correctness fixes (overrides, CLI filters, LabelsProvider priority)

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1470,6 +1470,39 @@ def _build_remote_kwargs(kwargs: dict) -> dict:
     return remote
 
 
+_SLP_ONLY_FRAME_FILTER_FLAGS = (
+    "only_labeled_frames",
+    "only_suggested_frames",
+    "exclude_user_labeled",
+    "only_predicted_frames",
+)
+
+
+def _reject_slp_filters_for_non_slp_source(kwargs: dict, src_suffix: str) -> None:
+    """Raise if any label-status frame filter is set for a non-``.slp`` source.
+
+    ``--only_labeled_frames`` / ``--only_suggested_frames`` /
+    ``--exclude_user_labeled`` / ``--only_predicted_frames`` select frames by
+    annotation status, which only exists for a ``.slp`` source. A raw video has
+    no annotations to filter on, so these flags are meaningless there -- prior
+    to this check they were silently dropped instead of erroring (matching
+    legacy ``legacy_predict.py``, which raises for exactly this case). Shared
+    by both the in-memory and stream-to-file flows so the two call sites can't
+    drift the way ``LabelsProvider`` vs. ``LabelsReader`` did.
+    """
+    if src_suffix == ".slp":
+        return
+    unsupported = [
+        f"--{flag}" for flag in _SLP_ONLY_FRAME_FILTER_FLAGS if kwargs.get(flag)
+    ]
+    if unsupported:
+        raise click.UsageError(
+            f"{', '.join(unsupported)} require a `.slp` --data_path (they filter "
+            "frames by annotation status); the given source has no annotations "
+            "to filter on. Use --frames to subset a video by index instead."
+        )
+
+
 def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     """Run the new ``predict()`` flow synchronously and save the resulting Labels.
 
@@ -1529,6 +1562,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     # through verbatim (Path() would corrupt scheme://). Remote auth/stream
     # options (--headers/--stream-mode) are forwarded to the URL-aware loaders.
     source_str, src_suffix, src_is_url = _resolve_data_path(kwargs["data_path"])
+    _reject_slp_filters_for_non_slp_source(kwargs, src_suffix)
     remote_kwargs = _build_remote_kwargs(kwargs)
 
     # Build source: use a provider when CLI-specific filtering or
@@ -2038,6 +2072,10 @@ def _run_stream_to_file(
     data_path = kwargs.get("data_path")
     if not data_path:
         raise click.UsageError("--data_path is required for --stream-to-file.")
+    # Fail fast (before loading a model) if a label-status frame filter is
+    # set for a non-`.slp` source -- same check as the in-memory flow.
+    _, _early_src_suffix, _ = _resolve_data_path(data_path)
+    _reject_slp_filters_for_non_slp_source(kwargs, _early_src_suffix)
 
     from pathlib import Path
 

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1478,28 +1478,29 @@ _SLP_ONLY_FRAME_FILTER_FLAGS = (
 )
 
 
-def _reject_slp_filters_for_non_slp_source(kwargs: dict, src_suffix: str) -> None:
-    """Raise if any label-status frame filter is set for a non-``.slp`` source.
+def _warn_ignored_slp_filters_for_non_slp_source(kwargs: dict, src_suffix: str) -> None:
+    """Warn (not error) if a label-status frame filter is set for a non-``.slp`` source.
 
     ``--only_labeled_frames`` / ``--only_suggested_frames`` /
     ``--exclude_user_labeled`` / ``--only_predicted_frames`` select frames by
-    annotation status, which only exists for a ``.slp`` source. A raw video has
-    no annotations to filter on, so these flags are meaningless there -- prior
-    to this check they were silently dropped instead of erroring (matching
-    legacy ``legacy_predict.py``, which raises for exactly this case). Shared
-    by both the in-memory and stream-to-file flows so the two call sites can't
-    drift the way ``LabelsProvider`` vs. ``LabelsReader`` did.
+    annotation status, which fundamentally doesn't exist for a raw video --
+    there's no way to know which frames are "predicted" or "user-labeled"
+    without a ``.slp``. These flags are inert for a non-``.slp`` source: the
+    inference dispatch below only reads them when building a source from a
+    ``.slp``, so a video source runs full-video inference either way. This
+    warns so that's not a silent surprise. Shared by both the in-memory and
+    stream-to-file flows so the two call sites can't drift the way
+    ``LabelsProvider`` vs. ``LabelsReader`` did.
     """
     if src_suffix == ".slp":
         return
-    unsupported = [
-        f"--{flag}" for flag in _SLP_ONLY_FRAME_FILTER_FLAGS if kwargs.get(flag)
-    ]
-    if unsupported:
-        raise click.UsageError(
-            f"{', '.join(unsupported)} require a `.slp` --data_path (they filter "
+    ignored = [f"--{flag}" for flag in _SLP_ONLY_FRAME_FILTER_FLAGS if kwargs.get(flag)]
+    if ignored:
+        logger.warning(
+            f"{', '.join(ignored)} require a `.slp` --data_path (they filter "
             "frames by annotation status); the given source has no annotations "
-            "to filter on. Use --frames to subset a video by index instead."
+            "to filter on, so these flags have no effect here. Running on all "
+            "frames. Use --frames to subset a video by index instead."
         )
 
 
@@ -1562,7 +1563,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
     # through verbatim (Path() would corrupt scheme://). Remote auth/stream
     # options (--headers/--stream-mode) are forwarded to the URL-aware loaders.
     source_str, src_suffix, src_is_url = _resolve_data_path(kwargs["data_path"])
-    _reject_slp_filters_for_non_slp_source(kwargs, src_suffix)
+    _warn_ignored_slp_filters_for_non_slp_source(kwargs, src_suffix)
     remote_kwargs = _build_remote_kwargs(kwargs)
 
     # Build source: use a provider when CLI-specific filtering or
@@ -2072,10 +2073,10 @@ def _run_stream_to_file(
     data_path = kwargs.get("data_path")
     if not data_path:
         raise click.UsageError("--data_path is required for --stream-to-file.")
-    # Fail fast (before loading a model) if a label-status frame filter is
+    # Warn early (before loading a model) if a label-status frame filter is
     # set for a non-`.slp` source -- same check as the in-memory flow.
     _, _early_src_suffix, _ = _resolve_data_path(data_path)
-    _reject_slp_filters_for_non_slp_source(kwargs, _early_src_suffix)
+    _warn_ignored_slp_filters_for_non_slp_source(kwargs, _early_src_suffix)
 
     from pathlib import Path
 

--- a/sleap_nn/inference/layers/bottomup.py
+++ b/sleap_nn/inference/layers/bottomup.py
@@ -204,7 +204,7 @@ class BottomUpLayer(InferenceLayer):
         The result is picklable and can be sent to a worker process.
         """
         # Prefer a predict-time override (set on ``postprocess_config`` by
-        # ``Predictor._postprocess_overrides``) over the build-time value
+        # ``Predictor._scoped_postprocess_layer``) over the build-time value
         # carried on ``self.max_instances`` (#582).
         max_instances = getattr(self.postprocess_config, "max_instances", None)
         if max_instances is None:

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -21,7 +21,7 @@ Three usage tiers:
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+import copy
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -1598,7 +1598,7 @@ class Predictor:
 
         self._log_inference_start(source, provider, videos)
         _prov_start = datetime.now()
-        with self._postprocess_overrides(
+        layer = self._scoped_postprocess_layer(
             peak_threshold=peak_threshold,
             centroid_threshold=centroid_threshold,
             keypoint_threshold=keypoint_threshold,
@@ -1611,8 +1611,8 @@ class Predictor:
             return_paf_graph=return_paf_graph,
             return_class_maps=return_class_maps,
             return_class_vectors=return_class_vectors,
-        ):
-            outputs_list = list(self._batch_iter(provider, progress_callback))
+        )
+        outputs_list = list(self._batch_iter(provider, progress_callback, layer=layer))
         _prov_end = datetime.now()
 
         if not make_labels:
@@ -1728,7 +1728,7 @@ class Predictor:
                 "full LabeledFrame list; use predict() instead."
             )
         provider, _ = self._make_provider(source, frames=frames)
-        with self._postprocess_overrides(
+        layer = self._scoped_postprocess_layer(
             peak_threshold=peak_threshold,
             centroid_threshold=centroid_threshold,
             keypoint_threshold=keypoint_threshold,
@@ -1741,13 +1741,13 @@ class Predictor:
             return_paf_graph=return_paf_graph,
             return_class_maps=return_class_maps,
             return_class_vectors=return_class_vectors,
-        ):
-            if self.paf_workers > 0 and self._can_pipeline():
-                yield from self._predict_streaming_pipelined(
-                    provider, progress_callback
-                )
-                return
-            yield from self._batch_iter(provider, progress_callback)
+        )
+        if self.paf_workers > 0 and self._can_pipeline():
+            yield from self._predict_streaming_pipelined(
+                provider, progress_callback, layer=layer
+            )
+            return
+        yield from self._batch_iter(provider, progress_callback, layer=layer)
 
     # ──────────────────────────────────────────────────────────────────
     # Disk-streaming: write to a .slp incrementally
@@ -1855,12 +1855,22 @@ class Predictor:
         self,
         provider: Provider,
         progress_callback: Optional[Callable[[int, int], None]] = None,
+        layer: Optional[Any] = None,
     ) -> Iterator[Outputs]:
-        """Run ``layer.predict`` + ``FilterPipeline`` per provider batch."""
+        """Run ``layer.predict`` + ``FilterPipeline`` per provider batch.
+
+        ``layer`` defaults to ``self.layer``; callers applying predict-time
+        postprocess overrides pass the scoped copy from
+        ``_scoped_postprocess_layer`` instead so ``self.layer`` is never
+        mutated.
+        """
         import inspect
 
+        if layer is None:
+            layer = self.layer
+
         try:
-            sig = inspect.signature(self.layer.predict)
+            sig = inspect.signature(layer.predict)
             layer_accepts_instances = "instances" in sig.parameters
         except (TypeError, ValueError):  # pragma: no cover — non-introspectable
             layer_accepts_instances = False
@@ -1876,7 +1886,7 @@ class Predictor:
                     if isinstance(batch.instances, torch.Tensor)
                     else torch.from_numpy(batch.instances)
                 )
-            outputs = self.layer.predict(batch.images, **kwargs)
+            outputs = layer.predict(batch.images, **kwargs)
             outputs = pipeline(outputs)
             outputs = self._stamp_metadata(outputs, batch)
             yield outputs
@@ -1898,12 +1908,19 @@ class Predictor:
         self,
         provider: Provider,
         progress_callback: Optional[Callable[[int, int], None]] = None,
+        layer: Optional[Any] = None,
     ) -> Iterator[Outputs]:
-        """Stream ``Outputs`` with the CPU grouping stage in a worker pool."""
+        """Stream ``Outputs`` with the CPU grouping stage in a worker pool.
+
+        ``layer`` defaults to ``self.layer``; see ``_batch_iter`` for why a
+        caller applying postprocess overrides passes a scoped copy instead.
+        """
         from sleap_nn.inference.streaming import PafGroupingPool
 
+        if layer is None:
+            layer = self.layer
+
         pipeline = self.filter_pipeline
-        layer = self.layer
         params = layer.grouping_params()
         total = _safe_num_frames(provider)
 
@@ -2127,8 +2144,7 @@ class Predictor:
             targets = []
         return targets
 
-    @contextmanager
-    def _postprocess_overrides(
+    def _scoped_postprocess_layer(
         self,
         peak_threshold: Optional[float] = None,
         centroid_threshold: Optional[float] = None,
@@ -2142,8 +2158,24 @@ class Predictor:
         return_paf_graph: Optional[bool] = None,
         return_class_maps: Optional[bool] = None,
         return_class_vectors: Optional[bool] = None,
-    ):
-        """Context manager that temporarily overrides postprocess configs.
+    ) -> Any:
+        """Return the layer to use for one predict call, with overrides applied.
+
+        Returns ``self.layer`` unchanged when no override is requested (the
+        common case). Otherwise returns a *private*, shallow-copied layer
+        (and shallow-copied sub-layers, for composed layers like
+        :class:`TopDownLayer`) with the overrides baked into the copies'
+        ``postprocess_config`` -- ``self.layer`` and its real sub-layers are
+        never mutated.
+
+        This matters because ``predict_streaming()`` is a generator: an
+        earlier version of this mutated ``self.layer.postprocess_config`` in
+        place and restored it when the generator was exhausted/closed. Two
+        ``predict_streaming()`` calls on the same ``Predictor`` interleaved
+        via alternating ``next()`` shared that same mutable state, so each
+        call's overrides could clobber the other's mid-stream. Returning an
+        independent copy per call makes concurrent/interleaved calls fully
+        isolated from each other, with nothing to restore.
 
         For top-down layers, ``centroid_threshold`` applies to the centroid
         stage and ``keypoint_threshold`` to the centered-instance stage.
@@ -2169,73 +2201,74 @@ class Predictor:
             )
         )
         if not has_any:
-            yield
-            return
+            return self.layer
 
-        saved: list[tuple[Any, PostprocessConfig]] = []
-        saved_return_crops: Optional[bool] = None
+        is_topdown = isinstance(self.layer, TopDownLayer)
 
-        try:
-            targets = self._collect_postprocess_targets(self.layer)
+        def _copy_with_overrides(target: Any) -> Any:
+            old_cfg = target.postprocess_config
+            overrides: dict = {}
 
-            for target in targets:
-                old_cfg = target.postprocess_config
-                saved.append((target, old_cfg))
-
-                overrides: dict = {}
-
-                # Threshold routing for top-down. Use explicit None checks so an
-                # explicit 0.0 override ("accept all peaks") is honored rather
-                # than swallowed by a falsy `or` (#584).
-                if isinstance(self.layer, TopDownLayer):
-                    is_centroid = target is self.layer.centroid_layer
-                    if is_centroid:
-                        t = (
-                            centroid_threshold
-                            if centroid_threshold is not None
-                            else peak_threshold
-                        )
-                    else:
-                        t = (
-                            keypoint_threshold
-                            if keypoint_threshold is not None
-                            else peak_threshold
-                        )
+            # Threshold routing for top-down. Use explicit None checks so an
+            # explicit 0.0 override ("accept all peaks") is honored rather
+            # than swallowed by a falsy `or` (#584).
+            if is_topdown:
+                is_centroid = target is self.layer.centroid_layer
+                if is_centroid:
+                    t = (
+                        centroid_threshold
+                        if centroid_threshold is not None
+                        else peak_threshold
+                    )
                 else:
-                    t = peak_threshold
+                    t = (
+                        keypoint_threshold
+                        if keypoint_threshold is not None
+                        else peak_threshold
+                    )
+            else:
+                t = peak_threshold
 
-                if t is not None:
-                    overrides["peak_threshold"] = t
-                if max_instances is not None and hasattr(old_cfg, "max_instances"):
-                    overrides["max_instances"] = max_instances
-                if integral_refinement is not None:
-                    overrides["refinement"] = integral_refinement
-                if integral_patch_size is not None:
-                    overrides["integral_patch_size"] = integral_patch_size
-                if return_confmaps is not None:
-                    overrides["return_confmaps"] = return_confmaps
-                # The remaining intermediate-tensor toggles all live on
-                # PostprocessConfig; guard with hasattr defensively (#583).
-                for _name, _val in (
-                    ("return_pafs", return_pafs),
-                    ("return_paf_graph", return_paf_graph),
-                    ("return_class_maps", return_class_maps),
-                    ("return_class_vectors", return_class_vectors),
-                ):
-                    if _val is not None and hasattr(old_cfg, _name):
-                        overrides[_name] = _val
+            if t is not None:
+                overrides["peak_threshold"] = t
+            if max_instances is not None and hasattr(old_cfg, "max_instances"):
+                overrides["max_instances"] = max_instances
+            if integral_refinement is not None:
+                overrides["refinement"] = integral_refinement
+            if integral_patch_size is not None:
+                overrides["integral_patch_size"] = integral_patch_size
+            if return_confmaps is not None:
+                overrides["return_confmaps"] = return_confmaps
+            # The remaining intermediate-tensor toggles all live on
+            # PostprocessConfig; guard with hasattr defensively (#583).
+            for _name, _val in (
+                ("return_pafs", return_pafs),
+                ("return_paf_graph", return_paf_graph),
+                ("return_class_maps", return_class_maps),
+                ("return_class_vectors", return_class_vectors),
+            ):
+                if _val is not None and hasattr(old_cfg, _name):
+                    overrides[_name] = _val
 
-                if overrides:
-                    target.postprocess_config = attrs.evolve(old_cfg, **overrides)
+            new_target = copy.copy(target)
+            if overrides:
+                new_target.postprocess_config = attrs.evolve(old_cfg, **overrides)
+            return new_target
 
-            # return_crops lives on TopDownLayer, not on postprocess_config
-            if return_crops is not None and isinstance(self.layer, TopDownLayer):
-                saved_return_crops = self.layer.return_crops
-                self.layer.return_crops = return_crops
+        if is_topdown:
+            new_layer = copy.copy(self.layer)
+            new_layer.centroid_layer = _copy_with_overrides(self.layer.centroid_layer)
+            new_layer.centered_instance_layer = _copy_with_overrides(
+                self.layer.centered_instance_layer
+            )
+            # return_crops lives on TopDownLayer, not on postprocess_config.
+            if return_crops is not None:
+                new_layer.return_crops = return_crops
+            return new_layer
 
-            yield
-        finally:
-            for target, old_cfg in saved:
-                target.postprocess_config = old_cfg
-            if saved_return_crops is not None:
-                self.layer.return_crops = saved_return_crops
+        targets = self._collect_postprocess_targets(self.layer)
+        if not targets:
+            return self.layer
+        # Non-top-down layers with a postprocess_config always have exactly
+        # one target: the layer itself.
+        return _copy_with_overrides(targets[0])

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -354,27 +354,33 @@ class LabelsProvider:
                 "mutually exclusive."
             )
 
-        if self.only_suggested_frames:
-            self._labeled_frames = self._collect_suggested_frames(sio)
-        elif self.only_predicted_frames:
-            self._labeled_frames = [
-                lf
-                for lf in self._sio_labels.labeled_frames
-                if lf.has_predicted_instances
-            ]
-        elif self.exclude_user_labeled:
-            self._labeled_frames = [
-                lf
-                for lf in self._sio_labels.labeled_frames
-                if not lf.has_user_instances
-            ]
-        elif self.only_labeled_frames:
+        # Priority order matches legacy LabelsReader exactly (data/providers.py):
+        # only_labeled_frames > only_suggested_frames > exclude_user_labeled >
+        # only_predicted_frames. When more than one flag is set, whichever comes
+        # first here wins -- this order is legacy-parity-load-bearing, not
+        # arbitrary; a previous version of this method used a different
+        # (effectively reversed) order with no test catching the drift.
+        if self.only_labeled_frames:
             # Keep only frames with >=1 USER (ground-truth) instance, and drop
             # predicted-only frames. Legacy LabelsReader restricted GT to user
             # instances; using lf.instances here would feed PredictedInstances
             # into the GT-centroid / GT-peaks paths (#582).
             self._labeled_frames = [
                 lf for lf in self._sio_labels.labeled_frames if lf.has_user_instances
+            ]
+        elif self.only_suggested_frames:
+            self._labeled_frames = self._collect_suggested_frames(sio)
+        elif self.exclude_user_labeled:
+            self._labeled_frames = [
+                lf
+                for lf in self._sio_labels.labeled_frames
+                if not lf.has_user_instances
+            ]
+        elif self.only_predicted_frames:
+            self._labeled_frames = [
+                lf
+                for lf in self._sio_labels.labeled_frames
+                if lf.has_predicted_instances
             ]
         else:
             self._labeled_frames = list(self._sio_labels.labeled_frames)

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -301,7 +301,14 @@ class LabelsProvider:
             ``sleap_io.Labels`` instance.
         batch_size: Frames per yielded ``Batch``.
         only_labeled_frames: Yield only frames that have at least one
-            user-supplied instance (default ``True``).
+            user-supplied instance (default ``False``, matching legacy
+            ``LabelsReader``). ``Predictor._make_provider`` always passes
+            this explicitly (computed from whether the layer needs GT
+            instances), so the default only matters for a ``LabelsProvider``
+            built directly. Since this is also the highest-priority filter
+            (see below), leaving it at a truthy default would silently
+            override any other ``only_*``/``exclude_*`` flag a direct caller
+            sets without also passing ``only_labeled_frames=False``.
         only_suggested_frames: Yield only frames listed in
             ``labels.suggestions`` that don't already have a user
             instance. Mutually exclusive with the other ``only_*`` /
@@ -324,7 +331,7 @@ class LabelsProvider:
 
     labels: "Union[str, sio.Labels]"
     batch_size: int = 4
-    only_labeled_frames: bool = True
+    only_labeled_frames: bool = False
     only_suggested_frames: bool = False
     exclude_user_labeled: bool = False
     only_predicted_frames: bool = False

--- a/tests/inference/layers/test_centroid.py
+++ b/tests/inference/layers/test_centroid.py
@@ -223,8 +223,9 @@ def test_postprocess_config_max_instances_override():
 
     Regression test for talmolab/sleap#2831: CentroidLayer.postprocess()
     read ``self.max_instances`` (frozen at __init__) instead of
-    ``self.postprocess_config.max_instances`` (set by _postprocess_overrides),
-    so predict-time --max_instances had no effect.
+    ``self.postprocess_config.max_instances`` (set by
+    ``Predictor._scoped_postprocess_layer``), so predict-time --max_instances
+    had no effect.
     """
     layer = CentroidLayer(
         backend=_StubBackend(),

--- a/tests/inference/test_issue_583.py
+++ b/tests/inference/test_issue_583.py
@@ -3,7 +3,7 @@
 Library-level coverage (CLI-level tests live in tests/cli/test_infer_command.py):
 
 * Predict-time ``return_*`` intermediate-tensor overrides via
-  ``Predictor._postprocess_overrides``.
+  ``Predictor._scoped_postprocess_layer``.
 * Streaming pool primitives (``PafGroupingPool.__len__`` / ``drain_one``) used
   by the bounded pipelined-streaming path.
 * Streaming writer accumulate-until-finalize contract + provenance persistence.
@@ -43,8 +43,14 @@ class _PostprocStub:
         self.postprocess_config = PostprocessConfig()
 
 
-def test_postprocess_overrides_thread_return_flags():
-    """Each return_* flag flips the layer's PostprocessConfig and restores (#583)."""
+def test_scoped_postprocess_layer_thread_return_flags():
+    """Each return_* flag flips the *scoped copy's* PostprocessConfig (#583).
+
+    The real ``predictor.layer`` is never mutated -- ``_scoped_postprocess_layer``
+    returns an independent copy with the override baked in, so concurrent /
+    interleaved ``predict_streaming()`` calls on the same ``Predictor`` can't
+    clobber each other's overrides.
+    """
     for name in (
         "return_pafs",
         "return_paf_graph",
@@ -53,19 +59,17 @@ def test_postprocess_overrides_thread_return_flags():
     ):
         predictor = Predictor(layer=_PostprocStub())
         assert getattr(predictor.layer.postprocess_config, name) is False
-        with predictor._postprocess_overrides(**{name: True}):
-            assert getattr(predictor.layer.postprocess_config, name) is True
-        # Restored on exit.
+        scoped = predictor._scoped_postprocess_layer(**{name: True})
+        assert getattr(scoped.postprocess_config, name) is True
+        # The real layer is untouched, not just "restored after".
         assert getattr(predictor.layer.postprocess_config, name) is False
 
 
-def test_postprocess_overrides_no_args_is_noop():
-    """With no overrides the config object is untouched (has_any short-circuit)."""
+def test_scoped_postprocess_layer_no_args_returns_same_layer():
+    """With no overrides, the real layer is returned as-is (no copy needed)."""
     predictor = Predictor(layer=_PostprocStub())
-    before = predictor.layer.postprocess_config
-    with predictor._postprocess_overrides():
-        pass
-    assert predictor.layer.postprocess_config is before
+    scoped = predictor._scoped_postprocess_layer()
+    assert scoped is predictor.layer
 
 
 @pytest.mark.skipif(

--- a/tests/inference/test_issue_584.py
+++ b/tests/inference/test_issue_584.py
@@ -203,8 +203,9 @@ def test_topdown_centroid_threshold_zero_override_is_honored():
     predictor = Predictor.from_model_paths(
         [str(CENTROID_CKPT), str(CENTERED_CKPT)], device="cpu", peak_threshold=0.2
     )
-    centroid_layer = predictor.layer.centroid_layer
-    with predictor._postprocess_overrides(centroid_threshold=0.0):
-        assert centroid_layer.postprocess_config.peak_threshold == 0.0
-    # Restored afterwards.
-    assert centroid_layer.postprocess_config.peak_threshold == 0.2
+    scoped_layer = predictor._scoped_postprocess_layer(centroid_threshold=0.0)
+    assert scoped_layer.centroid_layer.postprocess_config.peak_threshold == 0.0
+    # The real (unscoped) layer is never mutated -- the override is baked
+    # into a private copy so concurrent/interleaved predict_streaming() calls
+    # can't clobber each other's overrides (see _scoped_postprocess_layer).
+    assert predictor.layer.centroid_layer.postprocess_config.peak_threshold == 0.2

--- a/tests/inference/test_predictor_new.py
+++ b/tests/inference/test_predictor_new.py
@@ -100,6 +100,68 @@ def test_predict_streaming_yields_outputs():
     assert len(rest) == 2  # 5 frames / batch=2 → 3 batches total
 
 
+class _EchoThresholdLayer:
+    """Layer whose output encodes its *current* ``postprocess_config.peak_threshold``.
+
+    Used to detect whether two ``predict_streaming()`` calls interleaved via
+    alternating ``next()`` calls leak each other's postprocess overrides.
+    """
+
+    def __init__(self):
+        from sleap_nn.inference.layers.configs import PostprocessConfig
+
+        self.postprocess_config = PostprocessConfig()
+
+    def predict(self, image, **kwargs) -> Outputs:
+        """Return instance_scores filled with the current peak_threshold."""
+        b = image.shape[0]
+        t = self.postprocess_config.peak_threshold
+        return Outputs(
+            pred_keypoints=torch.zeros(b, 1, 4, 2),
+            pred_peak_values=torch.full((b, 1, 4), t),
+            instance_scores=torch.full((b, 1), t),
+        )
+
+
+def test_predict_streaming_interleaved_calls_do_not_clobber_overrides():
+    """Interleaved ``predict_streaming()`` calls must not leak overrides.
+
+    Regression test: an earlier implementation applied predict-time
+    postprocess overrides by mutating ``layer.postprocess_config`` in place
+    and restoring it when the generator exhausted/closed. Interleaving two
+    ``predict_streaming()`` calls on the same ``Predictor`` via alternating
+    ``next()`` shared that mutable state, so each call's override could
+    clobber the other's mid-stream.
+    """
+    predictor = Predictor(layer=_EchoThresholdLayer())
+    images_a = np.zeros((4, 1, 8, 8), dtype=np.float32)
+    images_b = np.zeros((4, 1, 8, 8), dtype=np.float32)
+    gen_a = predictor.predict_streaming(
+        NumpyProvider(images=images_a, batch_size=2), peak_threshold=0.9
+    )
+    gen_b = predictor.predict_streaming(
+        NumpyProvider(images=images_b, batch_size=2), peak_threshold=0.1
+    )
+
+    # Interleave: a, b, a, b -- each call's override must survive regardless
+    # of what the other call requested in between.
+    out_a1 = next(gen_a)
+    out_b1 = next(gen_b)
+    out_a2 = next(gen_a)
+    out_b2 = next(gen_b)
+
+    assert out_a1.instance_scores.flatten()[0].item() == pytest.approx(0.9)
+    assert out_a2.instance_scores.flatten()[0].item() == pytest.approx(0.9)
+    assert out_b1.instance_scores.flatten()[0].item() == pytest.approx(0.1)
+    assert out_b2.instance_scores.flatten()[0].item() == pytest.approx(0.1)
+
+    list(gen_a)
+    list(gen_b)
+
+    # The real (shared) layer was never mutated by either call.
+    assert predictor.layer.postprocess_config.peak_threshold == 0.2
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # 4. FilterPipeline propagation
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/inference/test_providers.py
+++ b/tests/inference/test_providers.py
@@ -165,6 +165,92 @@ def test_labels_provider_only_suggested_frames_yields_unlabeled_suggestions():
     assert len(provider._labeled_frames[0].instances) == 0
 
 
+def _build_priority_test_labels():
+    """Labels fixture exercising every ``only_*``/``exclude_*`` filter mode.
+
+    - frame 0: a user instance only.
+    - frame 1: a predicted instance only.
+    - frame 2: no instances.
+    - suggestions: frame_idx=0 (already user-labeled) and frame_idx=3
+      (unlabeled -- the only one ``only_suggested_frames`` should keep).
+    """
+    import sleap_io as sio
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="dummy.mp4")
+    user_inst = sio.Instance.from_numpy(
+        np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32), skeleton=skel
+    )
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[2.0, 2.0], [3.0, 3.0]], dtype=np.float32),
+        skeleton=skel,
+        score=0.9,
+    )
+    lf_user = sio.LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+    lf_pred = sio.LabeledFrame(video=video, frame_idx=1, instances=[pred_inst])
+    lf_empty = sio.LabeledFrame(video=video, frame_idx=2, instances=[])
+    return sio.Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[lf_user, lf_pred, lf_empty],
+        suggestions=[
+            sio.SuggestionFrame(video=video, frame_idx=0),  # already user-labeled
+            sio.SuggestionFrame(video=video, frame_idx=3),  # unlabeled
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "flags, expected_frame_idxs",
+    [
+        # only_labeled_frames wins over every other flag (legacy priority #1).
+        (
+            dict(only_labeled_frames=True, only_suggested_frames=True),
+            [0],
+        ),
+        # only_suggested_frames wins over exclude_user_labeled (priority #2).
+        (
+            dict(
+                only_labeled_frames=False,
+                only_suggested_frames=True,
+                exclude_user_labeled=True,
+            ),
+            [3],
+        ),
+        # only_suggested_frames wins over only_predicted_frames (priority #2).
+        (
+            dict(
+                only_labeled_frames=False,
+                only_suggested_frames=True,
+                only_predicted_frames=True,
+            ),
+            [3],
+        ),
+        # exclude_user_labeled wins over only_predicted_frames (priority #3) --
+        # previously unguarded and silently reversed vs. legacy.
+        (
+            dict(
+                only_labeled_frames=False,
+                exclude_user_labeled=True,
+                only_predicted_frames=True,
+            ),
+            [1, 2],
+        ),
+    ],
+)
+def test_labels_provider_filter_priority_matches_legacy_order(
+    flags, expected_frame_idxs
+):
+    """Multi-flag combinations resolve in the same priority order as legacy.
+
+    Legacy ``LabelsReader`` (data/providers.py) priority: ``only_labeled_frames
+    > only_suggested_frames > exclude_user_labeled > only_predicted_frames``.
+    """
+    labels = _build_priority_test_labels()
+    provider = LabelsProvider(labels=labels, **flags)
+    assert [lf.frame_idx for lf in provider._labeled_frames] == expected_frame_idxs
+
+
 def test_labels_provider_mixed_resolution_batches_by_shape(tmp_path):
     """Frames from videos of different shapes batch without crashing.
 

--- a/tests/inference/test_providers.py
+++ b/tests/inference/test_providers.py
@@ -251,6 +251,24 @@ def test_labels_provider_filter_priority_matches_legacy_order(
     assert [lf.frame_idx for lf in provider._labeled_frames] == expected_frame_idxs
 
 
+def test_labels_provider_only_labeled_frames_defaults_false_like_legacy():
+    """``only_labeled_frames`` defaults to ``False``, matching legacy ``LabelsReader``.
+
+    Regression test: since ``only_labeled_frames`` is the highest-priority
+    filter, a truthy default would silently override any other flag a caller
+    sets without also passing ``only_labeled_frames=False`` explicitly --
+    e.g. ``LabelsProvider(labels=labels, only_suggested_frames=True)`` would
+    otherwise ignore ``only_suggested_frames`` and yield only user-labeled
+    frames instead. ``Predictor._make_provider`` always passes this flag
+    explicitly, so this only bites direct construction -- exactly the
+    pattern this test exercises.
+    """
+    labels = _build_priority_test_labels()
+    provider = LabelsProvider(labels=labels, only_suggested_frames=True)
+    assert provider.only_labeled_frames is False
+    assert [lf.frame_idx for lf in provider._labeled_frames] == [3]
+
+
 def test_labels_provider_mixed_resolution_batches_by_shape(tmp_path):
     """Frames from videos of different shapes batch without crashing.
 

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -255,7 +255,7 @@ def test_predictor_predict_applies_tracker_after_to_labels(
     monkeypatch.setattr(
         Predictor,
         "_batch_iter",
-        lambda self, provider, progress_callback=None: iter([]),
+        lambda self, provider, progress_callback=None, layer=None: iter([]),
     )
     monkeypatch.setattr(
         Predictor,
@@ -297,7 +297,7 @@ def test_predictor_predict_clean_empty_frames_drops_empty(skeleton, video, monke
     monkeypatch.setattr(
         Predictor,
         "_batch_iter",
-        lambda self, provider, progress_callback=None: iter([]),
+        lambda self, provider, progress_callback=None, layer=None: iter([]),
     )
     monkeypatch.setattr(
         Predictor,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,10 +498,12 @@ class TestPredictSamBackend:
         assert "--overlay_path" in result.output
 
 
-class TestPredictFrameFilterFlagsRequireSlp:
-    """Label-status frame filters are now rejected for a non-`.slp` source.
+class TestPredictFrameFilterFlagsWarnForNonSlpSource:
+    """Label-status frame filters are inert (no-op) for a non-`.slp` source.
 
-    Previously silently dropped instead of erroring.
+    They filter by annotation status, which doesn't exist for a raw video.
+    Rather than silently ignoring them with no indication, a warning is
+    logged and inference proceeds on all frames.
     """
 
     @pytest.mark.parametrize(
@@ -513,8 +515,8 @@ class TestPredictFrameFilterFlagsRequireSlp:
             "--only_predicted_frames",
         ],
     )
-    def test_in_memory_flow_rejects_filter_flags_for_video(self, flag):
-        """A video --data_path + a label-status filter fails loudly."""
+    def test_in_memory_flow_warns_and_continues_for_video(self, flag):
+        """A video --data_path + a label-status filter warns but still runs."""
         runner = CliRunner()
         with patch("sleap_nn.inference.run.predict") as mock_predict:
             mock_predict.return_value = MagicMock()
@@ -529,9 +531,10 @@ class TestPredictFrameFilterFlagsRequireSlp:
                     flag,
                 ],
             )
-        assert result.exit_code != 0
+        assert result.exit_code == 0, result.output
         assert "require a `.slp`" in _norm_cli_output(result.output)
-        assert not mock_predict.called
+        assert "have no effect here" in _norm_cli_output(result.output)
+        assert mock_predict.called
 
     @pytest.mark.parametrize(
         "flag",
@@ -542,12 +545,15 @@ class TestPredictFrameFilterFlagsRequireSlp:
             "--only_predicted_frames",
         ],
     )
-    def test_stream_to_file_rejects_filter_flags_for_video(self, flag, tmp_path):
-        """Same rejection for --stream-to-file, before a model is even loaded."""
+    def test_stream_to_file_warns_and_continues_for_video(self, flag, tmp_path):
+        """Same warning for --stream-to-file, logged before a model is loaded."""
         runner = CliRunner()
         with patch(
             "sleap_nn.inference.predictor.Predictor.from_model_paths"
         ) as mock_from_model_paths:
+            mock_predictor = MagicMock()
+            mock_predictor.predict_to_file.return_value = str(tmp_path / "out.slp")
+            mock_from_model_paths.return_value = mock_predictor
             result = runner.invoke(
                 cli,
                 [
@@ -561,13 +567,14 @@ class TestPredictFrameFilterFlagsRequireSlp:
                     flag,
                 ],
             )
-        assert result.exit_code != 0
+        assert result.exit_code == 0, result.output
         assert "require a `.slp`" in _norm_cli_output(result.output)
-        # Fails before loading a model, not after.
-        assert not mock_from_model_paths.called
+        # Still logged before the model is loaded (fail/warn-fast ordering
+        # unchanged), even though it's no longer fatal.
+        assert mock_from_model_paths.called
 
-    def test_slp_source_allows_filter_flags(self, minimal_instance):
-        """A `.slp` --data_path still accepts these flags (no regression)."""
+    def test_slp_source_has_no_warning(self, minimal_instance):
+        """A `.slp` --data_path accepts these flags with no warning logged."""
         runner = CliRunner()
         with patch("sleap_nn.inference.run.predict") as mock_predict:
             mock_predict.return_value = MagicMock()
@@ -584,6 +591,7 @@ class TestPredictFrameFilterFlagsRequireSlp:
             )
         assert result.exit_code == 0, result.output
         assert mock_predict.called
+        assert "require a `.slp`" not in _norm_cli_output(result.output)
 
 
 class TestEvalCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,6 +498,94 @@ class TestPredictSamBackend:
         assert "--overlay_path" in result.output
 
 
+class TestPredictFrameFilterFlagsRequireSlp:
+    """Label-status frame filters are now rejected for a non-`.slp` source.
+
+    Previously silently dropped instead of erroring.
+    """
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--only_labeled_frames",
+            "--only_suggested_frames",
+            "--exclude_user_labeled",
+            "--only_predicted_frames",
+        ],
+    )
+    def test_in_memory_flow_rejects_filter_flags_for_video(self, flag):
+        """A video --data_path + a label-status filter fails loudly."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    "x.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                    flag,
+                ],
+            )
+        assert result.exit_code != 0
+        assert "require a `.slp`" in _norm_cli_output(result.output)
+        assert not mock_predict.called
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--only_labeled_frames",
+            "--only_suggested_frames",
+            "--exclude_user_labeled",
+            "--only_predicted_frames",
+        ],
+    )
+    def test_stream_to_file_rejects_filter_flags_for_video(self, flag, tmp_path):
+        """Same rejection for --stream-to-file, before a model is even loaded."""
+        runner = CliRunner()
+        with patch(
+            "sleap_nn.inference.predictor.Predictor.from_model_paths"
+        ) as mock_from_model_paths:
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    "x.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                    "--stream-to-file",
+                    str(tmp_path / "out.slp"),
+                    flag,
+                ],
+            )
+        assert result.exit_code != 0
+        assert "require a `.slp`" in _norm_cli_output(result.output)
+        # Fails before loading a model, not after.
+        assert not mock_from_model_paths.called
+
+    def test_slp_source_allows_filter_flags(self, minimal_instance):
+        """A `.slp` --data_path still accepts these flags (no regression)."""
+        runner = CliRunner()
+        with patch("sleap_nn.inference.run.predict") as mock_predict:
+            mock_predict.return_value = MagicMock()
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "-i",
+                    str(minimal_instance),
+                    "--model_paths",
+                    "/fake/model",
+                    "--only_predicted_frames",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_predict.called
+
+
 class TestEvalCommand:
     """Tests for eval command using CliRunner."""
 


### PR DESCRIPTION
## Summary

Three related correctness bugs, all in the predict-time code path, found by a repo-wide correctness audit. First of two follow-up PRs from that audit (see companion PR for the training/evaluation fixes).

- Fixes `predict_streaming()` overrides leaking across interleaved generator calls on the same `Predictor`.
- Fixes the CLI silently dropping frame-filter flags for video (non-`.slp`) inputs with no indication anything changed.
- Fixes `LabelsProvider`'s frame-filter priority order diverging from the legacy `LabelsReader`.

## Problem + Fix, per issue

### 1. `predict_streaming()` postprocess overrides leak across interleaved generators

**Root cause:** `_postprocess_overrides` (now `_scoped_postprocess_layer`) applied predict-time overrides (`peak_threshold`, `max_instances`, `integral_refinement`, etc.) by mutating the shared `layer.postprocess_config` in place, restoring it in a `finally` block tied to a `with` block wrapping a `yield from` inside the generator `predict_streaming()`. That `finally` only fires when the generator is exhausted or explicitly closed. Two `predict_streaming()` calls on the *same* `Predictor`, interleaved via alternating `next()` calls, shared that mutable state — whichever call's override was applied most recently is what both saw during the overlap window, and restore-on-exit timing depended on which generator finished first. This wasn't fixable by better restore bookkeeping: the two calls were reading/writing identical shared state at the same time, so the actual inference behavior (not just final state) was wrong during any overlap.

**Fix:** `_scoped_postprocess_layer` (`predictor.py`) now returns `self.layer` unchanged when no override is requested (the common case, zero cost), or a **private, shallow-copied layer** (and shallow-copied sub-layers, for composed layers like `TopDownLayer`) with the overrides baked into the copies' `postprocess_config` via `attrs.evolve`. `self.layer` and its real sub-layers are never touched. `_batch_iter` / `_predict_streaming_pipelined` now accept an explicit `layer` parameter (used for all `.predict()`/`.preprocess()`/`.backend()` calls) instead of reading `self.layer` directly, so each `predict_streaming()` call operates on its own independent layer graph. `predict()` (the synchronous, non-streaming path) was never actually vulnerable to this — it fully materializes `list(self._batch_iter(...))` inside the `with` block before returning, so no generator escapes to interleave with another call — but it's been switched to the same code path for consistency (one implementation, not two).

Layer objects (`InferenceLayer` subclasses, `TopDownLayer`) are plain mutable Python classes, not frozen — `copy.copy()` + reassigning `.postprocess_config` on the copy is safe and cheap. Heavy shared state (`backend`/model weights, `paf_scorer`) is intentionally left shared between the original and the copy (only read, never mutated during inference), so this adds no meaningful overhead.

**New regression test** (`test_predictor_new.py`): two `predict_streaming()` generators on the same `Predictor` with different `peak_threshold` overrides (0.9 / 0.1), interleaved `a, b, a, b` via alternating `next()`. Verified this test **fails against the pre-fix code** (second `next()` on generator A incorrectly picks up generator B's 0.1 override) and passes with the fix.

### 2. CLI silently drops frame-filter flags for video inputs, with no indication

**Root cause:** In `_run_in_memory_new_flow` (`cli.py`), the branch selecting how to build the inference source only checks `video_dataset`/`video_input_format`/`remote_kwargs` when `--data_path` is a video (`src_suffix != ".slp"`) — it never checks whether `--only_predicted_frames` (etc.) was also set. So `sleap-nn predict video.mp4 -m ckpt --only_predicted_frames` falls through to `source = source_str` with the flag silently ignored — full-video inference runs with no warning. `_run_stream_to_file` had the identical gap.

These flags are fundamentally inert for a raw video — there's no annotation data (no user instances, predicted instances, or suggestions) to filter by, so a `.slp` source is required for them to mean anything. That part isn't a bug. The bug is that the *inertness* was invisible: a user requesting a filtered subset silently got all frames instead, with nothing telling them the flag had no effect.

**Fix:** A shared helper, `_warn_ignored_slp_filters_for_non_slp_source(kwargs, src_suffix)`, called from both `_run_in_memory_new_flow` and `_run_stream_to_file` — deliberately shared (not two copy-pasted checks) since that exact kind of duplication is what caused issue #3 below. Logs a `logger.warning` naming the ignored flags and continues (does not raise); inference proceeds on all frames exactly as it would if the flags were never passed. For `_run_stream_to_file`, the check runs *before* `Predictor.from_model_paths(...)` (moved earlier in the function), so the warning surfaces before the cost of a model load, even though it's non-fatal.

(An earlier version of this fix raised `click.UsageError` instead, matching legacy `legacy_predict.py`'s behavior for this case — reverted to a warning after review: a hard error was an overcorrection for something that's a legitimate no-op, not a usage mistake worth blocking a run over, e.g. a script that reuses the same flags across both `.slp` and video inputs.)

### 3. New `LabelsProvider` frame-filter priority order diverges from legacy `LabelsReader`

**Root cause:** Legacy `LabelsReader.__init__` (`data/providers.py`) priority when multiple `only_*`/`exclude_*` flags are set: `only_labeled_frames > only_suggested_frames > exclude_user_labeled > only_predicted_frames`. The new `LabelsProvider.__attrs_post_init__` (`inference/providers.py`) had the reversed order: `only_suggested_frames > only_predicted_frames > exclude_user_labeled > only_labeled_frames`. Only `only_labeled_frames`+`exclude_user_labeled` was guarded as mutually exclusive; every other combination silently picked a different branch than legacy did, with the same CLI flags producing different frame sets between the legacy and new pipelines.

**Fix:** Reordered the if/elif chain to match legacy exactly, with a comment marking the order as parity-load-bearing (not arbitrary).

**Follow-up found while double-checking this fix:** reordering surfaced a *second*, related bug — `LabelsProvider.only_labeled_frames` defaulted to `True`, while legacy's default is `False`. Since `only_labeled_frames` is now (correctly) the highest-priority filter, that truthy default silently overrode any other flag a caller set without also passing `only_labeled_frames=False` — e.g. `LabelsProvider(labels=labels, only_suggested_frames=True)` ignored `only_suggested_frames` entirely and returned only user-labeled frames instead. This was invisible before the reorder (the old order checked `only_suggested_frames` first, so the truthy default on `only_labeled_frames` never got a chance to matter) — the reorder is what exposed it. `Predictor._make_provider` always passes this flag explicitly (computed from whether the layer needs GT instances), so CLI/internal usage was never affected, but direct construction of `LabelsProvider` was a real footgun. Fixed the default to `False` to match legacy fully (order *and* default), with a regression test reproducing the exact scenario above.

## Testing

- New tests (`tests/inference/test_predictor_new.py`, `tests/inference/test_providers.py`, `tests/test_cli.py`):
  - Interleaved-generator override isolation (verified to fail pre-fix, pass post-fix).
  - `_scoped_postprocess_layer` no-op case returns the same object (no copy overhead when unneeded); return-flag overrides land on the copy, never on the real layer.
  - Parametrized frame-filter priority-order tests covering every previously-untested flag combination (including `exclude_user_labeled`+`only_predicted_frames`, previously unguarded and silently reversed).
  - CLI tests for both the in-memory and `--stream-to-file` flows, over all four filter flags, confirming the warning is logged, the run still completes (`exit_code == 0`), and `predict()`/`Predictor.from_model_paths` are still reached; plus a `.slp`-source regression test confirming no warning is logged there.
- Updated 3 existing tests (`test_issue_583.py`, `test_issue_584.py`, `test_tracking.py`) that exercised the old mutate-in-place `_postprocess_overrides` API directly — now assert the stronger "real layer is never touched" property instead of "restored after."
- Full `tests/inference/` suite: 827 passed, 81 skipped, 1 xfailed (up from 824/81/1 pre-change; no regressions).
- Full `tests/test_cli.py` suite: 65 passed, no regressions.
- `black`/`ruff` clean on all changed files (verified zero *new* lint errors via before/after diff against the pre-existing baseline).

## Edge-Case Audit

Asked a subagent to adversarially check the `#1` refactor (the highest-risk change here) against every layer type in the codebase, specifically hunting for anything the `isinstance`/`hasattr` dispatch in `_scoped_postprocess_layer`/`_collect_postprocess_targets` might miss. Findings:

- **No regression in this PR.** The override-isolation fix is correct for every layer type that already supported predict-time overrides: `TopDownLayer`, `TopDownMultiClassLayer` (a `TopDownLayer` subclass — per-stage `centroid_threshold`/`keypoint_threshold` routing still works), `BottomUpLayer`, `BottomUpMultiClassLayer`, and the plain segmentation layers. Verified via diffing `_collect_postprocess_targets`'s dispatch logic before/after this PR — byte-identical; this PR only changed *how* an override is applied (copy vs. mutate-in-place), not *which* layers it applies to.
- **Three pre-existing gaps surfaced, none introduced by this PR, none fixed here:**
  1. Predict-time postprocess overrides (`peak_threshold`, `max_instances`, etc.) are complete no-ops for **every tiled layer** (`TiledLayer`, `TiledSegmentationLayer`, `TiledSemanticSegmentationLayer`) — they don't expose a `postprocess_config` attribute at all (the real one lives on the wrapped inner layer), so `_collect_postprocess_targets` returns no targets and the override is silently dropped.
  2. `TopDownSegmentationLayer`'s mask-decode stage thresholds on `fg_threshold` (a separate, non-overridable constructor-time attribute), so a `keypoint_threshold`/`peak_threshold` predict-time override is silently written to an unread config field.
  3. `TiledSegmentationLayer` doesn't re-expose `mask_output`/`polygon_epsilon` from its wrapped layer the way `TiledSemanticSegmentationLayer` already does, so `to_labels()`/`predict_to_file()` silently fall back to defaults for a tiled `bottomup_segmentation` model with non-default `mask_output`.

None of these are touched by this PR (confirmed pre-existing via `git show` diff comparison) and none are blockers for merging this — they're a separate, real follow-up (tiled-layer override support is the most impactful of the three). Flagging rather than fixing here to avoid scope creep into an already-reviewed PR; happy to open that as a tracked follow-up if wanted.

## Design Decisions

- **Copy-based isolation, not better mutate/restore bookkeeping**, for #1 — the bug isn't in the restore logic, it's that two concurrent calls need genuinely independent state, which only an actual copy provides.
- **Shared CLI validation helper, not duplicated checks**, for #2 — directly motivated by #3 having been exactly this kind of duplication-drift bug.
- **Warn-and-continue, not a hard error**, for #2 — the flags being inert for video is correct and expected (there's no annotation data to filter by); the fix targets making that inertness visible, not blocking a run over a combination that isn't actually invalid, just meaningless for that source.
- **Reorder to match legacy, not add new mutual-exclusivity errors**, for #3 — matches today's legacy CLI behavior (priority order, not a hard error) rather than introducing a new, broader validation behavior beyond what's needed to fix the parity gap.

## Related Issues

Part of a repo-wide correctness audit; companion PR (training/evaluation fixes: eval-callback `callback_metrics` gap, post-training eval ignoring configured OKS params, `find_frame_pairs` GT mutation) to follow once this one merges.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

