### PR TITLE
fix(infer): empty-frame retention, tracking-logging bug, and legacy log-line parity

### DIFF
--- a/sleap_nn/inference/bottomup.py
+++ b/sleap_nn/inference/bottomup.py
@@ -1,14 +1,12 @@
 """Inference modules for BottomUp models."""
 
-import logging
 from typing import Dict, List, Optional
 import torch
 import lightning as L
+from loguru import logger
 from sleap_nn.inference.peak_finding import find_local_peaks
 from sleap_nn.inference.paf_grouping import PAFScorer
 from sleap_nn.inference.identity import classify_peaks_from_maps
-
-logger = logging.getLogger(__name__)
 
 
 class BottomUpInferenceModel(L.LightningModule):

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1020,6 +1020,9 @@ class Predictor:
                 for ``mask_output`` polygon/both (bottom-up segmentation only).
         """
         from sleap_nn.inference.loaders import load_model_assets
+        from sleap_nn.system_info import get_startup_info_string
+
+        logger.info(get_startup_info_string())
 
         loaded, model_types = load_model_assets(
             model_paths,
@@ -1299,6 +1302,33 @@ class Predictor:
                 parts.append(f"fps={fps}")
         parts.append(f"tracking={self.tracker_config is not None}")
         logger.info("Starting inference | " + " | ".join(parts))
+
+    def _log_filter_config(self) -> None:
+        """Log which post-inference filters are active, with their values.
+
+        Matches legacy ``run_inference``'s per-filter confirmation messages
+        -- useful for confirming a filter flag actually took effect (silent
+        no-ops here have bitten us before, see #715/#716/#717).
+        """
+        cfg = self.filter_config
+        if cfg.min_visible_nodes > 0 or cfg.min_visible_node_fraction > 0.0:
+            logger.info(
+                f"Filtered instances by node count: "
+                f"min_visible_nodes={cfg.min_visible_nodes}, "
+                f"min_visible_node_fraction={cfg.min_visible_node_fraction}"
+            )
+        if cfg.min_mean_node_score > 0.0 or cfg.min_instance_score > 0.0:
+            logger.info(
+                f"Filtered instances by confidence: "
+                f"min_mean_node_score={cfg.min_mean_node_score}, "
+                f"min_instance_score={cfg.min_instance_score}"
+            )
+        if cfg.overlapping:
+            logger.info(
+                f"Filtered overlapping instances with "
+                f"{cfg.overlapping_method.upper()} threshold: "
+                f"{cfg.overlapping_threshold}"
+            )
 
     def _log_inference_summary(
         self,
@@ -1597,6 +1627,7 @@ class Predictor:
             videos = auto_videos
 
         self._log_inference_start(source, provider, videos)
+        self._log_filter_config()
         _prov_start = datetime.now()
         layer = self._scoped_postprocess_layer(
             peak_threshold=peak_threshold,
@@ -1813,6 +1844,7 @@ class Predictor:
         if videos is None:
             videos = derived
         self._log_inference_start(source, provider, derived)
+        self._log_filter_config()
         pkg = self._resolve_centroid_packaging()
         writer = IncrementalLabelsWriter(
             path=path,

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1633,7 +1633,7 @@ class Predictor:
         labels = self.to_labels(
             outputs_list,
             videos=videos,
-            keep_empty_frames=self.tracker_config is not None,
+            keep_empty_frames=True,
         )
         if self.tracker_config is not None:
             labels = apply_tracking(
@@ -2001,9 +2001,13 @@ class Predictor:
             outputs_list: Per-batch ``Outputs`` to concatenate.
             videos: List of ``sio.Video`` indexed by ``video_indices``.
             keep_empty_frames: Forwarded to :meth:`Outputs.to_labels` -- keep
-                zero-detection frames instead of dropping them. Set by
-                :meth:`predict` when tracking is enabled so the tracker sees
-                every processed frame, matching the legacy pipeline (#714).
+                zero-detection frames instead of dropping them.
+                :meth:`predict` always passes ``True`` here (matching the
+                legacy pipeline's default of keeping every processed frame,
+                tracking or not -- #714 fixed this for the tracking case,
+                #717 for the non-tracking default); ``clean_empty_frames``
+                (``--no_empty_frames`` on the CLI) is the opt-in way to drop
+                them afterward, applied uniformly regardless of tracking.
         """
         import sleap_io as sio
 

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -27,6 +27,7 @@ Usage::
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 
@@ -250,6 +251,8 @@ def save_predictions(
             embed=_resolve_embed(embed, labels),
             restore_original_videos=restore_source_videos,
         )
+        logger.info(f"Predictions output path: {output_path}")
+        logger.info(f"Saved file at: {datetime.now()}")
 
     h5_paths: List[Path] = []
     if "analysis_h5" in formats:

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -30,14 +30,12 @@ What this does NOT cover:
 
 from __future__ import annotations
 
-import logging
 from typing import Callable, Optional
 
 import attrs
+from loguru import logger
 
 import sleap_io as sio
-
-logger = logging.getLogger(__name__)
 
 # Default candidate window. Mask tracking uses a larger default than the
 # pose/centroid default because bottom-up segmentation is over-segmented (a

--- a/sleap_nn/inference/tracking.py
+++ b/sleap_nn/inference/tracking.py
@@ -30,6 +30,7 @@ What this does NOT cover:
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Callable, Optional
 
 import attrs
@@ -136,6 +137,9 @@ def apply_tracking(
         connect_single_breaks,
     )
     from sleap_nn.tracking.utils import cull_instances
+
+    start_time = datetime.now()
+    logger.info(f"Started tracking at: {start_time}")
 
     # Both post_connect_single_breaks and a non-zero pre-cull target require an
     # explicit tracking_target_instance_count (legacy parity — max_tracks was
@@ -346,6 +350,10 @@ def apply_tracking(
             tracked_lfs = connect_single_breaks(
                 tracked_lfs, max_instances=config.tracking_target_instance_count
             )
+
+    finish_time = datetime.now()
+    logger.info(f"Finished tracking at: {finish_time}")
+    logger.info(f"Total runtime: {(finish_time - start_time).total_seconds()} secs")
 
     return sio.Labels(
         labeled_frames=tracked_lfs,

--- a/tests/inference/test_issue_610_logging.py
+++ b/tests/inference/test_issue_610_logging.py
@@ -25,6 +25,7 @@ import sleap_io as sio
 from _pytest.logging import LogCaptureFixture
 from loguru import logger
 
+from sleap_nn.inference.filters import FilterConfig
 from sleap_nn.inference.predictor import Predictor
 from sleap_nn.inference.providers import NumpyProvider
 
@@ -156,6 +157,68 @@ def test_log_inference_summary_masks_label(caplog):
         n_frames=2, elapsed_s=1.0, n_objects=6, object_label="masks"
     )
     assert "masks=6 (3.00/frame)" in caplog.text
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _log_filter_config -- matches legacy run_inference's per-filter confirmation
+# messages (#717). Silent no-ops in this exact area (--input_scale, single-
+# instance --filter_min_instance_score) have bitten us before, so confirming
+# a filter flag actually took effect is worth the log line.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_log_filter_config_default_is_silent(caplog):
+    """A no-op ``FilterConfig`` (all thresholds 0 / False) logs nothing."""
+    predictor = Predictor(layer=_FakeLayer())
+    predictor._log_filter_config()
+    assert caplog.text == ""
+
+
+def test_log_filter_config_node_count(caplog):
+    predictor = Predictor(
+        layer=_FakeLayer(),
+        filter_config=FilterConfig(min_visible_nodes=3, min_visible_node_fraction=0.5),
+    )
+    predictor._log_filter_config()
+    assert "Filtered instances by node count" in caplog.text
+    assert "min_visible_nodes=3" in caplog.text
+    assert "min_visible_node_fraction=0.5" in caplog.text
+
+
+def test_log_filter_config_confidence(caplog):
+    predictor = Predictor(
+        layer=_FakeLayer(),
+        filter_config=FilterConfig(min_mean_node_score=0.4, min_instance_score=0.6),
+    )
+    predictor._log_filter_config()
+    assert "Filtered instances by confidence" in caplog.text
+    assert "min_mean_node_score=0.4" in caplog.text
+    assert "min_instance_score=0.6" in caplog.text
+
+
+def test_log_filter_config_overlapping(caplog):
+    predictor = Predictor(
+        layer=_FakeLayer(),
+        filter_config=FilterConfig(
+            overlapping=True, overlapping_method="oks", overlapping_threshold=0.75
+        ),
+    )
+    predictor._log_filter_config()
+    assert "Filtered overlapping instances with OKS threshold: 0.75" in caplog.text
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Startup info line (#717) -- matches legacy run_inference / train.py, which
+# both log sleap-nn/Python/PyTorch/device versions at the start of a run.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not SI_CKPT.exists(), reason="missing single-instance fixture")
+def test_from_model_paths_logs_startup_info(caplog):
+    Predictor.from_model_paths([str(SI_CKPT)], device="cpu", batch_size=4)
+    assert "sleap-nn" in caplog.text
+    assert "Python" in caplog.text
+    assert "PyTorch" in caplog.text
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/inference/test_run.py
+++ b/tests/inference/test_run.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import sleap_io as sio
+from _pytest.logging import LogCaptureFixture
+from loguru import logger
 
 from sleap_nn.inference.run import (
     _resolve_embed,
@@ -21,6 +23,20 @@ from sleap_nn.inference.run import (
     save_analysis_h5_files,
     save_predictions,
 )
+
+
+@pytest.fixture
+def caplog(caplog: LogCaptureFixture):
+    """Route loguru records into pytest's ``caplog`` (project convention)."""
+    handler_id = logger.add(
+        caplog.handler,
+        format="{message}",
+        level=0,
+        filter=lambda record: record["level"].no >= caplog.handler.level,
+        enqueue=False,
+    )
+    yield caplog
+    logger.remove(handler_id)
 
 
 def _mock_predictor():
@@ -215,6 +231,31 @@ def test_save_predictions_both_writes_slp_and_h5(minimal_instance, tmp_path):
     # Both files round-trip back to Labels.
     assert isinstance(sio.load_slp(out.as_posix()), sio.Labels)
     assert isinstance(sio.load_analysis_h5(h5_written[0].as_posix()), sio.Labels)
+
+
+def test_save_predictions_logs_output_path_and_saved_confirmation(
+    minimal_instance, tmp_path, caplog
+):
+    """Regression: legacy ``run_inference`` logs 'Predictions output path: ...'
+    and 'Saved file at: ...' after writing -- the new pipeline's
+    ``save_predictions`` previously logged nothing for the primary ``.slp``
+    write (only the optional ``analysis_h5`` export got a log line)."""
+    labels = sio.load_slp(minimal_instance.as_posix())
+    out = tmp_path / "preds.slp"
+    save_predictions(labels, out)
+    assert f"Predictions output path: {out}" in caplog.text
+    assert "Saved file at:" in caplog.text
+
+
+def test_save_predictions_analysis_h5_only_does_not_log_slp_confirmation(
+    minimal_instance, tmp_path, caplog
+):
+    """No .slp write -> no 'Predictions output path' / 'Saved file at' lines."""
+    labels = sio.load_slp(minimal_instance.as_posix())
+    out = tmp_path / "preds.slp"
+    save_predictions(labels, out, output_format="analysis_h5")
+    assert "Predictions output path:" not in caplog.text
+    assert "Saved file at:" not in caplog.text
 
 
 def test_save_predictions_analysis_h5_only_skips_slp(minimal_instance, tmp_path):

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -169,6 +169,22 @@ def test_apply_tracking_zero_frames_log_message_actually_emits(skeleton, video, 
     assert "0 frames to track; skipping tracking post-processing." in caplog.text
 
 
+def test_apply_tracking_logs_start_finish_and_runtime(skeleton, video, caplog):
+    """``apply_tracking`` logs 'Started tracking at' / 'Finished tracking at' /
+    'Total runtime' -- matching legacy ``run_inference``'s separate
+    tracking-phase timing lines (previously absent; the new pipeline only
+    reported one end-of-run summary line covering the whole inference run,
+    not tracking specifically)."""
+    labels = _make_labels(skeleton, video, frames=3, instances_per_frame=2)
+    apply_tracking(
+        labels, TrackerConfig(window_size=5, candidates_method="fixed_window")
+    )
+    assert "Started tracking at:" in caplog.text
+    assert "Finished tracking at:" in caplog.text
+    assert "Total runtime:" in caplog.text
+    assert "secs" in caplog.text
+
+
 def test_apply_tracking_single_node_default_resolution_log_actually_emits(
     video, caplog
 ):

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -318,6 +318,80 @@ def test_predictor_predict_clean_empty_frames_drops_empty(skeleton, video, monke
     assert [lf.frame_idx for lf in result.labeled_frames] == [1]
 
 
+def test_predictor_predict_keeps_empty_frames_by_default_without_tracking(
+    skeleton, video, monkeypatch
+):
+    """Regression: zero-detection frames must survive to the output even when
+    ``--tracking`` is off, matching the legacy pipeline's default of keeping
+    every processed frame.
+
+    Before this fix, ``predict()`` only passed ``keep_empty_frames=True`` to
+    ``to_labels()`` when a ``tracker_config`` was set (the #714 fix, scoped
+    narrowly to the tracking-ID divergence bug) -- so the much more common
+    non-tracking case still silently dropped every empty frame from the
+    output, unlike ``sleap-nn track``'s default.
+    """
+    outputs_list = [
+        _frame_outputs(0, True),
+        _frame_outputs(1, False),
+        _frame_outputs(2, False),
+        _frame_outputs(3, True),
+    ]
+    pred = Predictor(layer=_StubLayer())  # no tracker_config -- not tracking
+
+    class _Provider:
+        def __iter__(self):
+            return iter([])
+
+    monkeypatch.setattr(
+        Predictor,
+        "_batch_iter",
+        lambda self, provider, progress_callback=None, layer=None: iter(outputs_list),
+    )
+
+    result = pred.predict(
+        _Provider(), make_labels=True, skeleton=skeleton, videos=[video]
+    )
+    # All 4 processed frames survive, including the two empty ones.
+    assert [lf.frame_idx for lf in result.labeled_frames] == [0, 1, 2, 3]
+    assert result.labeled_frames[1].instances == []
+    assert result.labeled_frames[2].instances == []
+
+
+def test_predictor_predict_clean_empty_frames_still_drops_them_without_tracking(
+    skeleton, video, monkeypatch
+):
+    """``clean_empty_frames=True`` (``--no_empty_frames``) still removes empty
+    frames in the non-tracking case -- the existing opt-out is unaffected by
+    always keeping them by default now."""
+    outputs_list = [
+        _frame_outputs(0, True),
+        _frame_outputs(1, False),
+        _frame_outputs(2, False),
+        _frame_outputs(3, True),
+    ]
+    pred = Predictor(layer=_StubLayer())
+
+    class _Provider:
+        def __iter__(self):
+            return iter([])
+
+    monkeypatch.setattr(
+        Predictor,
+        "_batch_iter",
+        lambda self, provider, progress_callback=None, layer=None: iter(outputs_list),
+    )
+
+    result = pred.predict(
+        _Provider(),
+        make_labels=True,
+        skeleton=skeleton,
+        videos=[video],
+        clean_empty_frames=True,
+    )
+    assert [lf.frame_idx for lf in result.labeled_frames] == [0, 3]
+
+
 def _frame_outputs(frame_idx, has_instances, video_idx=0):
     """One-frame ``Outputs`` (batch_size=1): 2 fixed-position instances, or
     none. Used to build synthetic sequences with detection gaps for the

--- a/tests/inference/test_tracking.py
+++ b/tests/inference/test_tracking.py
@@ -8,11 +8,28 @@ import numpy as np
 import pytest
 import sleap_io as sio
 import torch
+from _pytest.logging import LogCaptureFixture
+from loguru import logger
 
 from sleap_nn.inference.filters import FilterConfig
 from sleap_nn.inference.outputs import Outputs
 from sleap_nn.inference.predictor import Predictor
 from sleap_nn.inference.tracking import TrackerConfig, apply_tracking
+
+
+@pytest.fixture
+def caplog(caplog: LogCaptureFixture):
+    """Route loguru records into pytest's ``caplog`` (project convention)."""
+    handler_id = logger.add(
+        caplog.handler,
+        format="{message}",
+        level=0,
+        filter=lambda record: record["level"].no >= caplog.handler.level,
+        enqueue=False,
+    )
+    yield caplog
+    logger.remove(handler_id)
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Fixtures
@@ -137,6 +154,41 @@ def test_apply_tracking_zero_frames_with_clean_instance_count_does_not_crash(
     out = apply_tracking(labels, TrackerConfig(tracking_clean_instance_count=2))
     assert isinstance(out, sio.Labels)
     assert len(out.labeled_frames) == 0
+
+
+def test_apply_tracking_zero_frames_log_message_actually_emits(skeleton, video, caplog):
+    """Regression: ``tracking.py`` used Python's stdlib ``logging.getLogger``
+    instead of the project's ``loguru`` logger, with no handler attached
+    anywhere -- so every message it logged (this one, and the two
+    auto-resolution notices below) was silently swallowed, in every mode
+    (CLI, ``--gui``, Python API). Fixed by switching to ``from loguru import
+    logger``, matching every other module in the pipeline.
+    """
+    labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[])
+    apply_tracking(labels, TrackerConfig())
+    assert "0 frames to track; skipping tracking post-processing." in caplog.text
+
+
+def test_apply_tracking_single_node_default_resolution_log_actually_emits(
+    video, caplog
+):
+    """Same regression as above, for the single-node auto-resolution notice."""
+    single_node_skeleton = sio.Skeleton(nodes=["centroid"])
+    inst = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[0.0, 0.0]], dtype=np.float32),
+        skeleton=single_node_skeleton,
+        score=0.9,
+    )
+    labels = sio.Labels(
+        videos=[video],
+        skeletons=[single_node_skeleton],
+        labeled_frames=[sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])],
+    )
+    apply_tracking(
+        labels,
+        TrackerConfig(scoring_method_explicit=False, features_explicit=False),
+    )
+    assert "Single-node skeleton detected" in caplog.text
 
 
 def test_apply_tracking_zero_frames_post_connect_requires_target_count_still_raises(


### PR DESCRIPTION
## Summary

Three related fixes found during the full `predict`-vs-`track` parity sweep (`scratch/2026-07-30-full-parity-sweep/README.md`), all addressing places where `sleap-nn predict` silently diverged from or said less than legacy `run_inference` (`sleap-nn track`):

- **Keep empty-detection frames in `predict` output by default** (Finding 4 of the sweep). `#714` fixed this for the `--tracking` case only (`keep_empty_frames=self.tracker_config is not None`); the far more common non-tracking path was untouched, so every zero-detection frame was silently dropped from the output `.slp` — unlike `track`, which keeps one `LabeledFrame` per processed frame by default regardless of tracking. Verified empirically: `--peak_threshold 0.99` on a 100-frame video gave `track` 100 output frames (all empty), `predict` 0.
- **`tracking.py` logged via stdlib `logging`, silently swallowed.** Found while investigating why `predict` emits noticeably fewer log lines than `track` for the same run. `sleap_nn/inference/tracking.py` (and one call in `bottomup.py`) used stdlib `logging.getLogger(__name__)` instead of the project's loguru-based logger — with no handler attached anywhere, every message was silently swallowed. Killed 3 messages entirely: the single-node-skeleton auto-resolution notice, the segmentation-model auto-resolution notice, and "0 frames to track; skipping tracking post-processing."
- **Restore legacy log-line parity** (startup info, filter config, save/tracking timestamps). Even with loguru wired up, `predict` still said less than `track` for the same run — which makes it harder to confirm a flag actually took effect (the exact class of bug the last two PRs, #715 and #716, and this sweep kept finding). Adds: a startup info line (sleap-nn/Python/PyTorch/device versions, matching `train.py` and `legacy_predict.py`); a per-filter confirmation log (node-count, confidence, overlap-NMS, with resolved values) right after inference starts; a "Predictions output path" / "Saved file at" pair after writing the primary `.slp` (previously only the optional `analysis_h5` export logged anything); and start/finish/runtime timestamps for the tracking phase specifically (previously only one end-of-run summary covered the whole run).

## Changes Made

- `sleap_nn/inference/predictor.py`: `predict()` now always passes `keep_empty_frames=True` to `to_labels()` (the existing `clean_empty_frames` / `--no_empty_frames` remains the opt-out, applied uniformly regardless of tracking); added `_log_filter_config()` and a startup-info log line in `from_model_paths`.
- `sleap_nn/inference/tracking.py`, `sleap_nn/inference/bottomup.py`: switch from stdlib `logging` to the project's `loguru` logger; added tracking start/finish/runtime log lines.
- `sleap_nn/inference/run.py`: `save_predictions()` logs the output path and a save-confirmation timestamp for the primary `.slp` write.

## Testing

- Regression tests added for every new/fixed log line and behavior change, each verified to fail without the corresponding fix and pass with it (`tests/inference/test_tracking.py`, `tests/inference/test_issue_610_logging.py`, `tests/inference/test_run.py`).
- Full suite: 2205 passed, 138 skipped, 4 xfailed.
- `black --check`, `ruff check`, and `codespell` all clean.

## Related

Findings from `scratch/2026-07-30-full-parity-sweep/README.md` (Finding 4, plus the tracking-logging bug and log-line-parity gaps found while investigating it). Continues the series from #714/#715/#716.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
