### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/sleap_nn/__init__.py
+++ b/sleap_nn/__init__.py
@@ -105,7 +105,7 @@ def redirect_logs_to_stderr() -> None:
     _add_default_sink("stderr")
 
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 # Public API
 from sleap_nn.evaluation import load_metrics


### PR DESCRIPTION
## Summary
- Bumps `sleap_nn.__version__` from `0.3.2` to `0.3.3` ahead of the next release.

## Dependency check
- `sleap-io` pin (`>=0.9.2,<0.10.0`) is unchanged — 0.9.2 remains the latest release on both PyPI and GitHub, so no upper-bound update was needed this cycle.

## Test plan
- No functional code changed; CI (lint + full test matrix) covers regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)