### PR TITLE
fix(eval): guard zero-matched-instance warnings + retire legacy predict pipeline from post-training eval

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -2119,6 +2119,13 @@ def run_evaluation(
         anchor_part: Name of the GT skeleton node used to compute GT centroids
             (centroid mode). Resolved against the GT skeleton; ``None`` (or an
             absent name) falls back to the mean of visible nodes (#586).
+
+    Returns:
+        The metrics dict, or ``None`` if the predicted labels have zero
+        frames or contain nothing usable (no instances for ``"oks"``/
+        ``"centroid"``/``"auto"``, no masks for ``"mask"``/``"semantic"``) --
+        metric computation is skipped entirely in that case, and no
+        ``save_metrics`` file is written.
     """
     logger.info("Loading ground truth labels...")
     ground_truth_instances = sio.load_slp(ground_truth_path)
@@ -2133,6 +2140,23 @@ def run_evaluation(
         f"  Predictions: {len(predicted_instances.videos)} videos, "
         f"{len(predicted_instances.labeled_frames)} frames"
     )
+
+    # Detect a fully collapsed prediction set up front and skip the metric
+    # math entirely (#719) -- frames may still be present (both predictor
+    # pipelines retain empty-detection frames by default), but nothing usable
+    # was predicted in any of them, so matching would only produce an
+    # all-NaN/all-zero result. ``mask``/``semantic`` predictions live on
+    # ``LabeledFrame.masks``, not ``.instances``.
+    if match_method in ("mask", "semantic"):
+        has_predictions = any(len(lf.masks) for lf in predicted_instances)
+    else:
+        has_predictions = any(len(lf.instances) for lf in predicted_instances)
+    if not len(predicted_instances) or not has_predictions:
+        logger.info(
+            "0 predicted instances: skipping metric computation (model "
+            "likely predicted nothing usable, or training collapsed)."
+        )
+        return None
 
     # Auto-detect centroid mode from the PREDICTION skeleton.
     pred_skeleton = (

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -1271,9 +1271,15 @@ class Evaluator:
             match_scores = np.array([oks for _, _, oks in self.positive_pairs])
             name = "oks_voc"
         elif match_score_by == "pck":
-            pck_metrics = self.pck_metrics()
-            match_scores = pck_metrics["pcks"].mean(axis=-1).mean(axis=-1)
             name = "pck_voc"
+            if not self.positive_pairs:
+                # Guard the empty-match case: the (n_pairs, n_nodes, n_thresholds)
+                # ``pcks`` array is empty along the pairs axis, so reducing it with
+                # nested .mean() calls would hit "Mean of empty slice".
+                match_scores = np.array([])
+            else:
+                pck_metrics = self.pck_metrics()
+                match_scores = pck_metrics["pcks"].mean(axis=-1).mean(axis=-1)
         else:
             message = "Invalid Option for match_score_by. Choose either `oks` or `pck`"
             logger.error(message)
@@ -1356,7 +1362,7 @@ class Evaluator:
     def mOKS(self):
         """Return the meanOKS value."""
         pair_oks = np.array([oks for _, _, oks in self.positive_pairs])
-        return {"mOKS": pair_oks.mean()}
+        return {"mOKS": float(pair_oks.mean()) if pair_oks.size else np.nan}
 
     def distance_metrics(self):
         """Compute the Euclidean distance error at different percentiles using the pairwise distances.
@@ -1826,14 +1832,23 @@ class Evaluator:
         dists = np.copy(dists)
         dists[np.isnan(dists)] = np.inf
         pcks = np.expand_dims(dists, -1) < np.reshape(thresholds, (1, 1, -1))
-        mPCK_parts = pcks.mean(axis=0).mean(axis=-1)
-        mPCK = mPCK_parts.mean()
 
-        # Precompute PCK at common thresholds
-        idx_5 = np.argmin(np.abs(thresholds - 5))
-        idx_10 = np.argmin(np.abs(thresholds - 10))
-        pck5 = pcks[:, :, idx_5].mean()
-        pck10 = pcks[:, :, idx_10].mean()
+        # Guard the empty-match case (0 positive pairs for the whole split) so
+        # the nested .mean() reductions below don't hit "Mean of empty slice".
+        if dists.size == 0:
+            mPCK_parts = np.array([])
+            mPCK = np.nan
+            pck5 = np.nan
+            pck10 = np.nan
+        else:
+            mPCK_parts = pcks.mean(axis=0).mean(axis=-1)
+            mPCK = float(mPCK_parts.mean())
+
+            # Precompute PCK at common thresholds
+            idx_5 = np.argmin(np.abs(thresholds - 5))
+            idx_10 = np.argmin(np.abs(thresholds - 10))
+            pck5 = float(pcks[:, :, idx_5].mean())
+            pck10 = float(pcks[:, :, idx_10].mean())
 
         return {
             "thresholds": thresholds,
@@ -1900,6 +1915,18 @@ class Evaluator:
             # Whole-frame binary foreground segmentation: no instances to match, so
             # report only matching-free foreground IoU / clDice / boundary-IoU.
             return {"semantic_metrics": self.semantic_metrics()}
+
+        if not self.positive_pairs:
+            # 0 matched instances for the whole split (e.g. a collapsed model
+            # predicting nothing, or predictions that never clear the OKS
+            # threshold) -- every metric below is undefined by construction.
+            # The individual methods already guard their own NaN/empty-array
+            # math, so this is just one clear line instead of relying on the
+            # reader to infer "collapsed model" from a wall of NaNs.
+            logger.info(
+                "0 matched instances: metrics undefined (model predicted "
+                "nothing usable, or training likely collapsed)."
+            )
 
         metrics = {}
         metrics["voc_metrics"] = self.voc_metrics(match_score_by="oks")
@@ -2281,8 +2308,11 @@ def run_evaluation(
     dists = metrics["distance_metrics"]["dists"]
     dists_clean = np.copy(dists)
     dists_clean[np.isnan(dists_clean)] = np.inf
-    pck_5 = (dists_clean < 5).mean()
-    pck_10 = (dists_clean < 10).mean()
+    # Guard the empty-match case (0 matched instances for the whole split) so
+    # this doesn't hit "Mean of empty slice" on top of the evaluate()-level
+    # log line already emitted for it.
+    pck_5 = float((dists_clean < 5).mean()) if dists_clean.size else np.nan
+    pck_10 = float((dists_clean < 10).mean()) if dists_clean.size else np.nan
 
     # Print key metrics
     logger.info("Evaluation Results:")

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional, List, Tuple, Union
 import sleap_io as sio
 from sleap_nn.config.training_job_config import TrainingJobConfig
 from sleap_nn.training.model_trainer import ModelTrainer
-from sleap_nn.legacy_predict import run_inference as predict
 from sleap_nn.evaluation import run_evaluation
 from sleap_nn.config.get_config import (
     get_trainer_config,
@@ -428,22 +427,31 @@ def run_training(
                     )
                     continue
 
-                pred_labels = predict(
-                    data_path=path,
+                # single_instance / centered_instance / bottomup (+ their
+                # multi_class_bottomup / multi_class_topdown ID variants) all
+                # route through the NEW inference flow here too (matching
+                # centroid-only/segmentation above) -- legacy_predict.run_inference
+                # is deprecated. ensure_rgb/ensure_grayscale are picked up
+                # automatically from the trained model's own training config,
+                # so they don't need to be forwarded explicitly.
+                from sleap_nn.inference.run import predict as predict_new
+
+                pred_labels = predict_new(
+                    path,
                     model_paths=[run_path],
                     peak_threshold=0.2,
-                    make_labels=True,
                     device=str(trainer.trainer.strategy.root_device),
                     output_path=pred_path,
-                    ensure_rgb=config.data_config.preprocessing.ensure_rgb,
-                    ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
                 )
 
-                if not len(pred_labels):
+                if not len(pred_labels) or not any(
+                    len(lf.instances) for lf in pred_labels
+                ):
                     logger.info(
-                        f"Skipping eval on `{d_name}` dataset as there are no labeled frames..."
+                        f"Skipping eval on `{d_name}` dataset as there are no "
+                        "predicted instances..."
                     )
-                    continue  # skip if there are no labeled frames
+                    continue  # skip if there are no predicted instances
 
                 # Run evaluation and save metrics.
                 metrics = run_evaluation(

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 import copy
 import torch
+import warnings
 from sleap_nn.legacy_predict import run_inference
 from sleap_nn.evaluation import (
     compute_instance_area,
@@ -435,6 +436,38 @@ def test_evaluator_more_predicted_instances(minimal_instance):
     assert len(eval.frame_pairs) == 1
     assert len(eval.positive_pairs) == 0
     assert len(eval.false_negatives) == 2
+
+
+def test_evaluator_zero_matched_instances_no_warnings(caplog, minimal_instance):
+    """Evaluator.evaluate() with 0 positive pairs must not warn (#719).
+
+    Regression test: a collapsed model (or here, a match_threshold strict
+    enough that nothing clears it) produces 0 positive pairs but non-empty
+    frame_pairs/false_negatives. mOKS()/pck_metrics()/voc_metrics(pck) used to
+    call .mean() on empty arrays unguarded, spamming "Mean of empty slice"
+    RuntimeWarnings. This checks the fix: no warnings, one clear log line, and
+    well-defined NaN/0 metrics.
+    """
+    user_labels, pred_labels = create_labels_more_predicted_instances(minimal_instance)
+    eval = Evaluator(user_labels, pred_labels, match_threshold=1)
+    assert len(eval.positive_pairs) == 0
+    assert len(eval.false_negatives) == 2
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with caplog.at_level("INFO"):
+            metrics = eval.evaluate()
+
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert not runtime_warnings, [str(w.message) for w in runtime_warnings]
+    assert "0 matched instances" in caplog.text
+
+    assert np.isnan(metrics["mOKS"]["mOKS"])
+    assert np.isnan(metrics["distance_metrics"]["avg"])
+    assert np.isnan(metrics["pck_metrics"]["mPCK"])
+    assert np.isnan(metrics["pck_metrics"]["PCK@5"])
+    assert metrics["voc_metrics"]["oks_voc.mAP"] == 0
+    assert metrics["voc_metrics"]["pck_voc.mAP"] == 0
 
 
 def test_find_frame_pairs_does_not_mutate_gt_labels():
@@ -887,7 +920,8 @@ def test_evaluator_centroid_match(minimal_instance):
 def test_evaluator_centroid_handles_fully_occluded_gt(minimal_instance):
     """Regression: a fully-occluded (all-NaN) GT instance must NOT crash
     centroid matching (scipy cdist/linear_sum_assignment reject NaN). It is
-    counted as a false negative."""
+    counted as a false negative.
+    """
     gt_skeleton = sio.Skeleton(
         nodes=["head", "thorax", "abdomen"],
         edges=[("head", "thorax"), ("thorax", "abdomen")],
@@ -935,7 +969,8 @@ def test_evaluator_centroid_handles_fully_occluded_gt(minimal_instance):
 
 def test_evaluator_centroid_middle_occluded_fn_attribution(minimal_instance):
     """An occluded GT between two matched GTs: the NaN-filter index map must
-    keep TP/FN attribution and matched distances correct."""
+    keep TP/FN attribution and matched distances correct.
+    """
     gt_skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
     centroid_skeleton = sio.get_centroid_skeleton()
     video = sio.load_slp(minimal_instance).videos[0]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1099,3 +1099,44 @@ def test_run_evaluation_auto_detects_centroid(minimal_instance, tmp_path):
     assert det["n_tp"] == 2
     assert det["n_fp"] == 1
     assert det["n_fn"] == 1
+
+
+def test_run_evaluation_skips_on_zero_predicted_instances(minimal_instance, tmp_path):
+    """run_evaluation() returns None and skips metric computation entirely
+    when predictions have frames but zero usable instances anywhere (#719) --
+    not just when the predicted file has zero frames. No metrics file is
+    written either.
+    """
+    user_labels, pred_labels = create_labels_more_predicted_instances(minimal_instance)
+
+    # Strip all instances from the predicted frame but keep it -- both
+    # predictor pipelines retain empty-detection frames by default.
+    pred_lf = pred_labels[0]
+    empty_pred_labels = sio.Labels(
+        videos=pred_labels.videos,
+        skeletons=pred_labels.skeletons,
+        labeled_frames=[
+            sio.LabeledFrame(
+                video=pred_lf.video, frame_idx=pred_lf.frame_idx, instances=[]
+            )
+        ],
+    )
+
+    gt_path = tmp_path / "gt.slp"
+    pred_path = tmp_path / "pred.slp"
+    metrics_path = tmp_path / "metrics.npz"
+    sio.save_slp(user_labels, gt_path.as_posix())
+    sio.save_slp(empty_pred_labels, pred_path.as_posix())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        metrics = run_evaluation(
+            ground_truth_path=gt_path.as_posix(),
+            predicted_path=pred_path.as_posix(),
+            save_metrics=metrics_path.as_posix(),
+        )
+
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert not runtime_warnings, [str(w.message) for w in runtime_warnings]
+    assert metrics is None
+    assert not metrics_path.exists()

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -214,6 +214,63 @@ def test_run_centroid_split_eval_defaults_and_empty(monkeypatch, tmp_path):
     assert captured["eval_kwargs"]["anchor_part"] is None
 
 
+def test_train_skips_eval_when_zero_predicted_instances(
+    minimal_instance, tmp_path, monkeypatch
+):
+    """Main eval loop skips run_evaluation when predictions have 0 instances.
+
+    Covers frames-present-but-zero-instances-anywhere, not just
+    pred_labels itself having zero frames.
+
+    Regression test: a fully collapsed model (#718/#719) keeps every
+    processed frame (empty ones included) via the new inference pipeline, so
+    `not len(pred_labels)` alone never catches this case. The loop's guard
+    must also check for zero predicted instances across all frames.
+    """
+    import sleap_nn.inference.run as run_mod
+    import sleap_nn.train as train_mod
+
+    def fake_predict(source, *, output_path=None, **kwargs):
+        gt = sio.load_slp(source)
+        empty_lfs = [
+            sio.LabeledFrame(video=lf.video, frame_idx=lf.frame_idx, instances=[])
+            for lf in gt.labeled_frames
+        ]
+        labels = sio.Labels(
+            videos=gt.videos, skeletons=gt.skeletons, labeled_frames=empty_lfs
+        )
+        if output_path is not None:
+            labels.save(str(output_path))
+        return labels
+
+    monkeypatch.setattr(run_mod, "predict", fake_predict)
+
+    def fail_eval(*a, **k):  # pragma: no cover - should not be called
+        raise AssertionError(
+            "run_evaluation should not run when 0 instances were predicted"
+        )
+
+    monkeypatch.setattr(train_mod, "run_evaluation", fail_eval)
+
+    train(
+        train_labels_path=[minimal_instance],
+        val_labels_path=[minimal_instance],
+        max_epochs=1,
+        trainer_num_devices=1,
+        trainer_accelerator="cpu" if torch.mps.is_available() else "auto",
+        head_configs="centered_instance",
+        save_ckpt=True,
+        ckpt_dir=Path(tmp_path).as_posix(),
+        run_name="test_skip_zero_instances",
+        min_train_steps_per_epoch=1,
+    )
+
+    run_path = Path(tmp_path) / "test_skip_zero_instances"
+    assert (run_path / "labels_pr.val.0.slp").exists()
+    assert not (run_path / "metrics.val.0.npz").exists()
+    assert not (run_path / "metrics.train.0.npz").exists()
+
+
 @pytest.fixture
 def sample_cfg(minimal_instance, tmp_path):
     config = DictConfig(


### PR DESCRIPTION
## Summary

- Fixes #719: a fully collapsed model (0 matched instances across a whole eval split) spammed `RuntimeWarning: Mean of empty slice` from `mOKS()`/`pck_metrics()`/`voc_metrics(match_score_by="pck")`, on top of silently returning NaN. `distance_metrics()` already had this guard; the others didn't.
- Retires the deprecated `legacy_predict.run_inference` from `train.py`'s post-training eval loop — `single_instance`/`centered_instance`/`bottomup` (+ multi-class ID variants) now route through `sleap_nn.inference.run.predict`, the same pipeline already used for centroid-only and segmentation eval.
- Extends the post-training eval skip-guard in `train.py` so a collapsed split (frames present, 0 predicted instances anywhere) skips `run_evaluation()` entirely, not just the "0 labeled frames" case.
- Adds the same skip to the standalone `run_evaluation()` itself, so the `sleap-nn eval` CLI and any other direct caller (not just `train.py`, which already had its own pre-check) gets a clean skip instead of computing an all-NaN/all-zero result.

## Changes Made

- `sleap_nn/evaluation.py`:
  - `mOKS()`, `pck_metrics()`, `voc_metrics(match_score_by="pck")` guard their `.mean()` calls against empty/all-collapsed input.
  - `evaluate()` logs one clear line (`"0 matched instances: metrics undefined..."`) instead of a wall of warnings when `positive_pairs` is empty.
  - The CLI's own `PCK@5`/`PCK@10` calc in `evaluate_and_log` got the same guard (it's outside the `Evaluator` class).
  - `run_evaluation()` now checks the loaded predictions right after loading them and returns `None` (skipping matching/metric computation and `save_metrics` entirely) when there's nothing usable — `LabeledFrame.masks` for `match_method in ("mask", "semantic")` since segmentation predictions don't populate `.instances`, `LabeledFrame.instances` otherwise.
- `sleap_nn/train.py`:
  - Removed `from sleap_nn.legacy_predict import run_inference as predict` (the last caller of that deprecated module in this file).
  - Main eval loop now calls `sleap_nn.inference.run.predict` directly, matching `_run_centroid_split_eval`/`_run_segmentation_split_eval`'s existing pattern.
  - Skip-guard extended: `if not len(pred_labels) or not any(len(lf.instances) for lf in pred_labels)`. Kept alongside (not replaced by) `run_evaluation()`'s new internal check: it's cheaper (no redundant disk reload of the already in-memory `pred_labels`) and gives a split-specific log message; `run_evaluation()`'s check is the safety net for callers without their own pre-check.

Confirmed via `grep` that `training/callbacks.py`'s per-epoch eval (`EpochEndEvaluationCallback`) never calls `run_evaluation()` — it constructs `Evaluator` directly from in-memory predictions — so none of this touches that path; it already has its own independent collapse handling (drops all-NaN frames in `_build_pred_labels`, then skips on 0 resulting frames).

## Testing

- `tests/test_evaluation.py::test_evaluator_zero_matched_instances_no_warnings` — constructs an `Evaluator` with `match_threshold=1` (forces 0 positive pairs, non-empty frame_pairs/false_negatives), asserts zero `RuntimeWarning`s, the clear log line, and well-defined NaN/0 metrics.
- `tests/test_evaluation.py::test_run_evaluation_skips_on_zero_predicted_instances` — builds a GT/pred `.slp` pair where the predicted frame is retained but empty, asserts `run_evaluation()` returns `None`, no `RuntimeWarning`s, and no `save_metrics` file is written.
- `tests/test_train.py::test_train_skips_eval_when_zero_predicted_instances` — monkeypatches `sleap_nn.inference.run.predict` to return frames with 0 instances, asserts `run_evaluation` is never called and no `metrics.<split>.npz` is written.
- Full suite: `tests/test_evaluation.py`, `tests/test_train.py`, `tests/test_segmentation_eval.py`, `tests/test_public_api.py`, `tests/export/test_export_accuracy.py`, `tests/test_semantic_segmentation.py`, `tests/training/test_callbacks.py` (130 tests, confirming the callback path is unaffected) — all passing.
- Manual parity check (not part of the automated suite): trained one `centered_instance` (top-down) and one `bottomup` checkpoint, then ran the exact same checkpoint through both the old (`legacy_predict.run_inference`) and new (`sleap_nn.inference.run.predict`) pipelines on the same GT split. Every predicted keypoint matched to `0.000000` px, and every metric (`mOKS`, `oks_voc.mAP`/`mAR`, `dist.avg`/`p50`, `mPCK`, `PCK@5`, `vis.precision`/`recall`) matched exactly between the two pipelines for both model types — the swap introduces no numerical drift.

## Related Issues
Closes #719

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
