### PR TITLE
feat(eval): emit a JSON sibling of the pickled .npz metrics

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -1,5 +1,7 @@
 """This module is to compute evaluation metrics for trained models."""
 
+import json
+import math
 from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import attrs
@@ -2078,6 +2080,64 @@ def _is_single_node_skeleton(skeleton: "sio.Skeleton") -> bool:
     return len(node_names) == 1
 
 
+def _metrics_to_json_safe(obj: Any) -> Any:
+    """Recursively convert a metrics object into a JSON-serializable form.
+
+    Used to write the ``.json`` sibling of the pickled ``.npz`` metrics file so
+    non-Python consumers (e.g. the sleap-app metrics UI) can read the metrics
+    without unpickling a numpy object array. Conversions:
+
+    - numpy scalar (``np.generic``) -> python ``int`` / ``float`` / ``bool``
+    - numpy ``ndarray`` -> nested python lists
+    - non-finite float (``NaN`` / ``+-Inf``) -> ``None`` (JSON ``null``)
+    - ``dict`` -> element-wise converted dict (keys coerced to ``str``)
+    - ``list`` / ``tuple`` -> element-wise converted list
+    - ``str`` and native JSON scalars pass through unchanged
+
+    Emitting ``null`` (not the string ``"NaN"``) for non-finite values keeps the
+    output valid JSON and lets the app treat missing-node distances as gaps.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, np.ndarray):
+        # ``.tolist()`` yields nested python lists with python floats/ints;
+        # recurse so NaN/Inf inside the array become ``None``.
+        return _metrics_to_json_safe(obj.tolist())
+    if isinstance(obj, np.generic):
+        # numpy scalar -> python scalar, then fall through to the checks below.
+        obj = obj.item()
+    if isinstance(obj, bool):  # must precede int (bool is a subclass of int)
+        return obj
+    if isinstance(obj, int):
+        return obj
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, dict):
+        return {str(k): _metrics_to_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_metrics_to_json_safe(v) for v in obj]
+    return obj
+
+
+def _write_metrics(save_path: Path, metrics: dict) -> None:
+    """Write ``metrics`` to ``save_path`` (``.npz``) plus a ``.json`` sibling.
+
+    The ``.npz`` is the SLEAP 1.4 format (a single pickled 0-d ``metrics``
+    object array, read back by :func:`load_metrics`) and is kept for
+    back-compat. The ``.json`` sibling shares the same stem
+    (``metrics.{split}.{idx}.json``) and holds the same metrics dict serialized
+    JSON-safely via :func:`_metrics_to_json_safe` so it can be read directly by
+    JavaScript (the sleap-app metrics UI).
+    """
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(save_path, **{"metrics": metrics})
+    json_path = save_path.with_suffix(".json")
+    with open(json_path, "w") as f:
+        json.dump(_metrics_to_json_safe(metrics), f)
+
+
 def run_evaluation(
     ground_truth_path: str,
     predicted_path: str,
@@ -2252,8 +2312,9 @@ def run_evaluation(
         if save_metrics:
             logger.info(f"Saving metrics to {save_metrics}...")
             save_path = Path(save_metrics)
-            save_path.parent.mkdir(parents=True, exist_ok=True)
-            np.savez_compressed(save_path, **{"metrics": metrics})
+            # Writes the pickled ``.npz`` (back-compat) plus a JSON sibling
+            # with the same stem so the app can read metrics without unpickling.
+            _write_metrics(save_path, metrics)
             logger.info(f"Metrics saved successfully to {save_path}")
 
         return metrics
@@ -2303,8 +2364,9 @@ def run_evaluation(
         if save_metrics:
             logger.info(f"Saving metrics to {save_metrics}...")
             save_path = Path(save_metrics)
-            save_path.parent.mkdir(parents=True, exist_ok=True)
-            np.savez_compressed(save_path, **{"metrics": metrics})
+            # Writes the pickled ``.npz`` (back-compat) plus a JSON sibling
+            # with the same stem so the app can read metrics without unpickling.
+            _write_metrics(save_path, metrics)
             logger.info(f"Metrics saved successfully to {save_path}")
 
         return metrics
@@ -2322,8 +2384,9 @@ def run_evaluation(
         if save_metrics:
             logger.info(f"Saving metrics to {save_metrics}...")
             save_path = Path(save_metrics)
-            save_path.parent.mkdir(parents=True, exist_ok=True)
-            np.savez_compressed(save_path, **{"metrics": metrics})
+            # Writes the pickled ``.npz`` (back-compat) plus a JSON sibling
+            # with the same stem so the app can read metrics without unpickling.
+            _write_metrics(save_path, metrics)
             logger.info(f"Metrics saved successfully to {save_path}")
 
         return metrics
@@ -2359,10 +2422,11 @@ def run_evaluation(
     if save_metrics:
         logger.info(f"Saving metrics to {save_metrics}...")
         save_path = Path(save_metrics)
-        save_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Save metrics in SLEAP 1.4 format (single "metrics" key)
-        np.savez_compressed(save_path, **{"metrics": metrics})
+        # Save metrics in SLEAP 1.4 format (single "metrics" key) plus a JSON
+        # sibling (same stem) that the app metrics UI can read without
+        # unpickling the numpy object array.
+        _write_metrics(save_path, metrics)
         logger.info(f"Metrics saved successfully to {save_path}")
 
     return metrics

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -2121,6 +2121,29 @@ def _metrics_to_json_safe(obj: Any) -> Any:
     return obj
 
 
+# Large per-pair arrays that are useful only for offline analysis, not for the
+# sleap-app metrics UI, and are dropped from the JSON sibling to keep it lean
+# (they remain in the pickled ``.npz``). ``pck_metrics.pcks`` is an
+# ``n_pairs x n_nodes x n_thresholds`` boolean array that otherwise dominates the
+# JSON file size.
+_JSON_PRUNE_KEYS: dict = {"pck_metrics": ("pcks",)}
+
+
+def _prune_json_bloat(json_safe: Any) -> None:
+    """Drop large, UI-unused arrays from a JSON-safe metrics dict, in place.
+
+    Args:
+        json_safe: A JSON-safe metrics dict (from :func:`_metrics_to_json_safe`).
+    """
+    if not isinstance(json_safe, dict):
+        return
+    for section, keys in _JSON_PRUNE_KEYS.items():
+        sub = json_safe.get(section)
+        if isinstance(sub, dict):
+            for key in keys:
+                sub.pop(key, None)
+
+
 def _write_metrics(save_path: Path, metrics: dict) -> None:
     """Write ``metrics`` to ``save_path`` (``.npz``) plus a ``.json`` sibling.
 
