### PR TITLE
fix(infer): make predict --tracking see empty-detection frames, matching legacy

### DIFF
--- a/sleap_nn/inference/outputs.py
+++ b/sleap_nn/inference/outputs.py
@@ -621,6 +621,7 @@ class Outputs:
         source: str = "center_of_mass",
         mask_output: str = "mask",
         polygon_epsilon: float = 0.01,
+        keep_empty_frames: bool = False,
     ) -> "sio.Labels":
         """Convert this ``Outputs`` to a ``sleap_io.Labels``.
 
@@ -649,10 +650,17 @@ class Outputs:
                 only), or ``"both"`` (exact mask + simplified ROI).
             polygon_epsilon: Douglas-Peucker tolerance (fraction of perimeter)
                 for the polygon/both ROIs.
+            keep_empty_frames: When ``True``, emit a ``LabeledFrame`` (with no
+                instances/centroids/masks/rois) for batch slots with zero
+                detections instead of skipping them. Needed so a downstream
+                tracker sees every processed frame in order -- including
+                detection gaps -- matching the legacy pipeline's per-frame
+                ``tracker.track()`` cadence (#714).
 
         Returns:
-            A ``sleap_io.Labels`` containing one ``LabeledFrame`` per
-            non-empty batch slot.
+            A ``sleap_io.Labels`` containing one ``LabeledFrame`` per batch
+            slot (``keep_empty_frames=True``), or one per non-empty batch
+            slot (default).
 
         Notes:
             For full multi-video / per-frame metadata handling, use
@@ -704,7 +712,13 @@ class Outputs:
                     )
                     if roi is not None:
                         rois.append(roi)
-            if not instances and not centroids and not masks and not rois:
+            if (
+                not keep_empty_frames
+                and not instances
+                and not centroids
+                and not masks
+                and not rois
+            ):
                 continue
             for inst in instances:
                 trk = getattr(inst, "track", None)

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1630,7 +1630,11 @@ class Predictor:
                 "`skeleton=...` or build the Predictor via Predictor.from_model_paths() "
                 "which sets it automatically from the training config."
             )
-        labels = self.to_labels(outputs_list, videos=videos)
+        labels = self.to_labels(
+            outputs_list,
+            videos=videos,
+            keep_empty_frames=self.tracker_config is not None,
+        )
         if self.tracker_config is not None:
             labels = apply_tracking(
                 labels, self.tracker_config, tracking_progress_callback
@@ -1989,8 +1993,18 @@ class Predictor:
         self,
         outputs_list: List[Outputs],
         videos: Optional[List["sio.Video"]] = None,
+        keep_empty_frames: bool = False,
     ) -> "sio.Labels":
-        """Concatenate per-batch ``Outputs`` into a single ``sio.Labels``."""
+        """Concatenate per-batch ``Outputs`` into a single ``sio.Labels``.
+
+        Args:
+            outputs_list: Per-batch ``Outputs`` to concatenate.
+            videos: List of ``sio.Video`` indexed by ``video_indices``.
+            keep_empty_frames: Forwarded to :meth:`Outputs.to_labels` -- keep
+                zero-detection frames instead of dropping them. Set by
+                :meth:`predict` when tracking is enabled so the tracker sees
+                every processed frame, matching the legacy pipeline (#714).
+        """
         import sleap_io as sio
 
         skeleton = self.skeleton
@@ -2021,6 +2035,7 @@ class Predictor:
                 source=pkg.source,
                 mask_output=mask_output,
                 polygon_epsilon=polygon_epsilon,
+                keep_empty_frames=keep_empty_frames,
             )
             all_lf.extend(sub.labeled_frames)
             for trk in sub.tracks:

--- a/tests/inference/test_outputs.py
+++ b/tests/inference/test_outputs.py
@@ -428,6 +428,24 @@ def test_to_labels_builds_one_frame_per_nonempty_batch():
     assert labels.labeled_frames[0].frame_idx == 10
 
 
+def test_to_labels_keep_empty_frames_retains_zero_detection_batches():
+    """``keep_empty_frames=True`` emits an (instances=[]) frame instead of
+    dropping it -- needed so a downstream tracker sees every processed frame,
+    including detection gaps, matching the legacy pipeline (#714)."""
+    skel = _toy_skeleton(n_nodes=2)
+    kpts = torch.zeros(2, 1, 2, 2)
+    kpts[1] = float("nan")  # second batch slot is empty
+    o = Outputs(
+        pred_keypoints=kpts,
+        pred_peak_values=torch.ones(2, 1, 2),
+        frame_indices=torch.tensor([10, 11], dtype=torch.int64),
+        video_indices=torch.zeros(2, dtype=torch.int64),
+    )
+    labels = o.to_labels(skeleton=skel, keep_empty_frames=True)
+    assert [lf.frame_idx for lf in labels.labeled_frames] == [10, 11]
+    assert labels.labeled_frames[1].instances == []
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Type-hint sanity (catches accidental Optional → required regressions)
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -386,7 +386,7 @@ def test_predictor_predict_tracking_flushes_window_across_long_empty_gap(
     Before the fix, ``Outputs.to_labels()`` unconditionally dropped
     zero-detection frames before tracking, so ``apply_tracking`` only ever
     saw the 4 non-empty frames -- well within ``window_size=5`` -- and
-    incorrectly re-used the pre-gap track ids after the gap.
+    incorrectly reused the pre-gap track ids after the gap.
     """
     tracks_before, tracks_after = _predict_with_gap(
         skeleton, video, monkeypatch, gap_frames=5

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -7,8 +7,10 @@ import pickle
 import numpy as np
 import pytest
 import sleap_io as sio
+import torch
 
 from sleap_nn.inference.filters import FilterConfig
+from sleap_nn.inference.outputs import Outputs
 from sleap_nn.inference.predictor import Predictor
 from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
 
@@ -260,7 +262,7 @@ def test_predictor_predict_applies_tracker_after_to_labels(
     monkeypatch.setattr(
         Predictor,
         "to_labels",
-        lambda self, outputs_list, videos=None: untracked,
+        lambda self, outputs_list, videos=None, keep_empty_frames=False: untracked,
     )
 
     result = pred.predict(
@@ -302,7 +304,7 @@ def test_predictor_predict_clean_empty_frames_drops_empty(skeleton, video, monke
     monkeypatch.setattr(
         Predictor,
         "to_labels",
-        lambda self, outputs_list, videos=None: raw_labels,
+        lambda self, outputs_list, videos=None, keep_empty_frames=False: raw_labels,
     )
 
     result = pred.predict(
@@ -314,6 +316,94 @@ def test_predictor_predict_clean_empty_frames_drops_empty(skeleton, video, monke
     )
     # Frame 1 (with the instance) survives; frames 0 and 2 are dropped.
     assert [lf.frame_idx for lf in result.labeled_frames] == [1]
+
+
+def _frame_outputs(frame_idx, has_instances, video_idx=0):
+    """One-frame ``Outputs`` (batch_size=1): 2 fixed-position instances, or
+    none. Used to build synthetic sequences with detection gaps for the
+    window-flush regression tests below."""
+    base = [[[0.0, 0.0], [10.0, 0.0]], [[100.0, 0.0], [110.0, 0.0]]]
+    if not has_instances:
+        return Outputs(
+            frame_indices=torch.tensor([frame_idx], dtype=torch.int64),
+            video_indices=torch.tensor([video_idx], dtype=torch.int64),
+        )
+    pts = torch.tensor(base, dtype=torch.float32).unsqueeze(0)  # (1, 2, 2, 2)
+    return Outputs(
+        pred_keypoints=pts,
+        pred_peak_values=torch.ones(1, 2, 2),
+        instance_scores=torch.full((1, 2), 0.9),
+        frame_indices=torch.tensor([frame_idx], dtype=torch.int64),
+        video_indices=torch.tensor([video_idx], dtype=torch.int64),
+    )
+
+
+def _predict_with_gap(skeleton, video, monkeypatch, gap_frames):
+    """Run ``predict()`` with tracking over frames 0, 1, <gap>, N, N+1 where
+    <gap> is ``gap_frames`` consecutive zero-detection frames, and the 2
+    instances at the start/end are at identical positions. Returns the sorted
+    track names at the first and last non-empty frames."""
+    n_before = 2
+    frame_specs = [(i, True) for i in range(n_before)]
+    frame_specs += [(n_before + i, False) for i in range(gap_frames)]
+    last_start = n_before + gap_frames
+    frame_specs += [(last_start + i, True) for i in range(2)]
+    outputs_list = [_frame_outputs(i, has) for i, has in frame_specs]
+
+    pred = Predictor(
+        layer=_StubLayer(),
+        tracker_config=TrackerConfig(window_size=5, candidates_method="fixed_window"),
+    )
+
+    class _Provider:
+        def __iter__(self):
+            return iter([])
+
+    monkeypatch.setattr(
+        Predictor,
+        "_batch_iter",
+        lambda self, provider, progress_callback=None, layer=None: iter(outputs_list),
+    )
+
+    result = pred.predict(
+        _Provider(), make_labels=True, skeleton=skeleton, videos=[video]
+    )
+    by_frame = {lf.frame_idx: lf for lf in result.labeled_frames}
+    tracks_before = sorted(inst.track.name for inst in by_frame[0].instances)
+    tracks_after = sorted(inst.track.name for inst in by_frame[last_start].instances)
+    return tracks_before, tracks_after
+
+
+def test_predictor_predict_tracking_flushes_window_across_long_empty_gap(
+    skeleton, video, monkeypatch
+):
+    """Regression (#714): a run of zero-detection frames >= ``window_size``
+    must flush the fixed-window candidate deque, spawning fresh track ids
+    after the gap -- matching the legacy pipeline, which calls
+    ``tracker.track()`` on every frame (including empty ones) and so
+    naturally flushes its window across such a gap.
+
+    Before the fix, ``Outputs.to_labels()`` unconditionally dropped
+    zero-detection frames before tracking, so ``apply_tracking`` only ever
+    saw the 4 non-empty frames -- well within ``window_size=5`` -- and
+    incorrectly re-used the pre-gap track ids after the gap.
+    """
+    tracks_before, tracks_after = _predict_with_gap(
+        skeleton, video, monkeypatch, gap_frames=5
+    )
+    assert tracks_before != tracks_after
+
+
+def test_predictor_predict_tracking_preserves_identity_across_short_gap(
+    skeleton, video, monkeypatch
+):
+    """Sanity check for the fix above: a gap *shorter* than ``window_size``
+    must NOT flush the window -- identity is preserved across short gaps,
+    exactly as it was (correctly) before and after the #714 fix."""
+    tracks_before, tracks_after = _predict_with_gap(
+        skeleton, video, monkeypatch, gap_frames=2
+    )
+    assert tracks_before == tracks_after
 
 
 def test_predictor_with_tracker_picklable_round_trip():


### PR DESCRIPTION
## Summary

- `sleap-nn predict --tracking` produced different track-ID assignments than `sleap-nn track --tracking` on the same video with identical per-frame detections, because zero-detection frames were silently dropped before tracking in the new pipeline but not in legacy.
- Root cause: `Outputs.to_labels()` unconditionally skipped batch slots with no instances/centroids/masks/rois, so `apply_tracking()` (which iterates `labels.labeled_frames` and calls `tracker.track()` once per frame) only ever saw non-empty frames. Since `FixedWindowCandidates` advances its bounded deque once per `tracker.track()` call — not once per elapsed video frame — this changed how far back the candidate window could see across a run of empty frames, letting identities persist across gaps that the legacy pipeline (which calls `tracker.track()` on *every* frame, including empty ones) would correctly flush.
- Fix: `Outputs.to_labels()` gains a `keep_empty_frames` flag; `Predictor.predict()` now sets it to `True` whenever a `tracker_config` is active, so the tracker sees every processed frame in order, exactly matching legacy's per-frame cadence. The existing `clean_empty_frames`/`--no_empty_frames` post-tracking cleanup step is untouched, so default output behavior is unaffected when tracking is off.

## Changes Made

- `sleap_nn/inference/outputs.py`: `Outputs.to_labels(..., keep_empty_frames: bool = False)` — when `True`, emits a `LabeledFrame` (empty instances/centroids/masks/rois) for zero-detection batch slots instead of skipping them.
- `sleap_nn/inference/predictor.py`: `Predictor.to_labels()` threads `keep_empty_frames` through to each `Outputs.to_labels()` call; `Predictor.predict()` passes `keep_empty_frames=self.tracker_config is not None`.
- `tests/inference/test_outputs.py`: unit test that `keep_empty_frames=True` retains zero-detection frames.
- `tests/inference/test_tracking.py`: two new regression tests reproducing the window-flush bug directly through `Predictor.predict()` — one with a detection gap ≥ `window_size` (must spawn fresh track IDs, matching legacy) and one with a gap < `window_size` (must preserve identity, sanity-checking the fix doesn't over-flush). Also updated two pre-existing `to_labels` monkeypatch stubs to accept the new keyword argument.

## Empirical verification

Ran `sleap-nn predict --tracking` and `sleap-nn track --tracking` against `tests/assets/datasets/centered_pair_small.mp4` (1100 frames, sparse detections) with `tests/assets/model_ckpts/minimal_instance_bottomup`:

| | frames output | unique tracks |
|---|---|---|
| `predict --tracking` (before fix) | 290 | 7 |
| `predict --tracking` (after fix) | 1100 | 27 |
| `track --tracking` (legacy) | 1100 | 27 |

After the fix, `predict --tracking` matches `track --tracking` exactly on both frame count and track-ID count.

## Testing

- New unit test: `tests/inference/test_outputs.py::test_to_labels_keep_empty_frames_retains_zero_detection_batches`
- New regression tests: `tests/inference/test_tracking.py::test_predictor_predict_tracking_flushes_window_across_long_empty_gap` and `test_predictor_predict_tracking_preserves_identity_across_short_gap`
- Full suite: `uv run pytest -q --cov --cov-branch tests/` → 2174 passed, 138 skipped, 4 xfailed (one `test_full_pipeline_parity[topdown-cpu]` failure seen in an earlier combined run was confirmed to be a pre-existing, order-dependent flake unrelated to this diff — it passes reliably in isolation and doesn't exercise `tracker_config` at all).
- Coverage: both changed lines/branches in `outputs.py` and `predictor.py` are fully exercised by the existing + new tests (confirmed via `coverage report -m` on the two files).
- `black`/`ruff` clean on the changed source files.

## Design Decisions

- Scoped the fix to the `Predictor.predict()` orchestration path (where the empirical divergence was observed and is unambiguously fixable), rather than making `apply_tracking()` itself gap-aware. A gap-filling approach at the `apply_tracking()` level can't distinguish "frame processed but zero detections" from "frame never selected" (e.g. `--frames`/`--only_labeled_frames` subsets) purely from `frame_idx` gaps in an already-built `Labels`, so it would require inventing frame data that wasn't actually part of the input. `predict()`'s `outputs_list` has unambiguous ground truth for this (every batch the model actually ran on), so gating there is precise.
- Left `Predictor.retrack()` (pure re-tracking of an already-loaded `.slp`, without fresh inference) unchanged — it has no equivalent ground truth about which frames were "really" empty vs. never processed, so this is a pre-existing, separate consideration outside this fix's scope.
- Kept the default (non-tracking) `predict()` output behavior — dropping empty frames — unchanged, so this only affects behavior when `--tracking`/`tracker_config` is active.

## Related

Found via an empirical parity investigation between the new `predict` pipeline and the legacy `track` pipeline (`scratch/2026-07-29-predict-vs-track-parity/`, not part of this PR — gitignored).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)