### PR TITLE
fix(training): training/evaluation correctness fixes (callback_metrics, OKS eval config, GT mutation)

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -593,10 +593,16 @@ def find_frame_pairs(
         # Find labeled frames in this video.
         labeled_frames_gt = labels_gt.find(video_gt)
         if user_labels_only:
-            for lf in labeled_frames_gt:
-                lf.instances = lf.user_instances
+            # Build fresh LabeledFrame copies restricted to user instances,
+            # rather than mutating `lf.instances` in place -- `labels_gt.find`
+            # returns references into the caller's actual Labels object, so
+            # mutating it here permanently discards PredictedInstances from
+            # ground truth the caller may reuse afterward (e.g. a second
+            # Evaluator call with user_labels_only=False on the same labels_gt).
             labeled_frames_gt = [
-                lf for lf in labeled_frames_gt if len(lf.user_instances) > 0
+                attrs.evolve(lf, instances=lf.user_instances)
+                for lf in labeled_frames_gt
+                if len(lf.user_instances) > 0
             ]
 
         # Attempt to match each labeled frame in the ground truth.

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -20,6 +20,32 @@ from sleap_nn.config.utils import get_model_type_from_cfg
 from sleap_nn.system_info import get_startup_info_string
 
 
+def _oks_run_evaluation_overrides(config: DictConfig) -> Dict[str, Any]:
+    """Config-driven ``run_evaluation`` overrides for the standard OKS eval path.
+
+    Forwards ``trainer_config.eval.oks_stddev``/``oks_scale`` -- the same
+    values ``EpochEndEvaluationCallback`` uses for the per-epoch OKS eval
+    (``model_trainer.py``) -- so the post-training ``metrics.<split>.npz``
+    isn't silently computed with ``run_evaluation``'s hardcoded defaults
+    (0.025 / ``None``) instead of what the user configured.
+
+    Deliberately does NOT forward ``trainer_config.eval.match_threshold``:
+    that shared config field's own default (50.0) is a centroid-mode PIXEL
+    distance, not a valid OKS threshold, and ``EpochEndEvaluationCallback``
+    doesn't forward it either for this same OKS eval path.
+    """
+    overrides: Dict[str, Any] = {}
+    oks_stddev = OmegaConf.select(
+        config, "trainer_config.eval.oks_stddev", default=None
+    )
+    if oks_stddev is not None:
+        overrides["oks_stddev"] = oks_stddev
+    oks_scale = OmegaConf.select(config, "trainer_config.eval.oks_scale", default=None)
+    if oks_scale is not None:
+        overrides["oks_scale"] = oks_scale
+    return overrides
+
+
 def _run_centroid_split_eval(
     config: DictConfig,
     d_name: str,
@@ -419,11 +445,12 @@ def run_training(
                     )
                     continue  # skip if there are no labeled frames
 
-                # Run evaluation and save metrics
+                # Run evaluation and save metrics.
                 metrics = run_evaluation(
                     ground_truth_path=path,
                     predicted_path=pred_path.as_posix(),
                     save_metrics=metrics_path.as_posix(),
+                    **_oks_run_evaluation_overrides(config),
                 )
 
                 logger.info(f"---------Evaluation on `{d_name}` dataset---------")

--- a/sleap_nn/training/callbacks.py
+++ b/sleap_nn/training/callbacks.py
@@ -1392,11 +1392,86 @@ class EpochEndEvaluationCallback(Callback):
         )
 
     def _log_metrics(self, trainer, metrics: dict, epoch: int):
-        """Log evaluation metrics to WandB."""
+        """Populate callback_metrics for ModelCheckpoint, then log to WandB."""
         import numpy as np
+        import torch
         from lightning.pytorch.loggers import WandbLogger
 
-        # Get WandB logger
+        # (metrics_to_log name, callback/wandb key, raw value, higher_is_better)
+        candidates = [
+            ("mOKS", "eval/val/mOKS", metrics["mOKS"]["mOKS"], True),
+            (
+                "oks_voc.mAP",
+                "eval/val/oks_voc_mAP",
+                metrics["voc_metrics"]["oks_voc.mAP"],
+                True,
+            ),
+            (
+                "oks_voc.mAR",
+                "eval/val/oks_voc_mAR",
+                metrics["voc_metrics"]["oks_voc.mAR"],
+                True,
+            ),
+            (
+                "distance/avg",
+                "eval/val/distance/avg",
+                metrics["distance_metrics"]["avg"],
+                False,
+            ),
+            (
+                "distance/p50",
+                "eval/val/distance/p50",
+                metrics["distance_metrics"]["p50"],
+                False,
+            ),
+            (
+                "distance/p95",
+                "eval/val/distance/p95",
+                metrics["distance_metrics"]["p95"],
+                False,
+            ),
+            (
+                "distance/p99",
+                "eval/val/distance/p99",
+                metrics["distance_metrics"]["p99"],
+                False,
+            ),
+            ("mPCK", "eval/val/mPCK", metrics["pck_metrics"]["mPCK"], True),
+            ("PCK@5", "eval/val/PCK_5", metrics["pck_metrics"]["PCK@5"], True),
+            ("PCK@10", "eval/val/PCK_10", metrics["pck_metrics"]["PCK@10"], True),
+            (
+                "visibility_precision",
+                "eval/val/visibility_precision",
+                metrics["visibility_metrics"]["precision"],
+                True,
+            ),
+            (
+                "visibility_recall",
+                "eval/val/visibility_recall",
+                metrics["visibility_metrics"]["recall"],
+                True,
+            ),
+        ]
+        tracked = [c for c in candidates if c[0] in self.metrics_to_log]
+
+        # Expose every tracked metric to ModelCheckpoint/EarlyStopping via
+        # callback_metrics (this runs in on_validation_epoch_end, before the
+        # ModelCheckpoint save in on_validation_end, so the value is
+        # available). ALWAYS populate the key -- a NaN/missing value (no
+        # matched instances this epoch) falls back to the worst possible
+        # value for that metric's direction (0.0 for higher-is-better scores
+        # in [0, 1]; +inf for lower-is-better pixel distances) instead of
+        # leaving the key unset, which would crash ModelCheckpoint on the
+        # first epoch a run monitors it.
+        for _name, ck_key, raw_value, higher_is_better in tracked:
+            worst = 0.0 if higher_is_better else float("inf")
+            fv = (
+                worst
+                if (raw_value is None or np.isnan(raw_value))
+                else float(raw_value)
+            )
+            trainer.callback_metrics[ck_key] = torch.as_tensor(fv)
+
         wandb_logger = None
         for log in trainer.loggers:
             if isinstance(log, WandbLogger):
@@ -1407,60 +1482,9 @@ class EpochEndEvaluationCallback(Callback):
             return
 
         log_dict = {"epoch": epoch}
-
-        # Extract key metrics with consistent naming
-        # All eval metrics use eval/val/ prefix since they're computed on validation data
-        if "mOKS" in self.metrics_to_log:
-            log_dict["eval/val/mOKS"] = metrics["mOKS"]["mOKS"]
-
-        if "oks_voc.mAP" in self.metrics_to_log:
-            log_dict["eval/val/oks_voc_mAP"] = metrics["voc_metrics"]["oks_voc.mAP"]
-
-        if "oks_voc.mAR" in self.metrics_to_log:
-            log_dict["eval/val/oks_voc_mAR"] = metrics["voc_metrics"]["oks_voc.mAR"]
-
-        # Distance metrics grouped under eval/val/distance/
-        if "distance/avg" in self.metrics_to_log:
-            val = metrics["distance_metrics"]["avg"]
-            if not np.isnan(val):
-                log_dict["eval/val/distance/avg"] = val
-
-        if "distance/p50" in self.metrics_to_log:
-            val = metrics["distance_metrics"]["p50"]
-            if not np.isnan(val):
-                log_dict["eval/val/distance/p50"] = val
-
-        if "distance/p95" in self.metrics_to_log:
-            val = metrics["distance_metrics"]["p95"]
-            if not np.isnan(val):
-                log_dict["eval/val/distance/p95"] = val
-
-        if "distance/p99" in self.metrics_to_log:
-            val = metrics["distance_metrics"]["p99"]
-            if not np.isnan(val):
-                log_dict["eval/val/distance/p99"] = val
-
-        # PCK metrics
-        if "mPCK" in self.metrics_to_log:
-            log_dict["eval/val/mPCK"] = metrics["pck_metrics"]["mPCK"]
-
-        # PCK at specific thresholds (precomputed in evaluation.py)
-        if "PCK@5" in self.metrics_to_log:
-            log_dict["eval/val/PCK_5"] = metrics["pck_metrics"]["PCK@5"]
-
-        if "PCK@10" in self.metrics_to_log:
-            log_dict["eval/val/PCK_10"] = metrics["pck_metrics"]["PCK@10"]
-
-        # Visibility metrics
-        if "visibility_precision" in self.metrics_to_log:
-            val = metrics["visibility_metrics"]["precision"]
-            if not np.isnan(val):
-                log_dict["eval/val/visibility_precision"] = val
-
-        if "visibility_recall" in self.metrics_to_log:
-            val = metrics["visibility_metrics"]["recall"]
-            if not np.isnan(val):
-                log_dict["eval/val/visibility_recall"] = val
+        for _name, ck_key, raw_value, _higher_is_better in tracked:
+            if not np.isnan(raw_value):
+                log_dict[ck_key] = raw_value
 
         wandb_logger.experiment.log(log_dict, commit=False)
 
@@ -2044,11 +2068,42 @@ class CentroidEvaluationCallback(Callback):
         }
 
     def _log_metrics(self, trainer, metrics: dict, epoch: int):
