### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/docs/guides/sam-inference-segmentation.md
+++ b/docs/guides/sam-inference-segmentation.md
@@ -126,27 +126,30 @@ The same masks are produced from the `sleap-nn predict` command (and its hidden
 as a pose file and masks are produced from its existing instances — there is **no
 trained segmentation model**, so `--mask_backend` is **mutually exclusive with
 `--model_paths`** (do not pass it). The `.slp` output is saved like the regular
-prediction path — by default images are **not** re-embedded; the output
-backreferences the input's source media via provenance (small output; a
-`.pkg.slp` input stays matchable to its source videos), and the masks always
-serialize into the `.slp`. Only `--output_format slp` is supported (the SLEAP
-Analysis HDF5 format stores poses/tracks, not segmentation masks).
+prediction path — by default images are **not** re-embedded, and the output
+backreferences the input file itself (small output; a `.pkg.slp` input stays
+matchable to itself, not to a pre-embedding source video that's often not on
+disk), and the masks always serialize into the `.slp`. Only `--output_format slp`
+is supported (the SLEAP Analysis HDF5 format stores poses/tracks, not
+segmentation masks).
 
 ### Controlling image embedding (`--embed` / `--restore_source_videos`)
 
 Two independent flags (also `embed` / `restore_source_videos` API kwargs on
 `predict` and `run_sam_segmentation`) control how the output `.slp` references
-image data. The defaults preserve today's behavior exactly.
+image data.
 
 - `--embed` (`auto` | `true` | `false`, default `false`): the embedding policy.
