### PR TITLE
fix(infer): predict-pipeline robustness hardening (3 small fixes)

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -81,7 +81,22 @@ uv run black sleap_nn tests
 uv run ruff check sleap_nn/ --fix
 ```
 
-## Step 6: Run Tests with Coverage
+## Step 6: Check Spelling
+
+This repo runs `codespell` in CI (`.github/workflows/codespell.yml`) against the whole tree
+(config in `pyproject.toml`'s `[tool.codespell]`), and it blocks merge on any hit — including in
+test docstrings/comments, not just source. Check it locally before pushing so it isn't caught only
+after CI runs:
+
+```bash
+uvx codespell sleap_nn tests docs *.md pyproject.toml
+```
+
+Fix any reported typos (codespell prints `word ==> suggestion`) and re-run until clean. Don't run
+bare `uvx codespell .` — it will also scan `.venv`/`scratch` if present locally and drown real hits
+in unrelated noise from vendored/third-party files that CI never sees.
+
+## Step 7: Run Tests with Coverage
 
 Run the full test suite with coverage:
 ```bash
@@ -106,7 +121,7 @@ Review the `,cover` files for your changed modules to ensure adequate coverage.
 | ! | Line was NOT executed (needs test coverage) |
 | - | Line is not executable (comments, blank lines) |
 
-## Step 7: Commit Changes
+## Step 8: Commit Changes
 
 ### Commit structure
 Make well-structured, atomic commits:
@@ -125,13 +140,13 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
 
-## Step 8: Push to GitHub
+## Step 9: Push to GitHub
 
 ```bash
 git push -u origin <branch-name>
 ```
 
