### PR TITLE
fix(train): anchor_part crashes confusingly deep; LR scheduler priority ignored

### DIFF
--- a/sleap_nn/training/lightning_modules.py
+++ b/sleap_nn/training/lightning_modules.py
@@ -784,59 +784,65 @@ class LightningModel(L.LightningModule):
         elif isinstance(self.lr_scheduler, dict):
             lr_scheduler_cfg = self.lr_scheduler
 
-        for k, v in self.lr_scheduler.items():
-            if v is not None:
-                if k == "cosine_annealing_warmup":
-                    cfg = self.lr_scheduler.cosine_annealing_warmup
-                    # Use trainer's max_epochs if not specified in config
-                    max_epochs = (
-                        cfg.max_epochs
-                        if cfg.max_epochs is not None
-                        else self.trainer.max_epochs
-                    )
-                    scheduler = LinearWarmupCosineAnnealingLR(
-                        optimizer=optimizer,
-                        warmup_epochs=cfg.warmup_epochs,
-                        max_epochs=max_epochs,
-                        warmup_start_lr=cfg.warmup_start_lr,
-                        eta_min=cfg.eta_min,
-                    )
-                    break
-                elif k == "linear_warmup_linear_decay":
-                    cfg = self.lr_scheduler.linear_warmup_linear_decay
-                    # Use trainer's max_epochs if not specified in config
-                    max_epochs = (
-                        cfg.max_epochs
-                        if cfg.max_epochs is not None
-                        else self.trainer.max_epochs
-                    )
-                    scheduler = LinearWarmupLinearDecayLR(
-                        optimizer=optimizer,
-                        warmup_epochs=cfg.warmup_epochs,
-                        max_epochs=max_epochs,
-                        warmup_start_lr=cfg.warmup_start_lr,
-                        end_lr=cfg.end_lr,
-                    )
-                    break
-                elif k == "step_lr":
-                    scheduler = torch.optim.lr_scheduler.StepLR(
-                        optimizer=optimizer,
-                        step_size=self.lr_scheduler.step_lr.step_size,
-                        gamma=self.lr_scheduler.step_lr.gamma,
-                    )
-                    break
-                elif k == "reduce_lr_on_plateau":
-                    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-                        optimizer,
-                        mode="min",
-                        threshold=self.lr_scheduler.reduce_lr_on_plateau.threshold,
-                        threshold_mode=self.lr_scheduler.reduce_lr_on_plateau.threshold_mode,
-                        cooldown=self.lr_scheduler.reduce_lr_on_plateau.cooldown,
-                        patience=self.lr_scheduler.reduce_lr_on_plateau.patience,
-                        factor=self.lr_scheduler.reduce_lr_on_plateau.factor,
-                        min_lr=self.lr_scheduler.reduce_lr_on_plateau.min_lr,
-                    )
-                    break
+        # Explicit priority order per LRSchedulerConfig's own docstring:
+        # cosine_annealing_warmup > linear_warmup_linear_decay > step_lr >
+        # reduce_lr_on_plateau. `reduce_lr_on_plateau` defaults to a populated
+        # (non-None) config while the other three default to None, so a plain
+        # `for k, v in self.lr_scheduler.items(): if v is not None: ... break`
+        # (the previous implementation) picked whichever scheduler happened to
+        # be first in the dataclass's FIELD DECLARATION order among the
+        # non-None ones -- silently ignoring this documented priority and
+        # defaulting to ReduceLROnPlateau for any user who set
+        # cosine_annealing_warmup/linear_warmup_linear_decay without also
+        # explicitly nulling reduce_lr_on_plateau. No error, no warning --
+        # training just ran with the wrong LR schedule indefinitely.
+        if self.lr_scheduler.cosine_annealing_warmup is not None:
+            cfg = self.lr_scheduler.cosine_annealing_warmup
+            # Use trainer's max_epochs if not specified in config
+            max_epochs = (
+                cfg.max_epochs
+                if cfg.max_epochs is not None
+                else self.trainer.max_epochs
+            )
+            scheduler = LinearWarmupCosineAnnealingLR(
+                optimizer=optimizer,
+                warmup_epochs=cfg.warmup_epochs,
+                max_epochs=max_epochs,
+                warmup_start_lr=cfg.warmup_start_lr,
+                eta_min=cfg.eta_min,
+            )
+        elif self.lr_scheduler.linear_warmup_linear_decay is not None:
+            cfg = self.lr_scheduler.linear_warmup_linear_decay
+            # Use trainer's max_epochs if not specified in config
+            max_epochs = (
+                cfg.max_epochs
+                if cfg.max_epochs is not None
+                else self.trainer.max_epochs
+            )
+            scheduler = LinearWarmupLinearDecayLR(
+                optimizer=optimizer,
+                warmup_epochs=cfg.warmup_epochs,
+                max_epochs=max_epochs,
+                warmup_start_lr=cfg.warmup_start_lr,
+                end_lr=cfg.end_lr,
+            )
+        elif self.lr_scheduler.step_lr is not None:
+            scheduler = torch.optim.lr_scheduler.StepLR(
+                optimizer=optimizer,
+                step_size=self.lr_scheduler.step_lr.step_size,
+                gamma=self.lr_scheduler.step_lr.gamma,
+            )
+        elif self.lr_scheduler.reduce_lr_on_plateau is not None:
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+                optimizer,
+                mode="min",
+                threshold=self.lr_scheduler.reduce_lr_on_plateau.threshold,
+                threshold_mode=self.lr_scheduler.reduce_lr_on_plateau.threshold_mode,
+                cooldown=self.lr_scheduler.reduce_lr_on_plateau.cooldown,
+                patience=self.lr_scheduler.reduce_lr_on_plateau.patience,
+                factor=self.lr_scheduler.reduce_lr_on_plateau.factor,
+                min_lr=self.lr_scheduler.reduce_lr_on_plateau.min_lr,
+            )
         if scheduler is None:
             return {
                 "optimizer": optimizer,

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -763,6 +763,31 @@ class ModelTrainer:
                     logger.error(message)
                     raise ValueError(message)
 
+            if (
+                "anchor_part" in head_config[key].keys()
+                and head_config[key]["anchor_part"] is not None
+                and self.model_type != "centroid"
+            ):
+                # `centroid`'s anchor_part deliberately falls back to None (mean
+                # of visible nodes) when absent from the skeleton -- see the
+                # comment at custom_datasets.py's centroid branch ("must NOT
+                # crash"). Every other head type that consumes anchor_part
+                # (centered_instance, multi_class_topdown,
+                # centered_instance_segmentation) does `nodes.index(anchor_part)`
+                # with no such guard, so a typo'd/nonexistent anchor_part
+                # currently passes setup cleanly and only fails deep inside
+                # dataset construction -- with an error message that
+                # misleadingly blames `part_names`, not the actual offending
+                # `anchor_part` field. Catch it here instead.
+                if head_config[key]["anchor_part"] not in skeleton_node_names:
+                    message = (
+                        f"model_config.head_configs.{self.model_type}.{key}"
+                        f".anchor_part {head_config[key]['anchor_part']!r} is not "
+                        f"a node in the skeleton {skeleton_node_names!r}."
+                    )
+                    logger.error(message)
+                    raise ValueError(message)
+
             if "edges" in head_config[key].keys():
                 if head_config[key]["edges"] is None:
                     edges = [

--- a/tests/training/test_lightning_modules.py
+++ b/tests/training/test_lightning_modules.py
@@ -737,3 +737,86 @@ def test_single_instance_forward_handles_4d_and_5d_inputs(config, tmp_path: str)
 
     # Both should produce consistent output shapes
     assert output_5d.shape == output_4d.shape
+
+
+@pytest.mark.parametrize(
+    "scheduler_kwarg,expected_type",
+    [
+        ("cosine_annealing_warmup", "LinearWarmupCosineAnnealingLR"),
+        ("linear_warmup_linear_decay", "LinearWarmupLinearDecayLR"),
+        ("step_lr", "StepLR"),
+    ],
+)
+def test_configure_optimizers_respects_documented_scheduler_priority(
+    scheduler_kwarg, expected_type
+):
+    """Setting a non-default scheduler must win over the populated-by-default
+    ``reduce_lr_on_plateau``, per ``LRSchedulerConfig``'s own documented
+    priority (cosine_annealing_warmup > linear_warmup_linear_decay > step_lr >
+    reduce_lr_on_plateau).
+
+    Regression: `configure_optimizers` used to iterate
+    `self.lr_scheduler.items()` in dataclass FIELD DECLARATION order (step_lr,
+    reduce_lr_on_plateau, cosine_annealing_warmup, linear_warmup_linear_decay)
+    and take the first non-None entry -- since `reduce_lr_on_plateau` defaults
+    to a populated (non-None) config while the other three default to `None`,
+    any user who set one of the other three WITHOUT ALSO explicitly nulling
+    `reduce_lr_on_plateau` silently got `ReduceLROnPlateau` instead, with no
+    error or warning.
+    """
+    from sleap_nn.config.trainer_config import (
+        CosineAnnealingWarmupConfig,
+        LinearWarmupLinearDecayConfig,
+        LRSchedulerConfig,
+        StepLRConfig,
+    )
+    from sleap_nn.training.schedulers import (
+        LinearWarmupCosineAnnealingLR,
+        LinearWarmupLinearDecayLR,
+    )
+
+    scheduler_cfg_cls = {
+        "cosine_annealing_warmup": CosineAnnealingWarmupConfig,
+        "linear_warmup_linear_decay": LinearWarmupLinearDecayConfig,
+        "step_lr": StepLRConfig,
+    }[scheduler_kwarg]
+    scheduler_cfg = (
+        scheduler_cfg_cls(max_epochs=10)
+        if scheduler_kwarg != "step_lr"
+        else scheduler_cfg_cls()
+    )
+
+    model = SingleInstanceLightningModule(
+        model_type="single_instance",
+        backbone_config="unet_medium_rf",
+        backbone_type="unet",
+        head_configs=OmegaConf.create(
+            {
+                "single_instance": {
+                    "confmaps": {
+                        "part_names": ["a", "b"],
+                        "sigma": 1.5,
+                        "output_stride": 2,
+                        "loss_weight": 1.0,
+                    }
+                }
+            }
+        ),
+        # reduce_lr_on_plateau left at its populated-by-default value on
+        # purpose -- exactly the scenario that used to silently win. Wrapped
+        # in OmegaConf.structured to match real usage: model_trainer.py always
+        # passes `config.trainer_config.lr_scheduler`, an OmegaConf DictConfig,
+        # never a raw attrs instance.
+        lr_scheduler=OmegaConf.structured(
+            LRSchedulerConfig(**{scheduler_kwarg: scheduler_cfg})
+        ),
+    )
+    result = model.configure_optimizers()
+    scheduler_types = {
+        "LinearWarmupCosineAnnealingLR": LinearWarmupCosineAnnealingLR,
+        "LinearWarmupLinearDecayLR": LinearWarmupLinearDecayLR,
+        "StepLR": torch.optim.lr_scheduler.StepLR,
+    }
+    assert isinstance(
+        result["lr_scheduler"]["scheduler"], scheduler_types[expected_type]
+    )


### PR DESCRIPTION
## Summary

Two more training-pipeline bugs found during the pre-release audit (`scratch/2026-08-10-pre-release-pipeline-audit/`), from a dedicated agent sweep of `sleap_nn/training/` for the same "unvalidated config value crashes confusingly deep" shape as the already-fixed `part_names` bug (see #726).

**Base branch note**: this PR targets `fix/predict-provenance-per-stage-scale` (#726), not `main`, because the `anchor_part` fix's surrounding code depends on the `part_names` validation block already committed there. Rebase onto `main` once that PR merges.

## Bug 1: `anchor_part` had no upfront validation

Same shape as the already-fixed `part_names` bug. A typo'd/nonexistent `anchor_part` passed config setup cleanly and only failed deep inside dataset construction (`custom_datasets.py`, `nodes.index(anchor_part)`) with an error message that misleadingly blamed `part_names` instead of the actual offending `anchor_part` field.

Only the `centroid` path already guarded against this — **deliberately**, per an existing comment: an unmatched `anchor_part` there must NOT crash, since it's only a fallback for frames without user centroids and degrades gracefully to the mean of visible nodes instead. No such fallback exists for `centered_instance`/`multi_class_topdown`/`centered_instance_segmentation`, which all call `nodes.index(anchor_part)` unguarded.

**Fix**: `_setup_head_config` now validates `anchor_part` against the skeleton for every head type **except** `centroid` (preserving its intentional leniency), raising a clear, correctly-attributed error instead of a deep, misdirected crash.

## Bug 2: `configure_optimizers`'s LR scheduler selection ignored its own documented priority

`LRSchedulerConfig`'s docstring says the priority is `cosine_annealing_warmup > linear_warmup_linear_decay > step_lr > reduce_lr_on_plateau`, but the implementation iterated `self.lr_scheduler.items()` in dataclass **field declaration order** (`step_lr`, `reduce_lr_on_plateau`, `cosine_annealing_warmup`, `linear_warmup_linear_decay`) and took the first non-`None` entry.

`reduce_lr_on_plateau` defaults to a populated (non-`None`) config while the other three default to `None` — so any user who set `cosine_annealing_warmup`/`linear_warmup_linear_decay` without **also** explicitly nulling `reduce_lr_on_plateau` silently got `ReduceLROnPlateau` instead. No error, no warning — training just ran with the wrong LR schedule indefinitely.

**Fix**: replaced the iteration with explicit `if`/`elif` checks in the documented priority order.

## Testing

- `anchor_part`: verified directly against real checkpoints — centroid's leniency preserved (training with an invalid `anchor_part` still succeeds, exit 0), `centered_instance` now raises a clear `ValueError` naming the correct field.
- LR scheduler: 3 new parametrized regression tests (`cosine_annealing_warmup`, `linear_warmup_linear_decay`, `step_lr`), each asserting `configure_optimizers()` returns the correct scheduler type when `reduce_lr_on_plateau` is left at its populated default. 2 of the 3 confirmed to **fail** on the pre-fix code with the exact wrong-scheduler symptom (`ReduceLROnPlateau` returned instead); the third (`step_lr`) passes on old code too, but only by field-declaration-order coincidence — matching the original finding precisely.
- Full `tests/training/` suite: 259 passed, 0 failed.
- `black`/`ruff`/`codespell` all clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)