-  `false` never embeds and backreferences the source media (today's behavior);
+  `false` never embeds and backreferences the input file (default behavior);
   `true` embeds images into a self-contained `.pkg.slp`-style output; `auto`
   embeds only when the input was itself an embedded `.pkg.slp`.
 - `--restore_source_videos` / `--no-restore_source_videos` (default
-  `--restore_source_videos`): on a non-embedding save, restore references to the
-  original source video files (provenance), or use `--no-restore_source_videos`
-  to keep references to the input `.pkg.slp` file(s) instead. Ignored when
-  embedding. Maps to sleap-io's `restore_original_videos`.
+  `--no-restore_source_videos`): on a non-embedding save, keep references to the
+  input `.pkg.slp` file(s) (default) — the pixels are already there, and the
+  pre-embedding source video is often unavailable — or use
+  `--restore_source_videos` to instead restore references to the original
+  pre-embedding source video files, when recorded. Ignored when embedding. Maps
+  to sleap-io's `restore_original_videos`.
 
 ```bash
 # Embed images into a self-contained output .pkg.slp:

--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -105,7 +105,7 @@ def redirect_logs_to_stderr() -> None:
     _add_default_sink("stderr")
 
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 # Public API
 from sleap_nn.evaluation import load_metrics

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1683,7 +1683,7 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         ),
         "output_format": kwargs.get("output_format") or ("slp",),
         "embed": kwargs.get("embed") or "false",
-        "restore_source_videos": kwargs.get("restore_source_videos", True),
+        "restore_source_videos": kwargs.get("restore_source_videos", False),
         # Bottom-up PAF grouping knobs (inert for non-bottom-up models). #583.
         "max_edge_length_ratio": kwargs.get("max_edge_length_ratio", 0.25),
         "dist_penalty_weight": kwargs.get("dist_penalty_weight", 1.0),
@@ -1878,7 +1878,7 @@ def _run_retrack_only(kwargs: dict, predictor_cls) -> "object":
         output_path,
         output_format=kwargs.get("output_format") or ("slp",),
         embed=kwargs.get("embed") or "false",
-        restore_source_videos=kwargs.get("restore_source_videos", True),
+        restore_source_videos=kwargs.get("restore_source_videos", False),
     )
     return out
 
@@ -2107,12 +2107,12 @@ def _run_stream_to_file(
             "--stream-to-file to write analysis HDF5 via the in-memory path."
         )
     if (kwargs.get("embed") or "false") != "false" or (
-        kwargs.get("restore_source_videos", True) is False
+        kwargs.get("restore_source_videos", False) is True
     ):
         raise click.UsageError(
             "--embed / --restore_source_videos are not supported with "
-            "--stream-to-file: the incremental writer saves with sleap-io "
-            "defaults (no embedding, original-video refs restored). Drop "
+            "--stream-to-file: the incremental writer always saves with "
+            "no embedding and .pkg.slp references preserved. Drop "
             "--stream-to-file to control embedding."
         )
     if not kwargs.get("model_paths"):
@@ -2319,11 +2319,13 @@ def _common_inference_options(f):
         click.option(
             "--restore_source_videos/--no-restore_source_videos",
             "restore_source_videos",
-            default=True,
-            help="On a non-embedding .slp save, restore references to the "
-            "original source video files (default). Use "
-            "--no-restore_source_videos to keep references to the input "
-            ".pkg.slp file(s) instead. Ignored when embedding.",
+            default=False,
+            help="On a non-embedding .slp save, keep references to the input "
+            ".pkg.slp file(s) (default) -- the pixels are already there, and "
+            "the pre-embedding source video is often unavailable. Use "
+            "--restore_source_videos to instead restore references to the "
+            "original pre-embedding source video files, when recorded. "
+            "Ignored when embedding.",
         ),
         click.option(
             "--device",

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Iterator, Optional, Protocol, Union
 import attrs
 import numpy as np
 import torch
+from loguru import logger
 
 if TYPE_CHECKING:
     import sleap_io as sio
@@ -36,6 +37,28 @@ if TYPE_CHECKING:
 # Sentinel marking end-of-stream on a prefetch queue; a plain `object()` so it
 # can never collide with a real `Batch` or exception payload.
 _SENTINEL = object()
+
+
+def _reopen_after_thread_local_copy(video: "sio.Video") -> None:
+    """Re-materialize ``video.backend`` after it was closed to make a cheap copy.
+
+    ``_thread_local_video``/``_thread_local_video_map`` close the *shared*
+    video (so ``deepcopy`` clones cheap path/config state, not a live handle)
+    before handing a private copy to the prefetch thread. Left closed, the
+    shared video — which is what ends up in the final output ``Labels`` for
+    saving — has ``backend=None``; sleap-io's embedded-image detection in
+    ``write_videos`` requires an actually-materialized ``HDF5Video`` instance,
+    so a closed embedded video silently falls back to re-serializing stale
+    backend metadata (whose ``filename: "."`` self-reference convention is
+    only valid inside its *original* file) into the new output file. Reopening
+    here restores a live backend on the shared video so save-time embedded
+    detection works. Best-effort: if the source is genuinely no longer
+    reachable, leave it closed rather than raising out of a prefetch setup path.
+    """
+    try:
+        video.open()
+    except Exception as e:
+        logger.debug(f"Could not reopen video backend after thread-local copy: {e}")
 
 
 class _ProducerError:
@@ -203,11 +226,15 @@ class VideoProvider:
         sharing ``self._sio_video`` with the background thread can silently
         return the wrong frame. Closing first drops the cached handle so
         ``deepcopy`` clones cheap (path + config) state rather than a live
-        handle; both the original and the copy lazily reopen independent
-        handles on next access.
+        handle. The copy lazily reopens its own handle on next access; the
+        shared original does not reopen on its own (``backend`` is a plain
+        attribute, not a lazy property), so it is explicitly reopened here —
+        it is also what ends up in the final output ``Labels`` for saving.
         """
         self._sio_video.close()
-        return deepcopy(self._sio_video)
+        thread_local = deepcopy(self._sio_video)
+        _reopen_after_thread_local_copy(self._sio_video)
+        return thread_local
 
     def _prefetch_worker(
         self, video: "sio.Video", q: "queue.Queue", stop_event: threading.Event
@@ -505,12 +532,16 @@ class LabelsProvider:
 
         Mirrors :meth:`VideoProvider._thread_local_video`: closing first drops
         each video's cached backend handle so ``deepcopy`` clones cheap
-        (path + config) state rather than a live, non-thread-safe handle.
+        (path + config) state rather than a live, non-thread-safe handle. Each
+        shared original is reopened afterward (see
+        ``_reopen_after_thread_local_copy``) since it is also what ends up in
+        ``self._sio_labels.videos`` / the final output ``Labels`` for saving.
         """
         mapping = {}
         for video in self._sio_labels.videos:
             video.close()
             mapping[id(video)] = deepcopy(video)
+            _reopen_after_thread_local_copy(video)
         return mapping
 
     def _prefetch_worker(

--- a/sleap_nn/inference/run.py
+++ b/sleap_nn/inference/run.py
@@ -211,7 +211,7 @@ def save_predictions(
     output_format: Union[str, Sequence[str]] = "slp",
     video_index: Optional[int] = None,
     embed: Union[str, bool] = "false",
-    restore_source_videos: bool = True,
+    restore_source_videos: bool = False,
 ) -> List[Path]:
     """Save predicted ``Labels`` to disk in the requested format(s).
 
@@ -230,10 +230,12 @@ def save_predictions(
             ``.pkg.slp``-style file), or ``"auto"`` (embed iff the input was
             itself an embedded ``.pkg.slp``). A bool passes through unchanged.
             Only applies to ``.slp`` output.
-        restore_source_videos: On a non-embedding ``.slp`` save, ``True`` (the
-            default) restores references to the original source video files;
-            ``False`` keeps references to the input ``.pkg.slp`` file(s). Maps
-            to sleap-io's ``restore_original_videos`` and is ignored when
+        restore_source_videos: On a non-embedding ``.slp`` save, ``False`` (the
+            default) keeps references to the input ``.pkg.slp`` file(s) — the
+            pixels are already there, and the pre-embedding source video is
+            often unavailable. ``True`` instead restores references to the
+            original pre-embedding source video files, when recorded. Maps to
+            sleap-io's ``restore_original_videos`` and is ignored when
             embedding.
 
     Returns:
@@ -330,7 +332,7 @@ def predict(
     output_path: Optional[str] = None,
     output_format: Union[str, Sequence[str]] = "slp",
     embed: Union[str, bool] = "false",
-    restore_source_videos: bool = True,
+    restore_source_videos: bool = False,
     clean_empty_frames: bool = False,
     progress_callback: Optional[Callable[[int, int], None]] = None,
     tracking_progress_callback: Optional[Callable[[int, int], None]] = None,
@@ -444,9 +446,11 @@ def predict(
             behavior), ``"true"`` (embed images into a self-contained
             ``.pkg.slp``-style file), or ``"auto"`` (embed iff the input was
             itself an embedded ``.pkg.slp``). Only applies to ``.slp`` output.
-        restore_source_videos: On a non-embedding ``.slp`` save, ``True`` (the
-            default) restores references to the original source video files;
-            ``False`` keeps references to the input ``.pkg.slp`` file(s).
+        restore_source_videos: On a non-embedding ``.slp`` save, ``False`` (the
+            default) keeps references to the input ``.pkg.slp`` file(s) — the
+            pixels are already there, and the pre-embedding source video is
+            often unavailable. ``True`` instead restores references to the
+            original pre-embedding source video files, when recorded.
             Ignored when embedding.
         clean_empty_frames: Drop frames with no instances.
         progress_callback: ``(processed_frames, total_frames)`` callback

--- a/sleap_nn/inference/sam/__init__.py
+++ b/sleap_nn/inference/sam/__init__.py
@@ -157,7 +157,7 @@ def run_sam_segmentation(
     frames: Optional[Sequence[int]] = None,
     clean_empty_frames: bool = False,
     embed: Union[str, bool] = "false",
-    restore_source_videos: bool = True,
+    restore_source_videos: bool = False,
 ):
     """Predict per-instance masks for a pose ``.slp`` with a SAM backend.
 
@@ -185,9 +185,10 @@ def run_sam_segmentation(
         output_path: Optional ``.slp`` path to save the result to. Saved like the
             regular prediction path (``labels.save``): the embedding policy is
             **configurable** via ``embed`` and defaults to ``"false"`` — images
-            are not re-embedded and the output backreferences the source media
-            via provenance, so a ``.pkg.slp`` input stays matchable to its
-            source videos without bloating the output.
+            are not re-embedded, and (with ``restore_source_videos`` also
+            defaulting to ``False``) the output backreferences the input file
+            itself, so a ``.pkg.slp`` input stays matchable without depending
+            on a pre-embedding source video that's often not on disk.
         overlay_path: Optional path to write a review overlay PNG of the first
             frame.
         frames: Optional frame indices (matched against ``lf.frame_idx``) to
@@ -203,9 +204,11 @@ def run_sam_segmentation(
             ``"true"`` (embed images into a self-contained ``.pkg.slp``-style
             file), or ``"auto"`` (embed iff the input was itself an embedded
             ``.pkg.slp``). A bool passes through unchanged.
-        restore_source_videos: On a non-embedding save, ``True`` (the default)
-            restores references to the original source video files; ``False``
-            keeps references to the input ``.pkg.slp`` file(s). Maps to
+        restore_source_videos: On a non-embedding save, ``False`` (the default)
+            keeps references to the input ``.pkg.slp`` file(s) — the pixels are
+            already there, and the pre-embedding source video is often
+            unavailable. ``True`` instead restores references to the original
+            pre-embedding source video files, when recorded. Maps to
             sleap-io's ``restore_original_videos`` and is ignored when embedding.
 
     Returns:
@@ -287,13 +290,12 @@ def run_sam_segmentation(
         # Save like the regular prediction path (``labels.save(path)``). The
         # embedding policy is configurable and defaults to ``embed="false"``: do
         # NOT re-embed images — that is large and wasteful. By default the output
-        # backreferences the source media via provenance (sleap-io's default
-        # ``embed=False``). A ``.pkg.slp`` input is typically aggregated training
-        # data; its frames stay matchable to the source videos (by comparing
-        # source-video provenance) without copying pixels into the output, even
-        # if those videos are no longer on disk. The masks always serialize into
-        # the ``.slp`` regardless. ``out.videos`` are the input videos, so
-        # ``source_video`` provenance is intact for ``embed="auto"`` detection.
+        # backreferences the input file itself (``restore_source_videos=False``,
+        # PRESERVE_SOURCE): a ``.pkg.slp`` input's frames stay matchable to that
+        # same ``.pkg.slp``, not to a pre-embedding source video that's often not
+        # on disk. The masks always serialize into the ``.slp`` regardless.
+        # ``out.videos`` are the input videos, so ``source_video`` provenance is
+        # intact for ``embed="auto"`` detection.
         from sleap_nn.inference.run import _resolve_embed
 
         out.save(

--- a/sleap_nn/inference/writer.py
+++ b/sleap_nn/inference/writer.py
@@ -209,6 +209,9 @@ class IncrementalLabelsWriter:
         tmp.parent.mkdir(parents=True, exist_ok=True)
         # Pass the format explicitly: ``sio.Labels.save`` infers from the
         # filename suffix, but our ``.tmp`` suffix isn't recognized.
-        labels.save(str(tmp), format="slp")
+        # restore_original_videos=False matches the non-streaming path's
+        # default (PRESERVE_SOURCE): a .pkg.slp input backreferences itself,
+        # not a pre-embedding source video that's often not on disk.
+        labels.save(str(tmp), format="slp", restore_original_videos=False)
         # Atomic rename — no half-written file on the destination path.
         tmp.replace(self.path)

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -1751,14 +1751,30 @@ class ModelTrainer:
             ):
                 # TRAIN decouple: the tiling knob overrides the tile-count length.
                 train_steps_per_epoch = tiling.steps_per_epoch
+                logger.info(
+                    f"train_steps_per_epoch not set; using tiling.steps_per_epoch={train_steps_per_epoch}"
+                )
             else:
                 train_steps_per_epoch = get_steps_per_epoch(
                     dataset=train_dataset,
                     batch_size=self.config.trainer_config.train_data_loader.batch_size,
                 )
-        if self.config.trainer_config.min_train_steps_per_epoch > train_steps_per_epoch:
-            train_steps_per_epoch = self.config.trainer_config.min_train_steps_per_epoch
+                logger.info(
+                    f"train_steps_per_epoch not set; computed {train_steps_per_epoch} from training dataset"
+                )
+        else:
+            logger.info(
+                f"Using configured train_steps_per_epoch={train_steps_per_epoch}"
+            )
+        min_train_steps_per_epoch = self.config.trainer_config.min_train_steps_per_epoch
+        if min_train_steps_per_epoch > train_steps_per_epoch:
+            logger.info(
+                f"train_steps_per_epoch={train_steps_per_epoch} is below "
+                f"min_train_steps_per_epoch={min_train_steps_per_epoch}; using the minimum"
+            )
+            train_steps_per_epoch = min_train_steps_per_epoch
         self.config.trainer_config.train_steps_per_epoch = train_steps_per_epoch
+        logger.info(f"Final train_steps_per_epoch={train_steps_per_epoch}")
 
         # VAL: always full-coverage (every grid tile visited once), NOT decoupled.
         val_steps_per_epoch = get_steps_per_epoch(

--- a/tests/cli/test_flag_validation.py
+++ b/tests/cli/test_flag_validation.py
@@ -93,8 +93,35 @@ def test_stream_to_file_with_embed_raises_usage_error():
     assert "stream-to-file" in result.output
 
 
-def test_stream_to_file_with_no_restore_source_videos_raises_usage_error():
-    """``--stream-to-file`` + ``--no-restore_source_videos`` is rejected (#652)."""
+def test_stream_to_file_with_restore_source_videos_raises_usage_error():
+    """``--stream-to-file`` + ``--restore_source_videos`` is rejected.
+
+    The incremental writer always saves with ``restore_original_videos=False``
+    (PRESERVE_SOURCE), matching the non-streaming default; requesting the
+    non-default ``True`` (restore the pre-embedding source video) can't be
+    honored there.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "predict",
+            "--data_path",
+            "/fake/path.mp4",
+            "--model_paths",
+            "/fake/model",
+            "--stream-to-file",
+            "/tmp/out.slp",
+            "--restore_source_videos",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "restore_source_videos" in result.output.lower()
+    assert "stream-to-file" in result.output
+
+
+def test_stream_to_file_with_no_restore_source_videos_is_allowed():
+    """``--stream-to-file`` + ``--no-restore_source_videos`` (the default) is fine."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -109,9 +136,9 @@ def test_stream_to_file_with_no_restore_source_videos_raises_usage_error():
             "--no-restore_source_videos",
         ],
     )
-    assert result.exit_code != 0
-    assert "restore_source_videos" in result.output.lower()
-    assert "stream-to-file" in result.output
+    # Should get past the flag-validation guard (may still fail later for
+    # unrelated reasons, e.g. the fake model/data paths not existing).
+    assert "restore_source_videos" not in result.output.lower()
 
 
 def test_write_interval_without_stream_to_file_errors():

--- a/tests/cli/test_predict_command.py
+++ b/tests/cli/test_predict_command.py
@@ -1215,7 +1215,7 @@ def test_predict_forwards_embed_and_restore(tmp_path):
 
 
 def test_predict_embed_restore_defaults(tmp_path):
-    """Without the new flags, predict() gets the byte-for-byte defaults (#652)."""
+    """Without the new flags, predict() gets the byte-for-byte defaults."""
     out = tmp_path / "out.slp"
     runner = CliRunner()
     with patch(
@@ -1238,11 +1238,11 @@ def test_predict_embed_restore_defaults(tmp_path):
     assert mock_predict.called
     call_kwargs = mock_predict.call_args[1]
     assert call_kwargs["embed"] == "false"
-    assert call_kwargs["restore_source_videos"] is True
+    assert call_kwargs["restore_source_videos"] is False
 
 
-def test_predict_embed_restore_explicit_defaults_accepted(tmp_path):
-    """Explicit default values for the new flags parse and forward (#652).
+def test_predict_embed_restore_explicit_nondefault_accepted(tmp_path):
+    """Explicitly requesting the non-default ``--restore_source_videos`` works.
 
     Unlike the bare-default test above (which would still pass if the options
     were deleted, because the kwargs fall back to the same defaults), this

--- a/tests/inference/sam/test_run_sam_segmentation.py
+++ b/tests/inference/sam/test_run_sam_segmentation.py
@@ -238,8 +238,9 @@ def test_run_sam_segmentation_restore_source_videos_controls_refs(
 ):
     """``restore_source_videos`` toggles the reloaded video filename reference.
 
-    #652: on a non-embedding save, default ``True`` restores the original source
-    video reference (the .mp4); ``False`` keeps the input ``.pkg.slp`` reference.
+    On a non-embedding save, ``True`` restores the original pre-embedding source
+    video reference (the .mp4); ``False`` (the default) keeps the input
+    ``.pkg.slp`` reference.
     """
     src = sio.load_slp(str(minimal_instance))
     source_name = Path(src.videos[0].source_video.filename).name
@@ -267,9 +268,9 @@ def test_run_sam_segmentation_restore_source_videos_controls_refs(
 
     restored = sio.load_slp(out_restore.as_posix())
     kept = sio.load_slp(out_keep.as_posix())
-    # Default True -> the original source .mp4 reference.
+    # True -> the original pre-embedding source .mp4 reference.
     assert Path(restored.videos[0].filename).name == source_name
-    # False -> the input .pkg.slp reference is kept.
+    # False (the default) -> the input .pkg.slp reference is kept.
     assert Path(kept.videos[0].filename).name == input_name
 
 
@@ -608,7 +609,7 @@ def test_predict_sam_default_embed_restore_forwarded(
         output_path=tmp_path / "e.slp",
     )
     assert captured["embed"] == "false"
-    assert captured["restore_source_videos"] is True
+    assert captured["restore_source_videos"] is False
 
 
 # --------------------------------------------------------------------------- save_mask_overlay

--- a/tests/inference/test_run.py
+++ b/tests/inference/test_run.py
@@ -432,13 +432,13 @@ def test_save_predictions_forwards_embed_and_restore_to_labels_save():
     assert labels.save.call_args.kwargs["restore_original_videos"] is False
 
 
-def test_save_predictions_default_embed_false_restore_true():
-    """Defaults preserve today's behavior: embed=False, restore=True."""
+def test_save_predictions_default_embed_false_restore_false():
+    """Defaults: embed=False, restore_source_videos=False (PRESERVE_SOURCE)."""
     labels = MagicMock()
     labels.videos = []
     save_predictions(labels, "out.slp", output_format="slp")
     assert labels.save.call_args.kwargs["embed"] is False
-    assert labels.save.call_args.kwargs["restore_original_videos"] is True
+    assert labels.save.call_args.kwargs["restore_original_videos"] is False
 
 
 def test_save_predictions_embed_true_writes_self_contained_slp(
@@ -500,4 +500,38 @@ def test_predict_default_embed_restore_forwarded(tmp_path):
             output_path=str(out),
         )
     assert mock_save.call_args.kwargs["embed"] == "false"
-    assert mock_save.call_args.kwargs["restore_source_videos"] is True
+    assert mock_save.call_args.kwargs["restore_source_videos"] is False
+
+
+def test_predict_on_pkg_slp_default_references_pkg_slp_not_source_video(
+    minimal_instance, tmp_path
+):
+    """Real end-to-end regression: a ``.pkg.slp`` input keeps referencing itself.
+
+    ``VideoProvider``/``LabelsProvider`` close the shared ``sio.Video`` to make
+    a cheap deepcopy for the prefetch thread (see
+    ``providers._reopen_after_thread_local_copy``); left closed, the video's
+    ``backend`` is ``None`` at save time, sleap-io's embedded-image detection
+    in ``write_videos`` silently misses it, and the output re-serializes stale
+    backend metadata whose ``filename: "."`` self-reference convention only
+    holds inside the *original* file -- producing an output that (on reload)
+    references itself instead of the ``.pkg.slp``. Locks that this is fixed:
+    the backend is reopened before saving, so the output backreferences the
+    input ``.pkg.slp`` (default ``restore_source_videos=False``), and its
+    embedded image still loads.
+    """
+    ckpt_root = Path(__file__).resolve().parents[1] / "assets" / "model_ckpts"
+    out_path = tmp_path / "out.predictions.slp"
+
+    result = predict(
+        str(minimal_instance),
+        model_paths=[str(ckpt_root / "minimal_instance_single_instance")],
+        device="cpu",
+        output_path=str(out_path),
+    )
+    assert result.videos[0].backend is not None
+
+    reloaded = sio.load_slp(out_path.as_posix())
+    assert Path(reloaded.videos[0].filename).name == "minimal_instance.pkg.slp"
+    # The embedded image must still be readable from the reloaded reference.
+    assert reloaded[0].image is not None


### PR DESCRIPTION
## Summary
- Bumps `sleap_nn.__version__` from `0.3.1` to `0.3.2` for the next release.
- Adds `logger.info` tracing to `ModelTrainer` showing how `train_steps_per_epoch` is resolved each run (tiling override / computed-from-dataset / configured value / clamped to `min_train_steps_per_epoch`), for easier training-config debugging.
- **Fixes `.pkg.slp` inference output referencing the wrong video by default.**

## `.pkg.slp` video-reference fix

`restore_source_videos` now defaults to `False` (sleap-io's `PRESERVE_SOURCE` mode) across `predict()`, `save_predictions()`, `run_sam_segmentation()`, and the `--restore_source_videos` CLI flag — matching what `sleap-nn track`'s legacy pipeline already hardcoded. A `.pkg.slp` input's frames already carry the embedded pixels; the old default (`True`, `RESTORE_ORIGINAL`) preferred referencing the pre-embedding source video instead, which is frequently unavailable — breaking visualization of the prediction output.

Flipping the default uncovered a second, previously-masked bug: `VideoProvider`/`LabelsProvider` close the shared `sio.Video` to cheaply `deepcopy` it for the prefetch thread, leaving `backend=None` on the video that ends up in the final output `Labels`. sleap-io's embedded-image detection at save time requires a materialized `HDF5Video` backend, so a closed embedded video fell through to re-serializing stale backend metadata whose `filename: "."` self-reference convention is only valid inside its *original* file — producing an output that referenced **itself** instead of the `.pkg.slp`. The old default's `RESTORE_ORIGINAL` mode happened to paper over this by writing a redundant `source_video` provenance group that reload preferred instead. Fixed by reopening the video's backend right after the thread-local copy is made (`sleap_nn/inference/providers.py`).

Also fixed the `--stream-to-file` flag-validation guard (which assumed the old default) and the streaming `IncrementalLabelsWriter` (which now explicitly passes `restore_original_videos=False` to match, instead of silently relying on sleap-io's own default of `True`).

## Dependencies
- `sleap-io` pin (`>=0.9.2,<0.10.0`) is unchanged — 0.9.2 is still the latest release on both PyPI and GitHub, so no upper-bound audit was needed this cycle.

## Testing
- `uv run black --check` / `ruff check` clean.
- `uvx codespell sleap_nn tests docs *.md pyproject.toml` clean.
- `uv lock --check` passes (no lockfile changes needed).
- New regression test (`test_predict_on_pkg_slp_default_references_pkg_slp_not_source_video`) runs the real end-to-end `predict()` pipeline on a `.pkg.slp` fixture and asserts the output backreferences the `.pkg.slp` (not the source video, not itself) and the embedded image still loads.
- Full suite: 2219 passed, 138 skipped, 4 xfailed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)