### PR TITLE
fix: disk-cache fallback uses cwd; legacy config rejects inert negative brightness

### DIFF
--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -460,9 +460,10 @@ def data_mapper(legacy_config: dict) -> DataConfig:
         )
         is not None
     ):
-        intensity_args["uniform_noise_min"] = legacy_config_optimization[
-            "augmentation_config"
-        ]["uniform_noise_min_val"]
+        intensity_args["uniform_noise_min"] = max(
+            legacy_config_optimization["augmentation_config"]["uniform_noise_min_val"],
+            0.0,
+        )
 
     if (
         legacy_config_optimization.get("augmentation_config", {}).get(
@@ -521,9 +522,10 @@ def data_mapper(legacy_config: dict) -> DataConfig:
         )
         is not None
     ):
-        intensity_args["contrast_min"] = legacy_config_optimization[
-            "augmentation_config"
-        ]["contrast_min_gamma"]
+        intensity_args["contrast_min"] = max(
+            legacy_config_optimization["augmentation_config"]["contrast_min_gamma"],
+            0.0,
+        )
 
     if (
         legacy_config_optimization.get("augmentation_config", {}).get(
@@ -531,9 +533,10 @@ def data_mapper(legacy_config: dict) -> DataConfig:
         )
         is not None
     ):
-        intensity_args["contrast_max"] = legacy_config_optimization[
-            "augmentation_config"
-        ]["contrast_max_gamma"]
+        intensity_args["contrast_max"] = max(
+            legacy_config_optimization["augmentation_config"]["contrast_max_gamma"],
+            0.0,
+        )
 
     if (
         legacy_config_optimization.get("augmentation_config", {}).get("contrast", None)
@@ -550,7 +553,11 @@ def data_mapper(legacy_config: dict) -> DataConfig:
         is not None
     ):
         intensity_args["brightness_min"] = min(
-            legacy_config_optimization["augmentation_config"]["brightness_min_val"], 2.0
+            max(
+                legacy_config_optimization["augmentation_config"]["brightness_min_val"],
+                0.0,
+            ),
+            2.0,
         )
 
     if (

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -921,12 +921,16 @@ class ModelTrainer:
                 img_channels = 3
             if self.config.data_config.preprocessing.ensure_grayscale:
                 img_channels = 1
-            if (
-                self.config.model_config.backbone_config[
-                    f"{self.backbone_type}"
-                ].in_channels
-                != img_channels
-            ):
+            model_in_channels = self.config.model_config.backbone_config[
+                f"{self.backbone_type}"
+            ].in_channels
+            if model_in_channels != img_channels:
+                target_format = "grayscale" if model_in_channels == 1 else "rgb"
+                logger.warning(
+                    f"Image has {img_channels} channel(s) but model has "
+                    f"{model_in_channels} input channel(s). Images will be "
+                    f"converted to {target_format} to fit the model architecture."
+                )
                 self.config.model_config.backbone_config[
                     f"{self.backbone_type}"
                 ].in_channels = img_channels
@@ -940,12 +944,16 @@ class ModelTrainer:
         ) and self.config.model_config.backbone_config[
             f"{self.backbone_type}"
         ].pre_trained_weights is not None:
-            if (
-                self.config.model_config.backbone_config[
-                    f"{self.backbone_type}"
-                ].in_channels
-                != 3
-            ):
+            current_in_channels = self.config.model_config.backbone_config[
+                f"{self.backbone_type}"
+            ].in_channels
+            if current_in_channels != 3:
+                logger.warning(
+                    f"Image has {current_in_channels} channel(s) but the "
+                    f"pretrained {self.backbone_type} backbone requires 3 "
+                    "(ImageNet RGB) input channels. Images will be converted "
+                    "to rgb to fit the model architecture."
+                )
                 self.config.model_config.backbone_config[
                     f"{self.backbone_type}"
                 ].in_channels = 3

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -1275,7 +1275,12 @@ class ModelTrainer:
                 self.config.data_config.data_pipeline_fw = (
                     "torch_dataset_cache_img_disk"
                 )
-                base_cache_img_path = Path("./")
+                base_cache_img_path = (
+                    Path(self.config.data_config.cache_img_path)
+                    if self.config.data_config.cache_img_path is not None
+                    else Path(self.config.trainer_config.ckpt_dir)
+                    / self.config.trainer_config.run_name
+                )
                 logger.info(
                     f"Insufficient memory for in-memory caching. `jpg` files will be created for disk-caching."
                 )

--- a/tests/config/test_data_config.py
+++ b/tests/config/test_data_config.py
@@ -231,6 +231,52 @@ def test_data_mapper():
     assert config.skeletons == None
 
 
