### PR TITLE
fix(eval): OKS false-negatives GT instances with a degenerate visible-keypoint bbox

### DIFF
--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -760,12 +760,70 @@ def compute_oks(
     return oks
 
 
+# OKS's normalization scale (the bounding-box area of a GT instance's visible
+# keypoints) collapses to exactly 0 when that bbox has zero width or height -- most
+# commonly with a single visible keypoint, but also with 2+ keypoints that happen to
+# be collinear on an axis. That drives the normalization factor to ~1e-18, which turns
+# OKS into a strict bit-for-bit equality test (see scratch/2026-08-21-oks-single-
+# keypoint-fn). `match_instances` routes those GT instances through
+# `compute_distance_match_score` instead.
+_DEGENERATE_AREA_EPS = 1e-9
+
+
+def compute_distance_match_score(
+    points_gt: np.ndarray,
+    points_pr: np.ndarray,
+    pixel_threshold: float = 50.0,
+) -> np.ndarray:
+    """Compute a pixel-distance-based match score for degenerate-scale GT instances.
+
+    Used as a fallback for GT instances whose visible-keypoint bounding box has zero
+    area (see `_DEGENERATE_AREA_EPS`), where `compute_oks` degenerates into a strict
+    equality test. Mirrors the pixel-distance matching already used for centroid-only
+    models (`match_method="centroid"`), but restricted to the nodes that are visible
+    in both the ground truth and predicted instance.
+
+    Args:
+        points_gt: Ground truth instances of shape (n_gt, n_nodes, n_ed).
+        points_pr: Predicted instances of shape (n_pr, n_nodes, n_ed).
+        pixel_threshold: Distance (in pixels) at which the score reaches 0.
+
+    Returns:
+        Match scores of shape (n_gt, n_pr) in the range [0, 1], with 1.0 denoting a
+        perfect match and 0.0 denoting no jointly-visible nodes or a mean distance at
+        or beyond `pixel_threshold`. Comparable in scale to `compute_oks`'s output, so
+        the two can be combined and thresholded uniformly.
+    """
+    if points_gt.ndim == 2:
+        points_gt = np.expand_dims(points_gt, axis=0)
+    if points_pr.ndim == 2:
+        points_pr = np.expand_dims(points_pr, axis=0)
+
+    n_gt = points_gt.shape[0]
+    n_pr = points_pr.shape[0]
+    scores = np.zeros((n_gt, n_pr))
+    for i in range(n_gt):
+        for j in range(n_pr):
+            jointly_visible = ~np.isnan(points_gt[i]).any(axis=-1) & ~np.isnan(
+                points_pr[j]
+            ).any(axis=-1)
+            if not jointly_visible.any():
+                continue
+            dists = np.linalg.norm(
+                points_gt[i, jointly_visible] - points_pr[j, jointly_visible], axis=-1
+            )
+            mean_dist = float(np.mean(dists))
+            scores[i, j] = max(0.0, 1.0 - mean_dist / pixel_threshold)
+    return scores
+
+
 def match_instances(
     frame_gt: sio.LabeledFrame,
     frame_pr: sio.LabeledFrame,
     stddev: float = 0.025,
     scale: Optional[float] = None,
     threshold: float = 0,
+    degenerate_pixel_threshold: float = 50.0,
 ) -> Tuple[List[Tuple[sio.Instance, sio.PredictedInstance, float]], List[sio.Instance]]:
     """Match pairs of instances between ground truth and predictions in a frame.
 
@@ -777,6 +835,9 @@ def match_instances(
             be used.
         threshold: The minimum OKS between a candidate pair of instances to be
             considered a match.
+        degenerate_pixel_threshold: Pixel distance threshold used to score GT
+            instances whose visible-keypoint bounding box has zero area (see
+            `compute_distance_match_score`), in place of OKS.
 
     Returns:
         A tuple of (`positive_pairs`, `false_negatives`).
@@ -831,6 +892,18 @@ def match_instances(
         oks = compute_oks(points_gt, points_pr, stddev=stddev, scale=scale)
         oks = np.squeeze(oks, axis=1)
         assert oks.shape == (len(points_gt),)
+
+        # GT instances with a zero-area visible-keypoint bbox make OKS collapse into a
+        # strict equality test (see `_DEGENERATE_AREA_EPS`). Score those against this
+        # prediction by pixel distance instead.
+        degenerate = compute_instance_area(points_gt) < _DEGENERATE_AREA_EPS
+        if degenerate.any():
+            distance_scores = compute_distance_match_score(
+                points_gt[degenerate],
+                points_pr,
+                pixel_threshold=degenerate_pixel_threshold,
+            )
+            oks[degenerate] = np.squeeze(distance_scores, axis=1)
 
         oks[oks <= threshold] = np.nan
         best_match_gt_idx = np.argsort(-oks, kind="mergesort")[0]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -10,6 +10,7 @@ from sleap_nn.legacy_predict import run_inference
 from sleap_nn.evaluation import (
     compute_instance_area,
     compute_oks,
+    compute_distance_match_score,
 )
 from sleap_nn.evaluation import Evaluator, load_metrics
 from loguru import logger
@@ -220,6 +221,129 @@ def test_evaluator_two_match_one_missed_inst(minimal_instance):
         ]
     )
     assert (gt_3.instance.numpy() == points).all()
+
+
+def test_compute_distance_match_score():
+    # Single jointly-visible node, close prediction -> high score.
+    inst_gt = np.array([[np.nan, np.nan], [100.0, 100.0], [np.nan, np.nan]])
+    inst_pr_close = np.array([[np.nan, np.nan], [102.0, 101.0], [np.nan, np.nan]])
+    score = compute_distance_match_score(inst_gt, inst_pr_close)
+    np.testing.assert_allclose(score, 1 - (5**0.5) / 50.0)
+
+    # Same, but beyond the pixel threshold -> score clipped to 0.
+    inst_pr_far = np.array([[np.nan, np.nan], [160.0, 100.0], [np.nan, np.nan]])
+    score = compute_distance_match_score(inst_gt, inst_pr_far)
+    np.testing.assert_allclose(score, 0.0)
+
+    # Exact match -> score of 1.
+    score = compute_distance_match_score(inst_gt, inst_gt)
+    np.testing.assert_allclose(score, 1.0)
+
+    # No jointly-visible nodes -> score of 0 (no basis for comparison).
+    inst_pr_no_overlap = np.array([[1.0, 1.0], [np.nan, np.nan], [2.0, 2.0]])
+    score = compute_distance_match_score(inst_gt, inst_pr_no_overlap)
+    np.testing.assert_allclose(score, 0.0)
+
+
+def create_labels_single_visible_keypoint(minimal_instance, pred_offset):
+    """One GT instance with a single visible node, and a prediction offset from it."""
+    skeleton = sio.Skeleton(
+        nodes=["head", "thorax", "abdomen"],
+        edges=[("head", "thorax"), ("thorax", "abdomen")],
+    )
+    min_labels = sio.load_slp(minimal_instance)
+    video = min_labels.videos[0]
+
+    user_inst = sio.Instance.from_numpy(
+        points_data=np.array([[np.nan, np.nan], [100.0, 100.0], [np.nan, np.nan]]),
+        skeleton=skeleton,
+    )
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points_data=np.array(
+            [[np.nan, np.nan], [100.0 + pred_offset, 100.0], [np.nan, np.nan]]
+        ),
+        skeleton=skeleton,
+        point_scores=np.array([np.nan, 0.9, np.nan]),
+        score=0.9,
+    )
+
+    user_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+    user_labels = sio.Labels(
+        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf]
+    )
+
+    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
+    pred_labels = sio.Labels(
+        videos=[video], skeletons=[skeleton], labeled_frames=[pred_lf]
+    )
+
+    return user_labels, pred_labels
+
+
+def test_evaluator_single_visible_keypoint_close_prediction_matches(minimal_instance):
+    # A single visible GT keypoint with a small (non-pixel-exact) prediction error
+    # should match via the distance fallback rather than falling through to a false
+    # negative purely because OKS's bbox-area scale collapsed to zero.
+    user_labels, pred_labels = create_labels_single_visible_keypoint(
+        minimal_instance, pred_offset=2.0
+    )
+    eval = Evaluator(user_labels, pred_labels)
+
+    assert len(eval.positive_pairs) == 1
+    assert len(eval.false_negatives) == 0
+
+
+def test_evaluator_single_visible_keypoint_far_prediction_still_missed(
+    minimal_instance,
+):
+    # A prediction far enough away (beyond the distance-fallback's pixel threshold)
+    # should still be a false negative -- the fallback isn't a rubber stamp.
+    user_labels, pred_labels = create_labels_single_visible_keypoint(
+        minimal_instance, pred_offset=60.0
+    )
+    eval = Evaluator(user_labels, pred_labels)
+
+    assert len(eval.positive_pairs) == 0
+    assert len(eval.false_negatives) == 1
+
+
+def test_evaluator_collinear_keypoints_use_distance_fallback(minimal_instance):
+    # Two visible GT keypoints that happen to be collinear on an axis also degenerate
+    # to a zero-area bbox (see compute_instance_area), and should be routed through
+    # the same distance fallback as the single-keypoint case.
+    skeleton = sio.Skeleton(
+        nodes=["head", "thorax", "abdomen"],
+        edges=[("head", "thorax"), ("thorax", "abdomen")],
+    )
+    min_labels = sio.load_slp(minimal_instance)
+    video = min_labels.videos[0]
+
+    user_inst = sio.Instance.from_numpy(
+        points_data=np.array([[100.0, 100.0], [160.0, 100.0], [np.nan, np.nan]]),
+        skeleton=skeleton,
+    )
+    assert compute_instance_area(user_inst.numpy())[0] == 0.0
+
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points_data=np.array([[101.0, 101.0], [161.0, 101.0], [np.nan, np.nan]]),
+        skeleton=skeleton,
+        point_scores=np.array([0.9, 0.9, np.nan]),
+        score=0.9,
+    )
+
+    user_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+    user_labels = sio.Labels(
+        videos=[video], skeletons=[skeleton], labeled_frames=[user_lf]
+    )
+    pred_lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
+    pred_labels = sio.Labels(
+        videos=[video], skeletons=[skeleton], labeled_frames=[pred_lf]
+    )
+
+    eval = Evaluator(user_labels, pred_labels)
+
+    assert len(eval.positive_pairs) == 1
+    assert len(eval.false_negatives) == 0
 
 
 def create_labels_no_match_frame_pairs(minimal_instance):


### PR DESCRIPTION
## Summary

- GT instances whose visible keypoints form a **zero-area bounding box** (most commonly a single visible keypoint, but also 2+ keypoints collinear on an axis) make `compute_oks`'s bbox-area scale collapse to 0. That drives the OKS normalization factor to ~1e-18, turning OKS into a strict bit-for-bit equality test — the OKS is `1.0` for an exact match and `0.0` for *any* nonzero localization error, however small. Real inference output is essentially never pixel-identical to GT, so these instances fell through `match_instances` into `false_negatives` almost unconditionally, silently deflating recall/mAP/mOKS for datasets with sparse per-instance visibility.
- Added `compute_distance_match_score()`: a pixel-distance-based match score (mirrors the existing `match_method="centroid"` fallback logic) used in `match_instances` in place of OKS specifically for GT instances whose visible-keypoint bbox area is ~0.
- `compute_oks`/`compute_instance_area` themselves are **untouched** — they're a byte-for-byte port of legacy SLEAP's `sleap/nn/evals.py`, verified against `talmolab/sleap@develop`, so they stay parity-checked. The fallback is applied one layer up, in the sleap-nn-specific `match_instances` orchestration, which already diverges from legacy SLEAP's version anyway.
- This is a default behavior change for `match_method="oks"` (deliberately not opt-in) — eval numbers for GT instances that hit this degenerate case will now reflect actual localization accuracy instead of collapsing to false negatives.

## Root cause

```python
# compute_instance_area: bbox of a single visible point has zero width AND height
min_pt = np.nanmin(points, axis=-2)
max_pt = np.nanmax(points, axis=-2)
area = np.prod(max_pt - min_pt, axis=-1)   # == 0

# compute_oks: scale=0 -> normalization_factor ~1e-18 -> any nonzero distance underflows to 0
scale_factor = 2 * (scale + np.spacing(1))          # ~4.4e-16
normalization_factor = spread_factor * scale_factor  # ~1e-18
ks = np.exp(-(distance / normalization_factor))      # underflows to 0.0 for any real error
```

Empirically:
```
1 visible point, exact match     -> OKS = 1.0
1 visible point, 0.01px offset   -> OKS = 0.0
1 visible point, 5px offset      -> OKS = 0.0
5 visible points, 1px offset     -> OKS = 0.996   (contrast: normal case is fine)
```

Same collapse occurs for 2+ visible points that are exactly collinear on an axis (bbox has zero width or height even with multiple points) — verified in `test_evaluator_collinear_keypoints_use_distance_fallback`.

## Fix

`match_instances` now checks `compute_instance_area(points_gt) < 1e-9` per GT candidate. For any that are degenerate, their OKS score against the current predicted instance is replaced with a pixel-distance-based score (`compute_distance_match_score`, default 50px threshold, same default as `match_method="centroid"`) before the usual greedy best-match selection and thresholding. Non-degenerate GT instances are completely unaffected — same OKS computation as before.

## Test plan

- [x] `pytest tests/test_evaluation.py` — 28 passed (24 existing + 4 new)
- [x] `black --check` / `ruff check` clean
- [x] New unit test for `compute_distance_match_score` (close match, out-of-threshold match, exact match, no jointly-visible nodes)
- [x] New integration tests via `Evaluator`:
  - single visible keypoint + close prediction -> now a positive pair (previously a false negative)
  - single visible keypoint + far prediction (beyond the 50px fallback threshold) -> still correctly a false negative
  - two collinear visible keypoints (degenerate bbox with >1 point) -> also uses the fallback and matches
- [x] Verified `compute_oks`/`compute_instance_area` still byte-for-byte match legacy SLEAP's `sleap/nn/evals.py` (unchanged in this PR)

Investigation notes: `scratch/2026-08-21-oks-single-keypoint-fn/` (not committed, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)