### PR TITLE
fix(infer): topdown centered-instance stage silently inherits centroid's scale

### DIFF
--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -620,9 +620,10 @@ def _build_topdown(
     # Resolve preprocess_config from both training configs. The confmap
     # config supplies crop_size (absent from centroid training configs),
     # so resolve centroid first, then confmap to fill remaining Nones.
-    # Capture whether the caller explicitly supplied a crop_size so the confmap
-    # default below does not override an intentional user value.
+    # Capture whether the caller explicitly supplied a crop_size/scale so the
+    # confmap default below does not override an intentional user value.
     user_crop_size = preprocess_config.crop_size
+    user_scale = preprocess_config.scale
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -638,6 +639,18 @@ def _build_topdown(
         confmap_crop = confmap_config.data_config.preprocessing.crop_size
         if user_crop_size is None and confmap_crop is not None:
             preprocess_config.crop_size = confmap_crop
+
+    # scale is per-stage like crop_size: an explicit --input_scale override
+    # (user_scale) applies to both stages, but absent one, each stage must use
+    # its OWN trained scale rather than inheriting the other stage's value
+    # through the shared preprocess_config (the two models' training scales
+    # commonly differ — e.g. a lower-res centroid model).
+    centroid_scale = user_scale
+    if centroid_scale is None and centroid_config is not None:
+        centroid_scale = centroid_config.data_config.preprocessing.scale
+    confmap_scale = user_scale
+    if confmap_scale is None and confmap_config is not None:
+        confmap_scale = confmap_config.data_config.preprocessing.scale
 
     # Resolve anchor_ind
     if anchor_part is not None:
@@ -679,7 +692,7 @@ def _build_topdown(
             return_crops=return_crops,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=preprocess_config.scale,
+            input_scale=centroid_scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -700,7 +713,7 @@ def _build_topdown(
             integral_patch_size=integral_patch_size,
             return_confmaps=return_confmaps,
             max_stride=max_stride_inst,
-            input_scale=preprocess_config.scale,
+            input_scale=confmap_scale,
         )
 
     inference_model = TopDownInferenceModel(
@@ -785,6 +798,7 @@ def _build_topdown_segmentation(
     # carries the crop_size — a centered-instance property), without clobbering an
     # explicit user crop_size.
     user_crop_size = preprocess_config.crop_size
+    user_scale = preprocess_config.scale
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -793,6 +807,17 @@ def _build_topdown_segmentation(
     seg_crop = seg_config.data_config.preprocessing.crop_size
     if user_crop_size is None and seg_crop is not None:
         preprocess_config.crop_size = seg_crop
+
+    # scale is per-stage like crop_size: an explicit --input_scale override
+    # (user_scale) applies to both stages, but absent one, each stage must use
+    # its OWN trained scale rather than inheriting the other stage's value
+    # through the shared preprocess_config.
+    centroid_scale = user_scale
+    if centroid_scale is None and centroid_config is not None:
+        centroid_scale = centroid_config.data_config.preprocessing.scale
+    seg_scale = user_scale
+    if seg_scale is None:
+        seg_scale = seg_config.data_config.preprocessing.scale
 
     # Resolve anchor_ind (only used by the GT-centroid crop path; the real
     # centroid model supplies crop centers directly).
@@ -833,7 +858,7 @@ def _build_topdown_segmentation(
             return_crops=True,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=preprocess_config.scale,
+            input_scale=centroid_scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -842,7 +867,7 @@ def _build_topdown_segmentation(
     instance_masks = CenteredInstanceMaskInferenceModel(
         torch_model=seg_model,
         output_stride=output_stride,
-        input_scale=preprocess_config.scale,
+        input_scale=seg_scale,
         max_stride=max_stride_seg,
         fg_threshold=fg_threshold,
         mask_output=mask_output,
@@ -918,9 +943,10 @@ def _build_topdown_multiclass(
         )
         skeletons = get_skeleton_from_config(confmap_config.data_config.skeletons)
 
-    # Capture whether the caller explicitly supplied a crop_size so the confmap
-    # default below does not override an intentional user value.
+    # Capture whether the caller explicitly supplied a crop_size/scale so the
+    # confmap default below does not override an intentional user value.
     user_crop_size = preprocess_config.crop_size
+    user_scale = preprocess_config.scale
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -936,6 +962,17 @@ def _build_topdown_multiclass(
         confmap_crop = confmap_config.data_config.preprocessing.crop_size
         if user_crop_size is None and confmap_crop is not None:
             preprocess_config.crop_size = confmap_crop
+
+    # scale is per-stage like crop_size: an explicit --input_scale override
+    # (user_scale) applies to both stages, but absent one, each stage must use
+    # its OWN trained scale rather than inheriting the other stage's value
+    # through the shared preprocess_config.
+    centroid_scale = user_scale
+    if centroid_scale is None and centroid_config is not None:
+        centroid_scale = centroid_config.data_config.preprocessing.scale
+    confmap_scale = user_scale
+    if confmap_scale is None and confmap_config is not None:
+        confmap_scale = confmap_config.data_config.preprocessing.scale
 
     # Resolve anchor_ind
     if anchor_part is not None:
@@ -976,7 +1013,7 @@ def _build_topdown_multiclass(
             return_crops=return_crops,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=preprocess_config.scale,
+            input_scale=centroid_scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -993,7 +1030,7 @@ def _build_topdown_multiclass(
         integral_patch_size=integral_patch_size,
         return_confmaps=return_confmaps,
         max_stride=max_stride_inst,
-        input_scale=preprocess_config.scale,
+        input_scale=confmap_scale,
     )
 
     inference_model = TopDownInferenceModel(

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -349,59 +349,45 @@ class Predictor(ABC):
             confmap_ckpt_path = None
             if "centroid" in model_names:
                 centroid_ckpt_path = model_paths[model_names.index("centroid")]
-                predictor = TopDownPredictor.from_trained_models(
-                    centroid_ckpt_path=centroid_ckpt_path,
-                    confmap_ckpt_path=confmap_ckpt_path,
-                    backbone_ckpt_path=backbone_ckpt_path,
-                    head_ckpt_path=head_ckpt_path,
-                    peak_threshold=peak_threshold,
-                    integral_refinement=integral_refinement,
-                    integral_patch_size=integral_patch_size,
-                    batch_size=batch_size,
-                    max_instances=max_instances,
-                    return_confmaps=return_confmaps,
-                    device=device,
-                    preprocess_config=preprocess_config,
-                    anchor_part=anchor_part,
-                    filter_overlapping=filter_overlapping,
-                    filter_overlapping_threshold=filter_overlapping_threshold,
-                    filter_overlapping_method=filter_overlapping_method,
-                    filter_min_visible_nodes=filter_min_visible_nodes,
-                    filter_min_visible_node_fraction=filter_min_visible_node_fraction,
-                    filter_min_mean_node_score=filter_min_mean_node_score,
-                    filter_min_instance_score=filter_min_instance_score,
-                )
             if "centered_instance" in model_names:
                 confmap_ckpt_path = model_paths[model_names.index("centered_instance")]
-                # create an instance of the TopDown predictor class
-                predictor = TopDownPredictor.from_trained_models(
-                    centroid_ckpt_path=centroid_ckpt_path,
-                    confmap_ckpt_path=confmap_ckpt_path,
-                    backbone_ckpt_path=backbone_ckpt_path,
-                    head_ckpt_path=head_ckpt_path,
-                    peak_threshold=peak_threshold,
-                    integral_refinement=integral_refinement,
-                    integral_patch_size=integral_patch_size,
-                    batch_size=batch_size,
-                    max_instances=max_instances,
-                    return_confmaps=return_confmaps,
-                    device=device,
-                    preprocess_config=preprocess_config,
-                    anchor_part=anchor_part,
-                    filter_overlapping=filter_overlapping,
-                    filter_overlapping_threshold=filter_overlapping_threshold,
-                    filter_overlapping_method=filter_overlapping_method,
-                    filter_min_visible_nodes=filter_min_visible_nodes,
-                    filter_min_visible_node_fraction=filter_min_visible_node_fraction,
-                    filter_min_mean_node_score=filter_min_mean_node_score,
-                    filter_min_instance_score=filter_min_instance_score,
-                )
             elif "multi_class_topdown" in model_names:
                 confmap_ckpt_path = model_paths[
                     model_names.index("multi_class_topdown")
                 ]
-                # create an instance of the TopDown predictor class
+
+            # Build the predictor with a SINGLE `from_trained_models` call, now
+            # that both ckpt paths are fully resolved. Calling it once per
+            # branch (as this used to do) mutates the shared `preprocess_config`
+            # in place on the first, discarded, centroid-only call -- corrupting
+            # the second, real call's per-stage `scale` resolution (#725-follow-up).
+            if "multi_class_topdown" in model_names:
+                # create an instance of the TopDown multiclass predictor class
                 predictor = TopDownMultiClassPredictor.from_trained_models(
+                    centroid_ckpt_path=centroid_ckpt_path,
+                    confmap_ckpt_path=confmap_ckpt_path,
+                    backbone_ckpt_path=backbone_ckpt_path,
+                    head_ckpt_path=head_ckpt_path,
+                    peak_threshold=peak_threshold,
+                    integral_refinement=integral_refinement,
+                    integral_patch_size=integral_patch_size,
+                    batch_size=batch_size,
+                    max_instances=max_instances,
+                    return_confmaps=return_confmaps,
+                    device=device,
+                    preprocess_config=preprocess_config,
+                    anchor_part=anchor_part,
+                    filter_overlapping=filter_overlapping,
+                    filter_overlapping_threshold=filter_overlapping_threshold,
+                    filter_overlapping_method=filter_overlapping_method,
+                    filter_min_visible_nodes=filter_min_visible_nodes,
+                    filter_min_visible_node_fraction=filter_min_visible_node_fraction,
+                    filter_min_mean_node_score=filter_min_mean_node_score,
+                    filter_min_instance_score=filter_min_instance_score,
+                )
+            else:
+                # create an instance of the TopDown predictor class
+                predictor = TopDownPredictor.from_trained_models(
                     centroid_ckpt_path=centroid_ckpt_path,
                     confmap_ckpt_path=confmap_ckpt_path,
                     backbone_ckpt_path=backbone_ckpt_path,
@@ -854,6 +840,8 @@ class TopDownPredictor(Predictor):
     return_confmaps: bool = False
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
+    centroid_scale: Optional[float] = None
+    confmap_scale: Optional[float] = None
     tracker: Optional[Tracker] = None
     anchor_part: Optional[str] = None
     max_stride: int = 16
@@ -923,7 +911,7 @@ class TopDownPredictor(Predictor):
                 return_crops=return_crops,
                 max_instances=self.max_instances,
                 max_stride=max_stride,
-                input_scale=self.preprocess_config.scale,
+                input_scale=self.centroid_scale,
                 crop_hw=(
                     self.preprocess_config.crop_size,
                     self.preprocess_config.crop_size,
@@ -947,7 +935,7 @@ class TopDownPredictor(Predictor):
                 integral_patch_size=self.integral_patch_size,
                 return_confmaps=self.return_confmaps,
                 max_stride=max_stride,
-                input_scale=self.preprocess_config.scale,
+                input_scale=self.confmap_scale,
             )
 
         if self.centroid_config is None and self.confmap_config is not None:
@@ -1273,6 +1261,11 @@ class TopDownPredictor(Predictor):
             confmap_config = None
             confmap_model = None
 
+        # Capture the caller's explicit --input_scale override (if any) before
+        # the fill-in below resolves `scale` from a single config, so each
+        # stage can still fall back to ITS OWN trained scale afterward.
+        user_scale = preprocess_config["scale"]
+
         if centroid_config is not None:
             preprocess_config["scale"] = (
                 centroid_config.data_config.preprocessing.scale
@@ -1333,6 +1326,18 @@ class TopDownPredictor(Predictor):
             else preprocess_config["crop_size"]
         )
 
+        # scale is per-stage like crop_size: an explicit --input_scale override
+        # (user_scale) applies to both stages, but absent one, each stage must
+        # use its OWN trained scale rather than inheriting the other stage's
+        # value through the shared preprocess_config (the two models' training
+        # scales commonly differ -- e.g. a lower-res centroid model).
+        centroid_scale = user_scale
+        if centroid_scale is None and centroid_config is not None:
+            centroid_scale = centroid_config.data_config.preprocessing.scale
+        confmap_scale = user_scale
+        if confmap_scale is None and confmap_config is not None:
+            confmap_scale = confmap_config.data_config.preprocessing.scale
+
         # create an instance of TopDownPredictor class
         obj = cls(
             centroid_config=centroid_config,
@@ -1350,6 +1355,8 @@ class TopDownPredictor(Predictor):
             return_confmaps=return_confmaps,
             device=device,
             preprocess_config=preprocess_config,
+            centroid_scale=centroid_scale,
+            confmap_scale=confmap_scale,
             anchor_part=anchor_part,
             max_stride=(
                 centroid_config.model_config.backbone_config[
@@ -3243,6 +3250,8 @@ class TopDownMultiClassPredictor(Predictor):
     return_confmaps: bool = False
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
+    centroid_scale: Optional[float] = None
+    confmap_scale: Optional[float] = None
     anchor_part: Optional[str] = None
     max_stride: int = 16
     filter_overlapping: bool = False
@@ -3311,7 +3320,7 @@ class TopDownMultiClassPredictor(Predictor):
                 return_crops=return_crops,
                 max_instances=self.max_instances,
                 max_stride=max_stride,
-                input_scale=self.preprocess_config.scale,
+                input_scale=self.centroid_scale,
                 crop_hw=(
                     self.preprocess_config.crop_size,
                     self.preprocess_config.crop_size,
@@ -3330,7 +3339,7 @@ class TopDownMultiClassPredictor(Predictor):
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
             max_stride=max_stride,
-            input_scale=self.preprocess_config.scale,
+            input_scale=self.confmap_scale,
         )
 
         if self.centroid_config is None:
@@ -3681,6 +3690,11 @@ class TopDownMultiClassPredictor(Predictor):
             logger.error(message)
             raise ValueError(message)
 
+        # Capture the caller's explicit --input_scale override (if any) before
+        # the fill-in below resolves `scale` from a single config, so each
+        # stage can still fall back to ITS OWN trained scale afterward.
+        user_scale = preprocess_config["scale"]
+
         if centroid_config is not None:
             preprocess_config["scale"] = (
                 centroid_config.data_config.preprocessing.scale
@@ -3741,6 +3755,17 @@ class TopDownMultiClassPredictor(Predictor):
             else preprocess_config["crop_size"]
         )
 
+        # scale is per-stage like crop_size: an explicit --input_scale override
+        # (user_scale) applies to both stages, but absent one, each stage must
+        # use its OWN trained scale rather than inheriting the other stage's
+        # value through the shared preprocess_config.
+        centroid_scale = user_scale
+        if centroid_scale is None and centroid_config is not None:
+            centroid_scale = centroid_config.data_config.preprocessing.scale
+        confmap_scale = user_scale
+        if confmap_scale is None and confmap_config is not None:
+            confmap_scale = confmap_config.data_config.preprocessing.scale
+
         # create an instance of TopDownPredictor class
         obj = cls(
             centroid_config=centroid_config,
@@ -3758,6 +3783,8 @@ class TopDownMultiClassPredictor(Predictor):
             return_confmaps=return_confmaps,
             device=device,
             preprocess_config=preprocess_config,
+            centroid_scale=centroid_scale,
+            confmap_scale=confmap_scale,
             anchor_part=anchor_part,
             max_stride=(
                 centroid_config.model_config.backbone_config[

--- a/tests/inference/test_loaders.py
+++ b/tests/inference/test_loaders.py
@@ -7,6 +7,7 @@ supported model type and return correct ``LoadedAssets``.
 from __future__ import annotations
 
 import gc
+import shutil
 from pathlib import Path
 
 import pytest
@@ -206,6 +207,54 @@ def test_load_topdown_input_scale_override_reaches_both_stages():
     )
     assert assets.inference_model.centroid_crop.input_scale == override
     assert assets.inference_model.instance_peaks.input_scale == override
+
+
+def _copy_ckpt_with_scale(src: Path, dst: Path, scale: float) -> Path:
+    """Copy a checkpoint dir to *dst*, overriding ``data_config.preprocessing.scale``."""
+    shutil.copytree(src, dst)
+    cfg = OmegaConf.load(str(dst / "training_config.yaml"))
+    cfg.data_config.preprocessing.scale = scale
+    OmegaConf.save(cfg, str(dst / "training_config.yaml"))
+    return dst
+
+
+def test_load_topdown_default_scale_is_per_stage_not_shared(tmp_path):
+    """Each stage must default to ITS OWN trained scale, not a shared value.
+
+    Regression test for #725: ``crop_size`` gets an explicit "force from the
+    confmap config" override in ``_build_topdown``, but ``scale`` did not, so
+    the *first* ``_resolve_preprocess_config`` call (centroid) filled the
+    shared ``preprocess_config.scale`` and the second call (confmap) silently
+    left it untouched -- the centered-instance stage inherited the centroid
+    model's scale. Both fixture checkpoints train at scale=1.0 by default,
+    which never exercises this path, so the scales are patched apart here.
+    """
+    if not (CENTROID_CKPT.exists() and CENTERED_CKPT.exists()):
+        pytest.skip("topdown ckpts absent")
+    centroid_dir = _copy_ckpt_with_scale(
+        CENTROID_CKPT, tmp_path / "centroid", scale=0.5
+    )
+    centered_dir = _copy_ckpt_with_scale(
+        CENTERED_CKPT, tmp_path / "centered_instance", scale=1.0
+    )
+    assets, _ = load_model_assets([str(centroid_dir), str(centered_dir)], device="cpu")
+    assert assets.inference_model.centroid_crop.input_scale == 0.5
+    assert assets.inference_model.instance_peaks.input_scale == 1.0
+
+
+def test_load_topdown_multiclass_default_scale_is_per_stage_not_shared(tmp_path):
+    """Same regression as above (#725), for the multiclass top-down builder."""
+    if not (CENTROID_CKPT.exists() and MULTICLASS_TD_CKPT.exists()):
+        pytest.skip("topdown-multiclass ckpts absent")
+    centroid_dir = _copy_ckpt_with_scale(
+        CENTROID_CKPT, tmp_path / "centroid", scale=0.5
+    )
+    confmap_dir = _copy_ckpt_with_scale(
+        MULTICLASS_TD_CKPT, tmp_path / "multiclass_centered_instance", scale=1.0
+    )
+    assets, _ = load_model_assets([str(centroid_dir), str(confmap_dir)], device="cpu")
+    assert assets.inference_model.centroid_crop.input_scale == 0.5
+    assert assets.inference_model.instance_peaks.input_scale == 1.0
 
 
 def test_load_topdown_multiclass(topdown_multiclass_assets):

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1110,13 +1110,13 @@ def test_multiclass_topdown_predictor_default_scale_is_per_stage_not_shared(
     assert predictor.inference_model.instance_peaks.input_scale == 1.0
 
 
-def test_topdown_predictor_mismatched_scale_coords_pinned(
+def test_topdown_predictor_mismatched_scale_coords_differ_from_shared_scale_bug(
     minimal_instance_centroid_ckpt,
     minimal_instance_centered_instance_ckpt,
     centered_instance_video,
     tmp_path,
 ):
-    """Golden/snapshot guard: pins exact predicted coordinates end to end.
+    """End-to-end guard: pins that fixed per-stage scale changes predicted coords.
 
     The attribute-level tests above check that each stage keeps its own
     `input_scale`, but don't exercise the actual forward pass. This one does,
@@ -1126,12 +1126,19 @@ def test_topdown_predictor_mismatched_scale_coords_pinned(
     produces the SAME instance count across a 0.15x-3x scale range -- the
     models are too small/robust for lost detections to show up in a count.
     Predicted *coordinates* do shift measurably (confirmed up to ~67px on a
-    96x96 crop), so this test pins those instead. If topdown scale-sharing
-    regresses again, this will catch it even if it doesn't collapse detections
-    the way it did on a real, larger model.
+    96x96 crop), so this test compares those instead.
 
-    Golden values recorded from a single deterministic run of the current
-    (fixed) pipeline -- confirmed byte-identical across repeated runs.
+    Deliberately NOT a golden/snapshot test pinning a literal recorded array:
+    an earlier version of this test did that and was flaky across CI
+    platforms (mac/ubuntu/windows CPU backends produce measurably different
+    conv/pooling reduction order, enough to shift which pixel wins an
+    argmax-based peak -- tens of px apart on some elements, not just
+    sub-pixel float noise). Instead, this reconstructs the pre-fix bug
+    in-process (forcing the confmap stage to share the centroid stage's
+    scale, exactly what the bug did) and asserts the two coordinate sets
+    differ substantially -- a comparison that's robust to whatever a given
+    CI platform's own numerics look like, since both sides run on the same
+    platform in the same process.
     """
     centroid_dir = _copy_ckpt_with_scale(
         minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=1.0
@@ -1141,41 +1148,30 @@ def test_topdown_predictor_mismatched_scale_coords_pinned(
         tmp_path / "centered_instance",
         scale=0.5,
     )
-    predictor = Predictor.from_model_paths(
-        [str(centroid_dir), str(centered_dir)],
-        peak_threshold=0.03,
-        max_instances=6,
-        preprocess_config=_scale_only_preprocess_config(None),
-    )
-    predictor.make_pipeline(centered_instance_video.as_posix(), frames=list(range(5)))
-    output = predictor.predict(make_labels=True)
-    coords = np.concatenate([inst.numpy() for lf in output for inst in lf.instances])
 
-    golden = np.array(
-        [
-            [95.950279, 201.836700],
-            [146.684677, 161.575989],
-            [211.206467, 189.888184],
-            [212.050568, 190.249908],
-            [96.069702, 201.522675],
-            [147.012451, 161.808167],
-            [211.269058, 189.270691],
-            [212.148224, 189.673065],
-            [96.311562, 202.784027],
-            [147.091812, 163.930878],
-            [210.216873, 189.312256],
-            [211.247314, 189.817810],
-            [97.070450, 202.523865],
-            [147.734528, 163.942291],
-            [209.834549, 189.232178],
-            [210.711349, 190.128693],
-            [97.703575, 203.105042],
-            [145.604309, 167.835220],
-            [209.265564, 189.009277],
-            [256.112091, 180.818771],
-        ]
-    )
-    np.testing.assert_allclose(coords, golden, atol=0.5)
+    def _predict_coords(force_shared_scale: bool) -> np.ndarray:
+        predictor = Predictor.from_model_paths(
+            [str(centroid_dir), str(centered_dir)],
+            peak_threshold=0.03,
+            max_instances=6,
+            preprocess_config=_scale_only_preprocess_config(None),
+        )
+        if force_shared_scale:
+            # Reconstruct the pre-fix bug: both stages share one scale.
+            predictor.inference_model.instance_peaks.input_scale = (
+                predictor.inference_model.centroid_crop.input_scale
+            )
+        predictor.make_pipeline(
+            centered_instance_video.as_posix(), frames=list(range(5))
+        )
+        output = predictor.predict(make_labels=True)
+        return np.concatenate([inst.numpy() for lf in output for inst in lf.instances])
+
+    fixed_coords = _predict_coords(force_shared_scale=False)
+    buggy_coords = _predict_coords(force_shared_scale=True)
+
+    assert fixed_coords.shape == buggy_coords.shape
+    assert np.nanmax(np.abs(fixed_coords - buggy_coords)) > 5.0
 
 
 def test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds(

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1110,6 +1110,74 @@ def test_multiclass_topdown_predictor_default_scale_is_per_stage_not_shared(
     assert predictor.inference_model.instance_peaks.input_scale == 1.0
 
 
+def test_topdown_predictor_mismatched_scale_coords_pinned(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_centered_instance_ckpt,
+    centered_instance_video,
+    tmp_path,
+):
+    """Golden/snapshot guard: pins exact predicted coordinates end to end.
+
+    The attribute-level tests above check that each stage keeps its own
+    `input_scale`, but don't exercise the actual forward pass. This one does,
+    on a real video with a real (deliberately mismatched-scale) checkpoint
+    pair. Instance *count* alone is not a reliable target here: forcing the
+    pre-fix bug (both stages sharing one scale) on these tiny fixture models
+    produces the SAME instance count across a 0.15x-3x scale range -- the
+    models are too small/robust for lost detections to show up in a count.
+    Predicted *coordinates* do shift measurably (confirmed up to ~67px on a
+    96x96 crop), so this test pins those instead. If topdown scale-sharing
+    regresses again, this will catch it even if it doesn't collapse detections
+    the way it did on a real, larger model.
+
+    Golden values recorded from a single deterministic run of the current
+    (fixed) pipeline -- confirmed byte-identical across repeated runs.
+    """
+    centroid_dir = _copy_ckpt_with_scale(
+        minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=1.0
+    )
+    centered_dir = _copy_ckpt_with_scale(
+        minimal_instance_centered_instance_ckpt,
+        tmp_path / "centered_instance",
+        scale=0.5,
+    )
+    predictor = Predictor.from_model_paths(
+        [str(centroid_dir), str(centered_dir)],
+        peak_threshold=0.03,
+        max_instances=6,
+        preprocess_config=_scale_only_preprocess_config(None),
+    )
+    predictor.make_pipeline(centered_instance_video.as_posix(), frames=list(range(5)))
+    output = predictor.predict(make_labels=True)
+    coords = np.concatenate([inst.numpy() for lf in output for inst in lf.instances])
+
+    golden = np.array(
+        [
+            [95.950279, 201.836700],
+            [146.684677, 161.575989],
+            [211.206467, 189.888184],
+            [212.050568, 190.249908],
+            [96.069702, 201.522675],
+            [147.012451, 161.808167],
+            [211.269058, 189.270691],
+            [212.148224, 189.673065],
+            [96.311562, 202.784027],
+            [147.091812, 163.930878],
+            [210.216873, 189.312256],
+            [211.247314, 189.817810],
+            [97.070450, 202.523865],
+            [147.734528, 163.942291],
+            [209.834549, 189.232178],
+            [210.711349, 190.128693],
+            [97.703575, 203.105042],
+            [145.604309, 167.835220],
+            [209.265564, 189.009277],
+            [256.112091, 180.818771],
+        ]
+    )
+    np.testing.assert_allclose(coords, golden, atol=0.5)
+
+
 def test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds(
     small_robot_minimal_video,
     minimal_instance_single_instance_ckpt,

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1,3 +1,4 @@
+import shutil
 import sleap_io as sio
 from pathlib import Path
 import numpy as np
@@ -1040,6 +1041,73 @@ def test_topdown_predictor_input_scale_override_reaches_both_stages(
     )
     assert predictor.inference_model.centroid_crop.input_scale == override
     assert predictor.inference_model.instance_peaks.input_scale == override
+
+
+def _copy_ckpt_with_scale(src: Path, dst: Path, scale: float) -> Path:
+    """Copy a checkpoint dir to *dst*, overriding ``data_config.preprocessing.scale``."""
+    shutil.copytree(src, dst)
+    cfg = OmegaConf.load(str(dst / "training_config.yaml"))
+    cfg.data_config.preprocessing.scale = scale
+    OmegaConf.save(cfg, str(dst / "training_config.yaml"))
+    return dst
+
+
+def test_topdown_predictor_default_scale_is_per_stage_not_shared(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_centered_instance_ckpt,
+    tmp_path,
+):
+    """Each stage must default to ITS OWN trained scale, not a shared value.
+
+    Regression test for the `track`-side half of #725: `TopDownPredictor`
+    used to build both `centroid_crop_layer.input_scale` and
+    `instance_peaks_layer.input_scale` from the same shared
+    `self.preprocess_config.scale`, resolved from whichever config
+    (`centroid_config` or `confmap_config`) happened to fill it first. Both
+    fixture checkpoints train at scale=1.0 by default, which never exercises
+    this path, so the scales are patched apart here. `Predictor.from_model_paths`
+    also used to call `TopDownPredictor.from_trained_models` twice (a discarded
+    centroid-only call, then the real call), mutating the shared
+    `preprocess_config` object in place on the first call and corrupting the
+    second -- covered here too since this test goes through `from_model_paths`,
+    not `TopDownPredictor.from_trained_models` directly.
+    """
+    centroid_dir = _copy_ckpt_with_scale(
+        minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=0.5
+    )
+    centered_dir = _copy_ckpt_with_scale(
+        minimal_instance_centered_instance_ckpt,
+        tmp_path / "centered_instance",
+        scale=1.0,
+    )
+    predictor = Predictor.from_model_paths(
+        [str(centroid_dir), str(centered_dir)],
+        preprocess_config=_scale_only_preprocess_config(None),
+    )
+    assert predictor.inference_model.centroid_crop.input_scale == 0.5
+    assert predictor.inference_model.instance_peaks.input_scale == 1.0
+
+
+def test_multiclass_topdown_predictor_default_scale_is_per_stage_not_shared(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_multi_class_topdown_ckpt,
+    tmp_path,
+):
+    """Same regression as above, for `TopDownMultiClassPredictor`."""
+    centroid_dir = _copy_ckpt_with_scale(
+        minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=0.5
+    )
+    confmap_dir = _copy_ckpt_with_scale(
+        minimal_instance_multi_class_topdown_ckpt,
+        tmp_path / "multiclass_centered_instance",
+        scale=1.0,
+    )
+    predictor = Predictor.from_model_paths(
+        [str(centroid_dir), str(confmap_dir)],
+        preprocess_config=_scale_only_preprocess_config(None),
+    )
+    assert predictor.inference_model.centroid_crop.input_scale == 0.5
+    assert predictor.inference_model.instance_peaks.input_scale == 1.0
 
 
 def test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds(


### PR DESCRIPTION
## Summary

`sleap-nn` 0.3.2 (pinned by SLEAP v1.6.5, not yet released) has a regression in the top-down inference pipelines: whenever a centroid model and its centered-instance model are trained at **different** `preprocessing.scale` values — a common setup, since centroid models are often trained at lower resolution for speed — the centered-instance stage silently inherits the centroid model's scale instead of its own. This corrupts confidence-map peak-finding badly enough to drop detections almost entirely.

Confirmed on a real project (centroid `scale=0.5`, centered_instance `scale=1.0`, 2560-frame video, same weights/data, only sleap-nn version differs):

| pipeline | sleap-nn 0.3.1 | sleap-nn 0.3.2 (before this fix) | after this fix |
|---|---|---|---|
| `sleap-nn predict` | 5120 instances (2.00/frame) | **0 instances** | 5120 instances (2.00/frame) |
| `sleap-nn track` (legacy) | 5120 instances (2.00/frame) | **11 instances total** | 5120 instances (2.00/frame) |

This is actually the GUI's own default training-profile pairing, not an edge case: `../sleap/sleap/training_profiles/baseline.centroid.yaml` ships `scale: 0.5`, while `baseline_medium_rf.topdown.yaml`/`baseline_large_rf.topdown.yaml` ship `scale: 1.0`.

## Root cause

Commit `2c1045147` (PR #716, "fix `--input_scale` override was broken in both predict and track") fixed a real, separate bug — an explicit `--input_scale` CLI override was being silently dropped/misapplied — by routing every `input_scale=` construction site through one shared, already-resolved `preprocess_config.scale` (`self.preprocess_config.scale` in the legacy pipeline) instead of each model's own training-config value.

That's correct when the caller passes an explicit override (both stages *should* share it). But for the **default** (no override) case, any predictor with two distinct models — centroid + centered-instance — now has its centered-instance stage's own trained `scale` silently overwritten by the centroid stage's value, because both stages read the same shared field and the null-fill resolution only lets the first-resolved config's value win.

Before PR #716, each stage read its own model's config directly:
```python
input_scale=self.centroid_config.data_config.preprocessing.scale,   # centroid stage
input_scale=self.confmap_config.data_config.preprocessing.scale,    # centered-instance stage
```
which was correct. PR #716 changed both to `input_scale=self.preprocess_config.scale`, reintroducing exactly this class of bug for the no-override case.

## Changes made

**`sleap_nn/inference/loaders.py`** — `_build_topdown`, `_build_topdown_segmentation`, `_build_topdown_multiclass`: each now resolves separate `centroid_scale`/`confmap_scale` (or `seg_scale`) local variables instead of relying on the shared `preprocess_config.scale`, mirroring the existing `crop_size` force-override pattern already used in these same functions. An explicit `--input_scale` override (captured as `user_scale` before per-stage fallback) still applies uniformly to both stages, exactly as before.

**`sleap_nn/inference/predictors.py`** (legacy `track` pipeline) — same fix for `TopDownPredictor` and `TopDownMultiClassPredictor`, via two new `centroid_scale`/`confmap_scale` attrs fields set in `from_trained_models` and consumed in `_initialize_inference_model`.

**`sleap_nn/inference/predictors.py`** — a second, independently-discovered bug in `Predictor.from_model_paths`, found while empirically verifying the fix above: this function called `TopDownPredictor.from_trained_models` **twice** whenever both a centroid and centered-instance model were present — once with a throwaway `confmap_ckpt_path=None` call (result discarded), then again with both paths set. Since `preprocess_config` is a mutable `OmegaConf` object passed by reference, the throwaway call's in-place mutation of `preprocess_config["scale"]` (to the centroid model's value) leaked into the second, real call — corrupting the per-stage fix before it could even run, since the "was an override actually supplied" check saw an already-mutated value instead of `None`. The same double-call existed for the centroid + `multi_class_topdown` combo. Restructured to resolve both ckpt paths first and call `from_trained_models` exactly once.

## Testing

- 4 new regression tests, each patching a fixture checkpoint pair to deliberately mismatched scales (every existing fixture pair in the repo coincidentally trains both stages at `scale=1.0`, which is exactly why this was never caught by the existing suite):
  - `tests/inference/test_loaders.py::test_load_topdown_default_scale_is_per_stage_not_shared`
  - `tests/inference/test_loaders.py::test_load_topdown_multiclass_default_scale_is_per_stage_not_shared`
  - `tests/inference/test_predictors.py::test_topdown_predictor_default_scale_is_per_stage_not_shared`
  - `tests/inference/test_predictors.py::test_multiclass_topdown_predictor_default_scale_is_per_stage_not_shared`
- All 4 confirmed to **fail without the fix and pass with it** (verified via `git stash`).
- `black --check` and `ruff check` clean on both changed source files.
- Full `tests/inference/` suite: 856 passed, 81 skipped, 1 xfailed, 0 failed (up from 852 passed baseline — net +4 for the new regression tests).
- `codespell` clean.
- End-to-end empirical verification against the real user project mentioned above, for both `sleap-nn predict` and `sleap-nn track` CLIs (not just unit-level attribute checks) — see table above.

## Design decisions

- Mirrors the existing `crop_size` force-override pattern already present in every affected function, rather than introducing new resolution machinery — `scale` needed the identical treatment `crop_size` already had.
- Kept the explicit-override semantics from PR #716 intact: passing `--input_scale` still applies that one value to both stages uniformly, since that's the documented, intended behavior for an override. Only the *default* (no override) resolution changes.
- Fixed the `from_model_paths` double-call bug at its root (eliminating the redundant first call) rather than working around the mutation, since the throwaway call served no purpose once both paths are known before either call is made.

## Not in scope (follow-ups, not blockers)

- `predictors.py`'s `TopDownPredictor`/`TopDownMultiClassPredictor` resolve `ensure_rgb`/`ensure_grayscale`/`max_height`/`max_width` via a single-pass if/else (fill from centroid OR confmap config, never both), unlike `loaders.py`'s two-pass `_resolve_preprocess_config`. Confirmed harmless today — these fields are frame-level-only, consumed once before either stage's model runs, never per-stage — but could matter for legacy SLEAP≤1.4 JSON config conversions missing a field on one side. Worth a follow-up ticket.
- `topdown_segmentation` has no real-checkpoint test fixture pair in the repo at all, so its crop_size/scale-override logic (which reads identically to the now-tested `_build_topdown`/`_build_topdown_multiclass`) is unverified by any running test. Worth adding fixtures in a follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)