+def test_data_mapper_negative_legacy_min_values():
+    """Test that negative legacy min values are clamped instead of failing validation.
+
+    Classic SLEAP's additive/imgaug augmentation could hold negative or inert
+    placeholder values (e.g. `brightness_min_val: -10.0`) for fields that map into
+    new `IntensityConfig` fields validated `>= 0` (multiplicative factors centered
+    on 1.0). This must not raise, even when the corresponding augmentation is
+    disabled. Regression test for #684.
+    """
+    legacy_config = {
+        "data": {
+            "labels": {
+                "training_labels": "notMISSING",
+                "validation_labels": "notMISSING",
+            },
+            "preprocessing": {
+                "ensure_rgb": True,
+                "target_height": 256,
+                "target_width": 256,
+                "input_scaling": 0.5,
+            },
+        },
+        "optimization": {
+            "augmentation_config": {
+                "uniform_noise_min_val": -5.0,
+                "uniform_noise": False,
+                "contrast_min_gamma": -0.5,
+                "contrast_max_gamma": -0.2,
+                "contrast": False,
+                "brightness_min_val": -10.0,
+                "brightness_max_val": 1.2,
+                "brightness": False,
+            },
+        },
+    }
+
+    config = data_mapper(legacy_config)
+
+    intensity = config.augmentation_config.intensity
+    assert intensity.uniform_noise_min == 0.0
+    assert intensity.contrast_min == 0.0
+    assert intensity.contrast_max == 0.0
+    assert intensity.brightness_min == 0.0
+    assert intensity.brightness_max == 1.2
+
+
 def test_data_mapper_flip(caplog):
     """Test that legacy random_flip/flip_horizontal map to the new flip_p field."""
     base_legacy_config = {

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -1701,6 +1701,47 @@ def test_multi_gpu_no_cache_auto_generates_run_name(config, tmp_path, minimal_in
         assert re.match(r"\d{6}_\d{6}\.", trainer.config.trainer_config.run_name)
 
 
+def test_memory_cache_fallback_to_disk_uses_ckpt_dir(
+    config, tmp_path, minimal_instance
+):
+    """Test that the memory->disk cache fallback defaults to ckpt_dir/run_name.
+
+    When `torch_dataset_cache_img_memory` falls back to disk caching because of
+    insufficient RAM and no explicit `cache_img_path` is set, the cache dir must
+    default to `ckpt_dir/run_name` (matching the explicit
+    `torch_dataset_cache_img_disk` pipeline's default) instead of the current
+    working directory, which may not be writable.
+    """
+    from unittest.mock import patch
+
+    cfg = config.copy()
+    OmegaConf.update(cfg, "trainer_config.ckpt_dir", f"{tmp_path}")
+    OmegaConf.update(cfg, "trainer_config.run_name", "mem_fallback_run")
+    OmegaConf.update(
+        cfg, "data_config.data_pipeline_fw", "torch_dataset_cache_img_memory"
+    )
+    OmegaConf.update(cfg, "data_config.cache_img_path", None)
+    OmegaConf.update(cfg, "trainer_config.trainer_devices", 1)
+    if torch.mps.is_available():
+        cfg.trainer_config.trainer_accelerator = "cpu"
+
+    labels = sio.load_slp(minimal_instance)
+    trainer = ModelTrainer.get_model_trainer_from_config(
+        cfg, train_labels=[labels], val_labels=[labels]
+    )
+
+    with patch(
+        "sleap_nn.training.model_trainer.check_cache_memory", return_value=False
+    ):
+        trainer.train()
+
+    # Cache dir must resolve under ckpt_dir/run_name, not the current working
+    # directory (`./train_imgs`), which may be on a read-only filesystem.
+    expected_cache_path = Path(tmp_path) / "mem_fallback_run"
+    assert Path(trainer.config.data_config.cache_img_path) == expected_cache_path
+    assert trainer.config.data_config.data_pipeline_fw == "torch_dataset_cache_img_disk"
+
+
 class TestCsvLogKeysEvalMetrics:
     """`csv_log_keys` (built in `_setup_loggers_callbacks`) must include the
     `eval/val/*` columns appropriate to `model_type` whenever

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -1398,6 +1398,44 @@ def test_verify_accelerator_config_unrecognized_value_falls_back(config, caplog)
     assert "not a recognized option" in caplog.text
 
 
+def test_verify_model_input_channels_warns_on_mismatch(config, caplog):
+    """Test that an image/model channel mismatch logs a warning before auto-correcting."""
+    cfg = config.copy()
+    OmegaConf.update(cfg, "data_config.preprocessing.ensure_rgb", True)
+    OmegaConf.update(cfg, "model_config.backbone_config.unet.in_channels", 1)
+
+    trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+
+    assert "Image has 3 channel(s) but model has 1 input channel(s)" in caplog.text
+    assert (
+        "Images will be converted to grayscale to fit the model architecture"
+        in caplog.text
+    )
+    assert trainer.config.model_config.backbone_config.unet.in_channels == 3
+
+
+def test_verify_model_input_channels_warns_on_pretrained_backbone_override(
+    config, caplog
+):
+    """Test that forcing in_channels=3 for an ImageNet-pretrained convnext backbone warns."""
+    cfg = config.copy()
+    OmegaConf.update(cfg, "model_config.backbone_config.unet", None)
+    OmegaConf.update(
+        cfg,
+        "model_config.backbone_config.convnext",
+        ConvNextConfig(pre_trained_weights="ConvNeXt_Tiny_Weights"),
+    )
+
+    trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+
+    assert "Image has 1 channel(s) but the pretrained convnext backbone" in caplog.text
+    assert (
+        "Images will be converted to rgb to fit the model architecture" in caplog.text
+    )
+    assert trainer.config.model_config.backbone_config.convnext.in_channels == 3
+    assert trainer.config.data_config.preprocessing.ensure_rgb is True
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("li")
     and not torch.cuda.is_available(),  # self-hosted GPUs have linux os but cuda is available, so will do test


### PR DESCRIPTION
## Summary
- The `torch_dataset_cache_img_memory` → disk-cache fallback (triggered when RAM is insufficient) defaulted the cache dir to `Path("./")` — the process's current working directory. If cwd is read-only, dataset construction crashed with `OSError: [Errno 30] Read-only file system: 'train_imgs'`. It now defaults to `ckpt_dir/run_name`, matching the explicit `torch_dataset_cache_img_disk` pipeline's existing default (and still honors an explicit `cache_img_path` if the user set one).
- Loading a legacy SLEAP model config could crash with `ValueError: 'brightness_min' must be >= 0` when the legacy config held an inert negative `brightness_min_val` (classic SLEAP's brightness aug was additive and could hold negative/placeholder values; the new `IntensityConfig.brightness_min` is a multiplicative factor validated `>= 0`). This blocked loading real production models (e.g. sleap-roots) even when brightness augmentation was disabled.
- `_verify_model_input_channels` silently auto-corrects the model's input channels whenever the training images' channel count doesn't match the configured backbone — either updating `backbone_config.<type>.in_channels` to match the images, or (for ImageNet-pretrained `convnext`/`swint` backbones, which always require 3-channel RGB input) forcing `in_channels=3` + `ensure_rgb=True`. This happened with only an info-level log, so users could be surprised by an architecture/preprocessing change they didn't request. Now logs a `warning` naming the mismatch and whether images will be treated as grayscale or rgb.

## Changes Made
- `sleap_nn/training/model_trainer.py`: `_setup_datasets` now resolves the memory→disk fallback's `cache_img_path` the same way the explicit disk-cache path does — explicit `cache_img_path` wins if set, otherwise `ckpt_dir/run_name`.
- `sleap_nn/config/data_config.py`: `data_mapper` now clamps `brightness_min`, `contrast_min`, `contrast_max`, and `uniform_noise_min` to `>= 0` when mapping from legacy config, symmetric to the existing upper clamps (`brightness_max`, `uniform_noise_max`). Applied to all four fields since they share the same failure mode (legacy min value mapped into a `>= 0`-validated new field with no lower clamp).
- `sleap_nn/training/model_trainer.py`: `_verify_model_input_channels` now logs a `logger.warning` before auto-correcting a generic image/model channel mismatch (naming whether images will be treated as grayscale or rgb), and before forcing `in_channels=3` for an ImageNet-pretrained `convnext`/`swint` backbone.

## Testing
- `test_memory_cache_fallback_to_disk_uses_ckpt_dir`: forces the memory-cache fallback via a mocked `check_cache_memory`, runs a real `trainer.train()`, and asserts the resolved cache path is `ckpt_dir/run_name` rather than cwd.
- `test_data_mapper_negative_legacy_min_values`: regression test for #684 — feeds `data_mapper` a legacy config with negative `uniform_noise_min_val`, `contrast_min_gamma`, `contrast_max_gamma`, and `brightness_min_val` (all with the corresponding augmentation disabled) and asserts the resulting `IntensityConfig` values are clamped to `0.0` instead of raising.
- `test_verify_model_input_channels_warns_on_mismatch`: forces `ensure_rgb=True` against a 1-channel-configured `unet` backbone and asserts the mismatch warning fires before `in_channels` is auto-corrected to 3.
- `test_verify_model_input_channels_warns_on_pretrained_backbone_override`: sets an ImageNet-pretrained `convnext` backbone with default `in_channels=1` and asserts the warning fires before `in_channels` is forced to 3 and `ensure_rgb` to `True`.
- `black`, `ruff` clean on changed files.
- `pytest tests/training/test_model_trainer.py tests/config/test_data_config.py` — 63 passed.

## Related Issues
Closes #684

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
