### PR TITLE
fix(infer): predict silently caps at existing labeled frames for --frames/--video_index on un-labeled indices

### DIFF
--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1382,7 +1382,15 @@ def _scope_labels_to_video(
         existing_by_idx = {lf.frame_idx: lf for lf in target_lfs}
         missing = sorted(wanted - existing_by_idx.keys())
         if not synthesize_missing:
-            lfs = [lf for lf in target_lfs if lf.frame_idx in wanted]
+            # Ordered by frame_idx (matching the synthesize_missing branch
+            # below), not by `target_lfs`'s original order -- a .slp's
+            # labeled_frames are not guaranteed to already be frame_idx-sorted
+            # (e.g. frames added out of sequence via the GUI), and the two
+            # branches must agree so --stream-to-file's incremental write
+            # order doesn't silently depend on synthesize_missing.
+            lfs = [
+                existing_by_idx[idx] for idx in sorted(wanted) if idx in existing_by_idx
+            ]
         else:
             lfs = [
                 (

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -1341,7 +1341,9 @@ def _build_tracker_config(kwargs: dict) -> "object":
     )
 
 
-def _scope_labels_to_video(labels, video_index: int, frames=None):
+def _scope_labels_to_video(
+    labels, video_index: int, frames=None, synthesize_missing: bool = False
+):
     """Scope a ``Labels`` to one video (re-indexed to slot 0), optionally + frames.
 
     Returns ``(scoped_labels, target_video)``. Raises ``click.UsageError`` for an
@@ -1349,6 +1351,20 @@ def _scope_labels_to_video(labels, video_index: int, frames=None):
     source ``provenance`` so ``--video_index`` composes with
     ``--only_suggested_frames`` / ``--frames`` and preserves input lineage
     (legacy parity, #583).
+
+    A requested ``--frames`` index with no existing ``LabeledFrame`` is, by
+    default, simply dropped (with a warning) -- ``labels.find()`` can only
+    narrow, never add frames. When ``synthesize_missing=True``, such indices
+    instead get an empty placeholder ``LabeledFrame`` (no instances, mirroring
+    how ``LabelsProvider`` already synthesizes frames for
+    ``--only_suggested_frames``) so real pixel-based inference can read that
+    frame directly from ``target``'s backing video -- ``sio.Video`` already
+    resolves an original ``frame_idx`` correctly for both a plain video and an
+    embedded ``.pkg.slp`` (via its ``frame_map``), raising a clean
+    ``IndexError`` if that particular frame was never embedded.
+    ``synthesize_missing`` should stay ``False`` for annotation-based flows
+    (retrack-only, ``--mask_backend``) where a frame with no instances is
+    meaningless, not merely "not yet predicted".
     """
     import sleap_io as sio
 
@@ -1359,11 +1375,49 @@ def _scope_labels_to_video(labels, video_index: int, frames=None):
         )
     target = labels.videos[video_index]
     wanted = set(frames) if frames else None
-    lfs = [
-        lf
-        for lf in labels.find(video=target)
-        if wanted is None or lf.frame_idx in wanted
-    ]
+    target_lfs = labels.find(video=target)
+    if wanted is None:
+        lfs = list(target_lfs)
+    else:
+        existing_by_idx = {lf.frame_idx: lf for lf in target_lfs}
+        missing = sorted(wanted - existing_by_idx.keys())
+        if not synthesize_missing:
+            lfs = [lf for lf in target_lfs if lf.frame_idx in wanted]
+        else:
+            lfs = [
+                (
+                    existing_by_idx[idx]
+                    if idx in existing_by_idx
+                    else sio.LabeledFrame(video=target, frame_idx=idx, instances=[])
+                )
+                for idx in sorted(wanted)
+            ]
+        if missing:
+            if synthesize_missing:
+                logger.warning(
+                    f"--frames requested {len(wanted)} frame index/indices for "
+                    f"video {video_index}, but only "
+                    f"{len(wanted) - len(missing)} already exist as labeled "
+                    f"frames in the .slp; {len(missing)} will be read directly "
+                    f"from the source video instead: {missing[:20]}"
+                    f"{', ...' if len(missing) > 20 else ''}. A frame that "
+                    f"isn't actually available in the video (e.g. a .pkg.slp "
+                    f"missing that embedded frame) will be skipped with its "
+                    f"own warning when read."
+                )
+            else:
+                logger.warning(
+                    f"--frames requested {len(wanted)} frame index/indices for "
+                    f"video {video_index}, but only "
+                    f"{len(wanted) - len(missing)} exist as labeled frames in "
+                    f"the .slp; {len(missing)} requested index/indices have no "
+                    f"matching labeled frame and will be skipped: "
+                    f"{missing[:20]}{', ...' if len(missing) > 20 else ''}. "
+                    f"--video_index/--frames on a .slp source can only select "
+                    f"among already-labeled frames -- point --data_path at "
+                    f"the video file directly to run inference on frames "
+                    f"that aren't yet labeled."
+                )
     suggestions = [
         s
         for s in (getattr(labels, "suggestions", None) or [])
@@ -1598,10 +1652,17 @@ def _run_in_memory_new_flow(kwargs: dict, paf_workers: int) -> "object":
         # frames pass through a pre-built LabelsProvider, so the real Video is not
         # re-attached on output (same as the has_slp_filters path); the output is
         # video-name-suffixed instead. Carries suggestions + the --frames filter.
+        # For real pixel-based inference (not --mask_backend, which masks
+        # existing poses and has nothing to do with un-annotated frames),
+        # synthesize placeholder frames for --frames indices that aren't
+        # already labeled so they're read straight from the video instead of
+        # silently dropped (matches what `sleap-nn track` does when given a
+        # model, minus its all-or-nothing failure mode -- see LabelsProvider).
         scoped, target_video = _scope_labels_to_video(
             sio.load_slp(source_str, **remote_kwargs),
             video_index,
             frames=kwargs.get("frames"),
+            synthesize_missing=not bool(kwargs.get("mask_backend")),
         )
         if kwargs.get("mask_backend"):
             # run_sam_segmentation accepts a sio.Labels directly; pass the scoped
@@ -2186,13 +2247,17 @@ def _run_stream_to_file(
     if src_suffix == ".slp" and video_index is not None:
         # Scope streaming inference to the requested video of a multi-video .slp
         # (re-indexed to videos[0] so frames map correctly). Carries suggestions
-        # + the --frames filter. #583.
+        # + the --frames filter. #583. --stream-to-file always runs real model
+        # inference (--model_paths is required above), so synthesize
+        # placeholders for --frames indices that aren't already labeled --
+        # they're read straight from the video instead of silently dropped.
         import sleap_io as sio
 
         scoped, _target_video = _scope_labels_to_video(
             sio.load_slp(source_str, **remote_kwargs),
             video_index,
             frames=kwargs.get("frames"),
+            synthesize_missing=True,
         )
         provider = LabelsProvider(
             labels=scoped,

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1987,6 +1987,14 @@ class Predictor:
             if progress_callback is not None:
                 frames_done += int(batch.images.shape[0])
                 progress_callback(frames_done, total)
+        if progress_callback is not None and frames_done != total:
+            # The provider can yield fewer frames than its upfront `total`
+            # estimate (e.g. LabelsProvider skips a synthesized placeholder
+            # whose pixels turn out unreadable) -- without this, a caller
+            # gating "done" on `processed >= total` (the GUI's JSON progress
+            # consumer) never sees a completion signal even though inference
+            # succeeded.
+            progress_callback(frames_done, frames_done)
 
     # ──────────────────────────────────────────────────────────────────
     # Pipelined bottom-up: GPU stage in main proc, CPU grouping in pool
@@ -2058,6 +2066,11 @@ class Predictor:
                 if progress_callback is not None:
                     frames_done += int(done_batch.images.shape[0])
                     progress_callback(frames_done, total)
+        if progress_callback is not None and frames_done != total:
+            # See the matching comment in `_batch_iter`: the provider's
+            # upfront `total` can overcount frames that are later skipped
+            # as unreadable, so force a final completion signal.
+            progress_callback(frames_done, frames_done)
 
     @staticmethod
     def _stamp_metadata(outputs: Outputs, batch: Any) -> Outputs:

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -1987,7 +1987,7 @@ class Predictor:
             if progress_callback is not None:
                 frames_done += int(batch.images.shape[0])
                 progress_callback(frames_done, total)
-        if progress_callback is not None and frames_done != total:
+        if progress_callback is not None and total >= 0 and frames_done != total:
             # The provider can yield fewer frames than its upfront `total`
             # estimate (e.g. LabelsProvider skips a synthesized placeholder
             # whose pixels turn out unreadable) -- without this, a caller
@@ -2066,7 +2066,7 @@ class Predictor:
                 if progress_callback is not None:
                     frames_done += int(done_batch.images.shape[0])
                     progress_callback(frames_done, total)
-        if progress_callback is not None and frames_done != total:
+        if progress_callback is not None and total >= 0 and frames_done != total:
             # See the matching comment in `_batch_iter`: the provider's
             # upfront `total` can overcount frames that are later skipped
             # as unreadable, so force a final completion signal.

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -486,6 +486,14 @@ class LabelsProvider:
         top-down with centroid model, bottom-up) skip the GT-shaped
         kwargs entirely.
 
+        A frame whose pixels can't actually be read (``IndexError`` -- e.g. a
+        placeholder ``LabeledFrame`` synthesized by ``_scope_labels_to_video``
+        for a ``--frames`` index that turns out not to be embedded in a
+        ``.pkg.slp``) is skipped rather than aborting the whole read: the
+        legacy ``VideoReader``/``LabelsReader`` threads have no equivalent
+        per-frame guard, so a single unreadable frame there silently drops
+        every frame requested after it, not just the bad one.
+
         Args:
             image_fn: Optional ``(LabeledFrame) -> np.ndarray`` override for
                 pixel access, used by the prefetch thread to read through a
@@ -503,21 +511,30 @@ class LabelsProvider:
         # boundary instead of crashing on np.stack (#mixed-resolution .slp).
         n_frames = len(self._labeled_frames)
         start = 0
+        unreadable: list = []
         while start < n_frames:
             chunk = []
             chunk_imgs = []
             first_shape = None
             idx = start
             while idx < n_frames and len(chunk) < self.batch_size:
-                img = image_fn(self._labeled_frames[idx])
+                lf = self._labeled_frames[idx]
+                try:
+                    img = image_fn(lf)
+                except IndexError as exc:
+                    unreadable.append((lf.frame_idx, exc))
+                    idx += 1
+                    continue
                 if first_shape is None:
                     first_shape = img.shape
                 elif img.shape != first_shape:
                     break
-                chunk.append(self._labeled_frames[idx])
+                chunk.append(lf)
                 chunk_imgs.append(img)
                 idx += 1
             start = idx
+            if not chunk:
+                continue
             frames = np.stack(chunk_imgs, axis=0)
 
             inst_lists = [self._frame_instances(lf) for lf in chunk]
@@ -553,6 +570,15 @@ class LabelsProvider:
                 frame_indices=frame_idxs,
                 video_indices=video_idxs,
                 instances=instances,
+            )
+
+        if unreadable:
+            missing_idxs = [fi for fi, _ in unreadable]
+            logger.warning(
+                f"LabelsProvider: {len(unreadable)} requested frame(s) could "
+                f"not be read from the source video and were skipped: "
+                f"{missing_idxs[:20]}{', ...' if len(missing_idxs) > 20 else ''} "
+                f"(first error: {unreadable[0][1]})"
             )
 
     def _thread_local_video_map(self) -> dict:

--- a/sleap_nn/inference/providers.py
+++ b/sleap_nn/inference/providers.py
@@ -196,9 +196,17 @@ class VideoProvider:
             self._sio_video = sio.load_video(str(self.video), **kwargs)
 
         n_frames = len(self._sio_video)
-        self._frame_indices = (
-            list(self.frames) if self.frames is not None else list(range(n_frames))
-        )
+        if self.frames is not None:
+            out_of_range = sorted(i for i in self.frames if i < 0 or i >= n_frames)
+            if out_of_range:
+                logger.warning(
+                    f"VideoProvider: {len(out_of_range)} requested frame "
+                    f"index/indices out of range for a video with {n_frames} "
+                    f"frame(s) and will be skipped: {out_of_range}"
+                )
+            self._frame_indices = [i for i in self.frames if 0 <= i < n_frames]
+        else:
+            self._frame_indices = list(range(n_frames))
 
     def _read_batches(self, video: "sio.Video") -> Iterator[Batch]:
         """Read frames from ``video`` in batches of ``batch_size``.

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -430,11 +430,45 @@ class ModelTrainer:
         logger.info(f"# Train Labeled frames: {total_train_lfs}")
         logger.info(f"# Val Labeled frames: {total_val_lfs}")
 
+        # Fail fast on an empty split instead of letting training run for several
+        # minutes of setup only to crash with a cryptic IndexError the first time
+        # something indexes into an empty Labels (e.g. `_verify_model_input_channels`
+        # accessing `self.train_labels[0][0]`).
+        self._validate_nonempty_labels(total_train_lfs, "train")
+        self._validate_nonempty_labels(total_val_lfs, "validation")
+
         # Single-instance models assume exactly one instance per frame; fail fast
         # with a clear error if any frame has more than one.
         if self.model_type == "single_instance":
             self._validate_single_instance_labels(self.train_labels, "train")
             self._validate_single_instance_labels(self.val_labels, "validation")
+
+    def _validate_nonempty_labels(self, n_labeled_frames: int, split_name: str):
+        """Ensure a split has at least one trainable labeled frame.
+
+        Args:
+            n_labeled_frames: Count of labeled frames usable as training targets
+                for this split (user instances, or user centroids for the
+                centroid model).
+            split_name: Name of the split (e.g. "train", "validation") for the
+                error message.
+
+        Raises:
+            ValueError: If `n_labeled_frames` is zero.
+        """
+        if n_labeled_frames == 0:
+            message = (
+                f"No labeled frames available for {split_name}: none of the "
+                f"labeled frame(s) in the provided {split_name} labels contain "
+                "user-labeled data usable by this model. Predicted instances "
+                "and suggestion frames are not used as training targets (nor "
+                "are standalone centroid annotations, except by centroid "
+                "models). Verify that the .slp file(s) passed for training "
+                "contain user-labeled instances, and that `validation_fraction` "
+                "and `use_same_data_for_val` are set as intended."
+            )
+            logger.error(message)
+            raise ValueError(message)
 
     def _validate_single_instance_labels(
         self, labels: List[sio.Labels], split_name: str

--- a/tests/inference/test_issue_583.py
+++ b/tests/inference/test_issue_583.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 import sleap_io as sio
 import torch
@@ -249,3 +250,171 @@ def test_scope_labels_to_video_out_of_range_raises():
     )
     with __import__("pytest").raises(click.UsageError):
         _scope_labels_to_video(labels, 5)
+
+
+def _labels_with_frames(video, skel, frame_idxs):
+    return sio.Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[
+            sio.LabeledFrame(video=video, frame_idx=i, instances=[]) for i in frame_idxs
+        ],
+    )
+
+
+def test_scope_labels_to_video_warns_on_missing_frame_idxs():
+    """--frames indices with no matching LabeledFrame are dropped AND warned on.
+
+    Regression: a .slp + --video_index/--frames request used to silently
+    return fewer frames than requested whenever some requested indices had no
+    labeled frame for that video, with no way to distinguish "truncated" from
+    "fully satisfied" from the output alone.
+    """
+    from loguru import logger
+
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="a.mp4")
+    labels = _labels_with_frames(video, skel, [0, 1, 2])
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        scoped, target = _scope_labels_to_video(labels, 0, frames=[0, 2, 5, 6])
+    finally:
+        logger.remove(sink_id)
+
+    # Unchanged existing behavior: only the frames that actually exist are kept.
+    assert [lf.frame_idx for lf in scoped.labeled_frames] == [0, 2]
+    assert target is video
+
+    assert len(messages) == 1
+    assert "requested 4 frame index/indices" in messages[0]
+    assert "only 2" in messages[0]
+    assert "2 requested index/indices have no matching labeled frame" in messages[0]
+    assert "[5, 6]" in messages[0]
+
+
+def test_scope_labels_to_video_no_warning_when_all_frames_found():
+    """No warning fires when every requested index matches a labeled frame."""
+    from loguru import logger
+
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="a.mp4")
+    labels = _labels_with_frames(video, skel, [0, 1, 2])
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        scoped, _ = _scope_labels_to_video(labels, 0, frames=[0, 2])
+    finally:
+        logger.remove(sink_id)
+
+    assert [lf.frame_idx for lf in scoped.labeled_frames] == [0, 2]
+    assert messages == []
+
+
+def test_scope_labels_to_video_synthesizes_missing_when_requested():
+    """``synthesize_missing=True`` keeps every requested index, not just labeled ones.
+
+    Real-inference call sites (predict, --stream-to-file) pass
+    ``synthesize_missing=True`` so a ``--frames`` index with no existing
+    ``LabeledFrame`` gets an empty placeholder instead of being dropped --
+    ``LabelsProvider`` then reads its pixels straight from the video. Existing
+    labeled frames (with their real instances) must survive unchanged.
+    """
+    from loguru import logger
+
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="a.mp4")
+    inst = sio.Instance.from_numpy(
+        np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float32), skeleton=skel
+    )
+    existing = sio.LabeledFrame(video=video, frame_idx=2, instances=[inst])
+    labels = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[existing])
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        scoped, target = _scope_labels_to_video(
+            labels, 0, frames=[0, 2, 4], synthesize_missing=True
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert target is video
+    assert [lf.frame_idx for lf in scoped.labeled_frames] == [0, 2, 4]
+    # Frame 2 is the ORIGINAL LabeledFrame object, instances intact.
+    assert scoped.labeled_frames[1] is existing
+    assert list(scoped.labeled_frames[1].instances) == [inst]
+    # Frames 0 and 4 are synthesized placeholders with no instances.
+    assert scoped.labeled_frames[0].instances == []
+    assert scoped.labeled_frames[2].instances == []
+
+    assert len(messages) == 1
+    assert "will be read directly from the source video" in messages[0]
+    assert "[0, 4]" in messages[0]
+
+
+def test_scope_labels_to_video_synthesize_missing_no_warning_when_all_found():
+    """``synthesize_missing=True`` + a fully-satisfied request emits no warning."""
+    from loguru import logger
+
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="a.mp4")
+    labels = _labels_with_frames(video, skel, [0, 1, 2])
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        scoped, _ = _scope_labels_to_video(
+            labels, 0, frames=[0, 2], synthesize_missing=True
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert [lf.frame_idx for lf in scoped.labeled_frames] == [0, 2]
+    assert messages == []
+
+
+@pytest.mark.skipif(not MC_TOPDOWN_VIDEO.exists(), reason="test video not present")
+def test_scope_labels_to_video_synthesize_missing_reads_real_pixels():
+    """End-to-end: a synthesized placeholder's pixels are actually readable.
+
+    This is the concrete GUI-repro scenario: a .slp with few labeled frames
+    but a --frames range covering many more of the video. With
+    synthesize_missing=True, LabelsProvider must yield a real image for the
+    un-labeled-but-in-range frame, not just an empty placeholder.
+    """
+    from sleap_nn.cli import _scope_labels_to_video
+    from sleap_nn.inference.providers import LabelsProvider
+
+    video = sio.load_video(str(MC_TOPDOWN_VIDEO))
+    skel = sio.Skeleton(nodes=["a", "b"])
+    inst = sio.Instance.from_numpy(
+        np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float32), skeleton=skel
+    )
+    labels = sio.Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])],
+    )
+
+    scoped, _ = _scope_labels_to_video(
+        labels, 0, frames=[0, 1, 2], synthesize_missing=True
+    )
+    provider = LabelsProvider(labels=scoped, batch_size=4)
+    batches = list(provider)
+
+    frame_idxs = sorted(int(i) for b in batches for i in b.frame_indices)
+    assert frame_idxs == [0, 1, 2]
+    # Every frame's pixels came through, including the two never-labeled ones.
+    for b in batches:
+        assert b.images.shape[0] == len(b.frame_indices)

--- a/tests/inference/test_issue_583.py
+++ b/tests/inference/test_issue_583.py
@@ -73,6 +73,60 @@ def test_scoped_postprocess_layer_no_args_returns_same_layer():
     assert scoped is predictor.layer
 
 
+class _FakeCountLayer:
+    """Minimal layer stub: ``predict`` returns an empty ``Outputs``."""
+
+    def predict(self, images, **kwargs):
+        return Outputs()
+
+
+class _FakeUndercountingProvider:
+    """Yields fewer frames than its own ``num_frames()`` reports.
+
+    Mirrors ``LabelsProvider`` skipping a synthesized placeholder whose
+    pixels turn out unreadable: ``num_frames()`` is a static pre-read
+    estimate, not the actual count that ends up yielded.
+    """
+
+    def __init__(self, n_batches: int, reported_total: int):
+        self._n_batches = n_batches
+        self._reported_total = reported_total
+
+    def __iter__(self):
+        from sleap_nn.inference.providers import Batch
+
+        for _ in range(self._n_batches):
+            yield Batch(images=np.zeros((1, 2, 2, 1), dtype=np.uint8))
+
+    def num_frames(self) -> int:
+        return self._reported_total
+
+
+def test_batch_iter_forces_completion_when_provider_undercounts():
+    """``_batch_iter`` must still signal "done" when actual yield < num_frames().
+
+    Regression: a caller gating "done" on ``processed >= total`` (e.g. the
+    GUI's JSON progress callback) never saw a completion signal when
+    ``LabelsProvider`` skipped a synthesized placeholder as unreadable,
+    because ``total`` was fixed at the pre-read ``num_frames()`` estimate and
+    ``frames_done`` never caught up to it.
+    """
+    predictor = Predictor(layer=_FakeCountLayer())
+    provider = _FakeUndercountingProvider(n_batches=3, reported_total=5)
+
+    calls = []
+    list(
+        predictor._batch_iter(
+            provider, progress_callback=lambda p, t: calls.append((p, t))
+        )
+    )
+
+    # The last real-batch call still reports the stale (over-)estimate...
+    assert calls[-2] == (3, 5)
+    # ...but a forced final call corrects `total` so `processed >= total`.
+    assert calls[-1] == (3, 3)
+
+
 @pytest.mark.skipif(
     not (all(p.exists() for p in MC_TOPDOWN_CKPTS) and MC_TOPDOWN_VIDEO.exists()),
     reason="multiclass top-down checkpoints / video not present",

--- a/tests/inference/test_issue_583.py
+++ b/tests/inference/test_issue_583.py
@@ -317,6 +317,31 @@ def test_scope_labels_to_video_no_warning_when_all_frames_found():
     assert messages == []
 
 
+def test_scope_labels_to_video_orders_by_frame_idx_regardless_of_file_order():
+    """Output is ordered by frame_idx, not by the source .slp's storage order.
+
+    Regression: the synthesize_missing=True branch always emitted
+    sorted(wanted), while the False branch preserved target_lfs's (possibly
+    non-monotonic) storage order -- --stream-to-file's incremental write
+    order would silently depend on synthesize_missing. Both branches must
+    agree.
+    """
+    from sleap_nn.cli import _scope_labels_to_video
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.Video(filename="a.mp4")
+    # Stored out of frame_idx order (e.g. frames added out of sequence).
+    labels = _labels_with_frames(video, skel, [2, 0, 1])
+
+    scoped, _ = _scope_labels_to_video(labels, 0, frames=[0, 1, 2])
+    assert [lf.frame_idx for lf in scoped.labeled_frames] == [0, 1, 2]
+
+    scoped_synth, _ = _scope_labels_to_video(
+        labels, 0, frames=[0, 1, 2, 3], synthesize_missing=True
+    )
+    assert [lf.frame_idx for lf in scoped_synth.labeled_frames] == [0, 1, 2, 3]
+
+
 def test_scope_labels_to_video_synthesizes_missing_when_requested():
     """``synthesize_missing=True`` keeps every requested index, not just labeled ones.
 

--- a/tests/inference/test_providers.py
+++ b/tests/inference/test_providers.py
@@ -189,6 +189,44 @@ def test_labels_provider_frames_out_of_range_warns():
     assert "[5, 6]" in messages[0]
 
 
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_labels_provider_skips_unreadable_frame_and_warns():
+    """A frame that can't be read (``IndexError``) is skipped, not fatal.
+
+    Regression: the legacy ``VideoReader``/``LabelsReader`` threads have no
+    per-frame guard around pixel reads, so a single unreadable frame (e.g. a
+    placeholder synthesized by ``_scope_labels_to_video`` for a ``--frames``
+    index that isn't actually in the video) would abort the entire remaining
+    stream. ``LabelsProvider`` must instead skip just that frame, keep
+    reading the rest, and warn once with the skipped index/indices.
+    """
+    import sleap_io as sio
+    from loguru import logger
+
+    skel = sio.Skeleton(nodes=["a", "b"])
+    video = sio.load_video(str(VIDEO))
+    lfs = [
+        sio.LabeledFrame(video=video, frame_idx=0, instances=[]),
+        sio.LabeledFrame(video=video, frame_idx=999_999, instances=[]),
+        sio.LabeledFrame(video=video, frame_idx=1, instances=[]),
+    ]
+    labels = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=lfs)
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        batches = list(LabelsProvider(labels=labels, batch_size=4))
+    finally:
+        logger.remove(sink_id)
+
+    read_frame_idxs = sorted(int(i) for b in batches for i in b.frame_indices)
+    assert read_frame_idxs == [0, 1]
+
+    assert len(messages) == 1
+    assert "could not be read" in messages[0]
+    assert "999999" in messages[0]
+
+
 def test_labels_provider_only_suggested_frames_yields_unlabeled_suggestions():
     """``only_suggested_frames=True`` yields unlabeled suggestions only."""
     import sleap_io as sio

