### PR TITLE
fix(infer): first inference on unlabeled video silently yields zero frames

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1359,11 +1359,24 @@ def _scope_labels_to_video(labels, video_index: int, frames=None):
         )
     target = labels.videos[video_index]
     wanted = set(frames) if frames else None
-    lfs = [
-        lf
-        for lf in labels.find(video=target)
-        if wanted is None or lf.frame_idx in wanted
-    ]
+    if wanted is not None:
+        # Use return_new=True so frames without existing labels get placeholder
+        # LabeledFrames — otherwise first-inference on a never-labeled video
+        # silently yields zero frames (sleap#2844).
+        lfs = labels.find(video=target, frame_idx=sorted(wanted), return_new=True)
+    else:
+        lfs = labels.find(video=target)
+        if not lfs:
+            try:
+                n = len(target)
+                if n > 0:
+                    lfs = labels.find(
+                        video=target,
+                        frame_idx=list(range(n)),
+                        return_new=True,
+                    )
+            except Exception:
+                pass
     suggestions = [
         s
         for s in (getattr(labels, "suggestions", None) or [])

--- a/tests/inference/test_issue_583.py
+++ b/tests/inference/test_issue_583.py
@@ -249,3 +249,40 @@ def test_scope_labels_to_video_out_of_range_raises():
     )
     with __import__("pytest").raises(click.UsageError):
         _scope_labels_to_video(labels, 5)
+
+
+def test_scope_labels_to_video_creates_placeholders_for_unlabeled_video():
+    """First inference on a never-labeled video produces placeholder frames.
+
+    Regression test for sleap#2844: ``_scope_labels_to_video`` called
+    ``labels.find(video=target)`` which only returns pre-existing
+    ``LabeledFrame``s. For a video with zero prior labels, this yielded an
+    empty list, so inference silently processed zero frames.
+    """
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a"])
+    video = sio.Video(filename="unlabeled.mp4")
+    labels = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[])
+
+    # Simulate the GUI's "Entire video" target: --frames 0-4 (5 frames).
+    scoped, target = _scope_labels_to_video(labels, 0, frames=[0, 1, 2, 3, 4])
+    assert target is video
+    assert len(scoped.labeled_frames) == 5
+    assert {lf.frame_idx for lf in scoped.labeled_frames} == {0, 1, 2, 3, 4}
+
+
+def test_scope_labels_to_video_preserves_existing_labels_with_frames():
+    """When some frames already have labels, those are kept alongside new ones."""
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a"])
+    video = sio.Video(filename="partial.mp4")
+    existing_lf = sio.LabeledFrame(video=video, frame_idx=2)
+    labels = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[existing_lf])
+
+    scoped, _ = _scope_labels_to_video(labels, 0, frames=[0, 1, 2, 3])
+    assert len(scoped.labeled_frames) == 4
+    # Frame 2 should be the original (with any instances), not a new empty one.
+    frame_2 = [lf for lf in scoped.labeled_frames if lf.frame_idx == 2]
+    assert len(frame_2) == 1


### PR DESCRIPTION
## Summary

Fixes talmolab/sleap#2844 — running inference with "Entire video" target on a video that has never been labeled/predicted on silently processes **zero frames**, even though the completion dialog reports success.

- `_scope_labels_to_video` called `labels.find(video=target)` which only returns pre-existing `LabeledFrame`s
- For a video with no prior labels, this returned `[]` regardless of `--frames`, so the downstream `LabelsProvider` yielded zero batches
- Uses `return_new=True` (already supported by sleap-io) so placeholder `LabeledFrame`s are created for requested frame indices that have no existing labels
- Also handles the no-`--frames` case (CLI without explicit frame range) by falling back to the full video length

## Test plan

- [x] `test_scope_labels_to_video_creates_placeholders_for_unlabeled_video` — verifies 5 placeholder frames are created for a video with zero existing labels
- [x] `test_scope_labels_to_video_preserves_existing_labels_with_frames` — verifies existing labeled frames are preserved alongside new placeholders
- [x] Existing `_scope_labels_to_video` tests still pass (suggestions, provenance, out-of-range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)