-        """Log centroid evaluation metrics to WandB."""
+        """Populate callback_metrics for ModelCheckpoint, then log to WandB."""
         import numpy as np
+        import torch
         from lightning.pytorch.loggers import WandbLogger
 
-        # Get WandB logger
+        # (callback/wandb key, raw value, higher_is_better)
+        tracked = [
+            ("eval/val/centroid_dist_avg", metrics["dist_avg"], False),
+            ("eval/val/centroid_dist_median", metrics["dist_median"], False),
+            ("eval/val/centroid_dist_p90", metrics["dist_p90"], False),
+            ("eval/val/centroid_dist_p95", metrics["dist_p95"], False),
+            ("eval/val/centroid_dist_max", metrics["dist_max"], False),
+            ("eval/val/centroid_precision", metrics["precision"], True),
+            ("eval/val/centroid_recall", metrics["recall"], True),
+            ("eval/val/centroid_f1", metrics["f1"], True),
+            ("eval/val/centroid_n_tp", metrics["n_true_positives"], True),
+            ("eval/val/centroid_n_fp", metrics["n_false_positives"], True),
+            ("eval/val/centroid_n_fn", metrics["n_false_negatives"], True),
+        ]
+
+        # Expose every metric to ModelCheckpoint/EarlyStopping via
+        # callback_metrics (mirrors EpochEndEvaluationCallback -- see its
+        # _log_metrics for the full rationale). ALWAYS populate the key: a
+        # NaN/missing distance metric (no matched instances this epoch) falls
+        # back to +inf (the worst value for a lower-is-better pixel distance)
+        # instead of leaving the key unset, which would crash ModelCheckpoint
+        # on the first epoch a run monitors it.
+        for ck_key, raw_value, higher_is_better in tracked:
+            worst = 0.0 if higher_is_better else float("inf")
+            fv = (
+                worst
+                if (raw_value is None or np.isnan(raw_value))
+                else float(raw_value)
+            )
+            trainer.callback_metrics[ck_key] = torch.as_tensor(fv)
+
         wandb_logger = None
         for log in trainer.loggers:
             if isinstance(log, WandbLogger):
