### PR TITLE
fix(infer): --input_scale override was broken in both predict and track

### DIFF
--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -272,7 +272,7 @@ def _build_single_instance(
         refinement=integral_refinement,
         integral_patch_size=integral_patch_size,
         return_confmaps=return_confmaps,
-        input_scale=config.data_config.preprocessing.scale,
+        input_scale=preprocess_config.scale,
     )
     return LoadedAssets(
         inference_model=inference_model,
@@ -340,7 +340,7 @@ def _build_bottomup(
         refinement=integral_refinement,
         integral_patch_size=integral_patch_size,
         return_confmaps=return_confmaps,
-        input_scale=config.data_config.preprocessing.scale,
+        input_scale=preprocess_config.scale,
     )
     return LoadedAssets(
         inference_model=inference_model,
@@ -385,7 +385,7 @@ def _build_bottomup_multiclass(
         refinement=integral_refinement,
         integral_patch_size=integral_patch_size,
         return_confmaps=return_confmaps,
-        input_scale=config.data_config.preprocessing.scale,
+        input_scale=preprocess_config.scale,
     )
     return LoadedAssets(
         inference_model=inference_model,
@@ -460,7 +460,7 @@ def _build_bottomup_segmentation(
         fg_threshold=fg_threshold,
         peak_threshold=peak_threshold,
         output_stride=output_stride,
-        input_scale=config.data_config.preprocessing.scale,
+        input_scale=preprocess_config.scale,
         min_mask_area=min_mask_area,
         max_instances=max_instances,
         center_nms_kernel=center_nms_kernel,
@@ -545,7 +545,7 @@ def _build_semantic_segmentation(
         torch_model=module,
         fg_threshold=fg_threshold,
         output_stride=output_stride,
-        input_scale=config.data_config.preprocessing.scale,
+        input_scale=preprocess_config.scale,
         min_mask_area=min_mask_area,
         full_res_masks=full_res_masks,
         mask_output=mask_output,
@@ -679,7 +679,7 @@ def _build_topdown(
             return_crops=return_crops,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=centroid_config.data_config.preprocessing.scale,
+            input_scale=preprocess_config.scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -700,7 +700,7 @@ def _build_topdown(
             integral_patch_size=integral_patch_size,
             return_confmaps=return_confmaps,
             max_stride=max_stride_inst,
-            input_scale=confmap_config.data_config.preprocessing.scale,
+            input_scale=preprocess_config.scale,
         )
 
     inference_model = TopDownInferenceModel(
@@ -833,7 +833,7 @@ def _build_topdown_segmentation(
             return_crops=True,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=centroid_config.data_config.preprocessing.scale,
+            input_scale=preprocess_config.scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -842,7 +842,7 @@ def _build_topdown_segmentation(
     instance_masks = CenteredInstanceMaskInferenceModel(
         torch_model=seg_model,
         output_stride=output_stride,
-        input_scale=seg_config.data_config.preprocessing.scale,
+        input_scale=preprocess_config.scale,
         max_stride=max_stride_seg,
         fg_threshold=fg_threshold,
         mask_output=mask_output,
@@ -976,7 +976,7 @@ def _build_topdown_multiclass(
             return_crops=return_crops,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=centroid_config.data_config.preprocessing.scale,
+            input_scale=preprocess_config.scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -993,7 +993,7 @@ def _build_topdown_multiclass(
         integral_patch_size=integral_patch_size,
         return_confmaps=return_confmaps,
         max_stride=max_stride_inst,
-        input_scale=confmap_config.data_config.preprocessing.scale,
+        input_scale=preprocess_config.scale,
     )
 
     inference_model = TopDownInferenceModel(

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -923,7 +923,7 @@ class TopDownPredictor(Predictor):
                 return_crops=return_crops,
                 max_instances=self.max_instances,
                 max_stride=max_stride,
-                input_scale=self.centroid_config.data_config.preprocessing.scale,
+                input_scale=self.preprocess_config.scale,
                 crop_hw=(
                     self.preprocess_config.crop_size,
                     self.preprocess_config.crop_size,
@@ -947,7 +947,7 @@ class TopDownPredictor(Predictor):
                 integral_patch_size=self.integral_patch_size,
                 return_confmaps=self.return_confmaps,
                 max_stride=max_stride,
-                input_scale=self.confmap_config.data_config.preprocessing.scale,
+                input_scale=self.preprocess_config.scale,
             )
 
         if self.centroid_config is None and self.confmap_config is not None:
@@ -1685,7 +1685,7 @@ class SingleInstancePredictor(Predictor):
             refinement=self.integral_refinement,
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
-            input_scale=self.confmap_config.data_config.preprocessing.scale,
+            input_scale=self.preprocess_config.scale,
         )
 
     @classmethod
@@ -2141,7 +2141,7 @@ class BottomUpPredictor(Predictor):
             refinement=self.integral_refinement,
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
-            input_scale=self.bottomup_config.data_config.preprocessing.scale,
+            input_scale=self.preprocess_config.scale,
         )
 
     @classmethod
@@ -2695,7 +2695,7 @@ class BottomUpMultiClassPredictor(Predictor):
             refinement=self.integral_refinement,
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
-            input_scale=self.bottomup_config.data_config.preprocessing.scale,
+            input_scale=self.preprocess_config.scale,
         )
 
     @classmethod
@@ -3311,7 +3311,7 @@ class TopDownMultiClassPredictor(Predictor):
                 return_crops=return_crops,
                 max_instances=self.max_instances,
                 max_stride=max_stride,
-                input_scale=self.centroid_config.data_config.preprocessing.scale,
+                input_scale=self.preprocess_config.scale,
                 crop_hw=(
                     self.preprocess_config.crop_size,
                     self.preprocess_config.crop_size,
@@ -3330,7 +3330,7 @@ class TopDownMultiClassPredictor(Predictor):
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
             max_stride=max_stride,
-            input_scale=self.confmap_config.data_config.preprocessing.scale,
+            input_scale=self.preprocess_config.scale,
         )
 
         if self.centroid_config is None:

--- a/tests/inference/test_loaders.py
+++ b/tests/inference/test_loaders.py
@@ -10,6 +10,7 @@ import gc
 from pathlib import Path
 
 import pytest
+from omegaconf import OmegaConf
 
 from sleap_nn.inference.loaders import (
     LoadedAssets,
@@ -144,6 +145,67 @@ def test_load_topdown_crop_size_resolved(topdown_assets):
     assets, _ = topdown_assets
     assert assets.preprocess_config.crop_size is not None
     assert assets.preprocess_config.crop_size > 0
+
+
+def _scale_only_preprocess_config(scale: float):
+    """A ``preprocess_config`` overriding only ``scale`` (rest ``None``)."""
+    return OmegaConf.create(
+        {
+            "ensure_rgb": None,
+            "ensure_grayscale": None,
+            "crop_size": None,
+            "max_width": None,
+            "max_height": None,
+            "scale": scale,
+        }
+    )
+
+
+def test_load_single_instance_input_scale_override_reaches_inference_model():
+    """A CLI/API ``--input_scale`` override must reach the inference model.
+
+    Regression test: ``load_model_assets`` used to build every
+    ``input_scale=`` kwarg from the *training config's* baked-in scale
+    (``config.data_config.preprocessing.scale``) instead of the resolved
+    ``preprocess_config.scale`` that reflects the caller's override -- so an
+    explicit override was silently dropped everywhere. Fixed to read the
+    already-resolved ``preprocess_config.scale`` local variable.
+    """
+    if not SINGLE_CKPT.exists():
+        pytest.skip("single-instance ckpt absent")
+    override = 0.37
+    assets, _ = load_model_assets(
+        [str(SINGLE_CKPT)],
+        device="cpu",
+        preprocess_config=_scale_only_preprocess_config(override),
+    )
+    assert assets.inference_model.input_scale == override
+
+
+def test_load_bottomup_input_scale_override_reaches_inference_model():
+    if not BOTTOMUP_CKPT.exists():
+        pytest.skip("bottomup ckpt absent")
+    override = 0.37
+    assets, _ = load_model_assets(
+        [str(BOTTOMUP_CKPT)],
+        device="cpu",
+        preprocess_config=_scale_only_preprocess_config(override),
+    )
+    assert assets.inference_model.input_scale == override
+
+
+def test_load_topdown_input_scale_override_reaches_both_stages():
+    """Both the centroid-crop and centered-instance stages must see the override."""
+    if not (CENTROID_CKPT.exists() and CENTERED_CKPT.exists()):
+        pytest.skip("topdown ckpts absent")
+    override = 0.37
+    assets, _ = load_model_assets(
+        [str(CENTROID_CKPT), str(CENTERED_CKPT)],
+        device="cpu",
+        preprocess_config=_scale_only_preprocess_config(override),
+    )
+    assert assets.inference_model.centroid_crop.input_scale == override
+    assert assets.inference_model.instance_peaks.input_scale == override
 
 
 def test_load_topdown_multiclass(topdown_multiclass_assets):

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -871,6 +871,7 @@ def test_bottomup_predictor(
         "crop_size": None,
         "max_width": None,
         "max_height": None,
+        "scale": None,
     }
 
     # load only backbone and head ckpt as None
@@ -943,6 +944,7 @@ def test_multi_class_bottomup_predictor(
         "crop_size": None,
         "max_width": None,
         "max_height": None,
+        "scale": None,
     }
 
     # load only backbone and head ckpt as None
@@ -977,6 +979,117 @@ def test_multi_class_bottomup_predictor(
     )
 
     assert np.all(np.abs(backbone_ckpt - model_weights) < 1e-6)
+
+
+def _scale_only_preprocess_config(scale):
+    """A ``preprocess_config`` overriding only ``scale`` (rest ``None``)."""
+    return OmegaConf.create(
+        {
+            "ensure_rgb": None,
+            "ensure_grayscale": None,
+            "crop_size": None,
+            "max_width": None,
+            "max_height": None,
+            "scale": scale,
+        }
+    )
+
+
+def test_single_instance_predictor_input_scale_override_reaches_inference_model(
+    minimal_instance_single_instance_ckpt,
+):
+    """A ``preprocess_config.scale`` override must reach the inference model.
+
+    Regression test: every legacy ``*Predictor._initialize_inference_model``
+    used to build its ``input_scale=`` kwarg from the *training config's*
+    baked-in scale (e.g. ``self.confmap_config.data_config.preprocessing.scale``)
+    instead of the already-resolved ``self.preprocess_config.scale`` -- so an
+    explicit override was applied to the forward image resize (via
+    ``self.preprocess_config["scale"]`` elsewhere) but NOT to the coordinate
+    rescale-back step, corrupting output coordinates. Fixed to read
+    ``self.preprocess_config.scale`` uniformly.
+    """
+    override = 0.37
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_single_instance_ckpt],
+        preprocess_config=_scale_only_preprocess_config(override),
+    )
+    assert predictor.inference_model.input_scale == override
+
+
+def test_bottomup_predictor_input_scale_override_reaches_inference_model(
+    minimal_instance_bottomup_ckpt,
+):
+    override = 0.37
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_bottomup_ckpt],
+        preprocess_config=_scale_only_preprocess_config(override),
+    )
+    assert predictor.inference_model.input_scale == override
+
+
+def test_topdown_predictor_input_scale_override_reaches_both_stages(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_centered_instance_ckpt,
+):
+    """Both the centroid-crop and centered-instance stages must see the override."""
+    override = 0.37
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_centroid_ckpt, minimal_instance_centered_instance_ckpt],
+        preprocess_config=_scale_only_preprocess_config(override),
+    )
+    assert predictor.inference_model.centroid_crop.input_scale == override
+    assert predictor.inference_model.instance_peaks.input_scale == override
+
+
+def test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds(
+    small_robot_minimal_video,
+    minimal_instance_single_instance_ckpt,
+):
+    """End-to-end: an ``--input_scale`` override must not corrupt output coordinates.
+
+    Before the fix, overriding ``scale`` away from the training config's value
+    applied the override to the forward image resize but NOT to the
+    coordinate rescale-back step (still using the stale training-config
+    scale), producing physically-impossible out-of-frame coordinates (e.g.
+    x > frame_width). Predicted keypoints must always land within the source
+    frame's bounds, regardless of ``--input_scale``.
+    """
+    import sleap_io as sio
+
+    video = sio.load_video(small_robot_minimal_video.as_posix())
+    height, width = video.shape[1], video.shape[2]
+
+    predictor = Predictor.from_model_paths(
+        [minimal_instance_single_instance_ckpt],
+        peak_threshold=0.3,
+        preprocess_config=_scale_only_preprocess_config(1.5),
+    )
+    predictor.make_pipeline(
+        small_robot_minimal_video.as_posix(),
+        frames=[x for x in range(20)],
+    )
+    output = predictor.predict(make_labels=True)
+    assert isinstance(output, sio.Labels)
+
+    saw_instance = False
+    for lf in output:
+        for inst in lf.instances:
+            pts = inst.numpy()
+            valid = ~np.isnan(pts).any(axis=1)
+            if not valid.any():
+                continue
+            saw_instance = True
+            xs, ys = pts[valid, 0], pts[valid, 1]
+            assert np.all(
+                (xs >= 0) & (xs <= width)
+            ), f"x coords out of [0, {width}] bounds: {xs[(xs < 0) | (xs > width)]}"
+            assert np.all(
+                (ys >= 0) & (ys <= height)
+            ), f"y coords out of [0, {height}] bounds: {ys[(ys < 0) | (ys > height)]}"
+    assert (
+        saw_instance
+    ), "test produced no instances to check -- fixture/threshold issue"
 
 
 def test_filter_user_labeled_frames(tmp_path):


### PR DESCRIPTION
## Summary

Found during a full preprocessing/postprocessing parity sweep between `sleap-nn predict` and `sleap-nn track` (`scratch/2026-07-30-full-parity-sweep/README.md`, not part of this PR — gitignored). **This is a real correctness bug in each pipeline independently, not just a `predict`-vs-`track` parity gap** — anyone using `--input_scale` to run inference at a different scale than a model was trained at (an explicitly supported, documented use case) got wrong results on both CLIs, just in different ways.

## Problem

**`predict` silently ignored the override entirely.** Every `input_scale=` construction site in `sleap_nn/inference/loaders.py` (11 call sites across every model-type builder: single_instance, bottomup, bottomup_multiclass, bottomup_segmentation, semantic_segmentation, topdown ×2, topdown_segmentation, topdown_multiclass ×2) read `config.data_config.preprocessing.scale` — the training config's own baked-in value — instead of the already-resolved `preprocess_config.scale` local variable that reflects the CLI/API override. `sleap_nn/inference/predictor.py`'s 9 `PreprocessConfig(scale=inf.input_scale, ...)` sites read this same (never-overridden) attribute back off the constructed inference model, so the override never reached anywhere in the new pipeline, with no error or warning.

**`track` (legacy) applied the override to the forward image resize but not to the coordinate rescale-back.** The actual image resize correctly used the resolved `self.preprocess_config["scale"]` (unchanged by this PR), but every `*Predictor._initialize_inference_model` (7 call sites across `TopDownPredictor`, `SingleInstancePredictor`, `BottomUpPredictor`, `BottomUpMultiClassPredictor`, `TopDownMultiClassPredictor`) built its `input_scale=` kwarg from `self.<config>.data_config.preprocessing.scale` — again the stale training value. Since `SingleInstanceInferenceModel`/etc. divide predicted peak coordinates by `self.input_scale` to map them from resized-image space back to original-image space, this produced physically-impossible output coordinates.

Verified directly (single_instance model, 320×560 video, `--input_scale 1.5`):

| | baseline | `--input_scale 1.5` |
|---|---|---|
| `track` | `(199.4, 199.3)` | `(544.5, 567.5)` and `(888.7, 113.1)` — out of frame |
| `predict` | `(199.4, 199.3)` | `(199.4, 199.3)` — unchanged, override silently dropped |

## Changes Made

- `sleap_nn/inference/loaders.py`: all 11 `input_scale=<config>.data_config.preprocessing.scale` sites → `input_scale=preprocess_config.scale` (the already-resolved local variable each function computes via `_resolve_preprocess_config` a few lines earlier).
- `sleap_nn/inference/predictors.py`: all 7 `input_scale=self.<config>.data_config.preprocessing.scale` sites → `input_scale=self.preprocess_config.scale` (same resolved-value pattern, confirmed present via a generic `for k, v in preprocess_config.items(): if v is None: ...` resolution loop in every predictor class's `from_trained_models`).
- `tests/inference/test_predictors.py`: fixed two pre-existing test fixtures (`test_bottomup_predictor`, `test_multi_class_bottomup_predictor`) whose `preprocess_config` dicts were missing a `"scale"` key entirely — this never mattered before since bottomup's `input_scale` never actually read that field, but the fix now correctly depends on it being present (matches every other `preprocess_config` dict in the file, which already includes it).

## Testing

- **Unit-level** (`tests/inference/test_loaders.py`, `tests/inference/test_predictors.py`): assert a `preprocess_config.scale` override reaches `assets.inference_model.input_scale` / `predictor.inference_model.input_scale` for single_instance, bottomup, and both stages of topdown, on both pipelines (6 new tests).
- **End-to-end** (`tests/inference/test_predictors.py::test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds`): runs real inference with `--input_scale 1.5` and asserts every predicted keypoint stays within the source frame's pixel bounds — the direct regression guard for the corrupted-coordinates symptom.
- All 7 new tests verified to **fail without the fix and pass with it** (confirmed by temporarily reverting the fix and re-running).
- Full suite: `uv run pytest -q --cov --cov-branch tests/` → 2193 passed, 138 skipped, 4 xfailed, 0 failed.
- Coverage: all 18 changed lines (11 in `loaders.py`, 7 in `predictors.py`) confirmed exercised via `coverage report -m`.
- `black`/`ruff` clean on `sleap_nn/`. `uvx codespell sleap_nn tests docs *.md pyproject.toml` clean.

## Design Decisions

- Fixed at the root cause (the `input_scale=` construction sites) rather than patching downstream — both pipelines already compute the correctly-resolved scale value earlier in the same function/method, so this is a one-line swap per site, no new resolution logic needed.
- Left the forward-resize code path in `track` untouched — it was already correct; only the rescale-back construction sites needed the fix.
- Fixed the two incomplete test fixtures rather than working around them, since they were a genuine (if previously harmless) gap relative to every other `preprocess_config` dict in the same file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)