### PR TITLE
fix(train): anchor_part crashes confusingly deep; LR scheduler priority ignored

### DIFF
--- a/sleap_nn/data/providers.py
+++ b/sleap_nn/data/providers.py
@@ -309,6 +309,15 @@ class LabelsReader(Thread):
         instances_key: If `True`, then instances are appended to the output dictionary.
         only_labeled_frames: (bool) `True` if inference should be run only on user-labeled frames. Default: `False`.
         only_suggested_frames: (bool) `True` if inference should be run only on unlabeled suggested frames. Default: `False`.
+        frames: Optional 0-indexed *positions* to keep from the (possibly
+            already `only_*`/`exclude_*`-filtered) labeled-frames list, in
+            file order -- e.g. `[0, 1, 2]` keeps the first three labeled
+            frames. NOT a filter on `LabeledFrame.frame_idx` values: for a
+            `.pkg.slp` with embedded, non-contiguously-sampled frames,
+            `frame_idx` is typically NOT sequential, so a `frame_idx`-range
+            filter would silently match the wrong (often near-empty)
+            subset. Positions beyond the list's length are dropped with a
+            logged warning rather than silently ignored.
     """
 
     def __init__(
@@ -320,6 +329,7 @@ class LabelsReader(Thread):
         only_suggested_frames: bool = False,
         exclude_user_labeled: bool = False,
         only_predicted_frames: bool = False,
+        frames: Optional[List[int]] = None,
     ):
         """Initialize attribute of the class."""
         super().__init__()
@@ -370,6 +380,21 @@ class LabelsReader(Thread):
 
         else:
             self.filtered_lfs = [lf for lf in self.labels]
+
+        if frames is not None:
+            n = len(self.filtered_lfs)
+            positions = set(frames)
+            out_of_range = sorted(p for p in positions if p < 0 or p >= n)
+            if out_of_range:
+                logger.warning(
+                    f"LabelsReader: {len(out_of_range)} requested frame "
+                    f"position(s) out of range for {n} labeled frame(s) "
+                    f"(after any only_*/exclude_* filtering) and will be "
+                    f"skipped: {out_of_range}"
+                )
+            self.filtered_lfs = [
+                lf for i, lf in enumerate(self.filtered_lfs) if i in positions
+            ]
 
         # Close the backend
         self.local_video_copy = []

--- a/sleap_nn/inference/layers/tiled.py
+++ b/sleap_nn/inference/layers/tiled.py
@@ -414,6 +414,13 @@ class TiledSegmentationLayer:
         # Exposed so the Predictor's pipelined / metadata helpers can read the
         # backend off a tiled layer the same way they read it off a plain one.
         self.backend = inner_layer.backend
+        # Same for the mask-packaging knobs (#712 follow-up): `predictor.py`
+        # reads these via `getattr(self.layer, "mask_output", "mask")` etc.
+        # directly off the top-level layer, so a bare `TiledSegmentationLayer`
+        # (bottomup_segmentation) previously fell back to the hardcoded
+        # defaults instead of the inner layer's actual configured values.
+        self.mask_output = getattr(inner_layer, "mask_output", "mask")
+        self.polygon_epsilon = getattr(inner_layer, "polygon_epsilon", 0.01)
         self.tile_batch_size = int(tile_batch_size)
         self.accumulator_device = accumulator_device
         self.cpu_thresh = cpu_thresh
@@ -562,20 +569,11 @@ class TiledSemanticSegmentationLayer(TiledSegmentationLayer):
     blend (identical to the ``foreground`` channel of the bottom-up path); with no
     offset field there is no translation-invariance subtlety.
 
-    Reuses :class:`TiledSegmentationLayer`'s ``__init__`` / window cache /
-    ``__call__`` / ``backend`` exposure verbatim; overrides only :meth:`predict`
-    to stitch one channel instead of four. Also re-exposes the inner layer's
-    ``mask_output`` / ``polygon_epsilon`` so the Predictor reads them off the
-    tiled layer (the base ``TiledSegmentationLayer`` omits these).
+    Reuses :class:`TiledSegmentationLayer`'s ``__init__`` (including its
+    ``mask_output``/``polygon_epsilon`` re-exposure) / window cache /
+    ``__call__`` / ``backend`` exposure verbatim; overrides only
+    :meth:`predict` to stitch one channel instead of four.
     """