@@ -2059,28 +2114,9 @@ class CentroidEvaluationCallback(Callback):
             return
 
         log_dict = {"epoch": epoch}
-
-        # Distance metrics (with NaN handling)
-        if not np.isnan(metrics["dist_avg"]):
-            log_dict["eval/val/centroid_dist_avg"] = metrics["dist_avg"]
-        if not np.isnan(metrics["dist_median"]):
-            log_dict["eval/val/centroid_dist_median"] = metrics["dist_median"]
-        if not np.isnan(metrics["dist_p90"]):
-            log_dict["eval/val/centroid_dist_p90"] = metrics["dist_p90"]
-        if not np.isnan(metrics["dist_p95"]):
-            log_dict["eval/val/centroid_dist_p95"] = metrics["dist_p95"]
-        if not np.isnan(metrics["dist_max"]):
-            log_dict["eval/val/centroid_dist_max"] = metrics["dist_max"]
-
-        # Detection metrics
-        log_dict["eval/val/centroid_precision"] = metrics["precision"]
-        log_dict["eval/val/centroid_recall"] = metrics["recall"]
-        log_dict["eval/val/centroid_f1"] = metrics["f1"]
-
-        # Counts
-        log_dict["eval/val/centroid_n_tp"] = metrics["n_true_positives"]
-        log_dict["eval/val/centroid_n_fp"] = metrics["n_false_positives"]
-        log_dict["eval/val/centroid_n_fn"] = metrics["n_false_negatives"]
+        for ck_key, raw_value, _higher_is_better in tracked:
+            if not np.isnan(raw_value):
+                log_dict[ck_key] = raw_value
 
         wandb_logger.experiment.log(log_dict, commit=False)
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -437,6 +437,51 @@ def test_evaluator_more_predicted_instances(minimal_instance):
     assert len(eval.false_negatives) == 2
 
 