@@ -2128,14 +2151,17 @@ def _write_metrics(save_path: Path, metrics: dict) -> None:
     object array, read back by :func:`load_metrics`) and is kept for
     back-compat. The ``.json`` sibling shares the same stem
     (``metrics.{split}.{idx}.json``) and holds the same metrics dict serialized
-    JSON-safely via :func:`_metrics_to_json_safe` so it can be read directly by
+    JSON-safely via :func:`_metrics_to_json_safe` (minus a few large, UI-unused
+    arrays, see :func:`_prune_json_bloat`) so it can be read directly by
     JavaScript (the sleap-app metrics UI).
     """
     save_path.parent.mkdir(parents=True, exist_ok=True)
     np.savez_compressed(save_path, **{"metrics": metrics})
     json_path = save_path.with_suffix(".json")
+    json_safe = _metrics_to_json_safe(metrics)
+    _prune_json_bloat(json_safe)
     with open(json_path, "w") as f:
-        json.dump(_metrics_to_json_safe(metrics), f)
+        json.dump(json_safe, f)
 
 
 def run_evaluation(

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -878,6 +878,13 @@ def test_write_metrics_emits_json_sibling(tmp_path):
         npz_metrics["visibility_metrics"]["tp"]
     )
 
+    # `pcks` (a large n_pairs x n_nodes x n_thresholds boolean array) is pruned
+    # from the JSON view to avoid bloat, but retained in the pickled .npz.
+    assert "pcks" not in loaded["pck_metrics"]
+    assert "pcks" in npz_metrics["pck_metrics"]
+    # The small, useful PCK scalars survive the prune.
+    assert loaded["pck_metrics"]["mPCK"] == pytest.approx(0.5)
+
     # App-loader key shapes: precisions is number[][], AP/recalls are number[].
     assert isinstance(loaded["voc_metrics"]["oks_voc.precisions"], list)
     assert isinstance(loaded["voc_metrics"]["oks_voc.precisions"][0], list)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -741,6 +741,158 @@ def test_load_metrics(single_instance_with_metrics_ckpt, tmp_path):
     assert loaded_old["voc_metrics"]["oks_voc.mAP"] == 0.6
 
 
+def _representative_metrics():
+    """A metrics dict mirroring ``Evaluator.evaluate()`` (OKS mode) output.
+
+    Uses numpy scalars/arrays and embedded NaNs to exercise the JSON-safe
+    conversion the same way a real ``run_evaluation`` result would.
+    """
+    return {
+        "voc_metrics": {
+            "oks_voc.match_score_thresholds": np.linspace(0.5, 0.95, 10),
+            "oks_voc.recall_thresholds": np.linspace(0, 1, 101),
+            "oks_voc.match_scores": np.array([0.9, 0.7, 0.3]),
+            "oks_voc.precisions": np.ones((10, 101)),
+            "oks_voc.recalls": np.array([0.8, 0.6, 0.4, 0.2, 0.1, 0.05, 0.0, 0, 0, 0]),
+            "oks_voc.AP": np.array([0.5, 0.4, 0.3, 0.2, 0.1, 0.05, 0, 0, 0, 0]),
+            "oks_voc.AR": np.array([0.8, 0.6, 0.4, 0.2, 0.1, 0.05, 0, 0, 0, 0]),
+            "oks_voc.mAP": np.float64(0.235),
+            "oks_voc.mAR": np.float64(0.32),
+            "pck_voc.match_score_thresholds": np.linspace(0.5, 0.95, 10),
+            "pck_voc.recall_thresholds": np.linspace(0, 1, 101),
+            "pck_voc.match_scores": np.array([0.95, 0.75, 0.35]),
+            "pck_voc.precisions": np.ones((10, 101)),
+            "pck_voc.recalls": np.array([0.9, 0.7, 0.5, 0.3, 0.2, 0.1, 0, 0, 0, 0]),
+            "pck_voc.AP": np.array([0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0, 0, 0, 0]),
+            "pck_voc.AR": np.array([0.9, 0.7, 0.5, 0.3, 0.2, 0.1, 0, 0, 0, 0]),
+            "pck_voc.mAP": np.float64(0.28),
+            "pck_voc.mAR": np.float64(0.38),
+        },
+        "mOKS": {"mOKS": np.float64(0.6543)},
+        "distance_metrics": {
+            "frame_idxs": [0, 1],
+            "video_paths": ["/data/vid.mp4", "/data/vid.mp4"],
+            # (n_pairs, n_nodes) with a missing node (NaN) -> must become null.
+            "dists": np.array([[1.5, np.nan], [2.0, 3.0]]),
+            "avg": np.float64(2.1667),
+            "p50": np.float64(2.0),
+            "p75": np.float64(2.5),
+            "p90": np.float64(2.8),
+            "p95": np.float64(2.9),
+            "p99": np.float64(2.99),
+        },
+        "pck_metrics": {
+            "thresholds": np.linspace(1, 10, 10),
+            "pcks": np.ones((2, 2, 10), dtype=bool),
+            "mPCK_parts": np.array([0.5, 0.5]),
+            "mPCK": np.float64(0.5),
+            "PCK@5": np.float64(0.75),
+            "PCK@10": np.float64(0.9),
+        },
+        "visibility_metrics": {
+            "tp": np.int64(3),
+            "fp": np.int64(1),
+            "tn": np.int64(0),
+            "fn": np.int64(1),
+            "precision": np.float64(0.75),
+            "recall": np.float64(0.75),
+        },
+    }
+
+
+def test_metrics_to_json_safe_conversions():
+    """``_metrics_to_json_safe`` maps numpy -> python and NaN/Inf -> None."""
+    from sleap_nn.evaluation import _metrics_to_json_safe
+
+    # numpy scalars -> python scalars
+    assert _metrics_to_json_safe(np.float64(1.5)) == 1.5
+    assert isinstance(_metrics_to_json_safe(np.float64(1.5)), float)
+    assert _metrics_to_json_safe(np.int64(3)) == 3
+    assert isinstance(_metrics_to_json_safe(np.int64(3)), int)
+    assert _metrics_to_json_safe(np.bool_(True)) is True
+
+    # non-finite floats -> None (JSON null), never the string "NaN"
+    assert _metrics_to_json_safe(np.float64("nan")) is None
+    assert _metrics_to_json_safe(float("nan")) is None
+    assert _metrics_to_json_safe(float("inf")) is None
+    assert _metrics_to_json_safe(float("-inf")) is None
+
+    # ndarray -> nested lists, NaN inside -> None
+    out = _metrics_to_json_safe(np.array([[1.0, np.nan], [2.0, 3.0]]))
+    assert out == [[1.0, None], [2.0, 3.0]]
+
+    # passthrough for native types
+    assert _metrics_to_json_safe("train") == "train"
+    assert _metrics_to_json_safe({"a": [np.int64(1), np.float64(2.0)]}) == {
+        "a": [1, 2.0]
+    }
+
+
+def test_write_metrics_emits_json_sibling(tmp_path):
+    """``_write_metrics`` writes the .npz AND a JSON sibling matching it.
+
+    Mirrors the existing metrics-write test but exercises the writer directly
+    on a representative metrics dict (no heavy inference/subprocess needed):
+    the JSON sibling exists, ``json.load`` parses it, NaN is serialized as
+    ``null`` (JSON ``None``), and scalar values match the pickled ``.npz``.
+    """
+    import json
+
+    from sleap_nn.evaluation import _write_metrics
+
+    metrics = _representative_metrics()
+    save_path = tmp_path / "metrics.val.0.npz"
+    _write_metrics(save_path, metrics)
+
+    json_path = tmp_path / "metrics.val.0.json"
+    assert save_path.exists()
+    assert json_path.exists()
+
+    # JSON must be valid and parseable (strict=True rejects bare NaN/Infinity).
+    with open(json_path) as f:
+        loaded = json.load(f, parse_constant=_reject_non_json_constant)
+
+    # Same nested structure the app loader expects.
+    assert set(loaded.keys()) == {
+        "voc_metrics",
+        "mOKS",
+        "distance_metrics",
+        "pck_metrics",
+        "visibility_metrics",
+    }
+
+    # NaN in the dists matrix serialized as null (None), not "NaN".
+    assert loaded["distance_metrics"]["dists"] == [[1.5, None], [2.0, 3.0]]
+
+    # Scalar values match the npz round-trip.
+    npz = np.load(save_path, allow_pickle=True)
+    npz_metrics = npz["metrics"].item()
+    assert loaded["mOKS"]["mOKS"] == pytest.approx(float(npz_metrics["mOKS"]["mOKS"]))
+    assert loaded["voc_metrics"]["oks_voc.mAP"] == pytest.approx(
+        float(npz_metrics["voc_metrics"]["oks_voc.mAP"])
+    )
+    assert loaded["pck_metrics"]["PCK@5"] == pytest.approx(
+        float(npz_metrics["pck_metrics"]["PCK@5"])
+    )
+    assert loaded["visibility_metrics"]["tp"] == int(
+        npz_metrics["visibility_metrics"]["tp"]
+    )
+
+    # App-loader key shapes: precisions is number[][], AP/recalls are number[].
+    assert isinstance(loaded["voc_metrics"]["oks_voc.precisions"], list)
+    assert isinstance(loaded["voc_metrics"]["oks_voc.precisions"][0], list)
+    assert isinstance(loaded["voc_metrics"]["oks_voc.AP"], list)
+    assert isinstance(loaded["distance_metrics"]["frame_idxs"], list)
+    assert loaded["distance_metrics"]["video_paths"] == [
+        "/data/vid.mp4",
+        "/data/vid.mp4",
+    ]
+
+
+def _reject_non_json_constant(name):  # pragma: no cover - only fires on bad JSON
+    raise AssertionError(f"non-JSON constant {name!r} present in output")
+
+
 # ---------------------------------------------------------------------------
 # Centroid-only / single-node distance evaluation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
After training/eval, sleap-nn writes `metrics.{split}.{idx}.npz` as a Python-pickled
object array that non-Python clients cannot read. This adds a **JSON sibling**
(`metrics.{split}.{idx}.json`) so the sleap-app metrics UI can read metrics
directly. The `.npz` is unchanged (back-compat).

## Changes
- **`sleap_nn/evaluation.py`**
  - `_metrics_to_json_safe(obj)` — recursive numpy → JSON-safe conversion
    (scalars → py numbers, arrays → nested lists, **NaN/±Inf → `null`**).
  - `_write_metrics(save_path, metrics)` — writes the `.npz` **plus** the `.json`
    sibling; wired into all four `save_metrics` branches (centroid/mask/semantic/
    oks).
  - `_prune_json_bloat` + `_JSON_PRUNE_KEYS` — drops the large, UI-unused
    `pck_metrics.pcks` (n_pairs × n_nodes × n_thresholds boolean) from the JSON
    view only; it stays in the `.npz`.

## Testing
- `tests/test_evaluation.py` — JSON sibling exists and parses under strict
  `parse_constant` (rejects bare `NaN`), NaN in `dists` → `null`, values match the
  npz round-trip, and `pcks` is pruned from JSON but retained in the npz.
- Gate green: `black --check`, `ruff check`, `pytest` (targeted).

## Notes
- JSON schema aligned to the sleap-app loader (`voc_metrics` / `mOKS` /
  `distance_metrics` / `pck_metrics` / `visibility_metrics`; non-OKS models emit
  their own key set). Coordinated with sleap-app `feat/eval-metrics-table`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