-## Step 9: Create Pull Request
+## Step 10: Create Pull Request
 
 ### Create the PR
 ```bash
@@ -212,6 +227,9 @@ git checkout -b feature/my-feature
 # Format and lint
 uv run black sleap_nn tests
 uv run ruff check sleap_nn/ --fix
+
+# Spelling (CI runs this on the whole tree, incl. tests/docs -- scope it locally to match)
+uvx codespell sleap_nn tests docs *.md pyproject.toml
 
 # Test with coverage
 uv run pytest -q --maxfail=1 --cov --cov-branch && rm -f .coverage.* && uv run coverage annotate

--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -48,29 +48,62 @@ def _should_log(record):
 logger.remove()
 
 
-def _safe_print(msg):
-    """Print with fallback for encoding errors."""
+def _safe_print(msg, stream_name="stdout"):
+    """Print with fallback for encoding errors.
+
+    ``stream_name`` (``"stdout"`` or ``"stderr"``) is looked up on ``sys`` at
+    call time rather than bound once at sink-creation time, so this respects
+    later redirection of ``sys.stdout``/``sys.stderr`` (e.g.
+    ``contextlib.redirect_stdout``, pytest's output capture).
+    """
+    stream = getattr(sys, stream_name)
     try:
-        print(msg, end="")
+        print(msg, end="", file=stream)
     except UnicodeEncodeError:
         # Fallback: replace unencodable characters with '?'
+        encoding = getattr(stream, "encoding", None) or "utf-8"
         print(
-            msg.encode(sys.stdout.encoding, errors="replace").decode(
-                sys.stdout.encoding
-            ),
+            msg.encode(encoding, errors="replace").decode(encoding),
             end="",
+            file=stream,
         )
+
+
+def _add_default_sink(stream_name="stdout"):
+    """(Re)install the standard sleap_nn log sink, targeting ``stream_name``.
+
+    Centralizes the sink config (level/filter/format) so callers only choose
+    *where* logs go, not how they're formatted -- used both for the default
+    stdout setup below and for :func:`redirect_logs_to_stderr`.
+    """
+    logger.add(
+        lambda msg: _safe_print(msg, stream_name=stream_name),
+        level="DEBUG",
+        filter=_should_log,
+        format="{time:YYYY-MM-DD HH:mm:ss} | {message}",
+        colorize=False,
+    )
 
 
 # Add logger with the custom filter
 # Disable colorization to avoid ANSI codes in captured output
-logger.add(
-    _safe_print,
-    level="DEBUG",
-    filter=_should_log,
-    format="{time:YYYY-MM-DD HH:mm:ss} | {message}",
-    colorize=False,
-)
+_add_default_sink("stdout")
+
+
+def redirect_logs_to_stderr() -> None:
+    """Redirect sleap_nn's log sink to stderr.
+
+    Call this once, early, whenever stdout must be reserved for a
+    machine-readable channel -- e.g. the CLI's ``--gui`` mode, which emits one
+    JSON progress line per batch on stdout for a GUI subprocess reader to
+    parse (see ``sleap_nn.cli._gui_progress_callback``). Without this, a
+    plain-text log line (e.g. "Loaded inference model | ...") can interleave
+    with the JSON lines on the same fd and break a naive per-line
+    ``json.loads()`` reader. Idempotent -- safe to call more than once.
+    """
+    logger.remove()
+    _add_default_sink("stderr")
+
 
 __version__ = "0.3.1"
 

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1023,7 +1023,11 @@ def track(**kwargs):
     This command uses the legacy ``run_inference`` pipeline. For the new
     inference pipeline, use ``sleap-nn predict``.
     """
+    from sleap_nn import redirect_logs_to_stderr
     from sleap_nn.legacy_predict import frame_list, run_inference
+
+    if kwargs.get("gui"):
+        redirect_logs_to_stderr()
 
     if "model_paths" in kwargs and kwargs["model_paths"]:
         kwargs["model_paths"] = list(kwargs["model_paths"])
@@ -1087,7 +1091,11 @@ def _run_inference_impl(**kwargs):
     ``--frames`` string into a list of int frame indices, and routes to
     the new :class:`Predictor`-based pipeline.
     """
+    from sleap_nn import redirect_logs_to_stderr
     from sleap_nn.legacy_predict import frame_list
+
+    if kwargs.get("gui"):
+        redirect_logs_to_stderr()
 
     paf_workers = kwargs.pop("paf_workers", 0) or 0
     cpu_workers = kwargs.pop("cpu_workers", None)
@@ -1772,7 +1780,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         predict_kwargs["progress_callback"] = _gui_progress_callback()
         if kwargs.get("tracking"):
             predict_kwargs["tracking_progress_callback"] = _gui_progress_callback()
-        return predict(source, **predict_kwargs)
+        return _run_guarded(lambda: predict(source, **predict_kwargs), gui=True)
 
     # Non-gui: show a Rich progress bar (parity with legacy `track`'s default
     # progress UX; the plumbing was wired but no callback was attached). #583.
@@ -1783,7 +1791,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
             progress, "Tracking..."
         )
     try:
-        return predict(source, **predict_kwargs)
+        return _run_guarded(lambda: predict(source, **predict_kwargs), gui=False)
     finally:
         progress.stop()
 
@@ -1835,15 +1843,19 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
         tracking_cb = _rich_task_callback(_progress, "Tracking...")
 
     _start = datetime.now()
+    _gui = bool(kwargs.get("gui"))
     try:
-        out = predictor_cls.retrack(
-            labels,
-            tracker_config,
-            clean_empty_frames=bool(kwargs.get("no_empty_frames")),
-            progress_callback=tracking_cb,
+        out = _run_guarded(
+            lambda: predictor_cls.retrack(
+                labels,
+                tracker_config,
+                clean_empty_frames=bool(kwargs.get("no_empty_frames")),
+                progress_callback=tracking_cb,
+            ),
+            gui=_gui,
         )
     finally:
-        if not kwargs.get("gui"):
+        if not _gui:
             _progress.stop()
     # Attach tracking-only provenance to the retracked .slp (legacy parity —
     # apply_tracking leaves provenance to the caller, and the legacy track path
@@ -1907,6 +1919,41 @@ def _gui_progress_callback():
         state["last"] = now
 
     return cb
+
+
+def _emit_gui_error(exc: BaseException) -> None:
+    """Emit a structured JSON error line on stdout for a ``--gui`` consumer.
+
+    Mirrors ``_gui_progress_callback``'s JSON-per-line schema (one line,
+    flushed immediately) so a GUI's per-line stdout reader can tell an error
+    line apart from a progress line with the same simple parse -- check for
+    an ``"error"`` key instead of ``"n_processed"``. Without this, a runtime
+    failure (CUDA OOM, corrupt checkpoint, mid-stream decode error, ...) was
+    only ever visible as a raw Python traceback (Bug 2).
+    """
+    import json
+
+    print(
+        json.dumps({"error": True, "type": type(exc).__name__, "message": str(exc)}),
+        flush=True,
+    )
+
+
+def _run_guarded(fn, *, gui: bool):
+    """Call ``fn()``; in ``--gui`` mode, emit a structured error line before re-raising on failure.
+
+    The exception always propagates unchanged (same type, same traceback,
+    same non-zero exit code) -- this only adds a machine-readable signal on
+    stdout ahead of it when ``gui=True``. Non-``--gui`` behavior (a raw
+    traceback via loguru + Python's default handling) is intentionally
+    unchanged; a human at a terminal doesn't need a JSON line.
+    """
+    try:
+        return fn()
+    except Exception as exc:
+        if gui:
+            _emit_gui_error(exc)
+        raise
 
 
 def _make_fps_column(window_s: float = 5.0, time_fn=None):
@@ -2176,21 +2223,27 @@ def _run_stream_to_file(
         )
 
     if kwargs.get("gui"):
-        return predictor.predict_to_file(
-            provider,
-            path=str(stream_to_file),
-            write_interval=write_interval,
-            progress_callback=_gui_progress_callback(),
+        return _run_guarded(
+            lambda: predictor.predict_to_file(
+                provider,
+                path=str(stream_to_file),
+                write_interval=write_interval,
+                progress_callback=_gui_progress_callback(),
+            ),
+            gui=True,
         )
 
     # Non-gui: Rich progress bar, stopped cleanly in finally (#583).
     cb, progress = _rich_progress_callback()
     try:
-        return predictor.predict_to_file(
-            provider,
-            path=str(stream_to_file),
-            write_interval=write_interval,
-            progress_callback=cb,
+        return _run_guarded(
+            lambda: predictor.predict_to_file(
+                provider,
+                path=str(stream_to_file),
+                write_interval=write_interval,
+                progress_callback=cb,
+            ),
+            gui=False,
         )
     finally:
         progress.stop()

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -1090,6 +1090,24 @@ def load_model_assets(
         configs.append(cfg)
         model_types.append(get_model_type_from_cfg(config=cfg))
 
+    # Reject duplicate model types up front. The dispatch below picks the
+    # FIRST path of a given type via `model_types.index(...)`, so passing two
+    # paths of the same type (e.g. two centroid dirs) would otherwise
+    # silently use only one and drop the other with no indication anything
+    # was wrong. (Detecting an *unrelated* extra path -- one whose type isn't
+    # consumed by whichever branch below ends up winning -- would need
+    # dispatch-branch-aware validation; that's a separate, bigger follow-up,
+    # not covered here.)
+    _seen_type_paths: dict = {}
+    for mp, mt in zip(model_paths, model_types):
+        if mt in _seen_type_paths:
+            raise ValueError(
+                f"Duplicate model type {mt!r} in --model_paths: got both "
+                f"{_seen_type_paths[mt]!r} and {mp!r}. Pass only one model "
+                "directory per type."
+            )
+        _seen_type_paths[mt] = mp
+
     common_kwargs = dict(
         device=device,
         backbone_ckpt_path=backbone_ckpt_path,

--- a/tests/cli/test_predict_command.py
+++ b/tests/cli/test_predict_command.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from sleap_nn.cli import cli
@@ -372,6 +373,83 @@ def test_predict_gui_emits_json_progress(tmp_path):
         assert parsed["n_total"] == 10
 
 
+def test_predict_gui_redirects_logs_to_stderr(tmp_path):
+    """``--gui`` redirects sleap_nn's log sink to stderr so plain-text log
+    lines can't interleave with the JSON progress channel on stdout (#714
+    follow-up: Bug 3)."""
+    import contextlib
+    import io
+
+    from loguru import logger
+
+    import sleap_nn
+
+    marker = "marker-for-gui-stderr-redirect-test"
+    runner = CliRunner()
+    try:
+        with patch("sleap_nn.inference.run.predict", return_value=MagicMock()):
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "--data_path",
+                    "/fake/path.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                    "--gui",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        out_buf, err_buf = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out_buf), contextlib.redirect_stderr(err_buf):
+            logger.info(marker)
+        assert marker not in out_buf.getvalue()
+        assert marker in err_buf.getvalue()
+    finally:
+        # Loguru's sink is process-global state; restore the default stdout
+        # sink so later tests in this session aren't affected.
+        logger.remove()
+        sleap_nn._add_default_sink("stdout")
+
+
+def test_predict_without_gui_keeps_logs_on_stdout(tmp_path):
+    """Without ``--gui``, the log sink stays on stdout (default, unaffected
+    by the Bug 3 fix -- a human running the CLI directly expects to see logs
+    on the terminal)."""
+    import contextlib
+    import io
+
+    from loguru import logger
+
+    import sleap_nn
+
+    marker = "marker-for-no-gui-stdout-test"
+    runner = CliRunner()
+    try:
+        with patch("sleap_nn.inference.run.predict", return_value=MagicMock()):
+            result = runner.invoke(
+                cli,
+                [
+                    "predict",
+                    "--data_path",
+                    "/fake/path.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        out_buf, err_buf = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out_buf), contextlib.redirect_stderr(err_buf):
+            logger.info(marker)
+        assert marker in out_buf.getvalue()
+        assert marker not in err_buf.getvalue()
+    finally:
+        logger.remove()
+        sleap_nn._add_default_sink("stdout")
+
+
 def test_predict_without_gui_attaches_rich_progress_callback(tmp_path):
     """No ``--gui`` => ``predict()`` gets a (non-JSON) Rich progress callback (#583)."""
     import io
@@ -469,6 +547,41 @@ def test_predict_retrack_only_dispatches_to_predictor_retrack(tmp_path):
         cfg = mock_retrack.call_args[0][1]
         assert cfg.window_size == 9
         # The result was saved.
+        tracked.save.assert_called_once()
+
+
+def test_predict_retrack_only_gui_uses_run_guarded(tmp_path):
+    """Retrack-only ``--gui`` mode also routes through ``_run_guarded`` (the
+    ``_gui=True`` branch skips the Rich-progress ``.stop()`` call, which only
+    applies to the non-gui path)."""
+    runner = CliRunner()
+    fake_labels = MagicMock()
+    fake_labels.videos = []
+    fake_labels.skeletons = []
+    fake_labels.labeled_frames = []
+    tracked = MagicMock()
+    with (
+        patch("sleap_io.load_slp", return_value=fake_labels),
+        patch(
+            "sleap_nn.inference.predictor.Predictor.retrack", return_value=tracked
+        ) as mock_retrack,
+        patch("sleap_nn.legacy_predict.run_inference") as mock_legacy,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.slp",
+                "--tracking",
+                "--gui",
+                "--output_path",
+                str(tmp_path / "out.slp"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_retrack.called
+        assert not mock_legacy.called
         tracked.save.assert_called_once()
 
 
@@ -659,6 +772,153 @@ def test_track_no_gui_defaults_false():
         )
         assert result.exit_code == 0, result.output
         assert mock_run.call_args[1]["gui"] is False
+
+
+def test_track_gui_redirects_logs_to_stderr():
+    """``track --gui`` also redirects logs to stderr (Bug 3 fix covers the
+    legacy pipeline's ``--gui`` mode too, not just ``predict``)."""
+    import contextlib
+    import io
+
+    from loguru import logger
+
+    import sleap_nn
+
+    marker = "marker-for-track-gui-stderr-redirect-test"
+    runner = CliRunner()
+    try:
+        with patch("sleap_nn.legacy_predict.run_inference", return_value=MagicMock()):
+            result = runner.invoke(
+                cli,
+                [
+                    "track",
+                    "--data_path",
+                    "/fake/path.mp4",
+                    "--model_paths",
+                    "/fake/model",
+                    "--gui",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        out_buf, err_buf = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out_buf), contextlib.redirect_stderr(err_buf):
+            logger.info(marker)
+        assert marker not in out_buf.getvalue()
+        assert marker in err_buf.getvalue()
+    finally:
+        logger.remove()
+        sleap_nn._add_default_sink("stdout")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Bug 2 -- structured error channel for --gui mode runtime failures
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_run_guarded_gui_emits_error_and_reraises(capsys):
+    """``_run_guarded(..., gui=True)`` prints a JSON error line matching the
+    progress schema's style, then re-raises the original exception unchanged."""
+    import json
+
+    from sleap_nn.cli import _run_guarded
+
+    def boom():
+        raise ValueError("oops")
+
+    with pytest.raises(ValueError, match="oops"):
+        _run_guarded(boom, gui=True)
+
+    parsed = json.loads(capsys.readouterr().out.strip())
+    assert parsed == {"error": True, "type": "ValueError", "message": "oops"}
+
+
+def test_run_guarded_non_gui_reraises_without_emitting(capsys):
+    """``_run_guarded(..., gui=False)`` re-raises but prints nothing -- the
+    default (non-``--gui``) raw-traceback behavior is unchanged."""
+    from sleap_nn.cli import _run_guarded
+
+    def boom():
+        raise ValueError("oops")
+
+    with pytest.raises(ValueError, match="oops"):
+        _run_guarded(boom, gui=False)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_run_guarded_success_passes_through():
+    """``_run_guarded`` returns ``fn()``'s result unchanged on success,
+    regardless of ``gui``."""
+    from sleap_nn.cli import _run_guarded
+
+    assert _run_guarded(lambda: 42, gui=True) == 42
+    assert _run_guarded(lambda: 42, gui=False) == 42
+
+
+def test_predict_gui_emits_json_error_on_failure():
+    """End-to-end: ``predict --gui`` wires ``_run_guarded`` so a runtime
+    failure in ``predict()`` emits a JSON error line on stdout before the
+    CLI exits non-zero (Bug 2)."""
+    import json
+
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--gui",
+            ],
+        )
+    assert result.exit_code != 0
+    error_lines = [
+        json.loads(line)
+        for line in result.output.splitlines()
+        if line.strip().startswith("{")
+    ]
+    matches = [line for line in error_lines if line.get("error") is True]
+    assert len(matches) == 1
+    assert matches[0]["type"] == "RuntimeError"
+    assert matches[0]["message"] == "boom"
+
+
+def test_predict_without_gui_does_not_emit_json_error_on_failure():
+    """Without ``--gui``, a runtime failure still raises (non-zero exit) but
+    prints no JSON error line -- the machine-readable channel is ``--gui``-only."""
+    import json
+
+    runner = CliRunner()
+    with patch(
+        "sleap_nn.inference.run.predict",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+            ],
+        )
+    assert result.exit_code != 0
+    error_lines = []
+    for line in result.output.splitlines():
+        if line.strip().startswith("{"):
+            try:
+                error_lines.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    assert not any(line.get("error") for line in error_lines)
 
 
 def test_predict_paf_knobs_thread_to_predict():
@@ -893,6 +1153,35 @@ def test_predict_stream_to_file_rejects_non_slp_format(tmp_path):
     )
     assert isinstance(result.exception, click.UsageError)
     assert "only supports --output_format slp" in result.exception.message
+
+
+def test_predict_stream_to_file_gui_uses_run_guarded(tmp_path):
+    """``--stream-to-file --gui`` routes ``predict_to_file`` through
+    ``_run_guarded`` (Bug 2 covers this dispatch path too, not just the
+    in-memory and retrack-only ones)."""
+    out = tmp_path / "out.slp"
+    runner = CliRunner()
+    mock_predictor = MagicMock()
+    with patch(
+        "sleap_nn.inference.predictor.Predictor.from_model_paths",
+        return_value=mock_predictor,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "predict",
+                "--data_path",
+                "/fake/path.mp4",
+                "--model_paths",
+                "/fake/model",
+                "--stream-to-file",
+                str(out),
+                "--gui",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_predictor.predict_to_file.called
+        assert mock_predictor.predict_to_file.call_args[1]["path"] == str(out)
 
 
 def test_predict_forwards_embed_and_restore(tmp_path):

--- a/tests/inference/test_loaders.py
+++ b/tests/inference/test_loaders.py
@@ -260,6 +260,25 @@ def test_load_model_assets_unsupported_type(tmp_path):
         load_model_assets([str(tmp_path)], device="cpu")
 
 
+def test_load_model_assets_rejects_duplicate_model_type():
+    """Two ``--model_paths`` of the same type raise instead of silently dropping the second one.
+
+    Bug 4 -- the dispatch below picks the first match via
+    ``model_types.index(...)``, so a duplicate would otherwise be silently
+    ignored with no indication anything was wrong.
+    """
+    if not CENTROID_CKPT.exists():
+        pytest.skip("centroid ckpt absent")
+    with pytest.raises(ValueError, match="Duplicate model type 'centroid'"):
+        load_model_assets([str(CENTROID_CKPT), str(CENTROID_CKPT)], device="cpu")
+
+
+def test_load_model_assets_allows_distinct_types_in_combo(topdown_assets):
+    """Sanity check: a genuine topdown combo (2 different types) is unaffected by the duplicate-type check."""
+    _assets, model_types = topdown_assets
+    assert sorted(model_types) == ["centered_instance", "centroid"]
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # #584 — legacy SLEAP<=1.4 JSON-config loader path (is_legacy=True)
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three small, independent robustness fixes to the `predict` inference pipeline, found during the sleap-nn `predict` vs `track` parity investigation ahead of the sleap GUI migrating from `track` to `predict`. All three are additive/narrow-scoped; none change default (non-`--gui`) behavior.

## Changes Made

### 1. stdout/stderr stream-mixing in `--gui` mode
`sleap_nn/__init__.py`'s loguru sink printed every log record to stdout unconditionally, regardless of `--gui`. The sleap GUI's inference dialog reads a child process's stdout line-by-line and does `json.loads()` on any line starting with `{`, expecting *only* the `--gui` mode's JSON progress lines — a plain-text log line (e.g. `"Loaded inference model | ..."`) could interleave with those and break a naive per-line parser.

- New `sleap_nn.redirect_logs_to_stderr()`: (re)installs the log sink targeting stderr instead of stdout. Idempotent.
- `_safe_print`/`_add_default_sink` now look up `sys.stdout`/`sys.stderr` by name at *call time* rather than binding a stream reference once at sink-creation time — this also makes the sink correctly respect later redirection (e.g. `contextlib.redirect_stdout`, pytest capture), which is how the test suite verifies it.
- Wired into `sleap_nn/cli.py`'s `track()` and `_run_inference_impl()` (shared by `predict`/`infer`) — called once, early, only when `--gui` is set.

### 2. No structured error channel for `predict` runtime failures
`predict`'s 3 call sites (in-memory flow, retrack-only, stream-to-file) only wrapped the actual inference/tracking call in `try: ... finally: progress.stop()` — no `except` — so a runtime failure (CUDA OOM, corrupt checkpoint, mid-stream decode error) surfaced as a raw Python traceback with no machine-readable signal for a GUI to key off of.

- New `_run_guarded(fn, *, gui: bool)` helper in `cli.py`: calls `fn()`; on exception, if `gui=True`, emits a JSON error line on stdout (`{"error": true, "type": ..., "message": ...}`, parallel to the existing progress-line schema) *before* re-raising. The exception always propagates unchanged (same type, same exit code) — this only adds a signal ahead of it.
- Used at all 3 call sites uniformly (in-memory, retrack-only, stream-to-file); non-`--gui` behavior is a no-op pass-through, unchanged.

### 3. Silent multi-model composition drop for duplicate types
`sleap_nn/inference/loaders.py`'s dispatch chain picks the first path of a given model type via `model_types.index(...)`. Passing two `--model_paths` of the same type (e.g. two centroid dirs by mistake) silently used only the first, with zero indication the second was ignored — a real risk once the GUI migration means the GUI always passes multiple `--model_paths`.

- Added a validation pass right after `model_types` is built: raises a clear `ValueError` naming the duplicate type and both paths (e.g. `Duplicate model type 'centroid' in --model_paths: got both <path1> and <path2>. Pass only one model directory per type.`).
- Scoped narrowly per design: this does **not** attempt to detect an *unrelated* extra path that isn't consumed by whichever dispatch branch wins — that needs dispatch-branch-aware validation, a separate, bigger follow-up (left as a code comment, not silently expanded here).

## Testing

- `tests/cli/test_predict_command.py`: `--gui` log-sink redirection (both `predict` and `track`), non-`--gui` log placement unchanged, `_run_guarded` unit tests (gui emits + reraises, non-gui reraises silently, success passes through), end-to-end `predict --gui` failure emits the JSON error line, retrack-only `--gui` and stream-to-file `--gui` both route through `_run_guarded`.
- `tests/inference/test_loaders.py`: duplicate-type rejection, sanity check that a genuine multi-type combo (centroid + centered_instance) is unaffected.
- Full suite: `uv run pytest -q --cov --cov-branch tests/` → 2186 passed, 138 skipped, 4 xfailed, 0 failed.
- Coverage: every new/changed line in `sleap_nn/__init__.py`, `sleap_nn/cli.py`, and `sleap_nn/inference/loaders.py` is exercised (verified via `coverage report -m` scoped to the 3 files — remaining "Missing" lines are all pre-existing, untouched code).
- `black`/`ruff` clean on `sleap_nn/`. `uvx codespell sleap_nn tests docs *.md pyproject.toml` clean.

## Design Decisions

- **Bug 2's error line is `--gui`-only, non-gui is untouched.** A human running the CLI directly wants the normal traceback, not a JSON blob.
- **Bug 3's fix redirects logs only when `--gui` is set, not globally.** Changing `sleap_nn/__init__.py`'s default sink would affect every caller, including Python-API users who never asked for GUI-mode stdout hygiene.
- **Bug 4 is scoped to duplicate-type detection only.** Full "extra unrelated path" detection needs to know which paths the winning dispatch branch actually consumed — a bigger, separate piece of work, called out explicitly in a code comment rather than silently expanded.

## Related

Also includes a small housekeeping commit (`chore(skill): add codespell check step to /pr skill`) carried over from the previous PR's branch setup — CI's codespell check caught a typo that local formatting/lint hadn't, so the `/pr` skill now has a dedicated step for it.

Follow-up to #714. Full investigation writeup: `scratch/2026-07-29-predict-vs-track-parity/README.md` (gitignored, not part of this PR).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)