-
-    def __init__(self, inner_layer, tile_size, overlap, **kwargs) -> None:
-        """Stash the inner layer + tiling knobs, re-exposing packaging knobs."""
-        super().__init__(inner_layer, tile_size, overlap, **kwargs)
-        # Re-expose the packaging knobs so ``predictor`` reads them off the tiled
-        # layer (via getattr) exactly as it does off the plain ``SegmentationLayer``.
-        self.mask_output = getattr(inner_layer, "mask_output", "mask")
-        self.polygon_epsilon = getattr(inner_layer, "polygon_epsilon", 0.01)
 
     def predict(self, image: ImageInput) -> Outputs:
         """Tile -> forward -> stitch fg -> threshold to one mask, per frame."""

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -620,9 +620,10 @@ def _build_topdown(
     # Resolve preprocess_config from both training configs. The confmap
     # config supplies crop_size (absent from centroid training configs),
     # so resolve centroid first, then confmap to fill remaining Nones.
-    # Capture whether the caller explicitly supplied a crop_size so the confmap
-    # default below does not override an intentional user value.
+    # Capture whether the caller explicitly supplied a crop_size/scale so the
+    # confmap default below does not override an intentional user value.
     user_crop_size = preprocess_config.crop_size
+    user_scale = preprocess_config.scale
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -638,6 +639,18 @@ def _build_topdown(
         confmap_crop = confmap_config.data_config.preprocessing.crop_size
         if user_crop_size is None and confmap_crop is not None:
             preprocess_config.crop_size = confmap_crop
+
+    # scale is per-stage like crop_size: an explicit --input_scale override
+    # (user_scale) applies to both stages, but absent one, each stage must use
+    # its OWN trained scale rather than inheriting the other stage's value
+    # through the shared preprocess_config (the two models' training scales
+    # commonly differ — e.g. a lower-res centroid model).
+    centroid_scale = user_scale
+    if centroid_scale is None and centroid_config is not None:
+        centroid_scale = centroid_config.data_config.preprocessing.scale
+    confmap_scale = user_scale
+    if confmap_scale is None and confmap_config is not None:
+        confmap_scale = confmap_config.data_config.preprocessing.scale
 
     # Resolve anchor_ind
     if anchor_part is not None:
@@ -679,7 +692,7 @@ def _build_topdown(
             return_crops=return_crops,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=preprocess_config.scale,
+            input_scale=centroid_scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -700,7 +713,7 @@ def _build_topdown(
             integral_patch_size=integral_patch_size,
             return_confmaps=return_confmaps,
             max_stride=max_stride_inst,
-            input_scale=preprocess_config.scale,
+            input_scale=confmap_scale,
         )
 
     inference_model = TopDownInferenceModel(
@@ -785,6 +798,7 @@ def _build_topdown_segmentation(
     # carries the crop_size — a centered-instance property), without clobbering an
     # explicit user crop_size.
     user_crop_size = preprocess_config.crop_size
+    user_scale = preprocess_config.scale
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -793,6 +807,17 @@ def _build_topdown_segmentation(
     seg_crop = seg_config.data_config.preprocessing.crop_size
     if user_crop_size is None and seg_crop is not None:
         preprocess_config.crop_size = seg_crop
+
+    # scale is per-stage like crop_size: an explicit --input_scale override
+    # (user_scale) applies to both stages, but absent one, each stage must use
+    # its OWN trained scale rather than inheriting the other stage's value
+    # through the shared preprocess_config.
+    centroid_scale = user_scale
+    if centroid_scale is None and centroid_config is not None:
+        centroid_scale = centroid_config.data_config.preprocessing.scale
+    seg_scale = user_scale
+    if seg_scale is None:
+        seg_scale = seg_config.data_config.preprocessing.scale
 
     # Resolve anchor_ind (only used by the GT-centroid crop path; the real
     # centroid model supplies crop centers directly).
@@ -833,7 +858,7 @@ def _build_topdown_segmentation(
             return_crops=True,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=preprocess_config.scale,
+            input_scale=centroid_scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -842,7 +867,7 @@ def _build_topdown_segmentation(
     instance_masks = CenteredInstanceMaskInferenceModel(
         torch_model=seg_model,
         output_stride=output_stride,
-        input_scale=preprocess_config.scale,
+        input_scale=seg_scale,
         max_stride=max_stride_seg,
         fg_threshold=fg_threshold,
         mask_output=mask_output,
@@ -918,9 +943,10 @@ def _build_topdown_multiclass(
         )
         skeletons = get_skeleton_from_config(confmap_config.data_config.skeletons)
 
-    # Capture whether the caller explicitly supplied a crop_size so the confmap
-    # default below does not override an intentional user value.
+    # Capture whether the caller explicitly supplied a crop_size/scale so the
+    # confmap default below does not override an intentional user value.
     user_crop_size = preprocess_config.crop_size
+    user_scale = preprocess_config.scale
     if centroid_config is not None:
         preprocess_config = _resolve_preprocess_config(
             preprocess_config, centroid_config
@@ -936,6 +962,17 @@ def _build_topdown_multiclass(
         confmap_crop = confmap_config.data_config.preprocessing.crop_size
         if user_crop_size is None and confmap_crop is not None:
             preprocess_config.crop_size = confmap_crop
+
+    # scale is per-stage like crop_size: an explicit --input_scale override
+    # (user_scale) applies to both stages, but absent one, each stage must use
+    # its OWN trained scale rather than inheriting the other stage's value
+    # through the shared preprocess_config.
+    centroid_scale = user_scale
+    if centroid_scale is None and centroid_config is not None:
+        centroid_scale = centroid_config.data_config.preprocessing.scale
+    confmap_scale = user_scale
+    if confmap_scale is None and confmap_config is not None:
+        confmap_scale = confmap_config.data_config.preprocessing.scale
 
     # Resolve anchor_ind
     if anchor_part is not None:
@@ -976,7 +1013,7 @@ def _build_topdown_multiclass(
             return_crops=return_crops,
             max_instances=max_instances,
             max_stride=max_stride_centroid,
-            input_scale=preprocess_config.scale,
+            input_scale=centroid_scale,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
@@ -993,7 +1030,7 @@ def _build_topdown_multiclass(
         integral_patch_size=integral_patch_size,
         return_confmaps=return_confmaps,
         max_stride=max_stride_inst,
-        input_scale=preprocess_config.scale,
+        input_scale=confmap_scale,
     )
 
     inference_model = TopDownInferenceModel(

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -659,12 +659,31 @@ def _select_layer(assets: Any, model_types: List[str], device: str):
             centered_instance_layer=inst_layer,
             crop_size=(crop_h, crop_w),
         )
+    if has_multi_centered:
+        # GT-centroid fallback for a solo multi_class_topdown model (no paired
+        # centroid model) -- mirrors the has_centered branch above. Without
+        # this, `sleap-nn train`'s automatic post-training eval step (which
+        # always calls predict_new on the just-trained run dir alone) crashes
+        # every standalone multiclass/ID topdown training run.
+        inst_layer = _build_centered_instance_multiclass_layer(
+            assets.inference_model.instance_peaks,
+            device,
+            class_names=_multiclass_class_names(assets, "multi_class_topdown"),
+        )
+        centroid_layer = _build_centroid_layer_gt_only(assets, inst_layer.backend)
+        crop_h, crop_w = assets.inference_model.centroid_crop.crop_hw
+        return TopDownMultiClassLayer(
+            centroid_layer=centroid_layer,
+            centered_instance_layer=inst_layer,
+            crop_size=(crop_h, crop_w),
+        )
     raise ValueError(
         f"Unsupported model_paths combination: detected types {model_types}. "
         f"Predictor.from_model_paths supports: single_instance, "
         f"bottomup, multi_class_bottomup, top-down (centroid + centered_instance), "
         f"top-down multiclass (centroid + multi_class_topdown), centroid-only, "
-        f"or centered-instance-only (requires a .slp source for GT centroids)."
+        f"centered-instance-only, or multi_class_topdown-only (the latter two "
+        f"require a .slp source for GT centroids)."
     )
 
 

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -2242,11 +2242,20 @@ class Predictor:
 
     @staticmethod
     def _collect_postprocess_targets(layer: Any) -> list:
-        """Return all sub-layers that own a ``postprocess_config``."""
+        """Return all sub-layers that own a ``postprocess_config``.
+
+        ``Tiled*`` wrappers (``TiledLayer``/``TiledSegmentationLayer``/
+        ``TiledSemanticSegmentationLayer``) hold their wrapped layer's
+        ``postprocess_config`` on ``.inner``, not on themselves -- unwrap so
+        callers see the real owner instead of concluding (via the `hasattr`
+        check below) that there's nothing to override (#712 follow-up).
+        """
         from sleap_nn.inference.layers.topdown import TopDownLayer
 
         if isinstance(layer, TopDownLayer):
             targets = [layer.centroid_layer, layer.centered_instance_layer]
+        elif hasattr(layer, "inner"):
+            targets = [layer.inner]
         elif hasattr(layer, "postprocess_config"):
             targets = [layer]
         else:
@@ -2379,5 +2388,12 @@ class Predictor:
         if not targets:
             return self.layer
         # Non-top-down layers with a postprocess_config always have exactly
-        # one target: the layer itself.
-        return _copy_with_overrides(targets[0])
+        # one target: the layer itself, or (for a Tiled* wrapper) its .inner.
+        new_target = _copy_with_overrides(targets[0])
+        if hasattr(self.layer, "inner"):
+            # Rewrap: the caller needs a layer that still tiles, not the bare
+            # overridden inner layer on its own.
+            new_layer = copy.copy(self.layer)
+            new_layer.inner = new_target
+            return new_layer
+        return new_target

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1240,6 +1240,39 @@ class Predictor:
             for c in candidates
         )
 
+    def _preprocess_provenance_params(self) -> dict:
+        """The scale/crop_size actually used for this run, for provenance.
+
+        Best-effort and defensive -- provenance must never break inference, so
+        every lookup falls back to omitting the field rather than raising.
+        Topdown-family layers (``TopDownLayer`` and its ``TopDownSegmentation``/
+        ``TopDownMultiClass`` subclasses) have two independently-scaled stages,
+        so both are recorded distinctly rather than collapsing to one shared
+        "scale" the way the training-config's own baked-in value might suggest.
+        """
+        layer = getattr(self.layer, "inner", self.layer)  # unwrap Tiled* wrappers
+        centroid_layer = getattr(layer, "centroid_layer", None)
+        instance_layer = getattr(layer, "centered_instance_layer", None)
+        if centroid_layer is None and instance_layer is None:
+            return {
+                "scale": getattr(
+                    getattr(layer, "preprocess_config", None), "scale", None
+                )
+            }
+        params: dict = {}
+        if centroid_layer is not None:
+            params["centroid_scale"] = getattr(
+                getattr(centroid_layer, "preprocess_config", None), "scale", None
+            )
+        if instance_layer is not None:
+            params["instance_scale"] = getattr(
+                getattr(instance_layer, "preprocess_config", None), "scale", None
+            )
+        crop_size = getattr(layer, "crop_size", None)
+        if crop_size is not None:
+            params["crop_size"] = crop_size
+        return params
+
     def _build_inference_provenance(
         self,
         *,
@@ -1685,6 +1718,7 @@ class Predictor:
                 "integral_refinement": integral_refinement,
                 "integral_patch_size": integral_patch_size,
                 "batch_size": self.batch_size,
+                **self._preprocess_provenance_params(),
             },
         )
 
@@ -1872,7 +1906,10 @@ class Predictor:
                 start_time=_prov_start,
                 end_time=_prov_end,
                 n_frames=writer.frame_count,
-                inference_params={"batch_size": self.batch_size},
+                inference_params={
+                    "batch_size": self.batch_size,
+                    **self._preprocess_provenance_params(),
+                },
             )
         # Post-run summary (#610). The streaming path drops per-frame objects to
         # keep memory O(window), so report frames / throughput only.

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1459,6 +1459,7 @@ class Predictor:
                 provider = LabelsProvider(
                     labels=labels,
                     batch_size=self.batch_size,
+                    frames=frames,
                     **provider_kwargs,
                 )
                 return provider, (list(labels.videos) if labels.videos else None)
@@ -1487,6 +1488,7 @@ class Predictor:
             provider = LabelsProvider(
                 labels=source,
                 batch_size=self.batch_size,
+                frames=frames,
                 **provider_kwargs,
             )
             videos = list(source.videos) if source.videos else None

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -349,59 +349,45 @@ class Predictor(ABC):
             confmap_ckpt_path = None
             if "centroid" in model_names:
                 centroid_ckpt_path = model_paths[model_names.index("centroid")]
-                predictor = TopDownPredictor.from_trained_models(
-                    centroid_ckpt_path=centroid_ckpt_path,
-                    confmap_ckpt_path=confmap_ckpt_path,
-                    backbone_ckpt_path=backbone_ckpt_path,
-                    head_ckpt_path=head_ckpt_path,
-                    peak_threshold=peak_threshold,
-                    integral_refinement=integral_refinement,
-                    integral_patch_size=integral_patch_size,
-                    batch_size=batch_size,
-                    max_instances=max_instances,
-                    return_confmaps=return_confmaps,
-                    device=device,
-                    preprocess_config=preprocess_config,
-                    anchor_part=anchor_part,
-                    filter_overlapping=filter_overlapping,
-                    filter_overlapping_threshold=filter_overlapping_threshold,
-                    filter_overlapping_method=filter_overlapping_method,
-                    filter_min_visible_nodes=filter_min_visible_nodes,
-                    filter_min_visible_node_fraction=filter_min_visible_node_fraction,
-                    filter_min_mean_node_score=filter_min_mean_node_score,
-                    filter_min_instance_score=filter_min_instance_score,
-                )
             if "centered_instance" in model_names:
                 confmap_ckpt_path = model_paths[model_names.index("centered_instance")]
-                # create an instance of the TopDown predictor class
-                predictor = TopDownPredictor.from_trained_models(
-                    centroid_ckpt_path=centroid_ckpt_path,
-                    confmap_ckpt_path=confmap_ckpt_path,
-                    backbone_ckpt_path=backbone_ckpt_path,
-                    head_ckpt_path=head_ckpt_path,
-                    peak_threshold=peak_threshold,
-                    integral_refinement=integral_refinement,
-                    integral_patch_size=integral_patch_size,
-                    batch_size=batch_size,
-                    max_instances=max_instances,
-                    return_confmaps=return_confmaps,
-                    device=device,
-                    preprocess_config=preprocess_config,
-                    anchor_part=anchor_part,
-                    filter_overlapping=filter_overlapping,
-                    filter_overlapping_threshold=filter_overlapping_threshold,
-                    filter_overlapping_method=filter_overlapping_method,
-                    filter_min_visible_nodes=filter_min_visible_nodes,
-                    filter_min_visible_node_fraction=filter_min_visible_node_fraction,
-                    filter_min_mean_node_score=filter_min_mean_node_score,
-                    filter_min_instance_score=filter_min_instance_score,
-                )
             elif "multi_class_topdown" in model_names:
                 confmap_ckpt_path = model_paths[
                     model_names.index("multi_class_topdown")
                 ]
-                # create an instance of the TopDown predictor class
+
+            # Build the predictor with a SINGLE `from_trained_models` call, now
+            # that both ckpt paths are fully resolved. Calling it once per
+            # branch (as this used to do) mutates the shared `preprocess_config`
+            # in place on the first, discarded, centroid-only call -- corrupting
+            # the second, real call's per-stage `scale` resolution (#725-follow-up).
+            if "multi_class_topdown" in model_names:
+                # create an instance of the TopDown multiclass predictor class
                 predictor = TopDownMultiClassPredictor.from_trained_models(
+                    centroid_ckpt_path=centroid_ckpt_path,
+                    confmap_ckpt_path=confmap_ckpt_path,
+                    backbone_ckpt_path=backbone_ckpt_path,
+                    head_ckpt_path=head_ckpt_path,
+                    peak_threshold=peak_threshold,
+                    integral_refinement=integral_refinement,
+                    integral_patch_size=integral_patch_size,
+                    batch_size=batch_size,
+                    max_instances=max_instances,
+                    return_confmaps=return_confmaps,
+                    device=device,
+                    preprocess_config=preprocess_config,
+                    anchor_part=anchor_part,
+                    filter_overlapping=filter_overlapping,
+                    filter_overlapping_threshold=filter_overlapping_threshold,
+                    filter_overlapping_method=filter_overlapping_method,
+                    filter_min_visible_nodes=filter_min_visible_nodes,
+                    filter_min_visible_node_fraction=filter_min_visible_node_fraction,
+                    filter_min_mean_node_score=filter_min_mean_node_score,
+                    filter_min_instance_score=filter_min_instance_score,
+                )
+            else:
+                # create an instance of the TopDown predictor class
+                predictor = TopDownPredictor.from_trained_models(
                     centroid_ckpt_path=centroid_ckpt_path,
                     confmap_ckpt_path=confmap_ckpt_path,
                     backbone_ckpt_path=backbone_ckpt_path,
@@ -854,6 +840,8 @@ class TopDownPredictor(Predictor):
     return_confmaps: bool = False
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
+    centroid_scale: Optional[float] = None
+    confmap_scale: Optional[float] = None
     tracker: Optional[Tracker] = None
     anchor_part: Optional[str] = None
     max_stride: int = 16
@@ -923,7 +911,7 @@ class TopDownPredictor(Predictor):
                 return_crops=return_crops,
                 max_instances=self.max_instances,
                 max_stride=max_stride,
-                input_scale=self.preprocess_config.scale,
+                input_scale=self.centroid_scale,
                 crop_hw=(
                     self.preprocess_config.crop_size,
                     self.preprocess_config.crop_size,
@@ -947,7 +935,7 @@ class TopDownPredictor(Predictor):
                 integral_patch_size=self.integral_patch_size,
                 return_confmaps=self.return_confmaps,
                 max_stride=max_stride,
-                input_scale=self.preprocess_config.scale,
+                input_scale=self.confmap_scale,
             )
 
         if self.centroid_config is None and self.confmap_config is not None:
@@ -1273,6 +1261,11 @@ class TopDownPredictor(Predictor):
             confmap_config = None
             confmap_model = None
 
+        # Capture the caller's explicit --input_scale override (if any) before
+        # the fill-in below resolves `scale` from a single config, so each
+        # stage can still fall back to ITS OWN trained scale afterward.
+        user_scale = preprocess_config["scale"]
+
         if centroid_config is not None:
             preprocess_config["scale"] = (
                 centroid_config.data_config.preprocessing.scale
@@ -1333,6 +1326,18 @@ class TopDownPredictor(Predictor):
             else preprocess_config["crop_size"]
         )
 
+        # scale is per-stage like crop_size: an explicit --input_scale override
+        # (user_scale) applies to both stages, but absent one, each stage must
+        # use its OWN trained scale rather than inheriting the other stage's
+        # value through the shared preprocess_config (the two models' training
+        # scales commonly differ -- e.g. a lower-res centroid model).
+        centroid_scale = user_scale
+        if centroid_scale is None and centroid_config is not None:
+            centroid_scale = centroid_config.data_config.preprocessing.scale
+        confmap_scale = user_scale
+        if confmap_scale is None and confmap_config is not None:
+            confmap_scale = confmap_config.data_config.preprocessing.scale
+
         # create an instance of TopDownPredictor class
         obj = cls(
             centroid_config=centroid_config,
@@ -1350,6 +1355,8 @@ class TopDownPredictor(Predictor):
             return_confmaps=return_confmaps,
             device=device,
             preprocess_config=preprocess_config,
+            centroid_scale=centroid_scale,
+            confmap_scale=confmap_scale,
             anchor_part=anchor_part,
             max_stride=(
                 centroid_config.model_config.backbone_config[
@@ -3243,6 +3250,8 @@ class TopDownMultiClassPredictor(Predictor):
     return_confmaps: bool = False
     device: str = "cpu"
     preprocess_config: Optional[OmegaConf] = None
+    centroid_scale: Optional[float] = None
+    confmap_scale: Optional[float] = None
     anchor_part: Optional[str] = None
     max_stride: int = 16
     filter_overlapping: bool = False
@@ -3311,7 +3320,7 @@ class TopDownMultiClassPredictor(Predictor):
                 return_crops=return_crops,
                 max_instances=self.max_instances,
                 max_stride=max_stride,
-                input_scale=self.preprocess_config.scale,
+                input_scale=self.centroid_scale,
                 crop_hw=(
                     self.preprocess_config.crop_size,
                     self.preprocess_config.crop_size,
@@ -3330,7 +3339,7 @@ class TopDownMultiClassPredictor(Predictor):
             integral_patch_size=self.integral_patch_size,
             return_confmaps=self.return_confmaps,
             max_stride=max_stride,
-            input_scale=self.preprocess_config.scale,
+            input_scale=self.confmap_scale,
         )
 
         if self.centroid_config is None:
@@ -3681,6 +3690,11 @@ class TopDownMultiClassPredictor(Predictor):
             logger.error(message)
             raise ValueError(message)
 
+        # Capture the caller's explicit --input_scale override (if any) before
+        # the fill-in below resolves `scale` from a single config, so each
+        # stage can still fall back to ITS OWN trained scale afterward.
+        user_scale = preprocess_config["scale"]
+
         if centroid_config is not None:
             preprocess_config["scale"] = (
                 centroid_config.data_config.preprocessing.scale
@@ -3741,6 +3755,17 @@ class TopDownMultiClassPredictor(Predictor):
             else preprocess_config["crop_size"]
         )
 
+        # scale is per-stage like crop_size: an explicit --input_scale override
+        # (user_scale) applies to both stages, but absent one, each stage must
+        # use its OWN trained scale rather than inheriting the other stage's
+        # value through the shared preprocess_config.
+        centroid_scale = user_scale
+        if centroid_scale is None and centroid_config is not None:
+            centroid_scale = centroid_config.data_config.preprocessing.scale
+        confmap_scale = user_scale
+        if confmap_scale is None and confmap_config is not None:
+            confmap_scale = confmap_config.data_config.preprocessing.scale
+
         # create an instance of TopDownPredictor class
         obj = cls(
             centroid_config=centroid_config,
@@ -3758,6 +3783,8 @@ class TopDownMultiClassPredictor(Predictor):
             return_confmaps=return_confmaps,
             device=device,
             preprocess_config=preprocess_config,
+            centroid_scale=centroid_scale,
+            confmap_scale=confmap_scale,
             anchor_part=anchor_part,
             max_stride=(
                 centroid_config.model_config.backbone_config[

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -1438,6 +1438,7 @@ class TopDownPredictor(Predictor):
                 only_suggested_frames=only_suggested_frames,
                 exclude_user_labeled=exclude_user_labeled,
                 only_predicted_frames=only_predicted_frames,
+                frames=frames,
             )
             self.videos = self.pipeline.labels.videos
 
@@ -1937,6 +1938,7 @@ class SingleInstancePredictor(Predictor):
                 only_suggested_frames=only_suggested_frames,
                 exclude_user_labeled=exclude_user_labeled,
                 only_predicted_frames=only_predicted_frames,
+                frames=frames,
             )
             self.videos = self.pipeline.labels.videos
 
@@ -2423,6 +2425,7 @@ class BottomUpPredictor(Predictor):
                 only_suggested_frames=only_suggested_frames,
                 exclude_user_labeled=exclude_user_labeled,
                 only_predicted_frames=only_predicted_frames,
+                frames=frames,
             )
 
             self.videos = self.pipeline.labels.videos
@@ -2987,6 +2990,7 @@ class BottomUpMultiClassPredictor(Predictor):
                 only_suggested_frames=only_suggested_frames,
                 exclude_user_labeled=exclude_user_labeled,
                 only_predicted_frames=only_predicted_frames,
+                frames=frames,
             )
 
             self.videos = self.pipeline.labels.videos
@@ -3866,6 +3870,7 @@ class TopDownMultiClassPredictor(Predictor):
                 only_suggested_frames=only_suggested_frames,
                 exclude_user_labeled=exclude_user_labeled,
                 only_predicted_frames=only_predicted_frames,
+                frames=frames,
             )
             self.videos = self.pipeline.labels.videos
 

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -354,6 +354,18 @@ class LabelsProvider:
             See :class:`VideoProvider` for the same mechanism.
         queue_maxsize: Bound on how many decoded batches may sit in the
             prefetch queue ahead of the consumer.
+        frames: Optional 0-indexed *positions* to keep from the (possibly
+            already `only_*`/`exclude_*`-filtered) labeled-frames list, in
+            file order -- e.g. ``[0, 1, 2]`` keeps the first three labeled
+            frames. NOT a filter on ``LabeledFrame.frame_idx`` values: for a
+            `.pkg.slp` with embedded, non-contiguously-sampled frames,
+            `frame_idx` is typically NOT sequential (e.g. a cluster-sampled
+            training package), so a `frame_idx`-range filter would silently
+            match the wrong (often near-empty) subset. Positional selection
+            gives a well-defined "first N labeled frames" preview regardless
+            of the source video's backing (embedded vs. external). Positions
+            beyond the list's length are dropped with a logged warning
+            rather than silently ignored.
     """
 
     labels: "Union[str, sio.Labels]"
@@ -365,6 +377,7 @@ class LabelsProvider:
     remote_kwargs: Optional[dict] = None
     prefetch: bool = True
     queue_maxsize: int = 4
+    frames: Optional[list] = None
 
     _sio_labels: "Optional[sio.Labels]" = attrs.field(
         default=None, init=False, repr=False
@@ -418,6 +431,21 @@ class LabelsProvider:
             ]
         else:
             self._labeled_frames = list(self._sio_labels.labeled_frames)
+
+        if self.frames is not None:
+            n = len(self._labeled_frames)
+            positions = set(self.frames)
+            out_of_range = sorted(p for p in positions if p < 0 or p >= n)
+            if out_of_range:
+                logger.warning(
+                    f"LabelsProvider: {len(out_of_range)} requested frame "
+                    f"position(s) out of range for {n} labeled frame(s) "
+                    f"(after any only_*/exclude_* filtering) and will be "
+                    f"skipped: {out_of_range}"
+                )
+            self._labeled_frames = [
+                lf for i, lf in enumerate(self._labeled_frames) if i in positions
+            ]
 
     def _frame_instances(self, lf) -> list:
         """Instances to expose as GT for a frame.

--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -784,59 +784,65 @@ class LightningModel(L.LightningModule):
         elif isinstance(self.lr_scheduler, dict):
             lr_scheduler_cfg = self.lr_scheduler
 
-        for k, v in self.lr_scheduler.items():
-            if v is not None:
-                if k == "cosine_annealing_warmup":
-                    cfg = self.lr_scheduler.cosine_annealing_warmup
-                    # Use trainer's max_epochs if not specified in config
-                    max_epochs = (
-                        cfg.max_epochs
-                        if cfg.max_epochs is not None
-                        else self.trainer.max_epochs
-                    )
-                    scheduler = LinearWarmupCosineAnnealingLR(
-                        optimizer=optimizer,
-                        warmup_epochs=cfg.warmup_epochs,
-                        max_epochs=max_epochs,
-                        warmup_start_lr=cfg.warmup_start_lr,
-                        eta_min=cfg.eta_min,
-                    )
-                    break
-                elif k == "linear_warmup_linear_decay":
-                    cfg = self.lr_scheduler.linear_warmup_linear_decay
-                    # Use trainer's max_epochs if not specified in config
-                    max_epochs = (
-                        cfg.max_epochs
-                        if cfg.max_epochs is not None
-                        else self.trainer.max_epochs
-                    )
-                    scheduler = LinearWarmupLinearDecayLR(
-                        optimizer=optimizer,
-                        warmup_epochs=cfg.warmup_epochs,
-                        max_epochs=max_epochs,
-                        warmup_start_lr=cfg.warmup_start_lr,
-                        end_lr=cfg.end_lr,
-                    )
-                    break
-                elif k == "step_lr":
-                    scheduler = torch.optim.lr_scheduler.StepLR(
-                        optimizer=optimizer,
-                        step_size=self.lr_scheduler.step_lr.step_size,
-                        gamma=self.lr_scheduler.step_lr.gamma,
-                    )
-                    break
-                elif k == "reduce_lr_on_plateau":
-                    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-                        optimizer,
-                        mode="min",
-                        threshold=self.lr_scheduler.reduce_lr_on_plateau.threshold,
-                        threshold_mode=self.lr_scheduler.reduce_lr_on_plateau.threshold_mode,
-                        cooldown=self.lr_scheduler.reduce_lr_on_plateau.cooldown,
-                        patience=self.lr_scheduler.reduce_lr_on_plateau.patience,
-                        factor=self.lr_scheduler.reduce_lr_on_plateau.factor,
-                        min_lr=self.lr_scheduler.reduce_lr_on_plateau.min_lr,
-                    )
-                    break
+        # Explicit priority order per LRSchedulerConfig's own docstring:
+        # cosine_annealing_warmup > linear_warmup_linear_decay > step_lr >
+        # reduce_lr_on_plateau. `reduce_lr_on_plateau` defaults to a populated
+        # (non-None) config while the other three default to None, so a plain
+        # `for k, v in self.lr_scheduler.items(): if v is not None: ... break`
+        # (the previous implementation) picked whichever scheduler happened to
+        # be first in the dataclass's FIELD DECLARATION order among the
+        # non-None ones -- silently ignoring this documented priority and
+        # defaulting to ReduceLROnPlateau for any user who set
+        # cosine_annealing_warmup/linear_warmup_linear_decay without also
+        # explicitly nulling reduce_lr_on_plateau. No error, no warning --
+        # training just ran with the wrong LR schedule indefinitely.
+        if self.lr_scheduler.cosine_annealing_warmup is not None:
+            cfg = self.lr_scheduler.cosine_annealing_warmup
+            # Use trainer's max_epochs if not specified in config
+            max_epochs = (
+                cfg.max_epochs
+                if cfg.max_epochs is not None
+                else self.trainer.max_epochs
+            )
+            scheduler = LinearWarmupCosineAnnealingLR(
+                optimizer=optimizer,
+                warmup_epochs=cfg.warmup_epochs,
+                max_epochs=max_epochs,
+                warmup_start_lr=cfg.warmup_start_lr,
+                eta_min=cfg.eta_min,
+            )
+        elif self.lr_scheduler.linear_warmup_linear_decay is not None:
+            cfg = self.lr_scheduler.linear_warmup_linear_decay
+            # Use trainer's max_epochs if not specified in config
+            max_epochs = (
+                cfg.max_epochs
+                if cfg.max_epochs is not None
+                else self.trainer.max_epochs
+            )
+            scheduler = LinearWarmupLinearDecayLR(
+                optimizer=optimizer,
+                warmup_epochs=cfg.warmup_epochs,
+                max_epochs=max_epochs,
+                warmup_start_lr=cfg.warmup_start_lr,
+                end_lr=cfg.end_lr,
+            )
+        elif self.lr_scheduler.step_lr is not None:
+            scheduler = torch.optim.lr_scheduler.StepLR(
+                optimizer=optimizer,
+                step_size=self.lr_scheduler.step_lr.step_size,
+                gamma=self.lr_scheduler.step_lr.gamma,
+            )
+        elif self.lr_scheduler.reduce_lr_on_plateau is not None:
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+                optimizer,
+                mode="min",
+                threshold=self.lr_scheduler.reduce_lr_on_plateau.threshold,
+                threshold_mode=self.lr_scheduler.reduce_lr_on_plateau.threshold_mode,
+                cooldown=self.lr_scheduler.reduce_lr_on_plateau.cooldown,
+                patience=self.lr_scheduler.reduce_lr_on_plateau.patience,
+                factor=self.lr_scheduler.reduce_lr_on_plateau.factor,
+                min_lr=self.lr_scheduler.reduce_lr_on_plateau.min_lr,
+            )
         if scheduler is None:
             return {
                 "optimizer": optimizer,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -734,12 +734,34 @@ class ModelTrainer:
         """Setup node, edge and class names in head config."""
         # if edges and part names aren't set in head configs, get it from labels object.
         head_config = self.config.model_config.head_configs[self.model_type]
+        skeleton_node_names = list(self.skeletons[0].node_names)
         for key in head_config:
             if "part_names" in head_config[key].keys():
                 if head_config[key]["part_names"] is None:
                     self.config.model_config.head_configs[self.model_type][key][
                         "part_names"
                     ] = self.skeletons[0].node_names
+                elif list(head_config[key]["part_names"]) != skeleton_node_names:
+                    # GT confidence-map generation always produces one channel
+                    # per node in the skeleton (custom_datasets.py's
+                    # generate_confmaps has no part_names/subset parameter), while
+                    # the head's own output channel count is len(part_names). An
+                    # explicit part_names that's shorter, longer, or reordered
+                    # relative to the skeleton silently mismatches those two
+                    # channel counts (a confusing tensor-shape error deep in the
+                    # loss) or silently mislabels channels (if the same length
+                    # but reordered). Catch it here, fail-fast, before any data
+                    # loading/model construction.
+                    message = (
+                        f"model_config.head_configs.{self.model_type}.{key}"
+                        f".part_names must exactly match the skeleton's node "
+                        f"names (in order) -- partial/reordered subsets are not "
+                        f"supported. Got {list(head_config[key]['part_names'])!r}, "
+                        f"skeleton has {skeleton_node_names!r}. Set part_names to "
+                        f"null to use the full skeleton automatically."
+                    )
+                    logger.error(message)
+                    raise ValueError(message)
 
             if "edges" in head_config[key].keys():
                 if head_config[key]["edges"] is None:

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -763,6 +763,31 @@ class ModelTrainer:
                     logger.error(message)
                     raise ValueError(message)
 
+            if (
+                "anchor_part" in head_config[key].keys()
+                and head_config[key]["anchor_part"] is not None
+                and self.model_type != "centroid"
+            ):
+                # `centroid`'s anchor_part deliberately falls back to None (mean
+                # of visible nodes) when absent from the skeleton -- see the
+                # comment at custom_datasets.py's centroid branch ("must NOT
+                # crash"). Every other head type that consumes anchor_part
+                # (centered_instance, multi_class_topdown,
+                # centered_instance_segmentation) does `nodes.index(anchor_part)`
+                # with no such guard, so a typo'd/nonexistent anchor_part
+                # currently passes setup cleanly and only fails deep inside
+                # dataset construction -- with an error message that
+                # misleadingly blames `part_names`, not the actual offending
+                # `anchor_part` field. Catch it here instead.
+                if head_config[key]["anchor_part"] not in skeleton_node_names:
+                    message = (
+                        f"model_config.head_configs.{self.model_type}.{key}"
+                        f".anchor_part {head_config[key]['anchor_part']!r} is not "
+                        f"a node in the skeleton {skeleton_node_names!r}."
+                    )
+                    logger.error(message)
+                    raise ValueError(message)
+
             if "edges" in head_config[key].keys():
                 if head_config[key]["edges"] is None:
                     edges = [

--- a/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
+++ b/tests/assets/model_ckpts/minimal_instance_multiclass_centered_instance/initial_config.yaml
@@ -87,9 +87,7 @@ model_config:
     multi_class_topdown:
       confmaps:
         part_names:
-        - head
-        - thorax
-        anchor_part: thorax
+        anchor_part: null
         sigma: 1.5
         output_stride: 2
         loss_weight: 1.0

--- a/tests/data/test_providers.py
+++ b/tests/data/test_providers.py
@@ -480,3 +480,63 @@ def test_only_predicted_frames_with_both_types(minimal_instance):
     # Frame with both types should be included
     assert reader.total_len() == 1
     assert reader.filtered_lfs[0].frame_idx == 0
+
+
+def _scattered_frame_idx_labels(minimal_instance):
+    """3 labeled frames with non-sequential ``frame_idx`` values.
+
+    Mirrors a real cluster-sampled `.pkg.slp` training package (e.g.
+    berman_flies' `train.pkg.slp`, whose embedded frames' `frame_idx` values
+    are scattered like `[8, 1064, 1198, ...]`, not `0, 1, 2, ...`).
+    """
+    labels = sio.load_slp(minimal_instance)
+    video = labels.videos[0]
+    labels.labeled_frames[0].frame_idx = 50
+    for fidx in (5, 900):
+        labels.labeled_frames.append(
+            sio.LabeledFrame(video=video, frame_idx=fidx, instances=[])
+        )
+    return labels
+
+
+def test_labels_reader_frames_selects_positionally_not_by_frame_idx_value(
+    minimal_instance,
+):
+    """``frames`` keeps list *positions*, not matching `LabeledFrame.frame_idx`.
+
+    Regression: `--frames` used to be silently ignored entirely for `.slp`
+    sources in the legacy `track` pipeline. The fix must NOT filter by
+    `frame_idx` value -- for a `.pkg.slp` with non-contiguously-sampled
+    embedded frames, `frame_idx` is typically scattered (not sequential),
+    so a value-based filter would silently match the wrong (often
+    near-empty) subset. `frames=[0, 2]` must keep the 1st and 3rd labeled
+    frames in file order (`frame_idx` 50 and 900), NOT frames whose
+    `frame_idx` equals 0 or 2 (neither of which exist here).
+    """
+    labels = _scattered_frame_idx_labels(minimal_instance)
+    queue = Queue(maxsize=4)
+    reader = LabelsReader(
+        labels=labels, frame_buffer=queue, instances_key=False, frames=[0, 2]
+    )
+    assert [lf.frame_idx for lf in reader.filtered_lfs] == [50, 900]
+
+
+def test_labels_reader_frames_out_of_range_warns(minimal_instance):
+    """Out-of-range ``frames`` positions are dropped with a logged warning."""
+    from loguru import logger
+
+    labels = _scattered_frame_idx_labels(minimal_instance)
+    queue = Queue(maxsize=4)
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        reader = LabelsReader(
+            labels=labels, frame_buffer=queue, instances_key=False, frames=[0, 5, 6]
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert [lf.frame_idx for lf in reader.filtered_lfs] == [50]
+    assert len(messages) == 1
+    assert "out of range" in messages[0]
+    assert "[5, 6]" in messages[0]

--- a/tests/inference/test_factory.py
+++ b/tests/inference/test_factory.py
@@ -202,6 +202,29 @@ def test_factory_centered_instance_only_uses_gt_centroids():
     assert p.layer.centroid_layer.use_gt_centroids is True
 
 
+@pytest.mark.skipif(
+    not MULTICLASS_TD_CKPT.exists(), reason="multiclass centered_instance ckpt absent"
+)
+def test_factory_multiclass_centered_instance_only_uses_gt_centroids():
+    """Standalone multi_class_topdown -> ``TopDownMultiClassLayer`` with GT centroids.
+
+    Regression: `_select_layer` had a GT-centroid fallback branch for a lone
+    plain `centered_instance` model (see the test above) but no equivalent
+    for its multiclass/ID sibling, so a solo `multi_class_topdown` model fell
+    through to the "Unsupported model_paths combination" `ValueError`.
+    `sleap-nn train`'s automatic post-training eval step always calls
+    `predict_new(path, model_paths=[run_path], ...)` on the just-trained run
+    dir alone, so this crashed at the end of EVERY standalone multiclass/ID
+    topdown training run (checkpoint saved fine; the CLI process still
+    exited non-zero). Confirmed via real training on real data before this
+    fix landed.
+    """
+    p = Predictor.from_model_paths([str(MULTICLASS_TD_CKPT)], device="cpu")
+    assert isinstance(p.layer, TopDownMultiClassLayer)
+    assert p.layer.centroid_layer.use_gt_centroids is True
+    assert p.layer.centered_instance_layer.class_names
+
+
 def test_factory_rejects_unrecognized_model_type():
     """Truly unrecognized model type → clear ``ValueError`` from ``_select_layer``."""
     from sleap_nn.inference.predictor import _select_layer

--- a/tests/inference/test_infer_provenance.py
+++ b/tests/inference/test_infer_provenance.py
@@ -8,15 +8,19 @@ helpers in isolation.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
+from omegaconf import OmegaConf
 
 from sleap_nn.inference.predictor import Predictor
 
 ASSETS = Path(__file__).resolve().parents[1] / "assets"
 SLP = ASSETS / "datasets" / "minimal_instance.pkg.slp"
 SINGLE = ASSETS / "model_ckpts" / "minimal_instance_single_instance"
+CENTROID = ASSETS / "model_ckpts" / "minimal_instance_centroid"
+CENTERED_INSTANCE = ASSETS / "model_ckpts" / "minimal_instance_centered_instance"
 
 
 @pytest.mark.skipif(not (SLP.exists() and SINGLE.exists()), reason="missing fixtures")
@@ -33,3 +37,53 @@ def test_predict_attaches_provenance():
     # Timestamps + runtime present.
     assert "inference_start_timestamp" in prov
     assert "inference_runtime_seconds" in prov
+
+
+@pytest.mark.skipif(not (SLP.exists() and SINGLE.exists()), reason="missing fixtures")
+def test_predict_provenance_records_scale_for_single_stage_model():
+    """`inference_config` must record the scale actually used, not just exist.
+
+    Complements `test_predict_attaches_provenance` (which only checks
+    `inference_config` is present) by checking its content.
+    """
+    pred = Predictor.from_model_paths([str(SINGLE)], device="cpu", batch_size=4)
+    labels = pred.predict(str(SLP), make_labels=True)
+    assert labels.provenance["inference_config"].get("scale") == pytest.approx(0.5)
+
+
+def _copy_ckpt_with_scale(src: Path, dst: Path, scale: float) -> Path:
+    """Copy a checkpoint dir to *dst*, overriding ``data_config.preprocessing.scale``."""
+    shutil.copytree(src, dst)
+    cfg = OmegaConf.load(str(dst / "training_config.yaml"))
+    cfg.data_config.preprocessing.scale = scale
+    OmegaConf.save(cfg, str(dst / "training_config.yaml"))
+    return dst
+
+
+@pytest.mark.skipif(
+    not (SLP.exists() and CENTROID.exists() and CENTERED_INSTANCE.exists()),
+    reason="missing fixtures",
+)
+def test_predict_provenance_records_distinct_per_stage_scale_for_topdown(tmp_path):
+    """Provenance gap fix: topdown's two stages must be recorded distinctly.
+
+    `predict`'s provenance previously never recorded `scale`/`crop_size` at
+    all (unlike the legacy `track` pipeline, which did). Now that it does,
+    verify it records the TWO stages' scales distinctly rather than one
+    shared value -- the same distinction the actual inference math needed
+    fixing for (topdown centroid/confmap scale-sharing bug, #725). Uses a
+    deliberately mismatched pair so a regression that collapsed both stages
+    to one value would be caught here too.
+    """
+    centroid_dir = _copy_ckpt_with_scale(CENTROID, tmp_path / "centroid", scale=0.5)
+    centered_dir = _copy_ckpt_with_scale(
+        CENTERED_INSTANCE, tmp_path / "centered_instance", scale=1.0
+    )
+    pred = Predictor.from_model_paths(
+        [str(centroid_dir), str(centered_dir)], device="cpu", batch_size=4
+    )
+    labels = pred.predict(str(SLP), make_labels=True)
+    cfg = labels.provenance["inference_config"]
+    assert cfg.get("centroid_scale") == pytest.approx(0.5)
+    assert cfg.get("instance_scale") == pytest.approx(1.0)
+    assert "crop_size" in cfg

--- a/tests/inference/test_loaders.py
+++ b/tests/inference/test_loaders.py
@@ -7,6 +7,7 @@ supported model type and return correct ``LoadedAssets``.
 from __future__ import annotations
 
 import gc
+import shutil
 from pathlib import Path
 
 import pytest
@@ -206,6 +207,54 @@ def test_load_topdown_input_scale_override_reaches_both_stages():
     )
     assert assets.inference_model.centroid_crop.input_scale == override
     assert assets.inference_model.instance_peaks.input_scale == override
+
+
+def _copy_ckpt_with_scale(src: Path, dst: Path, scale: float) -> Path:
+    """Copy a checkpoint dir to *dst*, overriding ``data_config.preprocessing.scale``."""
+    shutil.copytree(src, dst)
+    cfg = OmegaConf.load(str(dst / "training_config.yaml"))
+    cfg.data_config.preprocessing.scale = scale
+    OmegaConf.save(cfg, str(dst / "training_config.yaml"))
+    return dst
+
+
+def test_load_topdown_default_scale_is_per_stage_not_shared(tmp_path):
+    """Each stage must default to ITS OWN trained scale, not a shared value.
+
+    Regression test for #725: ``crop_size`` gets an explicit "force from the
+    confmap config" override in ``_build_topdown``, but ``scale`` did not, so
+    the *first* ``_resolve_preprocess_config`` call (centroid) filled the
+    shared ``preprocess_config.scale`` and the second call (confmap) silently
+    left it untouched -- the centered-instance stage inherited the centroid
+    model's scale. Both fixture checkpoints train at scale=1.0 by default,
+    which never exercises this path, so the scales are patched apart here.
+    """
+    if not (CENTROID_CKPT.exists() and CENTERED_CKPT.exists()):
+        pytest.skip("topdown ckpts absent")
+    centroid_dir = _copy_ckpt_with_scale(
+        CENTROID_CKPT, tmp_path / "centroid", scale=0.5
+    )
+    centered_dir = _copy_ckpt_with_scale(
+        CENTERED_CKPT, tmp_path / "centered_instance", scale=1.0
+    )
+    assets, _ = load_model_assets([str(centroid_dir), str(centered_dir)], device="cpu")
+    assert assets.inference_model.centroid_crop.input_scale == 0.5
+    assert assets.inference_model.instance_peaks.input_scale == 1.0
+
+
+def test_load_topdown_multiclass_default_scale_is_per_stage_not_shared(tmp_path):
+    """Same regression as above (#725), for the multiclass top-down builder."""
+    if not (CENTROID_CKPT.exists() and MULTICLASS_TD_CKPT.exists()):
+        pytest.skip("topdown-multiclass ckpts absent")
+    centroid_dir = _copy_ckpt_with_scale(
+        CENTROID_CKPT, tmp_path / "centroid", scale=0.5
+    )
+    confmap_dir = _copy_ckpt_with_scale(
+        MULTICLASS_TD_CKPT, tmp_path / "multiclass_centered_instance", scale=1.0
+    )
+    assets, _ = load_model_assets([str(centroid_dir), str(confmap_dir)], device="cpu")
+    assert assets.inference_model.centroid_crop.input_scale == 0.5
+    assert assets.inference_model.instance_peaks.input_scale == 1.0
 
 
 def test_load_topdown_multiclass(topdown_multiclass_assets):

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1110,13 +1110,13 @@ def test_multiclass_topdown_predictor_default_scale_is_per_stage_not_shared(
     assert predictor.inference_model.instance_peaks.input_scale == 1.0
 
 
-def test_topdown_predictor_mismatched_scale_coords_pinned(
+def test_topdown_predictor_mismatched_scale_coords_differ_from_shared_scale_bug(
     minimal_instance_centroid_ckpt,
     minimal_instance_centered_instance_ckpt,
     centered_instance_video,
     tmp_path,
 ):
-    """Golden/snapshot guard: pins exact predicted coordinates end to end.
+    """End-to-end guard: pins that fixed per-stage scale changes predicted coords.
 
     The attribute-level tests above check that each stage keeps its own
     `input_scale`, but don't exercise the actual forward pass. This one does,
@@ -1126,12 +1126,19 @@ def test_topdown_predictor_mismatched_scale_coords_pinned(
     produces the SAME instance count across a 0.15x-3x scale range -- the
     models are too small/robust for lost detections to show up in a count.
     Predicted *coordinates* do shift measurably (confirmed up to ~67px on a
-    96x96 crop), so this test pins those instead. If topdown scale-sharing
-    regresses again, this will catch it even if it doesn't collapse detections
-    the way it did on a real, larger model.
+    96x96 crop), so this test compares those instead.
 
-    Golden values recorded from a single deterministic run of the current
-    (fixed) pipeline -- confirmed byte-identical across repeated runs.
+    Deliberately NOT a golden/snapshot test pinning a literal recorded array:
+    an earlier version of this test did that and was flaky across CI
+    platforms (mac/ubuntu/windows CPU backends produce measurably different
+    conv/pooling reduction order, enough to shift which pixel wins an
+    argmax-based peak -- tens of px apart on some elements, not just
+    sub-pixel float noise). Instead, this reconstructs the pre-fix bug
+    in-process (forcing the confmap stage to share the centroid stage's
+    scale, exactly what the bug did) and asserts the two coordinate sets
+    differ substantially -- a comparison that's robust to whatever a given
+    CI platform's own numerics look like, since both sides run on the same
+    platform in the same process.
     """
     centroid_dir = _copy_ckpt_with_scale(
         minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=1.0
@@ -1141,41 +1148,30 @@ def test_topdown_predictor_mismatched_scale_coords_pinned(
         tmp_path / "centered_instance",
         scale=0.5,
     )
-    predictor = Predictor.from_model_paths(
-        [str(centroid_dir), str(centered_dir)],
-        peak_threshold=0.03,
-        max_instances=6,
-        preprocess_config=_scale_only_preprocess_config(None),
-    )
-    predictor.make_pipeline(centered_instance_video.as_posix(), frames=list(range(5)))
-    output = predictor.predict(make_labels=True)
-    coords = np.concatenate([inst.numpy() for lf in output for inst in lf.instances])
 
-    golden = np.array(
-        [
-            [95.950279, 201.836700],
-            [146.684677, 161.575989],
-            [211.206467, 189.888184],
-            [212.050568, 190.249908],
-            [96.069702, 201.522675],
-            [147.012451, 161.808167],
-            [211.269058, 189.270691],
-            [212.148224, 189.673065],
-            [96.311562, 202.784027],
-            [147.091812, 163.930878],
-            [210.216873, 189.312256],
-            [211.247314, 189.817810],
-            [97.070450, 202.523865],
-            [147.734528, 163.942291],
-            [209.834549, 189.232178],
-            [210.711349, 190.128693],
-            [97.703575, 203.105042],
-            [145.604309, 167.835220],
-            [209.265564, 189.009277],
-            [256.112091, 180.818771],
-        ]
-    )
-    np.testing.assert_allclose(coords, golden, atol=0.5)
+    def _predict_coords(force_shared_scale: bool) -> np.ndarray:
+        predictor = Predictor.from_model_paths(
+            [str(centroid_dir), str(centered_dir)],
+            peak_threshold=0.03,
+            max_instances=6,
+            preprocess_config=_scale_only_preprocess_config(None),
+        )
+        if force_shared_scale:
+            # Reconstruct the pre-fix bug: both stages share one scale.
+            predictor.inference_model.instance_peaks.input_scale = (
+                predictor.inference_model.centroid_crop.input_scale
+            )
+        predictor.make_pipeline(
+            centered_instance_video.as_posix(), frames=list(range(5))
+        )
+        output = predictor.predict(make_labels=True)
+        return np.concatenate([inst.numpy() for lf in output for inst in lf.instances])
+
+    fixed_coords = _predict_coords(force_shared_scale=False)
+    buggy_coords = _predict_coords(force_shared_scale=True)
+
+    assert fixed_coords.shape == buggy_coords.shape
+    assert np.nanmax(np.abs(fixed_coords - buggy_coords)) > 5.0
 
 
 def test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds(

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1110,6 +1110,74 @@ def test_multiclass_topdown_predictor_default_scale_is_per_stage_not_shared(
     assert predictor.inference_model.instance_peaks.input_scale == 1.0
 
 
+def test_topdown_predictor_mismatched_scale_coords_pinned(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_centered_instance_ckpt,
+    centered_instance_video,
+    tmp_path,
+):
+    """Golden/snapshot guard: pins exact predicted coordinates end to end.
+
+    The attribute-level tests above check that each stage keeps its own
+    `input_scale`, but don't exercise the actual forward pass. This one does,
+    on a real video with a real (deliberately mismatched-scale) checkpoint
+    pair. Instance *count* alone is not a reliable target here: forcing the
+    pre-fix bug (both stages sharing one scale) on these tiny fixture models
+    produces the SAME instance count across a 0.15x-3x scale range -- the
+    models are too small/robust for lost detections to show up in a count.
+    Predicted *coordinates* do shift measurably (confirmed up to ~67px on a
+    96x96 crop), so this test pins those instead. If topdown scale-sharing
+    regresses again, this will catch it even if it doesn't collapse detections
+    the way it did on a real, larger model.
+
+    Golden values recorded from a single deterministic run of the current
+    (fixed) pipeline -- confirmed byte-identical across repeated runs.
+    """
+    centroid_dir = _copy_ckpt_with_scale(
+        minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=1.0
+    )
+    centered_dir = _copy_ckpt_with_scale(
+        minimal_instance_centered_instance_ckpt,
+        tmp_path / "centered_instance",
+        scale=0.5,
+    )
+    predictor = Predictor.from_model_paths(
+        [str(centroid_dir), str(centered_dir)],
+        peak_threshold=0.03,
+        max_instances=6,
+        preprocess_config=_scale_only_preprocess_config(None),
+    )
+    predictor.make_pipeline(centered_instance_video.as_posix(), frames=list(range(5)))
+    output = predictor.predict(make_labels=True)
+    coords = np.concatenate([inst.numpy() for lf in output for inst in lf.instances])
+
+    golden = np.array(
+        [
+            [95.950279, 201.836700],
+            [146.684677, 161.575989],
+            [211.206467, 189.888184],
+            [212.050568, 190.249908],
+            [96.069702, 201.522675],
+            [147.012451, 161.808167],
+            [211.269058, 189.270691],
+            [212.148224, 189.673065],
+            [96.311562, 202.784027],
+            [147.091812, 163.930878],
+            [210.216873, 189.312256],
+            [211.247314, 189.817810],
+            [97.070450, 202.523865],
+            [147.734528, 163.942291],
+            [209.834549, 189.232178],
+            [210.711349, 190.128693],
+            [97.703575, 203.105042],
+            [145.604309, 167.835220],
+            [209.265564, 189.009277],
+            [256.112091, 180.818771],
+        ]
+    )
+    np.testing.assert_allclose(coords, golden, atol=0.5)
+
+
 def test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds(
     small_robot_minimal_video,
     minimal_instance_single_instance_ckpt,

--- a/tests/inference/test_predictors.py
+++ b/tests/inference/test_predictors.py
@@ -1,3 +1,4 @@
+import shutil
 import sleap_io as sio
 from pathlib import Path
 import numpy as np
@@ -1040,6 +1041,73 @@ def test_topdown_predictor_input_scale_override_reaches_both_stages(
     )
     assert predictor.inference_model.centroid_crop.input_scale == override
     assert predictor.inference_model.instance_peaks.input_scale == override
+
+
+def _copy_ckpt_with_scale(src: Path, dst: Path, scale: float) -> Path:
+    """Copy a checkpoint dir to *dst*, overriding ``data_config.preprocessing.scale``."""
+    shutil.copytree(src, dst)
+    cfg = OmegaConf.load(str(dst / "training_config.yaml"))
+    cfg.data_config.preprocessing.scale = scale
+    OmegaConf.save(cfg, str(dst / "training_config.yaml"))
+    return dst
+
+
+def test_topdown_predictor_default_scale_is_per_stage_not_shared(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_centered_instance_ckpt,
+    tmp_path,
+):
+    """Each stage must default to ITS OWN trained scale, not a shared value.
+
+    Regression test for the `track`-side half of #725: `TopDownPredictor`
+    used to build both `centroid_crop_layer.input_scale` and
+    `instance_peaks_layer.input_scale` from the same shared
+    `self.preprocess_config.scale`, resolved from whichever config
+    (`centroid_config` or `confmap_config`) happened to fill it first. Both
+    fixture checkpoints train at scale=1.0 by default, which never exercises
+    this path, so the scales are patched apart here. `Predictor.from_model_paths`
+    also used to call `TopDownPredictor.from_trained_models` twice (a discarded
+    centroid-only call, then the real call), mutating the shared
+    `preprocess_config` object in place on the first call and corrupting the
+    second -- covered here too since this test goes through `from_model_paths`,
+    not `TopDownPredictor.from_trained_models` directly.
+    """
+    centroid_dir = _copy_ckpt_with_scale(
+        minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=0.5
+    )
+    centered_dir = _copy_ckpt_with_scale(
+        minimal_instance_centered_instance_ckpt,
+        tmp_path / "centered_instance",
+        scale=1.0,
+    )
+    predictor = Predictor.from_model_paths(
+        [str(centroid_dir), str(centered_dir)],
+        preprocess_config=_scale_only_preprocess_config(None),
+    )
+    assert predictor.inference_model.centroid_crop.input_scale == 0.5
+    assert predictor.inference_model.instance_peaks.input_scale == 1.0
+
+
+def test_multiclass_topdown_predictor_default_scale_is_per_stage_not_shared(
+    minimal_instance_centroid_ckpt,
+    minimal_instance_multi_class_topdown_ckpt,
+    tmp_path,
+):
+    """Same regression as above, for `TopDownMultiClassPredictor`."""
+    centroid_dir = _copy_ckpt_with_scale(
+        minimal_instance_centroid_ckpt, tmp_path / "centroid", scale=0.5
+    )
+    confmap_dir = _copy_ckpt_with_scale(
+        minimal_instance_multi_class_topdown_ckpt,
+        tmp_path / "multiclass_centered_instance",
+        scale=1.0,
+    )
+    predictor = Predictor.from_model_paths(
+        [str(centroid_dir), str(confmap_dir)],
+        preprocess_config=_scale_only_preprocess_config(None),
+    )
+    assert predictor.inference_model.centroid_crop.input_scale == 0.5
+    assert predictor.inference_model.instance_peaks.input_scale == 1.0
 
 
 def test_single_instance_predictor_input_scale_override_end_to_end_coords_in_bounds(

--- a/tests/inference/test_providers.py
+++ b/tests/inference/test_providers.py
@@ -136,6 +136,59 @@ def test_labels_provider_only_predicted_frames_keeps_only_predicted():
     assert [lf.frame_idx for lf in provider._labeled_frames] == [1]
 
 
+def _scattered_frame_idx_labels():
+    """3 labeled frames with non-sequential ``frame_idx`` values.
+
+    Mirrors a real cluster-sampled `.pkg.slp` training package (e.g.
+    berman_flies' `train.pkg.slp`, whose embedded frames' `frame_idx` values
+    are scattered like `[8, 1064, 1198, ...]`, not `0, 1, 2, ...`).
+    """
+    import sleap_io as sio
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="dummy.mp4")
+    lfs = [
+        sio.LabeledFrame(video=video, frame_idx=fidx, instances=[])
+        for fidx in (50, 5, 900)
+    ]
+    return sio.Labels(videos=[video], skeletons=[skel], labeled_frames=lfs)
+
+
+def test_labels_provider_frames_selects_positionally_not_by_frame_idx_value():
+    """``frames`` keeps list *positions*, not matching `LabeledFrame.frame_idx`.
+
+    Regression: `--frames` used to be silently ignored entirely for `.slp`
+    sources. The fix must NOT filter by `frame_idx` value -- for a
+    `.pkg.slp` with non-contiguously-sampled embedded frames, `frame_idx`
+    is typically scattered (not sequential), so a value-based filter would
+    silently match the wrong (often near-empty) subset. `frames=[0, 2]`
+    must keep the 1st and 3rd labeled frames in file order (`frame_idx`
+    50 and 900), NOT frames whose `frame_idx` equals 0 or 2 (neither of
+    which exist here).
+    """
+    labels = _scattered_frame_idx_labels()
+    provider = LabelsProvider(labels=labels, frames=[0, 2])
+    assert [lf.frame_idx for lf in provider._labeled_frames] == [50, 900]
+
+
+def test_labels_provider_frames_out_of_range_warns():
+    """Out-of-range ``frames`` positions are dropped with a logged warning."""
+    from loguru import logger
+
+    labels = _scattered_frame_idx_labels()
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        provider = LabelsProvider(labels=labels, frames=[0, 5, 6])
+    finally:
+        logger.remove(sink_id)
+
+    assert [lf.frame_idx for lf in provider._labeled_frames] == [50]
+    assert len(messages) == 1
+    assert "out of range" in messages[0]
+    assert "[5, 6]" in messages[0]
+
+
 def test_labels_provider_only_suggested_frames_yields_unlabeled_suggestions():
     """``only_suggested_frames=True`` yields unlabeled suggestions only."""
     import sleap_io as sio

--- a/tests/inference/test_tiling_inference.py
+++ b/tests/inference/test_tiling_inference.py
@@ -395,3 +395,64 @@ def test_select_layer_routes_to_tiled_when_enabled(
     assert layer.tile_size == 128
     assert layer.overlap == 32
     assert layer.tile_batch_size == 8  # None -> conservative default
+
+
+def test_scoped_postprocess_layer_overrides_reach_tiled_inner(
+    minimal_instance_single_instance_ckpt,
+):
+    """Predict-time postprocess overrides must reach a ``TiledLayer``'s inner layer.
+
+    Regression (#712 follow-up): ``Predictor._collect_postprocess_targets``
+    only recognized a bare layer with its own ``postprocess_config`` (via
+    ``hasattr``) or a ``TopDownLayer``'s two named sub-layers -- a
+    ``TiledLayer`` exposes its wrapped layer's ``postprocess_config`` only on
+    ``.inner``, so every override (``--peak_threshold``, ``--max_instances``,
+    etc.) was a silent no-op for every tiled model. Also checks the returned
+    layer is still a ``TiledLayer`` (not the bare unwrapped inner layer) and
+    that the original layer's config is untouched (no in-place mutation).
+    """
+    from sleap_nn.inference.loaders import load_model_assets
+    from sleap_nn.inference.predictor import Predictor
+
+    loaded, model_types = load_model_assets(
+        [str(minimal_instance_single_instance_ckpt)],
+        device="cpu",
+        preprocess_config=OmegaConf.create(
+            {
+                "ensure_rgb": None,
+                "ensure_grayscale": None,
+                "crop_size": None,
+                "max_width": None,
+                "max_height": None,
+                "scale": None,
+            }
+        ),
+    )
+    OmegaConf.update(
+        loaded.confmap_config,
+        "data_config.preprocessing.tiling",
+        {
+            "enabled": True,
+            "tile_size": 128,
+            "overlap": 32,
+            "blend": "gaussian",
+            "sigma_scale": 0.125,
+            "min_overlap_fraction": 0.25,
+            "tile_batch_size": None,
+            "accumulator_device": "auto",
+            "cpu_thresh": 0.4,
+        },
+        force_add=True,
+    )
+    layer = _select_layer(loaded, model_types, "cpu")
+    assert isinstance(layer, TiledLayer)
+    original_threshold = layer.inner.postprocess_config.peak_threshold
+
+    predictor = Predictor(layer=layer)
+    new_layer = predictor._scoped_postprocess_layer(peak_threshold=0.9, max_instances=3)
+
+    assert isinstance(new_layer, TiledLayer)
+    assert new_layer.inner.postprocess_config.peak_threshold == 0.9
+    assert new_layer.inner.postprocess_config.max_instances == 3
+    # Original layer must be untouched.
+    assert layer.inner.postprocess_config.peak_threshold == original_threshold

--- a/tests/inference/test_tiling_seg_inference.py
+++ b/tests/inference/test_tiling_seg_inference.py
@@ -108,6 +108,27 @@ def test_single_tile_equals_whole_frame():
 
 
 # ---------------------------------------------------------------------------
+# 1b. mask_output/polygon_epsilon are re-exposed on the tiled wrapper
+# ---------------------------------------------------------------------------
+def test_tiled_segmentation_layer_reexposes_mask_output():
+    """``TiledSegmentationLayer`` must re-expose the inner layer's mask-packaging knobs.
+
+    Regression (#712 follow-up): only the ``TiledSemanticSegmentationLayer``
+    subclass copied ``mask_output``/``polygon_epsilon`` from the inner layer
+    onto itself; the base ``TiledSegmentationLayer`` (used for
+    ``bottomup_segmentation``) didn't, so ``Predictor``'s
+    ``getattr(self.layer, "mask_output", "mask")`` silently fell back to the
+    hardcoded default instead of the model's actual configured value.
+    """
+    inner = _make_inner(stride=2, tile_max_stride=8)
+    inner.mask_output = "polygon"
+    inner.polygon_epsilon = 0.05
+    tiled = TiledSegmentationLayer(inner, tile_size=16, overlap=8)
+    assert tiled.mask_output == "polygon"
+    assert tiled.polygon_epsilon == 0.05
+
+
+# ---------------------------------------------------------------------------
 # 2. A synthetic 2-tile stitch reconstructs a known fg/center/offset field
 # ---------------------------------------------------------------------------
 def test_two_tile_stitch_reconstructs_field():

--- a/tests/training/test_lightning_modules.py
+++ b/tests/training/test_lightning_modules.py
@@ -737,3 +737,86 @@ def test_single_instance_forward_handles_4d_and_5d_inputs(config, tmp_path: str)
 
     # Both should produce consistent output shapes
     assert output_5d.shape == output_4d.shape
+
+
+@pytest.mark.parametrize(
+    "scheduler_kwarg,expected_type",
+    [
+        ("cosine_annealing_warmup", "LinearWarmupCosineAnnealingLR"),
+        ("linear_warmup_linear_decay", "LinearWarmupLinearDecayLR"),
+        ("step_lr", "StepLR"),
+    ],
+)
+def test_configure_optimizers_respects_documented_scheduler_priority(
+    scheduler_kwarg, expected_type
+):
+    """Setting a non-default scheduler must win over the populated-by-default
+    ``reduce_lr_on_plateau``, per ``LRSchedulerConfig``'s own documented
+    priority (cosine_annealing_warmup > linear_warmup_linear_decay > step_lr >
+    reduce_lr_on_plateau).
+
+    Regression: `configure_optimizers` used to iterate
+    `self.lr_scheduler.items()` in dataclass FIELD DECLARATION order (step_lr,
+    reduce_lr_on_plateau, cosine_annealing_warmup, linear_warmup_linear_decay)
+    and take the first non-None entry -- since `reduce_lr_on_plateau` defaults
+    to a populated (non-None) config while the other three default to `None`,
+    any user who set one of the other three WITHOUT ALSO explicitly nulling
+    `reduce_lr_on_plateau` silently got `ReduceLROnPlateau` instead, with no
+    error or warning.
+    """
+    from sleap_nn.config.trainer_config import (
+        CosineAnnealingWarmupConfig,
+        LinearWarmupLinearDecayConfig,
+        LRSchedulerConfig,
+        StepLRConfig,
+    )
+    from sleap_nn.training.schedulers import (
+        LinearWarmupCosineAnnealingLR,
+        LinearWarmupLinearDecayLR,
+    )
+
+    scheduler_cfg_cls = {
+        "cosine_annealing_warmup": CosineAnnealingWarmupConfig,
+        "linear_warmup_linear_decay": LinearWarmupLinearDecayConfig,
+        "step_lr": StepLRConfig,
+    }[scheduler_kwarg]
+    scheduler_cfg = (
+        scheduler_cfg_cls(max_epochs=10)
+        if scheduler_kwarg != "step_lr"
+        else scheduler_cfg_cls()
+    )
+
+    model = SingleInstanceLightningModule(
+        model_type="single_instance",
+        backbone_config="unet_medium_rf",
+        backbone_type="unet",
+        head_configs=OmegaConf.create(
+            {
+                "single_instance": {
+                    "confmaps": {
+                        "part_names": ["a", "b"],
+                        "sigma": 1.5,
+                        "output_stride": 2,
+                        "loss_weight": 1.0,
+                    }
+                }
+            }
+        ),
+        # reduce_lr_on_plateau left at its populated-by-default value on
+        # purpose -- exactly the scenario that used to silently win. Wrapped
+        # in OmegaConf.structured to match real usage: model_trainer.py always
+        # passes `config.trainer_config.lr_scheduler`, an OmegaConf DictConfig,
+        # never a raw attrs instance.
+        lr_scheduler=OmegaConf.structured(
+            LRSchedulerConfig(**{scheduler_kwarg: scheduler_cfg})
+        ),
+    )
+    result = model.configure_optimizers()
+    scheduler_types = {
+        "LinearWarmupCosineAnnealingLR": LinearWarmupCosineAnnealingLR,
+        "LinearWarmupLinearDecayLR": LinearWarmupLinearDecayLR,
+        "StepLR": torch.optim.lr_scheduler.StepLR,
+    }
+    assert isinstance(
+        result["lr_scheduler"]["scheduler"], scheduler_types[expected_type]
+    )


### PR DESCRIPTION
## Summary

Two more training-pipeline bugs found during the pre-release audit (`scratch/2026-08-10-pre-release-pipeline-audit/`), from a dedicated agent sweep of `sleap_nn/training/` for the same "unvalidated config value crashes confusingly deep" shape as the already-fixed `part_names` bug (see #726).

**Base branch note**: this PR targets `fix/predict-provenance-per-stage-scale` (#726), not `main`, because the `anchor_part` fix's surrounding code depends on the `part_names` validation block already committed there. Rebase onto `main` once that PR merges.

## Bug 1: `anchor_part` had no upfront validation

Same shape as the already-fixed `part_names` bug. A typo'd/nonexistent `anchor_part` passed config setup cleanly and only failed deep inside dataset construction (`custom_datasets.py`, `nodes.index(anchor_part)`) with an error message that misleadingly blamed `part_names` instead of the actual offending `anchor_part` field.

Only the `centroid` path already guarded against this — **deliberately**, per an existing comment: an unmatched `anchor_part` there must NOT crash, since it's only a fallback for frames without user centroids and degrades gracefully to the mean of visible nodes instead. No such fallback exists for `centered_instance`/`multi_class_topdown`/`centered_instance_segmentation`, which all call `nodes.index(anchor_part)` unguarded.

**Fix**: `_setup_head_config` now validates `anchor_part` against the skeleton for every head type **except** `centroid` (preserving its intentional leniency), raising a clear, correctly-attributed error instead of a deep, misdirected crash.

## Bug 2: `configure_optimizers`'s LR scheduler selection ignored its own documented priority

`LRSchedulerConfig`'s docstring says the priority is `cosine_annealing_warmup > linear_warmup_linear_decay > step_lr > reduce_lr_on_plateau`, but the implementation iterated `self.lr_scheduler.items()` in dataclass **field declaration order** (`step_lr`, `reduce_lr_on_plateau`, `cosine_annealing_warmup`, `linear_warmup_linear_decay`) and took the first non-`None` entry.

`reduce_lr_on_plateau` defaults to a populated (non-`None`) config while the other three default to `None` — so any user who set `cosine_annealing_warmup`/`linear_warmup_linear_decay` without **also** explicitly nulling `reduce_lr_on_plateau` silently got `ReduceLROnPlateau` instead. No error, no warning — training just ran with the wrong LR schedule indefinitely.

**Fix**: replaced the iteration with explicit `if`/`elif` checks in the documented priority order.

## Testing

- `anchor_part`: verified directly against real checkpoints — centroid's leniency preserved (training with an invalid `anchor_part` still succeeds, exit 0), `centered_instance` now raises a clear `ValueError` naming the correct field.
- LR scheduler: 3 new parametrized regression tests (`cosine_annealing_warmup`, `linear_warmup_linear_decay`, `step_lr`), each asserting `configure_optimizers()` returns the correct scheduler type when `reduce_lr_on_plateau` is left at its populated default. 2 of the 3 confirmed to **fail** on the pre-fix code with the exact wrong-scheduler symptom (`ReduceLROnPlateau` returned instead); the third (`step_lr`) passes on old code too, but only by field-declaration-order coincidence — matching the original finding precisely.
- Full `tests/training/` suite: 259 passed, 0 failed.
- `black`/`ruff`/`codespell` all clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)