+def test_find_frame_pairs_does_not_mutate_gt_labels():
+    """``user_labels_only=True`` must not mutate the caller's GT ``Labels``.
+
+    Regression test: ``find_frame_pairs`` used to do ``lf.instances =
+    lf.user_instances`` directly on the ``LabeledFrame`` objects returned by
+    ``labels_gt.find(...)``, which are references into the caller's actual
+    ``Labels`` object (not copies) -- permanently discarding any
+    ``PredictedInstance``s from the real ground-truth object. A second
+    ``Evaluator`` built from the same ``labels_gt`` afterward (e.g. with
+    ``user_labels_only=False``) would then silently see fewer instances than
+    it should.
+    """
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="dummy.mp4")
+
+    user_inst = sio.Instance.from_numpy(
+        np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32), skeleton=skel
+    )
+    pred_inst_gt = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[2.0, 2.0], [3.0, 3.0]], dtype=np.float32),
+        skeleton=skel,
+        score=0.9,
+    )
+    lf_gt = sio.LabeledFrame(
+        video=video, frame_idx=0, instances=[user_inst, pred_inst_gt]
+    )
+    labels_gt = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[lf_gt])
+
+    pred_inst_pr = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[0.1, 0.1], [1.1, 1.1]], dtype=np.float32),
+        skeleton=skel,
+        score=0.95,
+    )
+    lf_pr = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst_pr])
+    labels_pr = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[lf_pr])
+
+    assert len(labels_gt.labeled_frames[0].instances) == 2
+
+    Evaluator(labels_gt, labels_pr, user_labels_only=True, match_threshold=100.0)
+
+    # The real GT Labels object must be untouched -- both the user and the
+    # predicted instance are still there.
+    assert len(labels_gt.labeled_frames[0].instances) == 2
+
+
 def test_evaluator_metrics(minimal_instance):
     user_labels, pred_labels = create_labels_two_match_one_missed_inst(minimal_instance)
     eval = Evaluator(user_labels, pred_labels)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -5,8 +5,40 @@ import copy
 import sys
 import torch
 import pytest
-from sleap_nn.train import train, run_training as main
+from sleap_nn.train import train, run_training as main, _oks_run_evaluation_overrides
 import sleap_io as sio