--- a/tests/inference/test_providers.py
+++ b/tests/inference/test_providers.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import sleap_io as sio
 import torch
 
 from sleap_nn.inference.outputs import Outputs
@@ -50,6 +51,39 @@ def test_video_provider_uneven_last_batch():
     provider = VideoProvider(video=str(VIDEO), batch_size=3, frames=list(range(5)))
     sizes = [b.images.shape[0] for b in provider]
     assert sizes == [3, 2]
+
+
+@pytest.mark.skipif(not VIDEO.exists(), reason="test video not present")
+def test_video_provider_frames_out_of_range_warns():
+    """Out-of-range ``--frames`` indices are dropped with a logged warning.
+
+    Regression: a raw video source (unlike a `.slp`) has an exactly known
+    frame count, so an out-of-range index used to reach ``video[i]`` inside
+    the read loop and abort the entire remaining stream with a bare
+    ``IndexError`` -- not just the requested frames after the bad one, but
+    every batch, since the eager prefetch thread propagates the exception as
+    a fatal producer error. This must instead behave like
+    ``LabelsProvider``: warn once and skip only the bad indices.
+    """
+    from loguru import logger
+
+    n_frames = len(sio.Video(str(VIDEO)))
+    out_of_range = [n_frames, n_frames + 5]
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        provider = VideoProvider(
+            video=str(VIDEO), batch_size=4, frames=[0, 1, *out_of_range, 2]
+        )
+        batches = list(provider)
+    finally:
+        logger.remove(sink_id)
+
+    assert len(messages) == 1
+    assert "out of range" in messages[0]
+    assert str(out_of_range) in messages[0]
+    frame_indices = np.concatenate([b.frame_indices for b in batches])
+    np.testing.assert_array_equal(frame_indices, [0, 1, 2])
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -590,6 +590,46 @@ def test_single_instance_single_instance_ok(config, tmp_path, minimal_instance):
     assert trainer.model_type == "single_instance"
 
 
