### PR TITLE
fix(config): convert legacy random_flip/flip_horizontal to flip_p

### DIFF
--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -620,6 +620,19 @@ def data_mapper(legacy_config: dict) -> DataConfig:
             "scale_max"
         ]
 
+    if legacy_config_optimization.get("augmentation_config", {}).get(
+        "random_flip", False
+    ):
+        if legacy_config_optimization["augmentation_config"].get(
+            "flip_horizontal", True
+        ):
+            geometric_args["flip_p"] = 0.5
+        else:
+            logger.warning(
+                "Legacy config has vertical flip (flip_horizontal=False) enabled; "
+                "vertical flip is not supported in sleap-nn and will be dropped."
+            )
+
     geometric_args["affine_p"] = (
         1.0
         if any(

--- a/tests/config/test_data_config.py
+++ b/tests/config/test_data_config.py
@@ -231,6 +231,44 @@ def test_data_mapper():
     assert config.skeletons == None
 
 
+def test_data_mapper_flip(caplog):
+    """Test that legacy random_flip/flip_horizontal map to the new flip_p field."""
+    base_legacy_config = {
+        "data": {
+            "labels": {
+                "training_labels": "notMISSING",
+                "validation_labels": "notMISSING",
+            },
+        },
+        "optimization": {"augmentation_config": {}},
+    }
+
+    # random_flip disabled -> flip_p stays at default (0.0)
+    config = data_mapper(base_legacy_config)
+    assert config.augmentation_config.geometric.flip_p == 0.0
+
+    # random_flip enabled + horizontal -> flip_p is set
+    horizontal_config = {
+        "data": base_legacy_config["data"],
+        "optimization": {
+            "augmentation_config": {"random_flip": True, "flip_horizontal": True}
+        },
+    }
+    config = data_mapper(horizontal_config)
+    assert config.augmentation_config.geometric.flip_p == 0.5
+
+    # random_flip enabled + vertical -> unsupported, flip_p stays at default and warns
+    vertical_config = {
+        "data": base_legacy_config["data"],
+        "optimization": {
+            "augmentation_config": {"random_flip": True, "flip_horizontal": False}
+        },
+    }
+    config = data_mapper(vertical_config)
+    assert config.augmentation_config.geometric.flip_p == 0.0
+    assert "vertical flip" in caplog.text
+
+
 def test_validate_test_file_path():
     """Test the validate_test_file_path validator function."""
     # Test with None (should pass)


### PR DESCRIPTION
## Summary
- Legacy SLEAP JSON training configs enable flip augmentation via `optimization.augmentation_config.random_flip` + `flip_horizontal`, but `data_mapper()` in `sleap_nn/config/data_config.py` never read either field — flip augmentation was silently dropped on every legacy-config conversion, regardless of whether it was enabled.
- Fixes the conversion so `random_flip=True` + `flip_horizontal=True` maps to `GeometricConfig.flip_p=0.5` (matching legacy SLEAP's fixed-probability coin-flip behavior).
- sleap-nn's flip augmentation only supports horizontal (left/right) flip, so a legacy vertical flip (`flip_horizontal=False`) has no destination field — this now logs a warning instead of silently doing nothing.

## Changes Made
- `sleap_nn/config/data_config.py`: added `random_flip`/`flip_horizontal` handling in `data_mapper()`.
- `tests/config/test_data_config.py`: added `test_data_mapper_flip` covering disabled, horizontal, and vertical cases.

## Testing
- Verified empirically against `tests/assets/legacy_sleap_json_configs/topdown_training_config.json` (which has `random_flip=False` in the fixture) by toggling `random_flip`/`flip_horizontal` and confirming `flip_p` output.
- `uv run pytest tests/config/test_data_config.py -q` — 18 passed.
- `black --check` / `ruff check` / `codespell` clean on changed files.

## Related Issues
None filed; found while verifying legacy config conversion behavior in a related discussion.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)