### PR TITLE
Add plot_metrics() for evaluation metric plots

### DIFF
--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -106,6 +106,75 @@ print(metrics.keys())
 
 ---
 
+## Plotting Metrics
+
+`sleap_nn.evaluation_plots.plot_metrics` draws the saved metrics. Point it at a
+model directory and it reads the metrics `.npz`, the node names from
+`training_config.yaml`, and the loss curve from `training_log.csv`:
+
+```python
+from sleap_nn.evaluation_plots import plot_metrics
+
+plot_metrics("models/my_model", kind="dashboard", save_path="eval.png")
+```
+
+The `dashboard` default draws every panel the metrics support. Ask for a single
+one with `kind`:
+
+| `kind` | Shows |
+|---|---|
+| `error_distribution` | Histogram of localization error with p50/p90/p99 marks, clipped at p99 so one outlier does not flatten the bulk |
+| `error_by_node` | Per-node error box plot, worst node first |
+| `pck_curve` | PCK against distance threshold |
+| `pck_by_node` | Mean PCK per node |
+| `precision_recall` | Precision-recall curves at each OKS threshold |
+| `visibility` | Node-visibility confusion matrix |
+| `training_curve` | Train and validation loss per epoch |
+| `dashboard` | All of the above in one figure |
+
+Every panel is also a standalone function taking an `ax`, so they compose into
+your own figures:
+
+```python
+import matplotlib.pyplot as plt
+from sleap_nn.evaluation import load_metrics
+from sleap_nn.evaluation_plots import plot_error_by_node, load_node_names
+
+metrics = load_metrics("models/my_model", split="val")
+names = load_node_names("models/my_model")
+
+fig, ax = plt.subplots(figsize=(7, 4))
+plot_error_by_node(metrics, ax=ax, node_names=names)
+```
+
+!!! note "Keypoint plots need keypoint metrics"
+
+    Only `match_method="oks"` produces `pck_metrics` and `visibility_metrics`.
+    Centroid, mask, semantic, and bbox evaluations report a different set, and
+    asking for a plot they cannot support raises `MetricsNotAvailable` naming
+    what the file actually contains.
+
+### Finding the Worst Frames
+
+The metrics file records a video path and frame index alongside every distance,
+so the largest errors can be traced back to specific frames and looked at:
+
+```python
+from sleap_nn.evaluation_plots import worst_instances
+
+for row in worst_instances(metrics, n=5):
+    print(f"frame {row['frame_idx']}: {row['error']:.1f} px mean, "
+          f"{row['max_error']:.1f} px worst node")
+```
+
+Feed those frame indices to
+[`sleap_io.render_image`](https://io.sleap.ai/latest/rendering/) to see the
+prediction overlaid on the frame. A mean error of 1 px with a p99 of 11 px means
+the model is fine and a handful of frames are not — and this is how you find
+which ones.
+
+---
+
 ## Next Steps
 
 - [:octicons-arrow-right-24: Evaluation Metrics Reference](../reference/evaluation_metrics.md) - Deep dive into OKS, PCK, and other metrics

--- a/sleap_nn/evaluation_plots.py
+++ b/sleap_nn/evaluation_plots.py
@@ -1,0 +1,647 @@
+"""Plots for the evaluation metrics computed by :mod:`sleap_nn.evaluation`.
+
+A trained model directory already carries everything needed to judge the model:
+ground truth, predictions, a metrics ``.npz`` per split, and the training log.
+This module draws that data. Nothing here recomputes a metric -- it reads what
+:func:`sleap_nn.evaluation.run_evaluation` already saved.
+
+The entry point is :func:`plot_metrics`, which takes a model directory (or a
+metrics ``.npz`` directly) and a ``kind``::
+
+    from sleap_nn.evaluation_plots import plot_metrics
+
+    plot_metrics("models/my_model", kind="dashboard", save_path="eval.png")
+
+Individual plots take an existing axes, so they compose into your own figures::
+
+    fig, ax = plt.subplots()
+    plot_error_by_node(metrics, ax=ax, node_names=names)
+
+The companion to the plots is :func:`worst_instances`, which returns the frames
+with the largest localization error. Those carry a video path and frame index,
+so a numeric outlier can be handed straight to ``sleap_io.render_image`` and
+looked at.
+
+Note:
+    This module needs only numpy, matplotlib, and PyYAML -- no torch. It can be
+    imported and used without a GPU or a training environment.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import matplotlib
+
+matplotlib.use(
+    "Agg"
+)  # Use non-interactive backend to avoid tkinter issues on Windows CI
+import matplotlib.figure
+import matplotlib.pyplot as plt
+import numpy as np
+import yaml
+from loguru import logger
+
+from sleap_nn.evaluation import load_metrics
+
+#: Keyword for a horizontal box plot. matplotlib 3.10 deprecated the `vert`
+#: bool in favor of `orientation`; the dependency is unpinned, so pick per
+#: installed version.
+_HORIZONTAL_BOXPLOT = (
+    {"orientation": "horizontal"}
+    if tuple(int(p) for p in matplotlib.__version__.split(".")[:2]) >= (3, 10)
+    else {"vert": False}
+)
+
+#: Plot kinds accepted by :func:`plot_metrics`, mapped to the metrics group each
+#: one needs. ``"dashboard"`` and ``"training_curve"`` are handled separately.
+PLOT_KINDS = {
+    "error_distribution": "distance_metrics",
+    "error_by_node": "distance_metrics",
+    "pck_curve": "pck_metrics",
+    "pck_by_node": "pck_metrics",
+    "precision_recall": "voc_metrics",
+    "visibility": "visibility_metrics",
+}
+
+#: Panels drawn by the ``"dashboard"`` kind, in layout order.
+DASHBOARD_PANELS = (
+    "error_distribution",
+    "error_by_node",
+    "pck_curve",
+    "pck_by_node",
+    "precision_recall",
+    "visibility",
+)
+
+
+class MetricsNotAvailable(KeyError):
+    """Raised when a requested plot's metrics are absent from the file.
+
+    A metrics file only carries the groups its match method computes -- a
+    segmentation or bbox model has no ``pck_metrics``, for instance -- so asking
+    for a keypoint plot on those metrics is a usage error, not a bug.
+    """
+
+
+def load_node_names(path: Union[str, Path]) -> Optional[List[str]]:
+    """Read skeleton node names from a model directory's training config.
+
+    Args:
+        path: Path to a model directory, or directly to a ``training_config.yaml``.
+
+    Returns:
+        The node names of the first skeleton, or ``None`` if the config is
+        missing or carries no skeleton. Metrics files do not store node names,
+        so this is how per-node plots get their labels.
+    """
+    path = Path(path)
+    config_path = (
+        path if path.suffix in (".yaml", ".yml") else path / "training_config.yaml"
+    )
+    if not config_path.exists():
+        return None
+
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    skeletons = (config or {}).get("data_config", {}).get("skeletons") or []
+    if not skeletons:
+        return None
+    nodes = skeletons[0].get("nodes") or []
+    return [n["name"] for n in nodes if "name" in n] or None
+
+
+def load_training_log(path: Union[str, Path]) -> Optional[Dict[str, np.ndarray]]:
+    """Read the per-epoch training log from a model directory.
+
+    Args:
+        path: Path to a model directory, or directly to a ``training_log.csv``.
+
+    Returns:
+        A dictionary of column name to values with the epoch rows collapsed (the
+        logger writes several rows per epoch, one per logged metric), or ``None``
+        if the log is missing or empty.
+    """
+    path = Path(path)
+    log_path = path if path.suffix == ".csv" else path / "training_log.csv"
+    if not log_path.exists():
+        return None
+
+    rows = np.genfromtxt(log_path, delimiter=",", names=True, dtype=float)
+    rows = np.atleast_1d(rows)
+    if rows.size == 0 or rows.dtype.names is None:
+        return None
+    return {name: rows[name] for name in rows.dtype.names}
+
+
+def _require(metrics: Dict[str, Any], group: str, kind: str) -> Dict[str, Any]:
+    """Return a metrics group, raising a clear error when it is absent.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        group: The group key required, e.g. ``"pck_metrics"``.
+        kind: The plot kind being drawn, used in the error message.
+
+    Returns:
+        The requested metrics group.
+
+    Raises:
+        MetricsNotAvailable: If the group is not present.
+    """
+    if group not in metrics:
+        raise MetricsNotAvailable(
+            f"Plot {kind!r} needs {group!r}, which these metrics do not contain "
+            f"(available: {sorted(metrics)}). Keypoint plots are only computed "
+            f'for match_method="oks"; centroid, mask, semantic and bbox '
+            f"evaluations report a different set."
+        )
+    return metrics[group]
+
+
+def _resolve_node_names(node_names: Optional[Sequence[str]], n_nodes: int) -> List[str]:
+    """Return one label per node, falling back to indices.
+
+    Args:
+        node_names: Caller-supplied names, possibly ``None`` or the wrong length.
+        n_nodes: Number of nodes that must be labeled.
+
+    Returns:
+        A list of exactly `n_nodes` labels.
+    """
+    if node_names is not None and len(node_names) == n_nodes:
+        return list(node_names)
+    if node_names is not None:
+        logger.warning(
+            f"Ignoring {len(node_names)} node names for {n_nodes} nodes "
+            "(the metrics file and the skeleton disagree)."
+        )
+    return [str(i) for i in range(n_nodes)]
+
+
+def plot_error_distribution(
+    metrics: Dict[str, Any], ax: Optional[plt.Axes] = None
+) -> plt.Axes:
+    """Plot the distribution of localization error with its percentile marks.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        ax: Axes to draw into. A new figure is created when ``None``.
+
+    Returns:
+        The axes drawn into.
+    """
+    dm = _require(metrics, "distance_metrics", "error_distribution")
+    ax = ax or plt.subplots()[1]
+
+    dists = np.asarray(dm["dists"], dtype=float).ravel()
+    finite = dists[np.isfinite(dists)]
+    title = "Error distribution"
+    if finite.size:
+        upper = float(np.percentile(finite, 99))
+        n_beyond = int((finite > upper).sum())
+        ax.hist(
+            finite,
+            bins=50,
+            range=(0.0, max(upper, np.spacing(1))),
+            color="#4C72B0",
+            alpha=0.85,
+        )
+        for key, color in (("p50", "#55A868"), ("p90", "#DD8452"), ("p99", "#C44E52")):
+            value = dm.get(key)
+            if value is not None and np.isfinite(value) and value <= upper:
+                ax.axvline(
+                    value, color=color, linestyle="--", linewidth=1.5, label=f"{key}"
+                )
+        ax.legend(frameon=False, fontsize=8)
+        if n_beyond:
+            title += f" ({n_beyond} beyond p99, max {finite.max():.1f} px)"
+
+    ax.set_xlabel("Localization error (px)")
+    ax.set_ylabel("Keypoints")
+    ax.set_title(title)
+    return ax
+
+
+def plot_error_by_node(
+    metrics: Dict[str, Any],
+    ax: Optional[plt.Axes] = None,
+    node_names: Optional[Sequence[str]] = None,
+) -> plt.Axes:
+    """Plot per-node localization error as a box plot, worst node first.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        ax: Axes to draw into. A new figure is created when ``None``.
+        node_names: Skeleton node names. Indices are used when omitted.
+
+    Returns:
+        The axes drawn into.
+    """
+    dm = _require(metrics, "distance_metrics", "error_by_node")
+    ax = ax or plt.subplots()[1]
+
+    dists = np.asarray(dm["dists"], dtype=float)
+    if dists.ndim != 2 or dists.size == 0:
+        ax.set_title("Error by node (no data)")
+        return ax
+
+    names = _resolve_node_names(node_names, dists.shape[1])
+    per_node = [d[np.isfinite(d)] for d in dists.T]
+    means = np.array([d.mean() if d.size else np.nan for d in per_node])
+    order = np.argsort(np.nan_to_num(means, nan=-np.inf))[::-1]
+
+    ax.boxplot(
+        [per_node[i] if per_node[i].size else [np.nan] for i in order],
+        showfliers=False,
+        medianprops={"color": "#C44E52"},
+        **_HORIZONTAL_BOXPLOT,
+    )
+    ax.set_yticklabels([names[i] for i in order], fontsize=8)
+    ax.invert_yaxis()
+    ax.set_xlabel("Localization error (px)")
+    ax.set_title("Error by node")
+    return ax
+
+
+def plot_pck_curve(metrics: Dict[str, Any], ax: Optional[plt.Axes] = None) -> plt.Axes:
+    """Plot PCK against the distance threshold.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        ax: Axes to draw into. A new figure is created when ``None``.
+
+    Returns:
+        The axes drawn into.
+    """
+    pm = _require(metrics, "pck_metrics", "pck_curve")
+    ax = ax or plt.subplots()[1]
+
+    thresholds = np.asarray(pm["thresholds"], dtype=float)
+    pcks = np.asarray(pm["pcks"], dtype=float)
+    if pcks.size:
+        # (n_instances, n_nodes, n_thresholds) -> mean over instances and nodes.
+        ax.plot(thresholds, pcks.mean(axis=(0, 1)), color="#4C72B0", marker="o")
+    ax.set_ylim(0, 1)
+    ax.set_xlabel("Threshold (px)")
+    ax.set_ylabel("PCK")
+    ax.set_title("PCK vs threshold")
+    return ax
+
+
+def plot_pck_by_node(
+    metrics: Dict[str, Any],
+    ax: Optional[plt.Axes] = None,
+    node_names: Optional[Sequence[str]] = None,
+) -> plt.Axes:
+    """Plot mean PCK per node as a horizontal bar chart, worst node first.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        ax: Axes to draw into. A new figure is created when ``None``.
+        node_names: Skeleton node names. Indices are used when omitted.
+
+    Returns:
+        The axes drawn into.
+    """
+    pm = _require(metrics, "pck_metrics", "pck_by_node")
+    ax = ax or plt.subplots()[1]
+
+    parts = np.asarray(pm["mPCK_parts"], dtype=float)
+    if parts.size == 0:
+        ax.set_title("PCK by node (no data)")
+        return ax
+
+    names = _resolve_node_names(node_names, parts.size)
+    order = np.argsort(parts)
+    ax.barh([names[i] for i in order], parts[order], color="#4C72B0")
+    ax.tick_params(axis="y", labelsize=8)
+    ax.set_xlim(0, 1)
+    ax.set_xlabel("mPCK")
+    ax.set_title("PCK by node")
+    return ax
+
+
+def plot_precision_recall(
+    metrics: Dict[str, Any],
+    ax: Optional[plt.Axes] = None,
+    match_score: str = "oks",
+) -> plt.Axes:
+    """Plot precision-recall curves across match-score thresholds.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        ax: Axes to draw into. A new figure is created when ``None``.
+        match_score: Which VOC family to draw, ``"oks"`` or ``"pck"``.
+
+    Returns:
+        The axes drawn into.
+    """
+    vm = _require(metrics, "voc_metrics", "precision_recall")
+    ax = ax or plt.subplots()[1]
+
+    prefix = f"{match_score}_voc."
+    precisions = np.asarray(vm.get(f"{prefix}precisions", []), dtype=float)
+    recalls = np.asarray(vm.get(f"{prefix}recall_thresholds", []), dtype=float)
+    thresholds = np.asarray(vm.get(f"{prefix}match_score_thresholds", []), dtype=float)
+
+    if precisions.ndim == 2 and precisions.size and recalls.size:
+        colors = plt.cm.viridis(np.linspace(0, 1, precisions.shape[0]))
+        for i, row in enumerate(precisions):
+            label = f"{thresholds[i]:.2f}" if i < thresholds.size else None
+            ax.plot(recalls, row, color=colors[i], linewidth=1.2, label=label)
+        if thresholds.size:
+            ax.legend(
+                title=f"{match_score.upper()} thr",
+                fontsize=6,
+                title_fontsize=7,
+                frameon=False,
+                ncol=2,
+            )
+
+    mAP = vm.get(f"{prefix}mAP")
+    title = "Precision-recall"
+    if mAP is not None and np.isfinite(mAP):
+        title += f" (mAP={mAP:.3f})"
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.set_xlabel("Recall")
+    ax.set_ylabel("Precision")
+    ax.set_title(title)
+    return ax
+
+
+def plot_visibility(metrics: Dict[str, Any], ax: Optional[plt.Axes] = None) -> plt.Axes:
+    """Plot the node-visibility confusion matrix.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        ax: Axes to draw into. A new figure is created when ``None``.
+
+    Returns:
+        The axes drawn into.
+    """
+    vm = _require(metrics, "visibility_metrics", "visibility")
+    ax = ax or plt.subplots()[1]
+
+    matrix = np.array(
+        [
+            [float(vm.get("tp", 0)), float(vm.get("fp", 0))],
+            [float(vm.get("fn", 0)), float(vm.get("tn", 0))],
+        ]
+    )
+    ax.imshow(matrix, cmap="Blues")
+    for (i, j), value in np.ndenumerate(matrix):
+        ax.text(
+            j,
+            i,
+            f"{int(value)}",
+            ha="center",
+            va="center",
+            color="white" if value > matrix.max() / 2 else "black",
+        )
+    ax.set_xticks([0, 1], ["visible", "not visible"])
+    ax.set_yticks([0, 1], ["visible", "not visible"])
+    ax.set_xlabel("Ground truth")
+    ax.set_ylabel("Predicted")
+
+    precision, recall = vm.get("precision"), vm.get("recall")
+    title = "Node visibility"
+    if precision is not None and recall is not None:
+        title += f" (P={precision:.3f}, R={recall:.3f})"
+    ax.set_title(title)
+    return ax
+
+
+def plot_training_curve(
+    log: Dict[str, np.ndarray], ax: Optional[plt.Axes] = None
+) -> plt.Axes:
+    """Plot train and validation loss against epoch.
+
+    Args:
+        log: A training log as returned by :func:`load_training_log`.
+        ax: Axes to draw into. A new figure is created when ``None``.
+
+    Returns:
+        The axes drawn into.
+    """
+    ax = ax or plt.subplots()[1]
+
+    epochs = log.get("epoch")
+    for key, color, label in (
+        ("train_loss", "#4C72B0", "train"),
+        ("val_loss", "#DD8452", "val"),
+    ):
+        values = log.get(key)
+        if values is None:
+            continue
+        finite = np.isfinite(values)
+        if not finite.any():
+            continue
+        x = epochs[finite] if epochs is not None else np.arange(finite.sum())
+        ax.plot(x, values[finite], color=color, label=label, marker=".")
+
+    ax.set_yscale("log")
+    ax.set_xlabel("Epoch")
+    ax.set_ylabel("Loss")
+    ax.set_title("Training curve")
+    ax.legend(frameon=False, fontsize=8)
+    return ax
+
+
+def worst_instances(metrics: Dict[str, Any], n: int = 10) -> List[Dict[str, Any]]:
+    """Return the instances with the largest mean localization error.
+
+    Each entry carries the video path and frame index the metrics file recorded
+    alongside the distances, so a numeric outlier can be rendered and inspected::
+
+        for row in worst_instances(metrics, n=3):
+            sio.render_image(labels, f"{row['frame_idx']}.png", ...)
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        n: Maximum number of instances to return.
+
+    Returns:
+        Dictionaries with keys ``"frame_idx"``, ``"video_path"``, ``"error"``
+        (mean over visible nodes), and ``"max_error"``, ordered worst first.
+        Instances with no finite distances are omitted.
+
+    Raises:
+        MetricsNotAvailable: If the metrics carry no ``distance_metrics``.
+    """
+    dm = _require(metrics, "distance_metrics", "worst_instances")
+    dists = np.asarray(dm["dists"], dtype=float)
+    if dists.ndim != 2 or dists.size == 0:
+        return []
+
+    frame_idxs = list(dm.get("frame_idxs", []))
+    video_paths = list(dm.get("video_paths", []))
+
+    finite = np.isfinite(dists)
+    counts = finite.sum(axis=1)
+    means = np.divide(
+        np.where(finite, dists, 0.0).sum(axis=1),
+        counts,
+        out=np.full(dists.shape[0], np.nan),
+        where=counts > 0,
+    )
+    maxes = np.where(counts > 0, np.where(finite, dists, -np.inf).max(axis=1), np.nan)
+
+    order = np.argsort(np.nan_to_num(means, nan=-np.inf))[::-1]
+    rows = []
+    for i in order:
+        if not np.isfinite(means[i]):
+            continue
+        rows.append(
+            {
+                "frame_idx": int(frame_idxs[i]) if i < len(frame_idxs) else None,
+                "video_path": video_paths[i] if i < len(video_paths) else None,
+                "error": float(means[i]),
+                "max_error": float(maxes[i]),
+            }
+        )
+        if len(rows) >= n:
+            break
+    return rows
+
+
+def _plot_dashboard(
+    metrics: Dict[str, Any],
+    node_names: Optional[Sequence[str]],
+    log: Optional[Dict[str, np.ndarray]],
+) -> matplotlib.figure.Figure:
+    """Draw every available panel into one figure.
+
+    Args:
+        metrics: The loaded metrics dictionary.
+        node_names: Skeleton node names, or ``None``.
+        log: A training log, or ``None`` to omit that panel.
+
+    Returns:
+        The composed figure.
+
+    Raises:
+        MetricsNotAvailable: If no panel could be drawn from these metrics.
+    """
+    panels = [k for k in DASHBOARD_PANELS if PLOT_KINDS[k] in metrics]
+    if log is not None:
+        panels.append("training_curve")
+    if not panels:
+        raise MetricsNotAvailable(
+            f"No plottable metrics found (available: {sorted(metrics)})."
+        )
+
+    n_cols = 2 if len(panels) > 1 else 1
+    n_rows = int(np.ceil(len(panels) / n_cols))
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(6.5 * n_cols, 4.2 * n_rows))
+    flat = np.atleast_1d(np.asarray(axes)).ravel()
+
+    for ax, kind in zip(flat, panels):
+        if kind == "training_curve":
+            plot_training_curve(log, ax=ax)
+        else:
+            _draw(kind, metrics, ax, node_names)
+    for ax in flat[len(panels) :]:
+        ax.axis("off")
+
+    fig.tight_layout()
+    return fig
+
+
+def _draw(
+    kind: str,
+    metrics: Dict[str, Any],
+    ax: plt.Axes,
+    node_names: Optional[Sequence[str]],
+) -> None:
+    """Dispatch a single metrics plot onto an axes.
+
+    Args:
+        kind: One of the keys of :data:`PLOT_KINDS`.
+        metrics: The loaded metrics dictionary.
+        ax: Axes to draw into.
+        node_names: Skeleton node names, or ``None``.
+    """
+    if kind == "error_distribution":
+        plot_error_distribution(metrics, ax=ax)
+    elif kind == "error_by_node":
+        plot_error_by_node(metrics, ax=ax, node_names=node_names)
+    elif kind == "pck_curve":
+        plot_pck_curve(metrics, ax=ax)
+    elif kind == "pck_by_node":
+        plot_pck_by_node(metrics, ax=ax, node_names=node_names)
+    elif kind == "precision_recall":
+        plot_precision_recall(metrics, ax=ax)
+    elif kind == "visibility":
+        plot_visibility(metrics, ax=ax)
+
+
+def plot_metrics(
+    path: Union[str, Path],
+    kind: str = "dashboard",
+    split: str = "val",
+    dataset_idx: int = 0,
+    node_names: Optional[Sequence[str]] = None,
+    save_path: Optional[Union[str, Path]] = None,
+) -> matplotlib.figure.Figure:
+    """Plot the evaluation metrics of a trained model.
+
+    Args:
+        path: A model directory or a metrics ``.npz`` file. When a directory is
+            given, node names are read from its ``training_config.yaml`` and the
+            training curve from its ``training_log.csv``.
+        kind: Which plot to draw. One of the keys of :data:`PLOT_KINDS`,
+            ``"training_curve"``, or ``"dashboard"`` (the default) for every
+            panel the metrics support.
+        split: Split to load when ``path`` is a directory: ``"train"``,
+            ``"val"``, or ``"test"``. Ignored for a direct ``.npz`` path.
+        dataset_idx: Dataset index to load for multi-dataset training. Ignored
+            for a direct ``.npz`` path.
+        node_names: Skeleton node names for per-node plots. Read from the model
+            directory when omitted; falls back to node indices.
+        save_path: If given, save the figure here.
+
+    Returns:
+        The figure that was drawn.
+
+    Raises:
+        ValueError: If `kind` is not a recognized plot kind.
+        FileNotFoundError: If no metrics file is found, or if
+            ``kind="training_curve"`` and no training log is present.
+        MetricsNotAvailable: If the metrics do not contain what `kind` needs.
+
+    Example:
+        >>> plot_metrics("models/my_model", kind="dashboard", save_path="eval.png")
+    """
+    if kind not in PLOT_KINDS and kind not in ("dashboard", "training_curve"):
+        raise ValueError(
+            f"Unknown plot kind {kind!r}. Expected one of "
+            f"{sorted(set(PLOT_KINDS) | {'dashboard', 'training_curve'})}."
+        )
+
+    path = Path(path)
+    model_dir = path.parent if path.suffix == ".npz" else path
+
+    if node_names is None:
+        node_names = load_node_names(model_dir)
+    log = load_training_log(model_dir)
+
+    if kind == "training_curve":
+        if log is None:
+            raise FileNotFoundError(f"No training_log.csv found in {model_dir}.")
+        fig, ax = plt.subplots(figsize=(6.5, 4.2))
+        plot_training_curve(log, ax=ax)
+        fig.tight_layout()
+    else:
+        metrics = load_metrics(str(path), split=split, dataset_idx=dataset_idx)
+        if kind == "dashboard":
+            fig = _plot_dashboard(metrics, node_names, log)
+        else:
+            fig, ax = plt.subplots(figsize=(6.5, 4.2))
+            _draw(kind, metrics, ax, node_names)
+            fig.tight_layout()
+
+    if save_path is not None:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info(f"Saved {kind} plot to {save_path}")
+    return fig

--- a/tests/test_evaluation_plots.py
+++ b/tests/test_evaluation_plots.py
@@ -1,0 +1,514 @@
+"""Tests for `sleap_nn.evaluation_plots`."""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import yaml
+from _pytest.logging import LogCaptureFixture
+from loguru import logger
+
+from sleap_nn.evaluation_plots import (
+    DASHBOARD_PANELS,
+    MetricsNotAvailable,
+    load_node_names,
+    load_training_log,
+    plot_error_by_node,
+    plot_error_distribution,
+    plot_metrics,
+    plot_pck_by_node,
+    plot_pck_curve,
+    plot_precision_recall,
+    plot_training_curve,
+    plot_visibility,
+    worst_instances,
+)
+
+NODE_NAMES = ["head", "thorax", "abdomen"]
+
+
+@pytest.fixture
+def caplog(caplog: LogCaptureFixture):
+    """Route loguru records into pytest's `caplog`."""
+    handler_id = logger.add(
+        caplog.handler,
+        format="{message}",
+        level=0,
+        filter=lambda record: record["level"].no >= caplog.handler.level,
+        enqueue=False,
+    )
+    yield caplog
+    logger.remove(handler_id)
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    """Close every figure a test opened so the plot cache stays bounded."""
+    yield
+    plt.close("all")
+
+
+def make_metrics(n_instances: int = 8, n_nodes: int = 3) -> dict:
+    """Build a metrics dictionary shaped like `Evaluator.evaluate()` output.
+
+    Args:
+        n_instances: Number of matched instances to synthesize.
+        n_nodes: Number of skeleton nodes.
+
+    Returns:
+        A metrics dictionary with the keypoint (``match_method="oks"``) groups.
+    """
+    rng = np.random.default_rng(0)
+    dists = rng.uniform(0.5, 5.0, size=(n_instances, n_nodes))
+    thresholds = np.linspace(1, 10, 10)
+    pcks = dists[..., None] < thresholds.reshape(1, 1, -1)
+
+    return {
+        "voc_metrics": {
+            "oks_voc.match_score_thresholds": np.linspace(0.5, 0.95, 10),
+            "oks_voc.recall_thresholds": np.linspace(0, 1, 101),
+            "oks_voc.precisions": rng.uniform(0.5, 1.0, size=(10, 101)),
+            "oks_voc.recalls": rng.uniform(0.5, 1.0, size=10),
+            "oks_voc.mAP": 0.82,
+            "oks_voc.mAR": 0.79,
+        },
+        "mOKS": {"mOKS": 0.9},
+        "distance_metrics": {
+            "frame_idxs": list(range(n_instances)),
+            "video_paths": ["video.mp4"] * n_instances,
+            "dists": dists,
+            "avg": float(dists.mean()),
+            "p50": float(np.percentile(dists, 50)),
+            "p90": float(np.percentile(dists, 90)),
+            "p99": float(np.percentile(dists, 99)),
+        },
+        "pck_metrics": {
+            "thresholds": thresholds,
+            "pcks": pcks,
+            "mPCK_parts": pcks.mean(axis=0).mean(axis=-1),
+            "mPCK": float(pcks.mean()),
+        },
+        "visibility_metrics": {
+            "tp": 100,
+            "fp": 5,
+            "tn": 10,
+            "fn": 3,
+            "precision": 100 / 105,
+            "recall": 100 / 103,
+        },
+    }
+
+
+def make_model_dir(
+    tmp_path: Path,
+    metrics: dict | None = None,
+    with_config: bool = True,
+    with_log: bool = True,
+    split: str = "val",
+) -> Path:
+    """Write a minimal model directory to disk.
+
+    Args:
+        tmp_path: Directory to build inside.
+        metrics: Metrics to save, or `make_metrics()` output when `None`.
+        with_config: Whether to write a `training_config.yaml` with a skeleton.
+        with_log: Whether to write a `training_log.csv`.
+        split: Split name for the metrics file.
+
+    Returns:
+        The model directory path.
+    """
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(exist_ok=True)
+
+    np.savez(
+        model_dir / f"metrics.{split}.0.npz",
+        metrics=metrics if metrics is not None else make_metrics(),
+    )
+
+    if with_config:
+        config = {
+            "data_config": {"skeletons": [{"nodes": [{"name": n} for n in NODE_NAMES]}]}
+        }
+        with open(model_dir / "training_config.yaml", "w") as f:
+            yaml.safe_dump(config, f)
+
+    if with_log:
+        (model_dir / "training_log.csv").write_text(
+            "epoch,train_loss,val_loss\n0,,0.5\n0,0.6,0.5\n1,0.3,0.25\n"
+        )
+
+    return model_dir
+
+
+# --- Metadata loading ---------------------------------------------------------
+
+
+def test_load_node_names_from_model_dir(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    assert load_node_names(model_dir) == NODE_NAMES
+
+
+def test_load_node_names_from_yaml_path(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    assert load_node_names(model_dir / "training_config.yaml") == NODE_NAMES
+
+
+def test_load_node_names_missing_config(tmp_path):
+    model_dir = make_model_dir(tmp_path, with_config=False)
+
+    assert load_node_names(model_dir) is None
+
+
+def test_load_node_names_without_skeletons(tmp_path):
+    model_dir = make_model_dir(tmp_path, with_config=False)
+    with open(model_dir / "training_config.yaml", "w") as f:
+        yaml.safe_dump({"data_config": {}}, f)
+
+    assert load_node_names(model_dir) is None
+
+
+def test_load_node_names_empty_config(tmp_path):
+    (tmp_path / "training_config.yaml").write_text("")
+
+    assert load_node_names(tmp_path) is None
+
+
+def test_load_training_log(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    log = load_training_log(model_dir)
+
+    assert set(log) == {"epoch", "train_loss", "val_loss"}
+    assert log["epoch"].tolist() == [0.0, 0.0, 1.0]
+
+
+def test_load_training_log_missing(tmp_path):
+    model_dir = make_model_dir(tmp_path, with_log=False)
+
+    assert load_training_log(model_dir) is None
+
+
+def test_load_training_log_header_only(tmp_path):
+    model_dir = make_model_dir(tmp_path, with_log=False)
+    (model_dir / "training_log.csv").write_text("epoch,train_loss\n")
+
+    assert load_training_log(model_dir) is None
+
+
+# --- Individual plots ---------------------------------------------------------
+
+
+def test_plot_error_distribution():
+    ax = plot_error_distribution(make_metrics())
+
+    assert ax.get_xlabel() == "Localization error (px)"
+    assert ax.patches  # histogram bars
+
+
+def test_plot_error_distribution_reports_tail():
+    metrics = make_metrics(n_instances=200)
+    metrics["distance_metrics"]["dists"][0, 0] = 500.0
+
+    ax = plot_error_distribution(metrics)
+
+    assert "beyond p99" in ax.get_title()
+    assert ax.get_xlim()[1] < 500.0  # a lone outlier does not stretch the axis
+
+
+def test_plot_error_distribution_with_no_finite_distances():
+    metrics = make_metrics()
+    metrics["distance_metrics"]["dists"] = np.full((4, 3), np.nan)
+
+    ax = plot_error_distribution(metrics)
+
+    assert ax.get_title() == "Error distribution"
+
+
+def test_plot_error_by_node_orders_worst_first():
+    metrics = make_metrics()
+    # Make "abdomen" clearly the worst node.
+    metrics["distance_metrics"]["dists"][:, 2] += 100.0
+
+    ax = plot_error_by_node(metrics, node_names=NODE_NAMES)
+
+    assert [t.get_text() for t in ax.get_yticklabels()][0] == "abdomen"
+
+
+def test_plot_error_by_node_falls_back_to_indices():
+    ax = plot_error_by_node(make_metrics())
+
+    assert set(t.get_text() for t in ax.get_yticklabels()) == {"0", "1", "2"}
+
+
+def test_plot_error_by_node_warns_on_name_mismatch(caplog):
+    plot_error_by_node(make_metrics(), node_names=["only_one"])
+
+    assert "the metrics file and the skeleton disagree" in caplog.text
+
+
+def test_plot_error_by_node_with_empty_distances():
+    metrics = make_metrics()
+    metrics["distance_metrics"]["dists"] = np.zeros((0, 3))
+
+    ax = plot_error_by_node(metrics)
+
+    assert "no data" in ax.get_title()
+
+
+def test_plot_pck_curve():
+    ax = plot_pck_curve(make_metrics())
+
+    assert ax.get_ylabel() == "PCK"
+    assert len(ax.lines) == 1
+    assert ax.get_ylim() == (0, 1)
+
+
+def test_plot_pck_by_node():
+    ax = plot_pck_by_node(make_metrics(), node_names=NODE_NAMES)
+
+    assert set(t.get_text() for t in ax.get_yticklabels()) == set(NODE_NAMES)
+
+
+def test_plot_pck_by_node_with_no_parts():
+    metrics = make_metrics()
+    metrics["pck_metrics"]["mPCK_parts"] = np.array([])
+
+    ax = plot_pck_by_node(metrics)
+
+    assert "no data" in ax.get_title()
+
+
+def test_plot_precision_recall_draws_one_line_per_threshold():
+    ax = plot_precision_recall(make_metrics())
+
+    assert len(ax.lines) == 10
+    assert "mAP=0.820" in ax.get_title()
+
+
+def test_plot_precision_recall_without_curves():
+    metrics = make_metrics()
+    metrics["voc_metrics"] = {}
+
+    ax = plot_precision_recall(metrics)
+
+    assert len(ax.lines) == 0
+    assert ax.get_title() == "Precision-recall"
+
+
+def test_plot_visibility_matrix_orientation():
+    ax = plot_visibility(make_metrics())
+
+    # Rows are predictions, columns ground truth: [[tp, fp], [fn, tn]].
+    assert ax.images[0].get_array().tolist() == [[100.0, 5.0], [3.0, 10.0]]
+    assert "P=0.952" in ax.get_title()
+
+
+def test_plot_training_curve(tmp_path):
+    log = load_training_log(make_model_dir(tmp_path))
+
+    ax = plot_training_curve(log)
+
+    assert {line.get_label() for line in ax.lines} == {"train", "val"}
+    assert ax.get_yscale() == "log"
+
+
+def test_plot_training_curve_without_epoch_column():
+    log = {"train_loss": np.array([1.0, 0.5])}
+
+    ax = plot_training_curve(log)
+
+    assert len(ax.lines) == 1
+
+
+def test_plot_training_curve_skips_all_nan_series():
+    log = {
+        "epoch": np.array([0.0, 1.0]),
+        "train_loss": np.array([np.nan, np.nan]),
+        "val_loss": np.array([1.0, 0.5]),
+    }
+
+    ax = plot_training_curve(log)
+
+    assert {line.get_label() for line in ax.lines} == {"val"}
+
+
+# --- worst_instances ----------------------------------------------------------
+
+
+def test_worst_instances_orders_by_mean_error():
+    metrics = make_metrics()
+    metrics["distance_metrics"]["dists"][3] += 100.0
+
+    rows = worst_instances(metrics, n=3)
+
+    assert rows[0]["frame_idx"] == 3
+    assert rows[0]["error"] > rows[1]["error"] > rows[2]["error"]
+    assert rows[0]["video_path"] == "video.mp4"
+    assert rows[0]["max_error"] >= rows[0]["error"]
+
+
+def test_worst_instances_caps_at_n():
+    assert len(worst_instances(make_metrics(n_instances=20), n=4)) == 4
+
+
+def test_worst_instances_skips_all_nan_rows():
+    metrics = make_metrics(n_instances=3)
+    metrics["distance_metrics"]["dists"][1] = np.nan
+
+    rows = worst_instances(metrics)
+
+    assert len(rows) == 2
+    assert 1 not in [r["frame_idx"] for r in rows]
+
+
+def test_worst_instances_without_frame_metadata():
+    metrics = make_metrics(n_instances=2)
+    metrics["distance_metrics"]["frame_idxs"] = []
+    metrics["distance_metrics"]["video_paths"] = []
+
+    rows = worst_instances(metrics)
+
+    assert rows[0]["frame_idx"] is None
+    assert rows[0]["video_path"] is None
+
+
+def test_worst_instances_with_empty_distances():
+    metrics = make_metrics()
+    metrics["distance_metrics"]["dists"] = np.zeros((0, 3))
+
+    assert worst_instances(metrics) == []
+
+
+def test_worst_instances_requires_distance_metrics():
+    with pytest.raises(MetricsNotAvailable):
+        worst_instances({"mOKS": {"mOKS": 0.5}})
+
+
+# --- plot_metrics -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", sorted(DASHBOARD_PANELS))
+def test_plot_metrics_each_kind(tmp_path, kind):
+    model_dir = make_model_dir(tmp_path)
+
+    fig = plot_metrics(model_dir, kind=kind)
+
+    assert len(fig.axes) == 1
+
+
+def test_plot_metrics_dashboard_draws_every_panel(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    fig = plot_metrics(model_dir, kind="dashboard")
+
+    # Six metric panels plus the training curve, rounded up to a 2-column grid.
+    assert len(fig.axes) == 8
+    titles = [ax.get_title() for ax in fig.axes]
+    assert "Training curve" in titles
+
+
+def test_plot_metrics_dashboard_without_training_log(tmp_path):
+    model_dir = make_model_dir(tmp_path, with_log=False)
+
+    fig = plot_metrics(model_dir, kind="dashboard")
+
+    assert "Training curve" not in [ax.get_title() for ax in fig.axes]
+
+
+def test_plot_metrics_dashboard_with_partial_metrics(tmp_path):
+    metrics = {"distance_metrics": make_metrics()["distance_metrics"]}
+    model_dir = make_model_dir(tmp_path, metrics=metrics, with_log=False)
+
+    fig = plot_metrics(model_dir, kind="dashboard")
+
+    titles = [ax.get_title() for ax in fig.axes]
+    assert len(titles) == 2
+    assert titles[0].startswith("Error distribution")
+    assert titles[1] == "Error by node"
+
+
+def test_plot_metrics_dashboard_with_nothing_plottable(tmp_path):
+    model_dir = make_model_dir(
+        tmp_path, metrics={"mOKS": {"mOKS": 0.5}}, with_log=False
+    )
+
+    with pytest.raises(MetricsNotAvailable, match="No plottable metrics"):
+        plot_metrics(model_dir, kind="dashboard")
+
+
+def test_plot_metrics_uses_node_names_from_config(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    fig = plot_metrics(model_dir, kind="pck_by_node")
+
+    labels = {t.get_text() for t in fig.axes[0].get_yticklabels()}
+    assert labels == set(NODE_NAMES)
+
+
+def test_plot_metrics_explicit_node_names_win(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    fig = plot_metrics(model_dir, kind="pck_by_node", node_names=["a", "b", "c"])
+
+    assert {t.get_text() for t in fig.axes[0].get_yticklabels()} == {"a", "b", "c"}
+
+
+def test_plot_metrics_accepts_npz_path(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    fig = plot_metrics(model_dir / "metrics.val.0.npz", kind="pck_by_node")
+
+    # Node names still resolve, from the config beside the npz.
+    assert {t.get_text() for t in fig.axes[0].get_yticklabels()} == set(NODE_NAMES)
+
+
+def test_plot_metrics_training_curve_kind(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    fig = plot_metrics(model_dir, kind="training_curve")
+
+    assert fig.axes[0].get_title() == "Training curve"
+
+
+def test_plot_metrics_training_curve_without_log(tmp_path):
+    model_dir = make_model_dir(tmp_path, with_log=False)
+
+    with pytest.raises(FileNotFoundError, match="training_log.csv"):
+        plot_metrics(model_dir, kind="training_curve")
+
+
+def test_plot_metrics_saves_file(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+    save_path = tmp_path / "eval.png"
+
+    plot_metrics(model_dir, kind="pck_curve", save_path=save_path)
+
+    assert save_path.exists()
+    assert save_path.stat().st_size > 0
+
+
+def test_plot_metrics_rejects_unknown_kind(tmp_path):
+    model_dir = make_model_dir(tmp_path)
+
+    with pytest.raises(ValueError, match="Unknown plot kind"):
+        plot_metrics(model_dir, kind="nonsense")
+
+
+def test_plot_metrics_reports_missing_group(tmp_path):
+    metrics = {"distance_metrics": make_metrics()["distance_metrics"]}
+    model_dir = make_model_dir(tmp_path, metrics=metrics)
+
+    with pytest.raises(MetricsNotAvailable, match="pck_metrics"):
+        plot_metrics(model_dir, kind="pck_curve")
+
+
+def test_plot_metrics_respects_split(tmp_path):
+    model_dir = make_model_dir(tmp_path, split="train")
+
+    fig = plot_metrics(model_dir, kind="pck_curve", split="train")
+
+    assert fig.axes[0].get_title() == "PCK vs threshold"


### PR DESCRIPTION
## Summary

A trained model directory already carries everything needed to judge a model — ground truth, predictions, a metrics `.npz` per split, and the training log — but nothing drew it. `grep matplotlib sleap_nn/` hit only `training/utils.py` and `lightning_modules.py`: training-time sample overlays logged to wandb. **There were no evaluation plots at all.** The arrays have been sitting in the `.npz` unplotted.

This adds the plotting layer. Nothing here recomputes a metric — it reads what `run_evaluation` already saved.

```python
from sleap_nn.evaluation_plots import plot_metrics

plot_metrics("models/my_model", kind="dashboard", save_path="eval.png")
```

## Key Changes

- **`sleap_nn/evaluation_plots.py`** (new) — `plot_metrics()` plus per-panel functions, `worst_instances()`, `load_node_names()`, `load_training_log()`, and a `MetricsNotAvailable` error.
- **`docs/guides/evaluation.md`** — new "Plotting Metrics" and "Finding the Worst Frames" sections.
- **`tests/test_evaluation_plots.py`** — 49 tests, 100% coverage of the new module.

### Panels

| `kind` | Shows |
|---|---|
| `error_distribution` | Error histogram with p50/p90/p99 marks |
| `error_by_node` | Per-node error box plot, worst first |
| `pck_curve` | PCK vs distance threshold |
| `pck_by_node` | Mean PCK per node |
| `precision_recall` | PR curves at each OKS threshold |
| `visibility` | Node-visibility confusion matrix |
| `training_curve` | Train/val loss per epoch |
| `dashboard` | Every panel the metrics support |

Each panel is also a standalone function taking an `ax`, so it composes into a caller's own figure.

## Example Usage

```python
import matplotlib.pyplot as plt
from sleap_nn.evaluation import load_metrics
from sleap_nn.evaluation_plots import plot_error_by_node, load_node_names, worst_instances

metrics = load_metrics("models/my_model", split="val")
names = load_node_names("models/my_model")

fig, ax = plt.subplots(figsize=(7, 4))
plot_error_by_node(metrics, ax=ax, node_names=names)

for row in worst_instances(metrics, n=5):
    print(f"frame {row['frame_idx']}: {row['error']:.1f} px mean")
```

Verified against a real checkpoint (`td_fast.centered_instance.n=1800`, 400 val instances, 13 nodes):

```
mOKS=0.931  mPCK=0.902   err px: avg=1.22 p50=0.75 p90=1.84 p99=11.16
worst: frame 245700 (25.03 px) | 675 (12.96) | 267300 (9.42)
```

## API Changes

Additive only — a new module. No existing behavior changes.

## Testing

49 tests, 100% statement coverage of `evaluation_plots.py`, driven by synthetic metrics dicts and temp model directories (no training required, so the suite stays fast). Also exercised end-to-end against a real trained checkpoint.

## Design Decisions

- **A separate module, not an addition to `evaluation.py`.** That file is already ~3000 lines, and plotting is a different concern from computing.

- **No torch.** The module needs only numpy, matplotlib and PyYAML, matching the existing torch-free import path of `sleap_nn.evaluation` (the package exports `load_metrics` eagerly and `Predictor` lazily). Metrics can be plotted without a training environment or a GPU.

- **Node names come from `training_config.yaml`.** The metrics `.npz` does not store them — only `mPCK_parts` and `dists`, both bare arrays. Reading the config is a plain YAML load; node indices are the fallback, and a length mismatch warns rather than silently mislabeling.

- **`worst_instances()` returns frame addresses, not just numbers.** `distance_metrics` records `frame_idxs` and `video_paths` beside `dists`, so the largest error can be traced to a specific frame and rendered with `sleap_io.render_image`. On the checkpoint above, avg error is 1.2 px and p99 is 11 px — the mean is fine and the tail is not, and this is how you find which frames make up the tail.

- **The error histogram clips at p99**, reporting the tail count in the title. A single 90 px outlier otherwise stretched the axis until the entire distribution was one bar.

- **Missing metric groups raise `MetricsNotAvailable` naming what the file does contain.** Only `match_method="oks"` produces `pck_metrics` / `visibility_metrics`; centroid, mask, semantic and bbox evaluations report a different set. Asking for a keypoint plot on those is a usage error and should say so, and `dashboard` simply draws whichever panels are supported.

- **matplotlib's `vert` → `orientation` rename is handled by version check**, since the dependency is unpinned in `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)