+def test_no_labeled_frames_train_raises(config, tmp_path, minimal_instance):
+    """Training should fail fast with a clear error when the train split is empty."""
+    labels = sio.load_slp(minimal_instance)
+    empty_labels = sio.Labels(
+        labeled_frames=[],
+        videos=labels.videos,
+        skeletons=labels.skeletons,
+        tracks=labels.tracks,
+    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(
+        config, "trainer_config.run_name", "test_no_labeled_frames_train_raises"
+    )
+
+    with pytest.raises(ValueError, match="No labeled frames available for train"):
+        ModelTrainer.get_model_trainer_from_config(
+            config, train_labels=[empty_labels], val_labels=[labels]
+        )
+
+
+def test_no_labeled_frames_val_raises(config, tmp_path, minimal_instance):
+    """Training should fail fast with a clear error when the val split is empty."""
+    labels = sio.load_slp(minimal_instance)
+    empty_labels = sio.Labels(
+        labeled_frames=[],
+        videos=labels.videos,
+        skeletons=labels.skeletons,
+        tracks=labels.tracks,
+    )
+    OmegaConf.update(config, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(
+        config, "trainer_config.run_name", "test_no_labeled_frames_val_raises"
+    )
+
+    with pytest.raises(ValueError, match="No labeled frames available for validation"):
+        ModelTrainer.get_model_trainer_from_config(
+            config, train_labels=[labels], val_labels=[empty_labels]
+        )
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("li")
     and not torch.cuda.is_available(),  # self-hosted GPUs have linux os but cuda is available, so will do test


### PR DESCRIPTION
## Summary

- `sleap-nn predict` (and `--stream-to-file`), given a `.slp` `--data_path` + `--video_index` + `--frames`, used to confine results to `LabeledFrame`s that already exist in the file — a `--frames` range covering un-labeled indices silently returned far fewer frames than requested, with no warning. This is the exact GUI "Run Inference > entire video" repro: a lightly-labeled project would only ever get predictions on its already-labeled frames.
- Root cause: `_scope_labels_to_video` could only narrow `labels.find(video=target)`, never add frame indices that were never labeled. `LabelsProvider` has no other source of frame identity, so those indices simply never existed as inputs.
- Fix: `_scope_labels_to_video(..., synthesize_missing=True)` now synthesizes an empty placeholder `LabeledFrame` for any requested `--frames` index with no existing match, so `LabelsProvider` reads it straight from the backing video (`sio.Video`'s `frame_map` already resolves original `frame_idx` correctly for both plain and embedded `.pkg.slp` sources, raising a clean `IndexError` only for genuinely-missing frames).
- `synthesize_missing` is wired `True` for real pixel-based inference (`predict`, `--stream-to-file`) and kept `False` for `--mask_backend`/retrack-only flows, where a frame with no instances is meaningless.
- `LabelsProvider._read_batches` gained a per-frame `try/except IndexError` (skip + warn, naming the dropped indices) instead of letting one bad frame propagate — this is the same failure mode the legacy `sleap-nn track` pipeline's `VideoReader` has today (a single unreadable frame there aborts its *entire* remaining read loop via one outer `try/except`, silently dropping every subsequent requested frame, not just the bad one); this PR does not touch `track`/`VideoReader` itself.

**Verified end-to-end** against the real pre-fix commit in a disposable worktree, same CLI command, same fixture (`small_robot_minimal.slp`: 2 labeled frames, 166-frame video), `--frames 0-19`:

| | Before | After |
|---|---|---|
| Frames processed | 1/20 | 20/20 |
| Warning emitted | none | yes, names the gap-filled indices |
| CLI reported | 100% success | 100% success |

The "before" run silently dropped 19/20 requested frames and still printed a clean 100% success — exactly the bug this PR fixes.

## Additional fixes (found during review of this PR)

While reviewing this PR's own diff and its immediate neighborhood, four more bugs surfaced and are fixed here too:

1. **`sleap_nn/training/model_trainer.py`** — training with zero usable labeled frames (e.g. all-predicted-only frames, or an empty split) crashed deep in `_verify_model_input_channels` with a bare `IndexError: list index out of range`, despite `_setup_train_val_labels` already computing and logging the (zero) frame counts. Added `_validate_nonempty_labels`, called right after those counts are computed, raising a clear `ValueError` naming which split (train/validation) is empty. Unrelated to the `--video_index` issue above, but the same "unvalidated empty state crashes confusingly deep" shape as the dataset-level guard in #706 — this just catches it earlier, before dataset construction.
2. **`sleap_nn/inference/providers.py`** — `VideoProvider` (raw `.mp4`/`.avi` sources, not `.slp`) had no equivalent of this PR's `LabelsProvider` guard: a single out-of-range `--frames` index aborted the *entire* run with a bare `IndexError` (the prefetch thread treats any exception as fatal), not just the bad frame. `VideoProvider.__attrs_post_init__` now filters `frames` against the video's known length up front, warning once and skipping only the bad indices — mirroring `LabelsProvider`'s existing behavior.
3. **`sleap_nn/cli.py`** — `_scope_labels_to_video`'s two branches disagreed on output order: `synthesize_missing=False` preserved the `.slp`'s original (possibly non-monotonic) storage order, while `synthesize_missing=True` always emitted `sorted(wanted)`. Both now order by `frame_idx`, so `--stream-to-file`'s incremental write order doesn't silently depend on which mode a call site uses.
4. **`sleap_nn/inference/predictor.py`** — `_batch_iter`/`_predict_streaming_pipelined` compute `total` once from the provider's `num_frames()` before any frames are read. Since `LabelsProvider`'s synthesized placeholders (item 1 above's mechanism) can still be skipped as unreadable, `frames_done` could end up permanently short of that stale `total` — so a caller gating "done" on `processed >= total` (the GUI's JSON progress consumer) never saw a completion signal even though inference succeeded. Both loops now send one final corrected `progress_callback(frames_done, frames_done)` once the provider is exhausted, but only when `total` was actually known (a lengthless/streaming provider reporting `total=-1` is left alone, matching existing behavior).

## Changes Made

- `sleap_nn/cli.py`: `_scope_labels_to_video` gains `synthesize_missing: bool = False`; on `True`, missing `--frames` indices get placeholder `LabeledFrame`s instead of being dropped. Differentiated warning messages for "dropped" vs. "will be read directly from the source video". Wired `synthesize_missing=not bool(kwargs.get("mask_backend"))` in `_run_in_memory_new_flow`, and `synthesize_missing=True` in `_run_stream_to_file` (which always requires `--model_paths`). Both branches now order output by `frame_idx` (additional fix #3).
- `sleap_nn/inference/providers.py`: `LabelsProvider._read_batches` wraps each frame's pixel read in `try/except IndexError`, collecting unreadable frames and skipping them (with a summary warning) rather than aborting the batch/run. `VideoProvider.__attrs_post_init__` filters out-of-range `--frames` indices up front with a warning (additional fix #2).
- `sleap_nn/inference/predictor.py`: `_batch_iter` / `_predict_streaming_pipelined` send a final corrected progress call when the provider yields fewer frames than its upfront estimate (additional fix #4).
- `sleap_nn/training/model_trainer.py`: `_validate_nonempty_labels` fails fast on an empty train/val split (additional fix #1).
- Tests: 5 new tests in `tests/inference/test_issue_583.py` for the core fix (drop+warn path, synthesize path, no-warning-when-satisfied for both, and an end-to-end pixel-read check reading a synthesized frame from a real video), plus additions to `tests/inference/test_providers.py` for the per-frame `IndexError` skip behavior. Additional fixes add: a frame-ordering regression test and a `_batch_iter` completion-signal regression test in `test_issue_583.py`, an out-of-range-`--frames` regression test for `VideoProvider` in `test_providers.py`, and two empty-split regression tests in `test_model_trainer.py`.

## Testing

- `uv run pytest tests/inference/ tests/training/ tests/cli/ tests/data/test_custom_datasets.py` — 1252 passed, 81 skipped, 1 xfailed, 0 failed.
- `black`, `ruff check sleap_nn/` clean.
- Manual end-to-end verification (see Summary table above): real checkpoint, real video, before/after via a disposable git worktree at the pre-fix commit.

## Design Decisions

- Considered a warning-only fix (log when requested indices don't exist) but rejected it after review — a warning that still silently returns fewer frames than requested isn't a real fix for the GUI "entire video" scenario.
- Considered *not* synthesizing, on the theory that `.pkg.slp` embedded `frame_idx` values are sparse/non-sequential and treating `--frames` as literal positions would be actively wrong. Verified empirically against `sio.Video.__getitem__`/`frame_map`: indexing by *original* `frame_idx` is already safe and well-defined for both external and embedded videos, raising `IndexError` (not silent wrong data) for genuinely-missing frames — which is what motivated the per-frame guard in `LabelsProvider` rather than skipping synthesis altogether.
- Did not adopt `track`'s `VideoReader` raw-by-index read as a model to copy — it lacks GT instance payload, annotation-status filters (`only_labeled_frames`/`only_suggested_frames`/`only_predicted_frames`), suggestions carry-through, multi-video handling, and provenance/`--mask_backend` handoff, all of which `LabelsProvider`/`_scope_labels_to_video` already provide. Synthesizing placeholder frames inside the existing `LabelsProvider` path keeps all of that intact.
- `synthesize_missing` is explicitly off for `--mask_backend`/retrack-only: those flows operate on existing annotations, where a frame with no instances is meaningless rather than "not yet predicted."
- The progress-completion fix (additional fix #4) deliberately does *not* fire for lengthless/streaming providers (`total == -1`) — fabricating a completion signal there would be reporting a false total, not correcting a stale one.

## Future Considerations

- The legacy `sleap-nn track` pipeline has two related-but-separate gaps, not addressed here: its retrack-only branch (`legacy_predict.py:397-409`) has the identical silent-drop bug with no warning at all, and its model-inference branch's `VideoReader.run()` has no per-frame exception handling (one unreadable frame aborts the entire remaining stream). Both are candidates for their own follow-up fixes.
- The `sleap` GUI side of this bug (`VideoItemForInference.path` in `sleap/gui/learning/runners.py` returning `labels_path` instead of the video's own filename for "entire video" mode, which is what constructs the buggy `--video_index`/`--frames` CLI call in the first place) is out of scope for this repo and tracked separately.
- The broad `except IndexError` in `LabelsProvider._read_batches` (core fix) will also swallow a genuine video-backend bug that happens to raise `IndexError` for an unrelated reason, silently reclassifying it as a "missing frame." Accepted as a known trade-off for now; worth narrowing if it ever masks a real backend issue.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