+
+
+def test_oks_run_evaluation_overrides_forwards_configured_values():
+    """The standard post-training OKS eval forwards the configured OKS params.
+
+    Regression test (#8/#10): must forward trainer_config.eval.oks_stddev/
+    oks_scale (matching what EpochEndEvaluationCallback uses per-epoch), not
+    silently fall back to run_evaluation's hardcoded defaults.
+    match_threshold is deliberately NOT forwarded -- its shared config
+    default (50.0) is a centroid-mode pixel distance, not a valid OKS
+    threshold.
+    """
+    config = OmegaConf.create(
+        {
+            "trainer_config": {
+                "eval": {
+                    "oks_stddev": 0.1,
+                    "oks_scale": 2.5,
+                    "match_threshold": 50.0,
+                }
+            }
+        }
+    )
+    overrides = _oks_run_evaluation_overrides(config)
+    assert overrides == {"oks_stddev": 0.1, "oks_scale": 2.5}
+
+
+def test_oks_run_evaluation_overrides_omits_unset_values():
+    """Missing config keys are omitted (not forwarded as None)."""
+    config = OmegaConf.create({"trainer_config": {"eval": {}}})
+    overrides = _oks_run_evaluation_overrides(config)
+    assert overrides == {}
 
 
 def test_run_centroid_split_eval_routing(monkeypatch, tmp_path):

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -1620,7 +1620,7 @@ class TestEpochEndEvaluationCallback:
         assert len(labels.labeled_frames[0].instances) == 1
 
     def test_log_metrics_no_wandb_logger(self, mock_skeleton, mock_videos):
-        """Does nothing if no wandb logger found."""
+        """Still populates callback_metrics (for ModelCheckpoint) with no wandb logger."""
         callback = EpochEndEvaluationCallback(
             skeleton=mock_skeleton,
             videos=mock_videos,
@@ -1628,17 +1628,23 @@ class TestEpochEndEvaluationCallback:
 
         mock_trainer = MagicMock()
         mock_trainer.loggers = []  # No loggers
+        mock_trainer.callback_metrics = {}
 
         metrics = {
             "mOKS": {"mOKS": 0.85},
             "voc_metrics": {"oks_voc.mAP": 0.75, "oks_voc.mAR": 0.80},
-            "distance_metrics": {"avg": 5.0, "p50": 4.0},
-            "pck_metrics": {"mPCK": 0.90},
+            "distance_metrics": {"avg": 5.0, "p50": 4.0, "p95": 8.0, "p99": 10.0},
+            "pck_metrics": {"mPCK": 0.90, "PCK@5": 0.85, "PCK@10": 0.92},
             "visibility_metrics": {"precision": 0.95, "recall": 0.92},
         }
 
-        # Should not raise
+        # Should not raise, and callback_metrics is populated regardless of
+        # wandb -- ModelCheckpoint needs this even in a non-wandb run.
         callback._log_metrics(mock_trainer, metrics, epoch=5)
+        assert mock_trainer.callback_metrics["eval/val/mOKS"] == pytest.approx(0.85)
+        assert mock_trainer.callback_metrics["eval/val/distance/avg"] == pytest.approx(
+            5.0
+        )
 
     def test_log_metrics_with_wandb_logger(self, mock_skeleton, mock_videos):
         """Logs metrics to wandb when logger present."""
@@ -1721,6 +1727,46 @@ class TestEpochEndEvaluationCallback:
         # Non-NaN values should be present
         assert log_dict["eval/val/mOKS"] == 0.85
         assert log_dict["eval/val/mPCK"] == 0.90
+
+    def test_log_metrics_nan_callback_metrics_use_direction_aware_worst_value(
+        self, mock_skeleton, mock_videos
+    ):
+        """NaN metrics fall back to the worst value for their direction.
+
+        Regression test (#8): callback_metrics must always have a key for
+        every tracked metric, even on an epoch with no valid value -- 0.0 for
+        a higher-is-better score in [0, 1] (mOKS), +inf for a lower-is-better
+        pixel distance (distance/avg). Otherwise ModelCheckpoint crashes the
+        first time it's asked to monitor one of these keys.
+        """
+        callback = EpochEndEvaluationCallback(
+            skeleton=mock_skeleton,
+            videos=mock_videos,
+        )
+        mock_trainer = MagicMock()
+        mock_trainer.loggers = []
+        mock_trainer.callback_metrics = {}
+
+        metrics = {
+            "mOKS": {"mOKS": np.nan},
+            "voc_metrics": {"oks_voc.mAP": np.nan, "oks_voc.mAR": np.nan},
+            "distance_metrics": {
+                "avg": np.nan,
+                "p50": np.nan,
+                "p95": np.nan,
+                "p99": np.nan,
+            },
+            "pck_metrics": {"mPCK": np.nan, "PCK@5": np.nan, "PCK@10": np.nan},
+            "visibility_metrics": {"precision": np.nan, "recall": np.nan},
+        }
+        callback._log_metrics(mock_trainer, metrics, epoch=5)
+
+        # Higher-is-better metrics -> 0.0 (worst score in [0, 1]).
+        assert mock_trainer.callback_metrics["eval/val/mOKS"] == 0.0
+        assert mock_trainer.callback_metrics["eval/val/mPCK"] == 0.0
+        # Lower-is-better distance metrics -> +inf (worst pixel distance).
+        assert mock_trainer.callback_metrics["eval/val/distance/avg"] == float("inf")
+        assert mock_trainer.callback_metrics["eval/val/distance/p50"] == float("inf")
 
 
 class TestUnifiedVizCallback:
@@ -2571,11 +2617,12 @@ class TestCentroidEvaluationCallback:
         assert metrics["n_total_ground_truth"] == 2
 
     def test_log_metrics_no_wandb_logger(self, mock_videos):
-        """Does nothing if no wandb logger found."""
+        """Still populates callback_metrics (for ModelCheckpoint) with no wandb logger."""
         callback = CentroidEvaluationCallback(videos=mock_videos)
 
         mock_trainer = MagicMock()
         mock_trainer.loggers = []
+        mock_trainer.callback_metrics = {}
 
         metrics = {
             "dist_avg": 5.0,
@@ -2593,8 +2640,53 @@ class TestCentroidEvaluationCallback:
             "n_total_ground_truth": 12,
         }
 
-        # Should not raise
+        # Should not raise, and callback_metrics is populated regardless of
+        # wandb -- ModelCheckpoint needs this even in a non-wandb run.
         callback._log_metrics(mock_trainer, metrics, epoch=5)
+        assert mock_trainer.callback_metrics[
+            "eval/val/centroid_dist_avg"
+        ] == pytest.approx(5.0)
+        assert mock_trainer.callback_metrics[
+            "eval/val/centroid_precision"
+        ] == pytest.approx(0.9)
+
+    def test_log_metrics_nan_distance_callback_metrics_fall_back_to_inf(
+        self, mock_videos
+    ):
+        """A NaN distance metric falls back to +inf in callback_metrics.
+
+        Regression test (#8): monitoring ``eval/val/centroid_dist_avg`` with
+        ``mode="min"`` must not crash ModelCheckpoint on an epoch with no
+        matched instances -- +inf (the worst possible distance) keeps it a
+        valid, never-selected-as-best value instead of an unset key.
+        """
+        callback = CentroidEvaluationCallback(videos=mock_videos)
+        mock_trainer = MagicMock()
+        mock_trainer.loggers = []
+        mock_trainer.callback_metrics = {}
+
+        metrics = {
+            "dist_avg": float("nan"),
+            "dist_median": float("nan"),
+            "dist_p90": float("nan"),
+            "dist_p95": float("nan"),
+            "dist_max": float("nan"),
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": 0.0,
+            "n_true_positives": 0,
+            "n_false_positives": 5,
+            "n_false_negatives": 3,
+            "n_total_predictions": 5,
+            "n_total_ground_truth": 3,
+        }
+        callback._log_metrics(mock_trainer, metrics, epoch=5)
+
+        assert mock_trainer.callback_metrics["eval/val/centroid_dist_avg"] == float(
+            "inf"
+        )
+        # Higher-is-better metrics still fall back to 0.0, not +inf.
+        assert mock_trainer.callback_metrics["eval/val/centroid_precision"] == 0.0
 
     def test_log_metrics_with_wandb_logger(self, mock_videos):
         """Logs metrics to wandb when logger present."""


### PR DESCRIPTION
## Summary

Three related correctness bugs, all in the training-time and standalone evaluation subsystem, found by a repo-wide correctness audit. Second of two follow-up PRs from that audit (companion to #712, already merged).

- `EpochEndEvaluationCallback` and `CentroidEvaluationCallback` now populate `trainer.callback_metrics`, so `ModelCheckpoint(monitor="eval/val/mOKS")` (or their other metrics) doesn't crash training.
- Post-training `run_evaluation()` for standard OKS pose models now forwards the configured `oks_stddev`/`oks_scale`, matching what the per-epoch callback already does.
- `find_frame_pairs` no longer mutates the caller's ground-truth `Labels` object in place.

## Problem + Fix, per issue

### 1. Two eval callbacks never populate `trainer.callback_metrics`

**Root cause:** `SegmentationEvaluationCallback` (`training/callbacks.py`) explicitly writes `trainer.callback_metrics[ck_key] = torch.as_tensor(fv)` for every metric it computes, with an inline comment explaining why: Lightning's `ModelCheckpoint` reads `callback_metrics` to decide whether/what to checkpoint, and the key must always exist (with a documented worst-value fallback for NaN/missing) or `ModelCheckpoint` raises `MisconfigurationException` the first time a run monitors it. `EpochEndEvaluationCallback` (OKS/mAP/PCK/distance metrics for standard pose models) and `CentroidEvaluationCallback` (centroid distance/precision/recall) only ever called `wandb_logger.experiment.log(...)` — never touched `callback_metrics` at all, and did nothing whatsoever when no WandB logger was configured.

**Fix:** Both callbacks now populate `callback_metrics` unconditionally (before any WandB-logger check, so it works with or without WandB), using a direction-aware worst-value fallback for NaN/missing values — **not** a blanket `0.0` like the segmentation callback, since these two callbacks mix higher-is-better metrics (mOKS, mAP, PCK, precision/recall/F1 — `0.0` is correct) with lower-is-better *distance* metrics (`distance/avg`, `centroid_dist_avg`, etc. — for these, `0.0` would look like a *perfect* zero-distance result on a missing epoch, the opposite of "worst," and could make `ModelCheckpoint(mode="min")` pick a broken epoch as best). Distance metrics fall back to `float("inf")` instead.

Refactored `EpochEndEvaluationCallback._log_metrics` around a single `(metrics_to_log name, callback/wandb key, raw value, higher_is_better)` list built once, so the `callback_metrics` population and the (unchanged) WandB `log_dict` + best-summary logic both read from the same source instead of duplicating each metric's extraction twice.

### 2. Post-training final-split evaluation ignores configured OKS eval parameters

**Root cause:** `train.py`'s post-training `run_evaluation()` call for the standard (non-centroid, non-segmentation) OKS eval path passed only `ground_truth_path`/`predicted_path`/`save_metrics` — no `oks_stddev`/`oks_scale` — so it silently fell back to `run_evaluation`'s hardcoded defaults (`0.025`/`None`) regardless of what `trainer_config.eval.oks_stddev`/`oks_scale` the user actually configured. The per-epoch `EpochEndEvaluationCallback` (`model_trainer.py`) gets this right, constructed with `oks_stddev=self.config.trainer_config.eval.oks_stddev, oks_scale=self.config.trainer_config.eval.oks_scale` — so the final saved `metrics.<split>.npz` (the file most users treat as the run's reported accuracy) could silently disagree with the training curves.

**Fix:** New `_oks_run_evaluation_overrides(config)` helper (mirroring the existing `_run_centroid_split_eval` pattern of small, independently-testable per-path helpers) reads `trainer_config.eval.oks_stddev`/`oks_scale` and returns them as a kwargs dict, omitting anything not set (rather than forwarding `None`). Used at the standard-path `run_evaluation(...)` call site via `**_oks_run_evaluation_overrides(config)`.

**Deliberately does NOT forward `match_threshold`:** I initially included it too, but caught this during verification — `trainer_config.eval.match_threshold`'s own default (`50.0`) is a **centroid-mode pixel distance**, not a valid OKS threshold (OKS scores are in `[0, 1]`); forwarding it into the OKS path would silently break OKS matching for anyone who hadn't touched that field. `EpochEndEvaluationCallback` doesn't forward it either for this same path — confirmed by reading its actual constructor call site — so the fix matches that established behavior exactly rather than introducing a new, broader change.

### 3. `find_frame_pairs` mutates the caller's ground-truth `Labels` object in place

**Root cause:** `evaluation.py`'s `find_frame_pairs`, when `user_labels_only=True`, did `for lf in labeled_frames_gt: lf.instances = lf.user_instances` directly on the `LabeledFrame` objects returned by `labels_gt.find(video_gt)` — which are references into the caller's actual `Labels` object, not copies (confirmed against sleap-io 0.9.2's `Labels.find`). This permanently discards any `PredictedInstance`s from the real ground-truth object the first time `user_labels_only=True` is used. A second `Evaluator` built from the same `labels_gt` afterward (e.g. with `user_labels_only=False`, expecting predicted instances to still be matchable) would silently see fewer instances than it should, with no error — or "Empty Frame Pairs" if that was the only instance in the frame.

**Fix:** `sio.LabeledFrame` is an attrs class, so replaced the in-place mutation with `attrs.evolve(lf, instances=lf.user_instances)`, building an independent `LabeledFrame` copy for the filtered list instead of mutating the shared one.

## Testing

- New tests:
  - `tests/training/test_callbacks.py`: `callback_metrics` is populated with no WandB logger present (both callbacks); NaN/missing metrics fall back to `0.0` for higher-is-better and `+inf` for lower-is-better distance metrics specifically (not a blanket default).
  - `tests/test_train.py`: two lightweight, isolated unit tests for `_oks_run_evaluation_overrides` — forwards configured values, omits unset ones. (Initially tried spying on `run_evaluation` inside the existing heavy `test_train_method` end-to-end test, but a real 1-epoch model on the `minimal_instance` fixture doesn't reliably produce confident-enough predictions to reach the eval call at all — unrelated to this fix. Extracting the config-reading logic into its own helper made it trivially and reliably unit-testable instead.)
  - `tests/test_evaluation.py`: constructing an `Evaluator(gt, preds, user_labels_only=True)` no longer mutates the real `labels_gt` object's frame instances. Verified this test **fails against the pre-fix code** (GT frame instance count drops from 2 → 1) and passes with the fix.
- Full `tests/training/` suite: 249 passed, no regressions.
- Full `tests/test_train.py` suite: 6 passed, no regressions.
- Full `tests/test_evaluation.py` suite: 20 passed, no regressions.
- `black`/`ruff` clean on all changed files (verified zero *new* lint errors via before/after diff against the pre-existing baseline).

## Design Decisions

- **Direction-aware worst-value fallback, not a blanket `0.0`**, for #1 — the segmentation callback's all-`[0,1]`-higher-is-better assumption doesn't hold for these two callbacks' distance metrics; using `0.0` there would actively mislead a `mode="min"` monitor.
- **A small, testable helper function, not inline logic**, for #2 — mirrors the existing `_run_centroid_split_eval`/`_run_segmentation_split_eval` pattern already established in this file, and made the fix reliably unit-testable without needing real model training to reach it.
- **`match_threshold` explicitly excluded**, for #2 — verified against what the per-epoch callback actually forwards before assuming "more forwarding = more correct"; this shared config field is mode-specific, not universal.
- **`attrs.evolve` over a full `copy.deepcopy`**, for #3 — cheapest fix that fully decouples the filtered list from the original without unnecessarily deep-copying `Instance` objects that aren't being mutated.

## Related Issues

Second of two follow-up PRs from a repo-wide correctness audit; companion to #712 (predict-pipeline fixes: override isolation, CLI frame-filter warning, `LabelsProvider` priority order), already merged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)