### PR TITLE
feat(centroid): expose sleap-io's centroid methods, and derive centroids from masks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,10 @@ wandb/
 # macOS
 .DS_Store
 
-# Development scratch folder
+# Development scratch folder -- as a directory OR a symlink to one. The
+# trailing-slash form matches directories only, so a `scratch` symlink slipped
+# past it and got committed (a broken absolute path for everyone else).
+scratch
 scratch/
 
 # Trained models

--- a/docs/guides/centroid-only-inference.md
+++ b/docs/guides/centroid-only-inference.md
@@ -165,23 +165,77 @@ The exported runtime reads the full training skeleton from
 bit-for-bit identical to the checkpoint path. See the
 [Export guide](export.md#standalone-centroid) for details.
 
-## Anchor-node convention (#586)
+## Choosing what "centroid" means (#586)
 
 The centroid's *meaning* is defined by
 [`generate_centroids`](../reference/sleap_nn/data/instance_centroids.md) — the
-same function used for training-target generation and GT-centroid evaluation:
+same function used for training-target generation, top-down crop centers and
+GT-centroid evaluation, so all three can never disagree. Four methods are
+available, spelled exactly as in `sio.Instance.to_centroid`:
 
-1. **`anchor_part`** in `training_config.yaml` (the centroid head config): the
-   centroid is that node when visible.
-2. **`anchor_part` unset** (recommended for a 1-node skeleton, where the sole
-   node *is* the centroid): the centroid is the **NaN-ignoring mean of all
-   visible nodes** in each instance.
+| `centroid_method` | centroid is | good for |
+|---|---|---|
+| `center_of_mass` *(default)* | mean of the visible nodes | most datasets |
+| `bbox_center` | midpoint of the visible nodes' bounding box | the pre-v0.3 convention |
+| `geometric_median` | Weiszfeld median of the visible nodes | elongated / curled animals, or skeletons with a long tail node that drags the mean off the body |
+| `anchor` | the `anchor_part` node, falling back to `centroid_fallback` when it is occluded | a reliable, consistently-visible landmark |
 
-This is project-wide convention as of v0.3 — earlier versions used the
-**bounding-box midpoint**, which differs on asymmetric instances (long tails,
-sprawled limbs). If you trained a centroid model on the old bbox-midpoint
-convention with `anchor_part` unset, the GT centroid targets for partial
-instances shift slightly; re-training is recommended.
+Set it on the head config:
+
+```yaml
+model_config:
+  head_configs:
+    centroid:
+      confmaps:
+        centroid_method: geometric_median   # or center_of_mass / bbox_center
+        anchor_part: null
+```
+
+and for an anchor with a non-default fallback:
+
+```yaml
+        anchor_part: thorax
+        centroid_fallback: bbox_center      # used only when `thorax` is occluded
+```
+
+**Defaults are unchanged.** `centroid_method: null` (the default) means "the
+anchor node when `anchor_part` is set, else `center_of_mass`" — exactly the
+behavior of every config written before this knob existed. Setting `anchor_part`
+*and* a non-anchor `centroid_method` is rejected at setup: they name two
+different centroids, and `centroid_fallback` is what you want instead.
+
+**Match it at inference and evaluation.** The knob rides the checkpoint, so
+`sleap-nn predict` reproduces the training geometry automatically, and the
+recorded `sio.Centroid.source` tag names the method used. When evaluating a
+prediction file against ground truth by hand, pass the same method — otherwise
+the distance metric scores the model against a different definition of centroid
+than the one it was trained on:
+
+```bash
+sleap-nn eval --match_method centroid --centroid_method geometric_median ...
+```
+
+`center_of_mass` became the project-wide default in v0.3 — earlier versions used
+the bounding-box midpoint, which differs on asymmetric instances (long tails,
+sprawled limbs). A model trained on the old convention is now expressible
+directly as `centroid_method: bbox_center`, so it no longer needs re-training to
+be described accurately.
+
+### Training a centroid model on mask-only labels
+
+Labels that carry segmentation masks but no poses have nothing for the centroid
+target to be derived from. `data_config.centroids_from_masks` names a method and
+derives a `UserCentroid` per mask at load time (via
+`sio.SegmentationMask.to_centroid`), after which the ordinary
+`centroid_source: user` path takes over unchanged:
+
+```yaml
+data_config:
+  centroids_from_masks: center_of_mass   # or bbox_center / geometric_median
+```
+
+Frames that already carry user centroids are left alone — a real annotation
+always outranks a derived one. `anchor` does not apply here: a mask has no nodes.
 
 ## Interaction with filtering, tracking, and metrics
 

--- a/docs/guides/centroid-only-inference.md
+++ b/docs/guides/centroid-only-inference.md
@@ -177,7 +177,7 @@ available, spelled exactly as in `sio.Instance.to_centroid`:
 |---|---|---|
 | `center_of_mass` *(default)* | mean of the visible nodes | most datasets |
 | `bbox_center` | midpoint of the visible nodes' bounding box | the pre-v0.3 convention |
-| `geometric_median` | Weiszfeld median of the visible nodes | elongated / curled animals, or skeletons with a long tail node that drags the mean off the body |
+| `geometric_median` | Weiszfeld median of the visible nodes | skeletons where a node is sometimes badly localized — measured on flies13 and gerbil pose, one node off by a body length moves this centroid ~1.7× less than `center_of_mass` and ~5× less than `bbox_center`. It is *not* more stable than the mean when a node goes **missing**, which is a different perturbation. |
 | `anchor` | the `anchor_part` node, falling back to `centroid_fallback` when it is occluded | a reliable, consistently-visible landmark |
 
 Set it on the head config:

--- a/docs/guides/config-generator.md
+++ b/docs/guides/config-generator.md
@@ -146,6 +146,7 @@ config = (
 | `.early_stopping(enabled, patience)` | Configure early stopping |
 | `.crop_size(size)` | Set crop size (centered_instance) |
 | `.anchor_part(name)` | Set anchor part (top-down) |
+| `.centroid_method(method, fallback=None)` | How the centroid / crop center is derived: `center_of_mass`, `bbox_center`, `geometric_median`, `anchor` (#586) |
 
 ### Get Recommendations
 

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -24,6 +24,8 @@ sleap-nn eval \
 | `--oks_scale` | Scale factor for OKS calculation | None |
 | `--match_method` | Instance matcher: `oks`, `centroid`, `mask`, or `auto` (centroid when the prediction skeleton is single-node) | `auto` |
 | `--anchor_part` | GT node for centroid-mode ground-truth centroids (defaults to mean of visible nodes) | None |
+| `--centroid_method` | How centroid-mode GT centroids are derived: `center_of_mass`, `bbox_center`, `geometric_median`, `anchor`. Pass the value the model was **trained** with (`head_configs.centroid.confmaps.centroid_method`) so the metric compares like with like | infer from `--anchor_part` |
+| `--centroid_fallback` | Reduce method used when the `--anchor_part` node is not visible | `center_of_mass` |
 | `--user_labels_only` / `--no-user_labels_only` | Only evaluate user-labeled frames | `True` |
 
 ---

--- a/scratch
+++ b/scratch
@@ -1,1 +1,0 @@
-/home/talmo/code/sleap-nn/scratch

--- a/scratch
+++ b/scratch
@@ -1,0 +1,1 @@
+/home/talmo/code/sleap-nn/scratch

--- a/sleap_nn/architectures/heads.py
+++ b/sleap_nn/architectures/heads.py
@@ -142,6 +142,14 @@ class CentroidConfmapsHead(Head):
             the head can be built from the confmaps config, which co-locates it
             with ``anchor_part``. See ``CentroidConfMapsConfig`` and
             ``resolve_centroid_source``.
+        centroid_method: How the centroid is derived from the instance's points --
+            ``"center_of_mass"``, ``"bbox_center"``, ``"geometric_median"`` or
+            ``"anchor"``; ``None`` infers it from ``anchor_part``. Data-pipeline
+            metadata only (does not affect the head tensor); stored here so it
+            rides the checkpoint and inference can reproduce the training
+            geometry. See ``sleap_nn.data.instance_centroids``.
+        centroid_fallback: Reduce method used when ``anchor_part`` is not visible.
+            Passthrough metadata, as ``centroid_method``.
         sigma: Spread of the confidence maps.
         output_stride: Stride of the output head tensor. The input tensor is expected to
             be at the same stride.
@@ -166,6 +174,8 @@ class CentroidConfmapsHead(Head):
         self,
         anchor_part: Optional[Text] = None,
         centroid_source: Optional[Text] = None,
+        centroid_method: Optional[Text] = None,
+        centroid_fallback: Optional[Text] = None,
         sigma: float = 5.0,
         output_stride: int = 1,
         loss_weight: float = 1.0,
@@ -180,6 +190,8 @@ class CentroidConfmapsHead(Head):
         # Data-pipeline metadata only (does not affect the head tensor); kept so
         # the head is constructible from ``**head_config.confmaps``.
         self.centroid_source = centroid_source
+        self.centroid_method = centroid_method
+        self.centroid_fallback = centroid_fallback
         self.sigma = sigma
         self.use_sigmoid_activation = use_sigmoid_activation
         # Training-loss metadata only (consumed by `CentroidLightningModule`, not
@@ -212,6 +224,8 @@ class CentroidConfmapsHead(Head):
         return cls(
             anchor_part=config.anchor_part,
             centroid_source=config.get("centroid_source", None),
+            centroid_method=config.get("centroid_method", None),
+            centroid_fallback=config.get("centroid_fallback", None),
             sigma=config.sigma,
             output_stride=config.output_stride,
             loss_weight=config.loss_weight,
@@ -229,6 +243,14 @@ class CenteredInstanceConfmapsHead(Head):
         part_names: List of strings specifying the part names associated with channels.
         anchor_part: Name of the part to use as an anchor node. If not specified, the
             bounding box centroid will be used.
+        centroid_method: How the centroid is derived from the instance's points --
+            ``"center_of_mass"``, ``"bbox_center"``, ``"geometric_median"`` or
+            ``"anchor"``; ``None`` infers it from ``anchor_part``. Data-pipeline
+            metadata only (does not affect the head tensor); stored here so it
+            rides the checkpoint and inference can reproduce the training
+            geometry. See ``sleap_nn.data.instance_centroids``.
+        centroid_fallback: Reduce method used when ``anchor_part`` is not visible.
+            Passthrough metadata, as ``centroid_method``.
         sigma: Spread of the confidence maps.
         output_stride: Stride of the output head tensor. The input tensor is expected to
             be at the same stride.
@@ -239,6 +261,8 @@ class CenteredInstanceConfmapsHead(Head):
         self,
         part_names: List[Text],
         anchor_part: Optional[Text] = None,
+        centroid_method: Optional[Text] = None,
+        centroid_fallback: Optional[Text] = None,
         sigma: float = 5.0,
         output_stride: int = 1,
         loss_weight: float = 1.0,
@@ -247,6 +271,10 @@ class CenteredInstanceConfmapsHead(Head):
         super().__init__(output_stride, loss_weight)
         self.part_names = part_names
         self.anchor_part = anchor_part
+        # Data-pipeline metadata only (does not affect the head tensor); see
+        # `CentroidConfmapsHead` and `sleap_nn.data.instance_centroids`.
+        self.centroid_method = centroid_method
+        self.centroid_fallback = centroid_fallback
         self.sigma = sigma
 
     @property
@@ -282,6 +310,8 @@ class CenteredInstanceConfmapsHead(Head):
         return cls(
             part_names=part_names,
             anchor_part=config.anchor_part,
+            centroid_method=config.get("centroid_method", None),
+            centroid_fallback=config.get("centroid_fallback", None),
             sigma=config.sigma,
             output_stride=config.output_stride,
             loss_weight=config.loss_weight,

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -2986,6 +2986,27 @@ def infer(**kwargs):
         "mode. Defaults to the mean of visible nodes when absent (#586)."
     ),
 )
+@click.option(
+    "--centroid_method",
+    type=click.Choice(["center_of_mass", "bbox_center", "geometric_median", "anchor"]),
+    default=None,
+    help=(
+        "How ground-truth centroids are derived in centroid mode. Defaults to "
+        "the anchor node when --anchor_part is given, else the mean of visible "
+        "nodes. Pass the value the model was TRAINED with (its "
+        "head_configs.centroid.confmaps.centroid_method) so the metric compares "
+        "like with like (#586)."
+    ),
+)
+@click.option(
+    "--centroid_fallback",
+    type=click.Choice(["center_of_mass", "bbox_center", "geometric_median"]),
+    default=None,
+    help=(
+        "Reduce method used when the --anchor_part node is not visible. "
+        "Default: center_of_mass."
+    ),
+)
 def eval(**kwargs):
     """Run evaluation workflow."""
     from sleap_nn.evaluation import run_evaluation

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -340,8 +340,11 @@ class DataConfig:
         centroids_from_masks: (str) Derive `UserCentroid` annotations from the labels'
             segmentation masks at load time, so a MASK-ONLY dataset (no pose
             annotations at all) can train a centroid model. The value names the
-            derivation method — `center_of_mass`, `bbox_center` or
-            `geometric_median` — and `None` (default) disables it. Frames that
+            derivation method — `center_of_mass` or `bbox_center`, the two
+            `sio.SegmentationMask.to_centroid` offers — and `None` (default)
+            disables it. (`geometric_median` is defined over a point set and does
+            not apply to masks; it is available for pose-derived centroids via
+            `centroid_method`.) Frames that
             already carry user centroids are left alone. Once derived, the ordinary
             `centroid_source="user"` path takes over unchanged; nothing downstream
             knows the centroids came from masks. *Default*: `None`.

--- a/sleap_nn/config/data_config.py
+++ b/sleap_nn/config/data_config.py
@@ -337,6 +337,14 @@ class DataConfig:
             Values < 1 down-weight negatives; values > 1 up-weight them. Only has effect when
             ``use_negative_frames`` is ``True``. *Default*: `1.0`.
         skeletons: skeleton configuration for the `.slp` file. This will be pulled from the train dataset and saved to the `training_config.yaml`
+        centroids_from_masks: (str) Derive `UserCentroid` annotations from the labels'
+            segmentation masks at load time, so a MASK-ONLY dataset (no pose
+            annotations at all) can train a centroid model. The value names the
+            derivation method — `center_of_mass`, `bbox_center` or
+            `geometric_median` — and `None` (default) disables it. Frames that
+            already carry user centroids are left alone. Once derived, the ordinary
+            `centroid_source="user"` path takes over unchanged; nothing downstream
+            knows the centroids came from masks. *Default*: `None`.
     """
 
     train_labels_path: Optional[List[str]] = None
@@ -362,6 +370,7 @@ class DataConfig:
     use_negative_frames: bool = False
     negative_loss_weight: float = field(default=1.0, validator=validators.gt(0))
     skeletons: Optional[list] = None
+    centroids_from_masks: Optional[str] = None
 
 
 def data_mapper(legacy_config: dict) -> DataConfig:

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -698,8 +698,10 @@ class CentroidConfMapsConfig:
             points, spelled as in ``sio.Instance.to_centroid``:
             ``"center_of_mass"`` (mean of visible nodes), ``"bbox_center"``
             (midpoint of the visible nodes' bounding box), ``"geometric_median"``
-            (Weiszfeld median — robust to a few outlying nodes, so it tracks the
-            body center better for elongated or curled animals), or ``"anchor"``
+            (Weiszfeld median — the least affected by a MISLOCALIZED node; measured
+            on real pose data, one node off by a body length moves it ~1.7x less
+            than the mean and ~5x less than the bbox midpoint. Not more stable
+            than the mean under node dropout), or ``"anchor"``
             (the ``anchor_part`` node). ``None`` (default) infers it: ``"anchor"``
             when ``anchor_part`` is set, else ``"center_of_mass"`` — i.e. exactly
             the historical behavior, so existing configs are unchanged. Setting
@@ -796,8 +798,10 @@ class CenteredInstanceConfMapsConfig:
             points, spelled as in ``sio.Instance.to_centroid``:
             ``"center_of_mass"`` (mean of visible nodes), ``"bbox_center"``
             (midpoint of the visible nodes' bounding box), ``"geometric_median"``
-            (Weiszfeld median — robust to a few outlying nodes, so it tracks the
-            body center better for elongated or curled animals), or ``"anchor"``
+            (Weiszfeld median — the least affected by a MISLOCALIZED node; measured
+            on real pose data, one node off by a body length moves it ~1.7x less
+            than the mean and ~5x less than the bbox midpoint. Not more stable
+            than the mean under node dropout), or ``"anchor"``
             (the ``anchor_part`` node). ``None`` (default) infers it: ``"anchor"``
             when ``anchor_part`` is set, else ``"center_of_mass"`` — i.e. exactly
             the historical behavior, so existing configs are unchanged. Setting
@@ -1120,8 +1124,10 @@ class CenteredInstanceSegmentationHeadConfig:
             points, spelled as in ``sio.Instance.to_centroid``:
             ``"center_of_mass"`` (mean of visible nodes), ``"bbox_center"``
             (midpoint of the visible nodes' bounding box), ``"geometric_median"``
-            (Weiszfeld median — robust to a few outlying nodes, so it tracks the
-            body center better for elongated or curled animals), or ``"anchor"``
+            (Weiszfeld median — the least affected by a MISLOCALIZED node; measured
+            on real pose data, one node off by a body length moves it ~1.7x less
+            than the mean and ~5x less than the bbox midpoint. Not more stable
+            than the mean under node dropout), or ``"anchor"``
             (the ``anchor_part`` node). ``None`` (default) infers it: ``"anchor"``
             when ``anchor_part`` is set, else ``"center_of_mass"`` — i.e. exactly
             the historical behavior, so existing configs are unchanged. Setting

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -694,6 +694,24 @@ class CentroidConfMapsConfig:
             reliable anchor point can significantly improve topdown model
             accuracy as they benefit from a consistent geometry of the body parts
             relative to the center of the image. Default is None.
+        centroid_method: (str) How the centroid is derived from the instance's
+            points, spelled as in ``sio.Instance.to_centroid``:
+            ``"center_of_mass"`` (mean of visible nodes), ``"bbox_center"``
+            (midpoint of the visible nodes' bounding box), ``"geometric_median"``
+            (Weiszfeld median — robust to a few outlying nodes, so it tracks the
+            body center better for elongated or curled animals), or ``"anchor"``
+            (the ``anchor_part`` node). ``None`` (default) infers it: ``"anchor"``
+            when ``anchor_part`` is set, else ``"center_of_mass"`` — i.e. exactly
+            the historical behavior, so existing configs are unchanged. Setting
+            both ``anchor_part`` and a non-anchor ``centroid_method`` is an error
+            (they name different centroids); use ``centroid_fallback`` for that.
+            Default is None.
+        centroid_fallback: (str) The reduce method used when ``anchor_part`` is
+            configured but that node is not visible: ``"center_of_mass"``
+            (default), ``"bbox_center"`` or ``"geometric_median"``. Only
+            meaningful for the anchor method. Unlike ``sio``'s ``fallback=None``,
+            sleap-nn always falls back rather than emitting a NaN centroid.
+            Default is None (= ``"center_of_mass"``).
         centroid_source: (str) Which centroid the model is trained to predict.
             The centroid head must use ONE source for the whole dataset —
             mixing user-annotated and computed centroids trains the head against
@@ -746,6 +764,8 @@ class CentroidConfMapsConfig:
     """
 
     anchor_part: Optional[str] = None
+    centroid_method: Optional[str] = None
+    centroid_fallback: Optional[str] = None
     centroid_source: Optional[str] = None
     sigma: float = 5.0
     output_stride: int = 1
@@ -772,6 +792,24 @@ class CenteredInstanceConfMapsConfig:
             reliable anchor point can significantly improve topdown model
             accuracy as they benefit from a consistent geometry of the body parts
             relative to the center of the image. Default is None.
+        centroid_method: (str) How the crop center is derived from the instance's
+            points, spelled as in ``sio.Instance.to_centroid``:
+            ``"center_of_mass"`` (mean of visible nodes), ``"bbox_center"``
+            (midpoint of the visible nodes' bounding box), ``"geometric_median"``
+            (Weiszfeld median — robust to a few outlying nodes, so it tracks the
+            body center better for elongated or curled animals), or ``"anchor"``
+            (the ``anchor_part`` node). ``None`` (default) infers it: ``"anchor"``
+            when ``anchor_part`` is set, else ``"center_of_mass"`` — i.e. exactly
+            the historical behavior, so existing configs are unchanged. Setting
+            both ``anchor_part`` and a non-anchor ``centroid_method`` is an error
+            (they name different centroids); use ``centroid_fallback`` for that.
+            Default is None.
+        centroid_fallback: (str) The reduce method used when ``anchor_part`` is
+            configured but that node is not visible: ``"center_of_mass"``
+            (default), ``"bbox_center"`` or ``"geometric_median"``. Only
+            meaningful for the anchor method. Unlike ``sio``'s ``fallback=None``,
+            sleap-nn always falls back rather than emitting a NaN centroid.
+            Default is None (= ``"center_of_mass"``).
         sigma: (float) Spread of the Gaussian distribution of the confidence maps as a
             scalar float. Smaller values are more precise but may be difficult to learn
             as they have a lower density within the image space. Larger values are
@@ -790,6 +828,8 @@ class CenteredInstanceConfMapsConfig:
 
     part_names: Optional[List[str]] = None
     anchor_part: Optional[str] = None
+    centroid_method: Optional[str] = None
+    centroid_fallback: Optional[str] = None
     sigma: float = 5.0
     output_stride: int = 1
     loss_weight: float = 1.0
@@ -1076,11 +1116,31 @@ class CenteredInstanceSegmentationHeadConfig:
         anchor_part: (str) Optional node name used to center crops during
             training. ``None`` (default) centers on the mean of each instance's
             visible nodes.
+        centroid_method: (str) How the centroid is derived from the instance's
+            points, spelled as in ``sio.Instance.to_centroid``:
+            ``"center_of_mass"`` (mean of visible nodes), ``"bbox_center"``
+            (midpoint of the visible nodes' bounding box), ``"geometric_median"``
+            (Weiszfeld median — robust to a few outlying nodes, so it tracks the
+            body center better for elongated or curled animals), or ``"anchor"``
+            (the ``anchor_part`` node). ``None`` (default) infers it: ``"anchor"``
+            when ``anchor_part`` is set, else ``"center_of_mass"`` — i.e. exactly
+            the historical behavior, so existing configs are unchanged. Setting
+            both ``anchor_part`` and a non-anchor ``centroid_method`` is an error
+            (they name different centroids); use ``centroid_fallback`` for that.
+            Default is None.
+        centroid_fallback: (str) The reduce method used when ``anchor_part`` is
+            configured but that node is not visible: ``"center_of_mass"``
+            (default), ``"bbox_center"`` or ``"geometric_median"``. Only
+            meaningful for the anchor method. Unlike ``sio``'s ``fallback=None``,
+            sleap-nn always falls back rather than emitting a NaN centroid.
+            Default is None (= ``"center_of_mass"``).
     """
 
     output_stride: int = 2
     loss_weight: float = 1.0
     anchor_part: Optional[str] = None
+    centroid_method: Optional[str] = None
+    centroid_fallback: Optional[str] = None
 
 
 @define

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -128,6 +128,59 @@ def check_output_strides(config: OmegaConf) -> OmegaConf:
     return config
 
 
+def check_centroid_methods(config: OmegaConf) -> OmegaConf:
+    """Validate every head config's centroid-method knobs (#586).
+
+    A contradictory pair (``anchor_part`` plus a non-anchor ``centroid_method``)
+    or an unknown method name must fail at setup with a message naming the head,
+    not deep inside the first ``__getitem__`` of a dataloader worker — where the
+    traceback is a multiprocessing wrapper and the run has already spent minutes
+    caching images.
+
+    Args:
+        config: The full training job config.
+
+    Returns:
+        The config, unchanged (validation only).
+
+    Raises:
+        ValueError: For any head whose centroid knobs do not resolve.
+    """
+    from sleap_nn.data.instance_centroids import resolve_centroid_method
+
+    head_configs = OmegaConf.select(config, "model_config.head_configs", default=None)
+    if head_configs is None:
+        return config
+    for head_type, head in head_configs.items():
+        if head is None:
+            continue
+        for leaf_name, leaf in head.items():
+            if leaf is None or not OmegaConf.is_config(leaf):
+                continue
+            if OmegaConf.select(leaf, "centroid_method", default=None) is None and (
+                OmegaConf.select(leaf, "centroid_fallback", default=None) is None
+            ):
+                continue
+            try:
+                resolve_centroid_method(
+                    anchor_part=OmegaConf.select(leaf, "anchor_part", default=None),
+                    centroid_method=OmegaConf.select(
+                        leaf, "centroid_method", default=None
+                    ),
+                    centroid_fallback=OmegaConf.select(
+                        leaf, "centroid_fallback", default=None
+                    ),
+                )
+            except ValueError as e:
+                message = (
+                    f"Invalid centroid config in "
+                    f"`head_configs.{head_type}.{leaf_name}`: {e}"
+                )
+                logger.error(message)
+                raise ValueError(message) from e
+    return config
+
+
 def check_tiling(config: OmegaConf) -> OmegaConf:
     """Validate + reconcile tiling geometry against the finalized backbone/head.
 

--- a/sleap_nn/config_generator/generator.py
+++ b/sleap_nn/config_generator/generator.py
@@ -116,6 +116,8 @@ class ConfigGenerator:
         self._early_stopping_min_delta: float = 1e-6  # Web-app HTML default
         self._validation_fraction: float = 0.1
         self._anchor_part: Optional[str] = None
+        self._centroid_method: Optional[str] = None
+        self._centroid_fallback: Optional[str] = None
         self._crop_size: Optional[int] = None
         self._min_crop_size: int = 100
         self._crop_padding: Optional[int] = None
@@ -604,6 +606,26 @@ class ConfigGenerator:
         self._anchor_part = part_name
         return self
 
+    def centroid_method(
+        self, method: str, fallback: Optional[str] = None
+    ) -> "ConfigGenerator":
+        """Set how the centroid / crop center is derived from an instance (#586).
+
+        Args:
+            method: One of ``"center_of_mass"`` (mean of visible nodes, the
+                default), ``"bbox_center"``, ``"geometric_median"`` (robust to
+                outlying nodes) or ``"anchor"`` (needs :meth:`anchor_part`).
+            fallback: Reduce method used when the anchor node is not visible.
+                Only meaningful with the anchor method; defaults to
+                ``"center_of_mass"``.
+
+        Returns:
+            self for method chaining.
+        """
+        self._centroid_method = method
+        self._centroid_fallback = fallback
+        return self
+
     def crop_size(self, size: int) -> "ConfigGenerator":
         """Set crop size for centered_instance models.
 
@@ -861,6 +883,8 @@ class ConfigGenerator:
             head_configs["centroid"] = {
                 "confmaps": {
                     "anchor_part": self._anchor_part,
+                    "centroid_method": self._centroid_method,
+                    "centroid_fallback": self._centroid_fallback,
                     "sigma": self._sigma,
                     "output_stride": self._output_stride,
                 }
@@ -871,6 +895,8 @@ class ConfigGenerator:
                 "confmaps": {
                     "part_names": part_names,
                     "anchor_part": self._anchor_part,
+                    "centroid_method": self._centroid_method,
+                    "centroid_fallback": self._centroid_fallback,
                     "sigma": self._sigma,
                     "output_stride": self._output_stride,
                     "loss_weight": 1.0,
@@ -914,6 +940,8 @@ class ConfigGenerator:
                 "confmaps": {
                     "part_names": part_names,
                     "anchor_part": self._anchor_part,
+                    "centroid_method": self._centroid_method,
+                    "centroid_fallback": self._centroid_fallback,
                     "sigma": self._sigma,
                     "output_stride": self._output_stride,
                     "loss_weight": self._mc_confmaps_loss_weight,

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -30,7 +30,11 @@ from torch.utils.data import Dataset, DataLoader, DistributedSampler
 import sleap_io as sio
 from sleap_nn.config.utils import get_backbone_type_from_cfg, get_model_type_from_cfg
 from sleap_nn.data.identity import generate_class_maps, make_class_vectors
-from sleap_nn.data.instance_centroids import generate_centroids
+from sleap_nn.data.instance_centroids import (
+    centroid_method_from_config,
+    degrade_anchor_if_unresolved,
+    generate_centroids,
+)
 from sleap_nn.data.instance_cropping import generate_crops
 from sleap_nn.data.normalization import (
     convert_to_grayscale,
@@ -1607,6 +1611,11 @@ class CenteredInstanceDataset(BaseDataset):
         self.crop_size = crop_size
         self.anchor_ind = anchor_ind
         self.confmap_head_config = confmap_head_config
+        # (method, fallback) for the crop center, resolved once from the head
+        # config so training crops and inference crops agree (#586).
+        self.centroid_method, self.centroid_fallback = degrade_anchor_if_unresolved(
+            *centroid_method_from_config(confmap_head_config), anchor_ind
+        )
         self.instance_idx_list = self._get_instance_idx_list(labels)
         self.cache_lf = [None, None]
 
@@ -1706,7 +1715,12 @@ class CenteredInstanceDataset(BaseDataset):
         instances = instances * eff_scale
 
         # get the centroids based on the anchor idx
-        centroids = generate_centroids(instances, anchor_ind=self.anchor_ind)
+        centroids = generate_centroids(
+            instances,
+            anchor_ind=self.anchor_ind,
+            method=self.centroid_method,
+            fallback=self.centroid_fallback,
+        )
 
         instance, centroid = instances[0], centroids[0]  # (n_samples=1)
 
@@ -2110,7 +2124,12 @@ class CenteredInstanceSegmentationDataset(CenteredInstanceDataset):
         )
         instances = instances * eff_scale
 
-        centroids = generate_centroids(instances, anchor_ind=self.anchor_ind)
+        centroids = generate_centroids(
+            instances,
+            anchor_ind=self.anchor_ind,
+            method=self.centroid_method,
+            fallback=self.centroid_fallback,
+        )
         instance, centroid = instances[0], centroids[0]
 
         # Oversized (sqrt(2)) crop for rotation headroom — kept for parity with
@@ -2389,7 +2408,12 @@ class TopDownCenteredInstanceMultiClassDataset(CenteredInstanceDataset):
         )
 
         # get the centroids based on the anchor idx
-        centroids = generate_centroids(instances, anchor_ind=self.anchor_ind)
+        centroids = generate_centroids(
+            instances,
+            anchor_ind=self.anchor_ind,
+            method=self.centroid_method,
+            fallback=self.centroid_fallback,
+        )
 
         instance, centroid = instances[0], centroids[0]  # (n_samples=1)
 
@@ -2585,6 +2609,11 @@ class CentroidDataset(BaseDataset):
         )
         self.anchor_ind = anchor_ind
         self.confmap_head_config = confmap_head_config
+        # (method, fallback) for the centroid TARGET, resolved once from the head
+        # config so the trained target and inference agree (#586).
+        self.centroid_method, self.centroid_fallback = degrade_anchor_if_unresolved(
+            *centroid_method_from_config(confmap_head_config), anchor_ind
+        )
 
         # Resolve ONE centroid source for the whole dataset so the head is never
         # trained against a per-frame mix of user-annotated and computed
@@ -2800,7 +2829,10 @@ class CentroidDataset(BaseDataset):
         else:
             # get the centroids based on the anchor idx
             centroids = generate_centroids(
-                sample["instances"], anchor_ind=self.anchor_ind
+                sample["instances"],
+                anchor_ind=self.anchor_ind,
+                method=self.centroid_method,
+                fallback=self.centroid_fallback,
             )
 
         sample["centroids"] = centroids
@@ -5151,7 +5183,13 @@ def get_train_val_datasets(
         )
 
     elif model_type == "centroid":
-        nodes = [x["name"] for x in config.data_config.skeletons[0]["nodes"]]
+        # Mask-only labels carry no skeleton at all (the centroid target comes from
+        # `UserCentroid` annotations, possibly derived from masks via
+        # `data_config.centroids_from_masks`). Indexing `skeletons[0]` crashed with
+        # a bare `ConfigIndexError: list index out of range`; an absent skeleton
+        # just means there is no anchor node to resolve.
+        skeletons_cfg = OmegaConf.select(config, "data_config.skeletons", default=None)
+        nodes = [x["name"] for x in skeletons_cfg[0]["nodes"]] if skeletons_cfg else []
         anchor_part = config.model_config.head_configs.centroid.confmaps.anchor_part
         # The anchor/instance-keypoint path is now only a FALLBACK for frames
         # without user centroids, so an anchor_part that is None OR absent from

--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -42,6 +42,12 @@ CENTROID_METHODS = ("center_of_mass", "bbox_center", "geometric_median", "anchor
 #: These are the valid values for an anchor *fallback*.
 REDUCE_METHODS = ("center_of_mass", "bbox_center", "geometric_median")
 
+#: The subset a SEGMENTATION MASK can be reduced by. A mask has no nodes, so
+#: ``"anchor"`` is meaningless -- and ``sio.SegmentationMask.to_centroid`` also has
+#: no ``"geometric_median"``: that is defined over a point set, and a mask's
+#: foreground is thousands of pixels rather than a handful of landmarks.
+MASK_REDUCE_METHODS = ("center_of_mass", "bbox_center")
+
 #: Fallback applied when a configured anchor node is not visible. Unlike
 #: ``sio.Instance.to_centroid``, whose ``fallback=None`` yields a NaN centroid,
 #: sleap-nn always falls back — a NaN training target for a partially-visible
@@ -377,8 +383,7 @@ def add_centroids_from_masks(
 
     Args:
         labels: An ``sio.Labels`` to annotate **in place**.
-        method: The derivation method, one of :data:`REDUCE_METHODS`. Masks have
-            no nodes, so ``"anchor"`` is meaningless here.
+        method: The derivation method, one of :data:`MASK_REDUCE_METHODS`.
         overwrite: If ``False`` (default), frames that already carry user
             centroids are left alone — a real annotation always outranks a
             derived one. If ``True``, derived centroids replace them.
@@ -389,11 +394,16 @@ def add_centroids_from_masks(
     Raises:
         ValueError: If ``method`` is not a mask-applicable reduce method.
     """
-    if method not in REDUCE_METHODS:
+    if method not in MASK_REDUCE_METHODS:
+        extra = (
+            " ('geometric_median' is defined over a point set and is not offered "
+            "for masks; it applies to pose-derived centroids only)"
+            if method == "geometric_median"
+            else " (a mask has no nodes, so 'anchor' does not apply)"
+        )
         message = (
-            f"centroids_from_masks: unknown method {method!r}. Expected one of "
-            f"{', '.join(repr(m) for m in REDUCE_METHODS)} (a mask has no nodes, "
-            f"so 'anchor' does not apply)."
+            f"centroids_from_masks: unsupported method {method!r}. Expected one of "
+            f"{', '.join(repr(m) for m in MASK_REDUCE_METHODS)}{extra}."
         )
         raise ValueError(message)
 

--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -7,9 +7,13 @@ several ways, and sleap-nn now exposes the same four-way vocabulary as
 ===================== =========================================================
 ``center_of_mass``    Mean of the visible nodes (the historical default).
 ``bbox_center``       Midpoint of the visible nodes' bounding box.
-``geometric_median``  Weiszfeld geometric median of the visible nodes; robust to
-                      a few outlying nodes, so it tracks the body center better
-                      for elongated or curled animals.
+``geometric_median``  Weiszfeld geometric median of the visible nodes. The
+                      least affected by a MISLOCALIZED node: with one node off by
+                      a body length, the centroid moves ~1.7x less than the mean
+                      and ~5x less than the bbox midpoint (measured on flies13 and
+                      gerbil pose). It is NOT more stable than the mean when a
+                      node goes MISSING -- a different perturbation, where it
+                      measured slightly worse.
 ``anchor``            A named node, with a reduce-method fallback when that node
                       is not visible.
 ===================== =========================================================
@@ -122,9 +126,25 @@ def find_points_geometric_median(
     """Find the geometric median of a set of points via Weiszfeld's algorithm.
 
     The geometric median minimizes the sum of Euclidean distances to the input
-    points, which makes it markedly more robust than the mean to a few badly
-    localized or anatomically extreme nodes — a curled tail pulls
+    points, which makes it markedly more robust than the mean to a badly localized
+    node — a tracker that flings one node across the frame pulls
     :func:`find_points_mean` off the body, but barely moves this.
+
+    Measured on real pose data (flies13, gerbil; one visible node displaced by one
+    body length), the resulting centroid shift is:
+
+    ==================  ===============  ===============
+    method              flies13 median   gerbil median
+    ==================  ===============  ===============
+    geometric_median    3.7 px           4.4 px
+    center_of_mass      6.6 px           6.9 px
+    bbox_center         21.3 px          17.8 px
+    ==================  ===============  ===============
+
+    This is robustness to a node in the WRONG PLACE, not to a node being absent:
+    under single-node dropout the geometric median moved slightly MORE than the
+    mean (4.8 px vs 3.4 px median on flies13), since removing a node can move the
+    Fermat point it was pinned near.
 
     Args:
         points: A torch.Tensor of dtype torch.float32 and of shape (..., n_points, 2),

--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -1,7 +1,52 @@
-"""Handle calculation of instance centroids."""
+"""Handle calculation of instance centroids.
+
+**Centroid methods (#586).** A centroid can be derived from an instance's points in
+several ways, and sleap-nn now exposes the same four-way vocabulary as
+``sleap_io``'s ``Instance.to_centroid`` / ``SegmentationMask.to_centroid``:
+
+===================== =========================================================
+``center_of_mass``    Mean of the visible nodes (the historical default).
+``bbox_center``       Midpoint of the visible nodes' bounding box.
+``geometric_median``  Weiszfeld geometric median of the visible nodes; robust to
+                      a few outlying nodes, so it tracks the body center better
+                      for elongated or curled animals.
+``anchor``            A named node, with a reduce-method fallback when that node
+                      is not visible.
+===================== =========================================================
+
+Two levels compute centroids and **must agree**: this batched torch op (training
+targets, top-down crop centers, GT-centroid inference) and ``to_centroid`` at the
+object level. :func:`resolve_centroid_method` is the single place that turns the
+config pair (``anchor_part``, ``centroid_method``/``centroid_fallback``) into the
+``(method, fallback)`` argument pair both levels take, so there is one spelling of
+these concepts across sleap-nn and sleap-io. ``tests/data/test_instance_centroids.py``
+asserts the two levels agree per method.
+
+**Divergence from ``sleap_io``, deliberate.** ``sleap_io`` decides node visibility
+from the x-coordinate alone (``~isnan(pts[:, 0])``); the reductions here count
+non-NaN values *per axis* (``find_points_mean``, #584) or per point
+(``find_points_geometric_median``). The two agree whenever a node's coordinates are
+NaN together — which is what ``sleap_io`` itself writes — and differ only for a
+half-NaN point, where this module's answer is the better-defined one.
+"""
 
 from typing import Optional
+
 import torch
+from loguru import logger
+
+#: Centroid derivation methods, spelled as in ``sleap_io``'s ``to_centroid``.
+CENTROID_METHODS = ("center_of_mass", "bbox_center", "geometric_median", "anchor")
+
+#: The subset that reduces a whole point set (i.e. everything but ``"anchor"``).
+#: These are the valid values for an anchor *fallback*.
+REDUCE_METHODS = ("center_of_mass", "bbox_center", "geometric_median")
+
+#: Fallback applied when a configured anchor node is not visible. Unlike
+#: ``sio.Instance.to_centroid``, whose ``fallback=None`` yields a NaN centroid,
+#: sleap-nn always falls back — a NaN training target for a partially-visible
+#: instance would be a silent data loss. This is the pre-#586 behavior.
+DEFAULT_ANCHOR_FALLBACK = "center_of_mass"
 
 
 def find_points_mean(points: torch.Tensor) -> torch.Tensor:
@@ -62,37 +107,398 @@ def find_points_bbox_midpoint(points: torch.Tensor) -> torch.Tensor:
     return (pts_max + pts_min) * 0.5
 
 
-def generate_centroids(
-    points: torch.Tensor, anchor_ind: Optional[int] = None
+def find_points_geometric_median(
+    points: torch.Tensor,
+    max_iter: int = 100,
+    tol: float = 1e-6,
+    eps: float = 1e-12,
 ) -> torch.Tensor:
-    """Return centroids, falling back to the mean of visible nodes.
+    """Find the geometric median of a set of points via Weiszfeld's algorithm.
+
+    The geometric median minimizes the sum of Euclidean distances to the input
+    points, which makes it markedly more robust than the mean to a few badly
+    localized or anatomically extreme nodes — a curled tail pulls
+    :func:`find_points_mean` off the body, but barely moves this.
+
+    Args:
+        points: A torch.Tensor of dtype torch.float32 and of shape (..., n_points, 2),
+            i.e., rank >= 2.
+        max_iter: Maximum Weiszfeld iterations.
+        tol: Convergence tolerance on the estimate's movement between iterations.
+            Iteration stops once *every* slot has moved less than this.
+        eps: Distances below this are treated as coincident with the estimate and
+            dropped from the reweighting (their weight would be unbounded).
+
+    Returns:
+        The geometric medians. The output will be of shape (..., 2), reducing the
+        rank of the input by 1. Slots whose points are all NaN return NaN.
+
+    Notes:
+        A point is used only when BOTH of its coordinates are non-NaN — the
+        estimate is a joint 2D quantity, so per-axis visibility (which
+        :func:`find_points_mean` uses) has no meaning here. Matches the algorithm
+        in ``sleap_io.model.centroid._geometric_median`` (initialized at the
+        arithmetic mean, inverse-distance reweighting) so the object level and
+        this batched op agree.
+
+        The iteration runs in float64 regardless of the input dtype, and the
+        result is cast back. Weiszfeld reweights by ``1 / distance``, so near a
+        Fermat point that sits on one of the input nodes the distances approach
+        zero and float32 loses all relative precision there: measured against the
+        numpy reference on random 13-node instances, float32 drifts up to 0.18 px
+        while float64 agrees to ~1e-13. The tensors involved are a few hundred
+        floats, so the promotion costs nothing worth measuring — and it is what
+        lets the object/tensor parity test assert equality rather than a loose
+        tolerance.
+    """
+    out_dtype = points.dtype
+    points = points.to(torch.float64)
+
+    visible = ~torch.isnan(points).any(dim=-1)  # (..., n_points)
+    vis_f = visible.to(points.dtype).unsqueeze(-1)  # (..., n_points, 1)
+    # Zero out invisible points so they contribute nothing to any sum; they are
+    # excluded from every weight by `visible`, so the zeros are never read back.
+    pts = torch.where(visible.unsqueeze(-1), points, torch.zeros_like(points))
+
+    # Initialize at the arithmetic mean of the visible points.
+    counts = vis_f.sum(dim=-2).clamp(min=1)  # (..., 1)
+    estimate = pts.sum(dim=-2) / counts  # (..., 2)
+
+    # Convergence is tracked PER SLOT, not for the batch as a whole. Stopping the
+    # whole loop once every slot has converged would let a slow-converging slot
+    # keep iterating while its neighbours are done -- so an instance's centroid
+    # would depend on which other instances shared its batch. Freezing each slot
+    # as it converges makes the result batch-invariant and identical to the
+    # per-instance numpy reference.
+    active = torch.ones_like(estimate[..., 0], dtype=torch.bool)
+    for _ in range(max_iter):
+        dist = torch.linalg.vector_norm(pts - estimate.unsqueeze(-2), dim=-1)
+        # Points coincident with the current estimate would get an unbounded
+        # weight; drop them, exactly as the numpy reference does.
+        usable = visible & (dist > eps)
+        weights = torch.where(usable, 1.0 / dist.clamp(min=eps), torch.zeros_like(dist))
+        wsum = weights.sum(dim=-1, keepdim=True)  # (..., 1)
+        update = (weights.unsqueeze(-1) * pts).sum(dim=-2) / wsum.clamp(min=eps)
+        # wsum == 0 means every visible point coincides with the estimate (or
+        # there are none): the estimate is already the answer.
+        new_estimate = torch.where(wsum > 0, update, estimate)
+        shift = torch.linalg.vector_norm(new_estimate - estimate, dim=-1)
+        # The converging step is applied before the slot is frozen, matching the
+        # reference's `estimate = new_estimate; break` ordering.
+        estimate = torch.where(active.unsqueeze(-1), new_estimate, estimate)
+        active = active & (shift >= tol)
+        if not bool(active.any()):
+            break
+
+    none_visible = ~visible.any(dim=-1, keepdim=True)
+    estimate = torch.where(
+        none_visible, torch.full_like(estimate, float("nan")), estimate
+    )
+    return estimate.to(out_dtype)
+
+
+def reduce_points(points: torch.Tensor, method: str) -> torch.Tensor:
+    """Reduce a set of points to one centroid by the named method.
+
+    Args:
+        points: A torch.Tensor of shape (..., n_points, 2), i.e., rank >= 2.
+        method: One of :data:`REDUCE_METHODS` — ``"center_of_mass"``,
+            ``"bbox_center"`` or ``"geometric_median"``. ``"anchor"`` is not a
+            reduction (it selects a node) and is rejected here; see
+            :func:`generate_centroids`.
+
+    Returns:
+        The centroids, of shape (..., 2).
+
+    Raises:
+        ValueError: If ``method`` is not a known reduce method.
+    """
+    if method == "center_of_mass":
+        return find_points_mean(points)
+    if method == "bbox_center":
+        return find_points_bbox_midpoint(points)
+    if method == "geometric_median":
+        return find_points_geometric_median(points)
+    message = (
+        f"Unknown centroid reduce method {method!r}. Expected one of "
+        f"{', '.join(repr(m) for m in REDUCE_METHODS)}."
+    )
+    raise ValueError(message)
+
+
+def resolve_centroid_method(
+    anchor_part: Optional[str] = None,
+    centroid_method: Optional[str] = None,
+    centroid_fallback: Optional[str] = None,
+) -> tuple:
+    """Resolve the head config's centroid knobs into ``(method, fallback)``.
+
+    The single place that maps sleap-nn's config fields onto ``sleap_io``'s
+    ``to_centroid`` vocabulary, so the object level, the batched tensor level
+    (:func:`generate_centroids`) and the recorded ``sio.Centroid.source`` tag can
+    never disagree about what a model's centroid means.
+
+    Args:
+        anchor_part: The configured anchor node name, or ``None``. Setting it
+            implies ``method="anchor"`` — that is the pre-#586 behavior and stays
+            the meaning of a config that predates ``centroid_method``.
+        centroid_method: One of :data:`CENTROID_METHODS`, or ``None`` (default) to
+            infer: ``"anchor"`` when ``anchor_part`` is set, else
+            ``"center_of_mass"``.
+        centroid_fallback: The reduce method used when the anchor node is not
+            visible. One of :data:`REDUCE_METHODS`, or ``None`` for
+            :data:`DEFAULT_ANCHOR_FALLBACK`. Only meaningful for the anchor method.
+
+    Returns:
+        ``(method, fallback)``, where ``method`` is a member of
+        :data:`CENTROID_METHODS` and ``fallback`` is a member of
+        :data:`REDUCE_METHODS` when ``method == "anchor"`` and ``None`` otherwise.
+
+    Raises:
+        ValueError: If a value is not in the vocabulary, if ``centroid_method`` is
+            a reduce method while ``anchor_part`` is set (contradictory — the two
+            name different centroids), or if ``"anchor"`` is requested without an
+            ``anchor_part``.
+    """
+    if centroid_method is not None and centroid_method not in CENTROID_METHODS:
+        message = (
+            f"Unknown centroid_method {centroid_method!r}. Expected one of "
+            f"{', '.join(repr(m) for m in CENTROID_METHODS)}."
+        )
+        raise ValueError(message)
+    if centroid_fallback is not None and centroid_fallback not in REDUCE_METHODS:
+        message = (
+            f"Unknown centroid_fallback {centroid_fallback!r}. Expected one of "
+            f"{', '.join(repr(m) for m in REDUCE_METHODS)} (an anchor cannot fall "
+            f"back to another anchor)."
+        )
+        raise ValueError(message)
+
+    if anchor_part is not None:
+        if centroid_method is not None and centroid_method != "anchor":
+            message = (
+                f"Contradictory centroid config: anchor_part={anchor_part!r} asks "
+                f"for the anchor node, but centroid_method={centroid_method!r} asks "
+                f"for a whole-instance reduction. Set centroid_fallback="
+                f"{centroid_method!r} to use it when the anchor is occluded, or "
+                f"drop anchor_part to use it for every instance."
+            )
+            raise ValueError(message)
+        return "anchor", centroid_fallback or DEFAULT_ANCHOR_FALLBACK
+
+    if centroid_method == "anchor":
+        message = (
+            "centroid_method='anchor' requires anchor_part to name the node to "
+            "anchor on."
+        )
+        raise ValueError(message)
+    return (centroid_method or "center_of_mass"), None
+
+
+def centroid_method_from_config(head_config) -> tuple:
+    """Read and resolve the centroid knobs off a head-config leaf.
+
+    Convenience wrapper over :func:`resolve_centroid_method` for the many callers
+    that hold a head-config leaf (``head_configs.centroid.confmaps``,
+    ``...centered_instance.confmaps``, ``...embedding.embedding``, ...). Missing
+    keys resolve to ``None``, so a config written before #586 — or a plain dict —
+    yields the historical behavior.
+
+    Args:
+        head_config: A head-config leaf (``DictConfig``, dataclass or mapping), or
+            ``None``.
+
+    Returns:
+        ``(method, fallback)`` as documented on :func:`resolve_centroid_method`.
+    """
+    from omegaconf import OmegaConf
+
+    def get(key):
+        if head_config is None:
+            return None
+        if isinstance(head_config, dict):
+            return head_config.get(key)
+        if OmegaConf.is_config(head_config):
+            return OmegaConf.select(head_config, key, default=None)
+        return getattr(head_config, key, None)
+
+    return resolve_centroid_method(
+        anchor_part=get("anchor_part"),
+        centroid_method=get("centroid_method"),
+        centroid_fallback=get("centroid_fallback"),
+    )
+
+
+def degrade_anchor_if_unresolved(
+    method: str, fallback: Optional[str], anchor_ind: Optional[int]
+) -> tuple:
+    """Degrade an ``"anchor"`` method to its fallback when the node is unresolvable.
+
+    ``anchor_part`` names a node that may be absent from the skeleton — the
+    centroid model deliberately tolerates this (an anchor is only a fallback path
+    there), and the embedding dataset resolves the index leniently. Rather than
+    raising from deep inside the batched op, degrade to the configured fallback,
+    which is what the pre-#586 code did implicitly, and say so once.
+
+    Args:
+        method: The resolved method, as returned by :func:`resolve_centroid_method`.
+        fallback: The resolved fallback.
+        anchor_ind: The anchor node index, or ``None`` if it could not be resolved.
+
+    Returns:
+        ``(method, fallback)`` unchanged, unless the anchor is unresolvable, in
+        which case ``(fallback, None)``.
+    """
+    if method != "anchor" or anchor_ind is not None:
+        return method, fallback
+    effective = fallback or DEFAULT_ANCHOR_FALLBACK
+    logger.warning(
+        f"Centroid anchor node could not be resolved against the skeleton; "
+        f"deriving centroids with {effective!r} for every instance instead. Check "
+        f"that `anchor_part` names a node in the skeleton."
+    )
+    return effective, None
+
+
+def add_centroids_from_masks(
+    labels,
+    method: str = "center_of_mass",
+    overwrite: bool = False,
+) -> int:
+    """Derive ``UserCentroid`` annotations from a labels' segmentation masks.
+
+    Mask-only datasets (no pose annotations at all) cannot train a centroid model
+    today: the confmap target needs either pose keypoints or first-class centroid
+    annotations, and such labels have neither. ``sio.SegmentationMask.to_centroid``
+    supplies the missing piece — one call per mask, carrying the mask's ``track`` /
+    ``identity`` / ``instance`` linkage — after which the ordinary
+    ``centroid_source="user"`` path takes over unchanged. Nothing downstream of
+    this function knows the centroids came from masks.
+
+    Args:
+        labels: An ``sio.Labels`` to annotate **in place**.
+        method: The derivation method, one of :data:`REDUCE_METHODS`. Masks have
+            no nodes, so ``"anchor"`` is meaningless here.
+        overwrite: If ``False`` (default), frames that already carry user
+            centroids are left alone — a real annotation always outranks a
+            derived one. If ``True``, derived centroids replace them.
+
+    Returns:
+        The number of centroids added.
+
+    Raises:
+        ValueError: If ``method`` is not a mask-applicable reduce method.
+    """
+    if method not in REDUCE_METHODS:
+        message = (
+            f"centroids_from_masks: unknown method {method!r}. Expected one of "
+            f"{', '.join(repr(m) for m in REDUCE_METHODS)} (a mask has no nodes, "
+            f"so 'anchor' does not apply)."
+        )
+        raise ValueError(message)
+
+    n_added = 0
+    n_frames = 0
+    for lf in labels:
+        masks = getattr(lf, "masks", None)
+        if not masks:
+            continue
+        existing = [c for c in getattr(lf, "centroids", []) if not c.is_predicted]
+        if existing and not overwrite:
+            continue
+        if existing and overwrite:
+            lf.centroids = [c for c in lf.centroids if c.is_predicted]
+        added_here = 0
+        for mask in masks:
+            if getattr(mask, "is_predicted", False):
+                continue
+            centroid = mask.to_centroid(method=method)
+            # A mask can be empty (every pixel background) after a filter or a
+            # bad annotation; `to_centroid` returns NaN rather than raising.
+            if centroid.x != centroid.x or centroid.y != centroid.y:
+                continue
+            lf.centroids.append(centroid)
+            added_here += 1
+        n_added += added_here
+        n_frames += bool(added_here)
+
+    if n_added:
+        logger.info(
+            f"Derived {n_added} centroid annotation(s) from segmentation masks "
+            f"across {n_frames} frame(s) using method={method!r}."
+        )
+    else:
+        logger.warning(
+            "centroids_from_masks is enabled but no centroids were derived: the "
+            "labels carry no user segmentation masks (or every frame already has "
+            "user centroids)."
+        )
+    return n_added
+
+
+def generate_centroids(
+    points: torch.Tensor,
+    anchor_ind: Optional[int] = None,
+    method: Optional[str] = None,
+    fallback: Optional[str] = None,
+) -> torch.Tensor:
+    """Return centroids derived from instance points by the configured method.
 
     Args:
         points: A torch.Tensor of dtype torch.float32 and of shape (..., n_nodes, 2),
             i.e., rank >= 2.
         anchor_ind: The index of the node to use as the anchor for the centroid.
-            If not provided, or if the anchor node is NaN (not visible) for a given
-            instance, the centroid falls back to the NaN-ignoring mean of all visible
-            nodes for that instance.
+            Required by (and only used by) ``method="anchor"``. If the anchor node
+            is NaN (not visible) for a given instance, that instance's centroid
+            falls back to ``fallback``.
+        method: One of :data:`CENTROID_METHODS`. ``None`` (default) infers it from
+            ``anchor_ind`` — ``"anchor"`` when an index is given, else
+            ``"center_of_mass"`` — which is exactly the pre-#586 behavior, so
+            existing callers are unchanged. Use
+            :func:`resolve_centroid_method` to derive this from a head config.
+        fallback: The reduce method for a missing anchor, one of
+            :data:`REDUCE_METHODS`. ``None`` means :data:`DEFAULT_ANCHOR_FALLBACK`.
 
     Returns:
         The centroids of the instances. The output will be of shape (..., 2),
         reducing the rank of the input by 1. NaNs will be ignored in the calculation.
 
+    Raises:
+        ValueError: If ``method="anchor"`` without an ``anchor_ind``, or if
+            ``method``/``fallback`` is not in the vocabulary.
+
     Note:
-        The missing/occluded-anchor fallback is the mean of visible nodes
-        (``find_points_mean``). Pre-#530 this was the bounding-box midpoint
-        (``find_points_bbox_midpoint``). The two modes are tracked for a future
-        revisit in https://github.com/talmolab/sleap-nn/issues/586 — keep this
-        consistent with the centroid target generated during training.
+        This op defines what a centroid *means* for training targets, top-down crop
+        centers and GT-centroid inference alike; it must stay in lockstep with the
+        object-level ``to_centroid`` (see the module docstring) and with the
+        ``sio.Centroid.source`` tag written by
+        ``sleap_nn.inference.centroid_convert``.
     """
-    if anchor_ind is not None:
-        centroids = points[..., anchor_ind, :].clone()
-    else:
-        centroids = torch.full_like(points[..., 0, :], torch.nan).clone()
+    if method is None:
+        method = "anchor" if anchor_ind is not None else "center_of_mass"
+
+    if method != "anchor":
+        return reduce_points(points, method)
+
+    if anchor_ind is None:
+        message = (
+            "generate_centroids(method='anchor') requires anchor_ind, the index of "
+            "the node to anchor on."
+        )
+        raise ValueError(message)
+    if fallback is None:
+        fallback = DEFAULT_ANCHOR_FALLBACK
+    elif fallback not in REDUCE_METHODS:
+        message = (
+            f"Unknown anchor fallback {fallback!r}. Expected one of "
+            f"{', '.join(repr(m) for m in REDUCE_METHODS)}."
+        )
+        raise ValueError(message)
+
+    centroids = points[..., anchor_ind, :].clone()
 
     missing_anchors = torch.isnan(centroids).any(dim=-1)
     if missing_anchors.any():
-        centroids[missing_anchors] = find_points_mean(points[missing_anchors])
+        centroids[missing_anchors] = reduce_points(points[missing_anchors], fallback)
 
     return centroids  # (..., n_instances, 2)

--- a/sleap_nn/data/instance_centroids.py
+++ b/sleap_nn/data/instance_centroids.py
@@ -447,6 +447,11 @@ def add_centroids_from_masks(
             # bad annotation; `to_centroid` returns NaN rather than raising.
             if centroid.x != centroid.x or centroid.y != centroid.y:
                 continue
+            # Record the provenance: `to_centroid` leaves `source` empty, so
+            # nothing downstream could tell a mask-derived centroid from a
+            # hand-annotated one. Compound tag in the same style as the
+            # model-level `anchor:<node>` (see `centroid_source_for_anchor`).
+            centroid.source = f"mask:{method}"
             lf.centroids.append(centroid)
             added_here += 1
         n_added += added_here

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -555,8 +555,37 @@ def get_instances(labeled_frame: sio.LabeledFrame) -> List[MatchInstance]:
     return instance_list
 
 
+def _user_centroids(frame: sio.LabeledFrame) -> List[Any]:
+    """Return a frame's user (non-predicted) ``Centroid`` annotations."""
+    return [c for c in getattr(frame, "centroids", []) or [] if not c.is_predicted]
+
+
+def _instances_from_user_centroids(frame: sio.LabeledFrame) -> List[sio.Instance]:
+    """Represent a frame's user centroid annotations as single-node instances.
+
+    The centroid evaluator's matching, distance and detection metrics all speak
+    ``sio.Instance``; a ``Centroid`` annotation carries the same information with
+    no skeleton. Wrapping each one in a one-node instance on sleap-io's canonical
+    centroid skeleton lets the whole pipeline run unchanged on files that have no
+    poses at all -- and the wrapped point is exact, since every reduce method over
+    a single point returns that point.
+    """
+    skeleton = sio.get_centroid_skeleton()
+    return [
+        sio.Instance.from_numpy(
+            np.array([[float(c.x), float(c.y)]], dtype="float64"),
+            skeleton=skeleton,
+            track=getattr(c, "track", None),
+        )
+        for c in _user_centroids(frame)
+    ]
+
+
 def find_frame_pairs(
-    labels_gt: sio.Labels, labels_pr: sio.Labels, user_labels_only: bool = True
+    labels_gt: sio.Labels,
+    labels_pr: sio.Labels,
+    user_labels_only: bool = True,
+    keep_user_centroid_frames: bool = False,
 ) -> List[Tuple[sio.LabeledFrame, sio.LabeledFrame]]:
     """Find corresponding frames across two sets of labels.
 
@@ -567,6 +596,14 @@ def find_frame_pairs(
     Args:
         labels_gt: A `sio.Labels` instance with ground truth instances.
         labels_pr: A `sio.Labels` instance with predicted instances.
+        keep_user_centroid_frames: If True, a ground-truth frame also survives the
+            ``user_labels_only`` filter when it carries user ``Centroid``
+            annotations but no user instances. Set by ``match_method="centroid"``:
+            centroid annotations (hand-made, or derived from segmentation masks by
+            ``data_config.centroids_from_masks``) are the ground truth for a
+            centroid model, and a mask-only file has no instances at all -- so the
+            instance-only filter dropped every frame and evaluation died with
+            "Empty Frame Pairs".
         user_labels_only: If False, frames with predicted instances in `labels_gt` will
             also be considered for matching.
 
@@ -605,6 +642,7 @@ def find_frame_pairs(
                 attrs.evolve(lf, instances=lf.user_instances)
                 for lf in labeled_frames_gt
                 if len(lf.user_instances) > 0
+                or (keep_user_centroid_frames and _user_centroids(lf))
             ]
 
         # Attempt to match each labeled frame in the ground truth.
@@ -1100,7 +1138,10 @@ class Evaluator:
 
     def _process_frames(self):
         self.frame_pairs = find_frame_pairs(
-            self.ground_truth_instances, self.predicted_instances, self.user_labels_only
+            self.ground_truth_instances,
+            self.predicted_instances,
+            self.user_labels_only,
+            keep_user_centroid_frames=self.match_method == "centroid",
         )
         if not self.frame_pairs:
             message = "Empty Frame Pairs. No match found for the video frames"
@@ -1145,6 +1186,15 @@ class Evaluator:
         self.false_positives = []
 
         for frame_gt, frame_pr in self.frame_pairs:
+            # A mask-only or centroid-annotation-only ground-truth frame has no
+            # instances; its centroids ARE the ground truth (#586).
+            if not get_instances(frame_gt) and _user_centroids(frame_gt):
+                frame_gt = attrs.evolve(
+                    frame_gt, instances=_instances_from_user_centroids(frame_gt)
+                )
+                gt_from_centroid_annotations = True
+            else:
+                gt_from_centroid_annotations = False
             gt_match_instances = get_instances(frame_gt)
             pr_match_instances = get_instances(frame_pr)
 
@@ -1156,14 +1206,25 @@ class Evaluator:
                 ]
             ).reshape(-1, 2)
 
-            # GT centroids come from generate_centroids itself (#586).
+            # GT centroids come from generate_centroids itself (#586) -- except
+            # when they came from `Centroid` annotations, which are already the
+            # centroid: the wrapper is one node, so `anchor_ind` (an index into
+            # the POSE skeleton) does not apply to it.
             gt_centroids = np.array(
                 [
                     compute_gt_centroids(
                         m.instance.numpy(),
-                        self.anchor_ind,
-                        method=self.centroid_method,
-                        fallback=self.centroid_fallback,
+                        None if gt_from_centroid_annotations else self.anchor_ind,
+                        method=(
+                            None
+                            if gt_from_centroid_annotations
+                            else self.centroid_method
+                        ),
+                        fallback=(
+                            None
+                            if gt_from_centroid_annotations
+                            else self.centroid_fallback
+                        ),
                     )
                     for m in gt_match_instances
                 ]

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -6,55 +6,55 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import attrs
 import sleap_io as sio
+import torch
 from loguru import logger
 import click
 from pathlib import Path
 
+from sleap_nn.data.instance_centroids import generate_centroids
+
 
 def compute_gt_centroids(
-    instance_gt_points: np.ndarray, anchor_ind: Optional[int]
+    instance_gt_points: np.ndarray,
+    anchor_ind: Optional[int] = None,
+    method: Optional[str] = None,
+    fallback: Optional[str] = None,
 ) -> np.ndarray:
-    """Compute ground-truth centroids mirroring ``generate_centroids`` in numpy.
+    """Compute ground-truth centroids for a numpy array of instance keypoints.
 
-    This is the numpy mirror of
-    :func:`sleap_nn.data.instance_centroids.generate_centroids`. The centroid's
-    MEANING is defined by that function (see also #586): when the configured
-    anchor node is present (non-NaN) it is that node; otherwise the centroid
-    falls back to the NaN-ignoring MEAN of visible nodes (NOT the bounding-box
-    midpoint). The fallback is computed via ``np.nanmean`` over the node axis,
-    and is NaN only when every node of an instance is NaN.
+    A thin numpy-in/numpy-out wrapper around
+    :func:`sleap_nn.data.instance_centroids.generate_centroids`, which is the
+    single definition of what a centroid MEANS (see also #586). It used to be a
+    hand-written numpy mirror; delegating removes the drift that
+    ``sleap_nn.inference.centroid_convert`` warns about — evaluation now cannot
+    disagree with the trained target about the centroid, including for the
+    ``bbox_center`` / ``geometric_median`` methods.
 
     Args:
         instance_gt_points: Ground-truth keypoints of shape ``(n_instances,
             n_nodes, 2)`` or ``(n_nodes, 2)``. Missing/occluded nodes are NaN.
-        anchor_ind: Index of the node to use as the anchor. If ``None``, or if
-            the anchor node is NaN for a given instance, the centroid falls back
-            to the NaN-ignoring mean of visible nodes for that instance.
+        anchor_ind: Index of the node to use as the anchor. Required by (and only
+            used by) ``method="anchor"``; when that node is NaN for an instance,
+            that instance falls back to ``fallback``.
+        method: One of ``sleap_nn.data.instance_centroids.CENTROID_METHODS``.
+            ``None`` (default) infers it from ``anchor_ind`` — the historical
+            behavior: the anchor node when given, else the NaN-ignoring mean of
+            visible nodes.
+        fallback: Reduce method for a missing anchor. ``None`` means
+            ``"center_of_mass"``.
 
     Returns:
         Centroids of shape ``(n_instances, 2)`` (or ``(2,)`` for a single
         instance input), reducing the node axis.
     """
     points = np.asarray(instance_gt_points, dtype=np.float64)
-
-    if anchor_ind is not None:
-        centroids = points[..., anchor_ind, :].copy()
-    else:
-        centroids = np.full(points.shape[:-2] + (2,), np.nan, dtype=points.dtype)
-
-    missing_anchors = np.isnan(centroids).any(axis=-1)
-    if np.any(missing_anchors):
-        # NaN-ignoring mean of visible nodes. np.nanmean over the node axis
-        # yields NaN only when all nodes for that instance are NaN (matching
-        # find_points_mean). Suppress the all-NaN-slice RuntimeWarning.
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=RuntimeWarning)
-            mean_fallback = np.nanmean(points, axis=-2)
-        centroids[missing_anchors] = mean_fallback[missing_anchors]
-
-    return centroids
+    centroids = generate_centroids(
+        torch.from_numpy(points),
+        anchor_ind=anchor_ind,
+        method=method,
+        fallback=fallback,
+    )
+    return centroids.numpy()
 
 
 def match_centroids(
@@ -1039,6 +1039,13 @@ class Evaluator:
             skeleton node used to compute each ground-truth centroid (see
             :func:`compute_gt_centroids` and #586). ``None`` falls back to the
             NaN-ignoring mean of visible nodes.
+        centroid_method: For ``match_method="centroid"``, how the GT centroid is
+            derived -- ``"center_of_mass"``, ``"bbox_center"``,
+            ``"geometric_median"`` or ``"anchor"``. ``None`` (default) infers it
+            from ``anchor_ind``. Must match what the model was trained on, or the
+            distance metric compares two different definitions of "centroid";
+            :func:`run_evaluation` reads it off the training config.
+        centroid_fallback: Reduce method used when the anchor node is not visible.
 
     """
 
@@ -1052,6 +1059,8 @@ class Evaluator:
         user_labels_only: bool = True,
         match_method: str = "oks",
         anchor_ind: Optional[int] = None,
+        centroid_method: Optional[str] = None,
+        centroid_fallback: Optional[str] = None,
         exclude_predicted_instance_masks: bool = False,
     ):
         """Initialize the Evaluator class with ground-truth and predicted labels.
@@ -1072,6 +1081,8 @@ class Evaluator:
         self.user_labels_only = user_labels_only
         self.match_method = match_method
         self.anchor_ind = anchor_ind
+        self.centroid_method = centroid_method
+        self.centroid_fallback = centroid_fallback
         self.exclude_predicted_instance_masks = exclude_predicted_instance_masks
         # Populated only in centroid / mask mode.
         self.false_positives = []
@@ -1145,10 +1156,15 @@ class Evaluator:
                 ]
             ).reshape(-1, 2)
 
-            # GT centroids mirror generate_centroids exactly (#586).
+            # GT centroids come from generate_centroids itself (#586).
             gt_centroids = np.array(
                 [
-                    compute_gt_centroids(m.instance.numpy(), self.anchor_ind)
+                    compute_gt_centroids(
+                        m.instance.numpy(),
+                        self.anchor_ind,
+                        method=self.centroid_method,
+                        fallback=self.centroid_fallback,
+                    )
                     for m in gt_match_instances
                 ]
             ).reshape(-1, 2)
@@ -2247,6 +2263,8 @@ def run_evaluation(
     save_metrics: Optional[str] = None,
     match_method: str = "oks",
     anchor_part: Optional[str] = None,
+    centroid_method: Optional[str] = None,
+    centroid_fallback: Optional[str] = None,
 ):
     """Evaluate SLEAP-NN model predictions against ground truth labels.
 
@@ -2278,6 +2296,14 @@ def run_evaluation(
         anchor_part: Name of the GT skeleton node used to compute GT centroids
             (centroid mode). Resolved against the GT skeleton; ``None`` (or an
             absent name) falls back to the mean of visible nodes (#586).
+        centroid_method: How GT centroids are derived (centroid mode) --
+            ``"center_of_mass"``, ``"bbox_center"``, ``"geometric_median"`` or
+            ``"anchor"``. ``None`` (default) infers it from ``anchor_part``. Pass
+            the value the model was TRAINED with (its
+            ``head_configs.centroid.confmaps.centroid_method``), or the distance
+            metric scores predictions against a different centroid than the one
+            they were trained to predict.
+        centroid_fallback: Reduce method used when the anchor node is not visible.
 
     Returns:
         The metrics dict, or ``None`` if the predicted labels have zero
@@ -2381,6 +2407,8 @@ def run_evaluation(
         user_labels_only=user_labels_only,
         match_method=match_method,
         anchor_ind=anchor_ind,
+        centroid_method=centroid_method,
+        centroid_fallback=centroid_fallback,
         exclude_predicted_instance_masks=exclude_predicted_instance_masks,
     )
     logger.info(

--- a/sleap_nn/export/cli.py
+++ b/sleap_nn/export/cli.py
@@ -100,6 +100,7 @@ def export(
         load_training_config,
         warn_on_tiled_export,
         resolve_anchor_part,
+        resolve_centroid_method,
         resolve_backbone_type,
         resolve_class_maps_output_stride,
         resolve_class_names,
@@ -353,6 +354,7 @@ def export(
             class_names=metadata_class_names,
             peak_threshold=peak_threshold,
             anchor_part=resolve_anchor_part(cfg, model_type),
+            centroid_method=resolve_centroid_method(cfg, model_type),
         )
 
         metadata.save(export_dir / "export_metadata.json")
@@ -428,6 +430,7 @@ def export(
                 class_names=metadata_class_names,
                 peak_threshold=peak_threshold,
                 anchor_part=resolve_anchor_part(cfg, model_type),
+                centroid_method=resolve_centroid_method(cfg, model_type),
             )
             trt_metadata.save(export_dir / "model.trt.metadata.json")
         return
@@ -581,6 +584,7 @@ def export(
             normalization="0_to_1",
             peak_threshold=peak_threshold,
             anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
+            centroid_method=resolve_centroid_method(centroid_cfg, "centroid"),
         )
 
         metadata.save(export_dir / "export_metadata.json")
@@ -633,6 +637,7 @@ def export(
                 normalization="0_to_1",
                 peak_threshold=peak_threshold,
                 anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
+                centroid_method=resolve_centroid_method(centroid_cfg, "centroid"),
             )
             trt_metadata.save(export_dir / "model.trt.metadata.json")
         return
@@ -792,6 +797,7 @@ def export(
             class_names=class_names,
             peak_threshold=peak_threshold,
             anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
+            centroid_method=resolve_centroid_method(centroid_cfg, "centroid"),
         )
         metadata.save(export_dir / "export_metadata.json")
         click.echo(f"ONNX model exported to: {model_out_path}")
@@ -840,6 +846,7 @@ def export(
                 class_names=class_names,
                 peak_threshold=peak_threshold,
                 anchor_part=resolve_anchor_part(centroid_cfg, "centroid"),
+                centroid_method=resolve_centroid_method(centroid_cfg, "centroid"),
             )
             trt_metadata.save(export_dir / "model.trt.metadata.json")
         return

--- a/sleap_nn/export/metadata.py
+++ b/sleap_nn/export/metadata.py
@@ -54,8 +54,11 @@ class ExportMetadata:
     n_classes: Optional[int] = None
     class_names: Optional[List[str]] = None
 
-    # Centroid/top-down anchor point
+    # Centroid/top-down anchor point, and how the centroid is derived (#586).
+    # ``centroid_method`` is what `resolve_centroid_method` returned at export
+    # time; ``None`` in older exports, which then infer it from ``anchor_part``.
     anchor_part: Optional[str] = None
+    centroid_method: Optional[str] = None
 
     # Training config reference
     training_config_embedded: bool = False
@@ -102,6 +105,7 @@ class ExportMetadata:
             class_names=data.get("class_names"),
             peak_threshold=data.get("peak_threshold"),
             anchor_part=data.get("anchor_part"),
+            centroid_method=data.get("centroid_method"),
             training_config_embedded=bool(data.get("training_config_embedded", False)),
             training_config_hash=data.get("training_config_hash", ""),
         )
@@ -161,6 +165,7 @@ def build_base_metadata(
     class_names: Optional[List[str]] = None,
     peak_threshold: Optional[float] = None,
     anchor_part: Optional[str] = None,
+    centroid_method: Optional[str] = None,
 ) -> ExportMetadata:
     """Create an ExportMetadata instance with standard defaults."""
     return ExportMetadata(
@@ -189,6 +194,7 @@ def build_base_metadata(
         class_names=class_names,
         peak_threshold=peak_threshold,
         anchor_part=anchor_part,
+        centroid_method=centroid_method,
         training_config_embedded=training_config_embedded,
         training_config_hash=training_config_hash,
     )

--- a/sleap_nn/export/utils.py
+++ b/sleap_nn/export/utils.py
@@ -214,6 +214,39 @@ def resolve_anchor_part(cfg: DictConfig, model_type: str) -> Optional[str]:
     return None
 
 
+def resolve_centroid_method(cfg: DictConfig, model_type: str) -> Optional[str]:
+    """Resolve the trained centroid method for centroid / centered_instance models.
+
+    Companion to :func:`resolve_anchor_part`. Recorded in the export metadata so a
+    consumer of the exported model can tag predicted centroids with the method the
+    model was actually trained on (#586) — without it, a ``bbox_center`` model's
+    predictions would be recorded as ``center_of_mass``.
+
+    Args:
+        cfg: The training job configuration.
+        model_type: The model type (e.g., "centroid", "centered_instance").
+
+    Returns:
+        The resolved method (one of
+        ``sleap_nn.data.instance_centroids.CENTROID_METHODS``), or ``None`` for
+        model types that have no centroid.
+    """
+    from sleap_nn.data.instance_centroids import centroid_method_from_config
+
+    head_configs = cfg.model_config.head_configs
+
+    if model_type == "centroid":
+        head = getattr(head_configs, "centroid", None)
+    elif model_type == "centered_instance":
+        head = getattr(head_configs, "centered_instance", None)
+    else:
+        return None
+
+    if head and hasattr(head, "confmaps"):
+        return centroid_method_from_config(head.confmaps)[0]
+    return None
+
+
 def resolve_input_shape(
     cfg: DictConfig,
     input_height: Optional[int] = None,

--- a/sleap_nn/inference/centroid_convert.py
+++ b/sleap_nn/inference/centroid_convert.py
@@ -7,18 +7,19 @@ vs ``sio.PredictedCentroid``) and the ``source`` tag stay consistent across
 
 **#586 consistency.** The centroid's *meaning* is defined by
 ``sleap_nn/data/instance_centroids.py::generate_centroids`` (shared by training
-target generation AND GT-centroid inference). Its fallback when the configured
-anchor is missing/occluded is the NaN-ignoring mean of visible nodes
-(``find_points_mean``). The ``source`` tag we record mirrors that and the
+target generation AND GT-centroid inference), and is selected by the head
+config's ``centroid_method`` / ``centroid_fallback`` (resolved by
+``resolve_centroid_method``). The ``source`` tag we record mirrors that, in the
 ``sio.Centroid.from_instance(method=...)`` vocabulary:
 
 * an explicit, configured anchor node  -> ``"anchor:<node>"``
-* no anchor configured (mean-of-visible) -> ``"center_of_mass"``
-* (reserved) bbox-midpoint fallback      -> ``"bbox_center"``
+* no anchor configured                 -> the reduce method itself,
+  ``"center_of_mass"`` (the default), ``"bbox_center"`` or
+  ``"geometric_median"``
 
-so the recorded metadata never contradicts the trained target. If #586 later
-makes the fallback config-selectable, extend ``centroid_source_for_anchor`` in
-lockstep with ``generate_centroids``.
+so the recorded metadata never contradicts the trained target. Keep this in
+lockstep with ``generate_centroids``: whatever ``resolve_centroid_method``
+returns for a config is what a model trained on it predicts.
 """
 
 from __future__ import annotations
@@ -37,28 +38,36 @@ CENTER_OF_MASS = "center_of_mass"
 def centroid_source_for_anchor(
     anchor_ind: Optional[int],
     node_names: Optional[List[str]] = None,
+    centroid_method: Optional[str] = None,
 ) -> str:
     """Return the ``sio.Centroid.source`` tag for a centroid model.
 
     Args:
         anchor_ind: The configured anchor-node index (``None`` when the model
-            was trained with no explicit anchor, i.e. the mean-of-visible
-            fallback governs the target — see :data:`CENTER_OF_MASS`).
+            was trained with no explicit anchor — see :data:`CENTER_OF_MASS`).
         node_names: The training skeleton's node names, used to resolve a
             human-readable ``"anchor:<name>"`` tag. When unavailable, the
             index is used (``"anchor:<ind>"``).
+        centroid_method: The resolved method the model was trained with, one of
+            ``sleap_nn.data.instance_centroids.CENTROID_METHODS``. ``None``
+            (default) infers it from ``anchor_ind``, matching
+            ``resolve_centroid_method``.
 
     Returns:
-        ``"center_of_mass"`` when ``anchor_ind is None``; otherwise
-        ``"anchor:<node-name-or-index>"``.
+        ``"anchor:<node-name-or-index>"`` for the anchor method; otherwise the
+        reduce method itself (``"center_of_mass"`` by default).
 
     Note:
         This is a MODEL-level descriptor, not per-instance: a trained centroid
         model with an anchor will have learned to predict that anchor when
-        visible and (per #586) the mean-of-visible otherwise, but we cannot
-        recover per-instance visibility from a bare centroid peak. ``anchor:*``
-        is the closest faithful model-level tag.
+        visible and (per #586) its fallback otherwise, but we cannot recover
+        per-instance visibility from a bare centroid peak. ``anchor:*`` is the
+        closest faithful model-level tag.
     """
+    if centroid_method is None:
+        centroid_method = "anchor" if anchor_ind is not None else CENTER_OF_MASS
+    if centroid_method != "anchor":
+        return centroid_method
     if anchor_ind is None:
         return CENTER_OF_MASS
     if node_names is not None and 0 <= anchor_ind < len(node_names):

--- a/sleap_nn/inference/layers/centroid.py
+++ b/sleap_nn/inference/layers/centroid.py
@@ -26,7 +26,10 @@ from typing import Optional
 import attrs
 import torch
 
-from sleap_nn.data.instance_centroids import generate_centroids
+from sleap_nn.data.instance_centroids import (
+    degrade_anchor_if_unresolved,
+    generate_centroids,
+)
 from sleap_nn.inference.layers.backends.base import ModelBackend
 from sleap_nn.inference.layers.base import ImageInput, InferenceLayer
 from sleap_nn.inference.layers.configs import PostprocessConfig, PreprocessConfig
@@ -53,6 +56,13 @@ class CentroidLayer(InferenceLayer):
         max_stride: Maximum stride the model requires the input to be
             divisible by. Padding is applied bottom-right after the
             preprocess input-scale resize.
+        centroid_method: How a GT centroid is derived from the instance's points
+            when ``use_gt_centroids=True`` -- one of ``"center_of_mass"``,
+            ``"bbox_center"``, ``"geometric_median"``, ``"anchor"``. ``None``
+            (default) infers it from ``anchor_ind``, i.e. the historical behavior.
+            Must match the training config; the loaders read it off the
+            checkpoint's head config (#586).
+        centroid_fallback: Reduce method used when the anchor node is not visible.
         anchor_ind: Skeleton-node index to use as the centroid anchor when
             ``use_gt_centroids=True``. ``None`` falls back to the NaN-ignoring
             mean of all visible nodes for each instance.
@@ -70,6 +80,8 @@ class CentroidLayer(InferenceLayer):
         max_instances: Optional[int] = None,
         max_stride: int = 1,
         anchor_ind: Optional[int] = None,
+        centroid_method: Optional[str] = None,
+        centroid_fallback: Optional[str] = None,
         use_gt_centroids: bool = False,
         preprocess_config: Optional[PreprocessConfig] = None,
         postprocess_config: Optional[PostprocessConfig] = None,
@@ -87,6 +99,12 @@ class CentroidLayer(InferenceLayer):
         )
         self.max_instances = max_instances
         self.anchor_ind = anchor_ind
+        self.centroid_method, self.centroid_fallback = degrade_anchor_if_unresolved(
+            centroid_method
+            or ("anchor" if anchor_ind is not None else "center_of_mass"),
+            centroid_fallback,
+            anchor_ind,
+        )
         self.use_gt_centroids = use_gt_centroids
 
     # ──────────────────────────────────────────────────────────────────
@@ -134,7 +152,12 @@ class CentroidLayer(InferenceLayer):
         B = x.shape[0]
         H, W = x.shape[-2], x.shape[-1]
 
-        centroids = generate_centroids(instances, anchor_ind=self.anchor_ind)
+        centroids = generate_centroids(
+            instances,
+            anchor_ind=self.anchor_ind,
+            method=self.centroid_method,
+            fallback=self.centroid_fallback,
+        )
         # ``centroids`` shape: ``(B, max_inst, 2)`` (3D — same rank as
         # ``Outputs.pred_centroids``).
         device = centroids.device

--- a/sleap_nn/inference/layers/exported.py
+++ b/sleap_nn/inference/layers/exported.py
@@ -165,10 +165,15 @@ class ExportedCentroidLayer:
             ``Predictor._packaging_anchor_ind`` so the centroid lands on the
             configured anchor node rather than node 0 (#582). ``None`` (old
             exports without ``anchor_part``) keeps the node-0 behavior.
+        centroid_method: The method the exported model was trained to predict
+            (``ExportMetadata.centroid_method``), read at packaging time for the
+            recorded ``sio.Centroid.source`` tag (#586). ``None`` (old exports)
+            infers it from ``anchor_ind``.
     """
 
     backend: Any
     anchor_ind: Optional[int] = None
+    centroid_method: Optional[str] = None
 
     def predict(self, image: Any, **_kwargs: Any) -> Outputs:
         """Run the backend and translate to :class:`Outputs`."""

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -220,6 +220,38 @@ def _load_lightning_module(
     return module, config, backbone_type
 
 
+def _resolve_centroid_method(head_config: Any, anchor_override: Optional[str] = None):
+    """Resolve ``(method, fallback)`` for a GT-centroid crop path.
+
+    The crop geometry must reproduce what the crop-consuming model was TRAINED
+    with, so the knobs are read off that model's saved head config (#586).
+
+    Args:
+        head_config: The crop-consuming model's head-config leaf (the one carrying
+            ``anchor_part`` / ``centroid_method`` / ``centroid_fallback``).
+        anchor_override: An explicit user/CLI ``anchor_part``. When given it wins --
+            the caller asked for that node by name -- so only the config's
+            ``centroid_fallback`` is carried over; its ``centroid_method`` would
+            contradict the override.
+
+    Returns:
+        ``(method, fallback)`` as documented on
+        :func:`sleap_nn.data.instance_centroids.resolve_centroid_method`.
+    """
+    from sleap_nn.data.instance_centroids import (
+        centroid_method_from_config,
+        resolve_centroid_method,
+    )
+
+    if anchor_override is None:
+        return centroid_method_from_config(head_config)
+    if head_config is not None and OmegaConf.is_config(head_config):
+        fallback = OmegaConf.select(head_config, "centroid_fallback", default=None)
+    else:
+        fallback = getattr(head_config, "centroid_fallback", None)
+    return resolve_centroid_method(anchor_override, "anchor", fallback)
+
+
 def _resolve_preprocess_config(preprocess_config: Any, training_config: Any) -> Any:
     """Fill ``None`` fields in *preprocess_config* from the training config.
 
@@ -668,6 +700,20 @@ def _build_topdown(
         anchor_ind = (
             skeletons[0].node_names.index(anch_pt) if anch_pt is not None else None
         )
+    # Crop geometry follows the crop-CONSUMING model when there is one, else the
+    # centroid model's own config (#586).
+    _crop_head = (
+        confmap_config.model_config.head_configs.centered_instance.confmaps
+        if confmap_config is not None
+        else (
+            centroid_config.model_config.head_configs.centroid.confmaps
+            if centroid_config is not None
+            else None
+        )
+    )
+    centroid_method, centroid_fallback = _resolve_centroid_method(
+        _crop_head, anchor_part
+    )
 
     # Build CentroidCrop
     return_crops = confmap_model is not None
@@ -676,6 +722,8 @@ def _build_topdown(
             use_gt_centroids=True,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
             return_crops=return_crops,
         )
     else:
@@ -696,6 +744,8 @@ def _build_topdown(
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
         )
 
     # Build FindInstancePeaks
@@ -828,6 +878,10 @@ def _build_topdown_segmentation(
     anchor_ind = None
     if anch_pt is not None and skeletons:
         anchor_ind = skeletons[0].node_names.index(anch_pt)
+    centroid_method, centroid_fallback = _resolve_centroid_method(
+        seg_config.model_config.head_configs.centered_instance_segmentation.segmentation,
+        anchor_part,
+    )
 
     output_stride = (
         seg_config.model_config.head_configs.centered_instance_segmentation.segmentation.output_stride
@@ -842,6 +896,8 @@ def _build_topdown_segmentation(
             use_gt_centroids=True,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
             return_crops=True,
         )
     else:
@@ -862,6 +918,8 @@ def _build_topdown_segmentation(
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
         )
 
     instance_masks = CenteredInstanceMaskInferenceModel(
@@ -990,6 +1048,18 @@ def _build_topdown_multiclass(
         anchor_ind = (
             skeletons[0].node_names.index(anch_pt) if anch_pt is not None else None
         )
+    _crop_head = (
+        confmap_config.model_config.head_configs.multi_class_topdown.confmaps
+        if confmap_config is not None
+        else (
+            centroid_config.model_config.head_configs.centroid.confmaps
+            if centroid_config is not None
+            else None
+        )
+    )
+    centroid_method, centroid_fallback = _resolve_centroid_method(
+        _crop_head, anchor_part
+    )
 
     return_crops = confmap_model is not None
     if centroid_config is None:
@@ -997,6 +1067,8 @@ def _build_topdown_multiclass(
             use_gt_centroids=True,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
             return_crops=return_crops,
         )
     else:
@@ -1017,6 +1089,8 @@ def _build_topdown_multiclass(
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
         )
 
     max_stride_inst = confmap_config.model_config.backbone_config[

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -799,7 +799,11 @@ def _select_export_layer(
                     f"Anchor part {anchor_part!r} not found in export node_names: "
                     f"{node_names}."
                 )
-        return ExportedCentroidLayer(backend=backend, anchor_ind=anchor_ind)
+        return ExportedCentroidLayer(
+            backend=backend,
+            anchor_ind=anchor_ind,
+            centroid_method=getattr(metadata, "centroid_method", None),
+        )
     if model_type == "topdown":
         return ExportedTopDownLayer(backend=backend)
     if model_type == "bottomup":
@@ -2183,6 +2187,14 @@ class Predictor:
             return self.layer.anchor_ind
         return None
 
+    def _packaging_centroid_method(self) -> Optional[str]:
+        """Resolved centroid method for the ``sio.Centroid.source`` tag (#586)."""
+        from sleap_nn.inference.layers.exported import ExportedCentroidLayer
+
+        if isinstance(self.layer, (CentroidLayer, ExportedCentroidLayer)):
+            return getattr(self.layer, "centroid_method", None)
+        return None
+
     def _is_centroid_only_layer(self) -> bool:
         """``True`` iff ``layer`` is a standalone centroid layer."""
         from sleap_nn.inference.layers.exported import ExportedCentroidLayer
@@ -2236,7 +2248,9 @@ class Predictor:
         node_names = (
             list(self.skeleton.node_names) if self.skeleton is not None else None
         )
-        source = centroid_source_for_anchor(anchor_ind, node_names)
+        source = centroid_source_for_anchor(
+            anchor_ind, node_names, self._packaging_centroid_method()
+        )
         collapse_skeleton = None
         if self.skeleton is not None and len(self.skeleton.nodes) > 1:
             import sleap_io as sio

--- a/sleap_nn/inference/predictor.py
+++ b/sleap_nn/inference/predictor.py
@@ -441,6 +441,13 @@ def _build_centroid_layer(
         max_instances=centroid_model.max_instances,
         max_stride=centroid_model.max_stride,
         anchor_ind=centroid_model.anchor_ind,
+        # Carry the loaders' resolution (#586). Without these the layer re-infers
+        # the method from `anchor_ind` alone, so a checkpoint trained with
+        # `centroid_method: bbox_center` (or `geometric_median`) silently reverted
+        # to `center_of_mass` here -- and `sio.Centroid.source`, which reads
+        # `layer.centroid_method`, then recorded the wrong method too.
+        centroid_method=getattr(centroid_model, "centroid_method", None),
+        centroid_fallback=getattr(centroid_model, "centroid_fallback", None),
         use_gt_centroids=False,
         preprocess_config=PreprocessConfig(
             scale=centroid_model.input_scale,
@@ -494,6 +501,11 @@ def _build_centroid_layer_gt_only(assets: Any, backend: Any) -> CentroidLayer:
         max_instances=None,
         max_stride=1,
         anchor_ind=getattr(centroid_model, "anchor_ind", None),
+        # As in `_build_centroid_layer`: keep the loaders' resolved method. This
+        # path derives centroids from GT instances, so the method is what
+        # actually computes them -- dropping it silently changed the crop centers.
+        centroid_method=getattr(centroid_model, "centroid_method", None),
+        centroid_fallback=getattr(centroid_model, "centroid_fallback", None),
         use_gt_centroids=True,
         preprocess_config=PreprocessConfig(
             scale=1.0,

--- a/sleap_nn/inference/predictors.py
+++ b/sleap_nn/inference/predictors.py
@@ -886,6 +886,21 @@ class TopDownPredictor(Predictor):
             )
 
         if self.centroid_config is None:
+            # GT-centroid crops: the centroid is computed HERE from the instance's
+            # points, so the method must reproduce what the crop-consuming model
+            # was trained with (#586). Resolved off that model's head config, the
+            # same way the new-flow loaders do. (The model path below needs none
+            # of this -- there the centroid comes from the model's own peak.)
+            from sleap_nn.inference.loaders import _resolve_centroid_method
+
+            centroid_method, centroid_fallback = _resolve_centroid_method(
+                (
+                    self.confmap_config.model_config.head_configs.centered_instance.confmaps
+                    if self.confmap_config is not None
+                    else None
+                ),
+                self.anchor_part,
+            )
             centroid_crop_layer = CentroidCrop(
                 use_gt_centroids=True,
                 crop_hw=(
@@ -893,6 +908,8 @@ class TopDownPredictor(Predictor):
                     self.preprocess_config.crop_size,
                 ),
                 anchor_ind=anchor_ind,
+                centroid_method=centroid_method,
+                centroid_fallback=centroid_fallback,
                 return_crops=return_crops,
             )
 
@@ -3299,6 +3316,21 @@ class TopDownMultiClassPredictor(Predictor):
             )
 
         if self.centroid_config is None:
+            # GT-centroid crops: the centroid is computed HERE from the instance's
+            # points, so the method must reproduce what the crop-consuming model
+            # was trained with (#586). Resolved off that model's head config, the
+            # same way the new-flow loaders do. (The model path below needs none
+            # of this -- there the centroid comes from the model's own peak.)
+            from sleap_nn.inference.loaders import _resolve_centroid_method
+
+            centroid_method, centroid_fallback = _resolve_centroid_method(
+                (
+                    self.confmap_config.model_config.head_configs.multi_class_topdown.confmaps
+                    if self.confmap_config is not None
+                    else None
+                ),
+                self.anchor_part,
+            )
             centroid_crop_layer = CentroidCrop(
                 use_gt_centroids=True,
                 crop_hw=(
@@ -3306,6 +3338,8 @@ class TopDownMultiClassPredictor(Predictor):
                     self.preprocess_config.crop_size,
                 ),
                 anchor_ind=anchor_ind,
+                centroid_method=centroid_method,
+                centroid_fallback=centroid_fallback,
                 return_crops=return_crops,
             )
 

--- a/sleap_nn/inference/topdown.py
+++ b/sleap_nn/inference/topdown.py
@@ -9,7 +9,10 @@ from sleap_nn.data.resizing import (
     apply_pad_to_stride,
 )
 from sleap_nn.inference.peak_finding import crop_bboxes
-from sleap_nn.data.instance_centroids import generate_centroids
+from sleap_nn.data.instance_centroids import (
+    degrade_anchor_if_unresolved,
+    generate_centroids,
+)
 from sleap_nn.data.instance_cropping import make_centered_bboxes
 from sleap_nn.inference.peak_finding import find_global_peaks, find_local_peaks
 from sleap_nn.inference.identity import get_class_inds_from_vectors
@@ -56,6 +59,12 @@ class CentroidCrop(L.LightningModule):
         anchor_ind: The index of the node to use as the anchor for the centroid. If not
             provided or if not present in the instance, the NaN-ignoring mean of all
             visible nodes is used instead.
+        centroid_method: How a GT centroid is derived from the instance's points --
+            one of ``"center_of_mass"``, ``"bbox_center"``, ``"geometric_median"``,
+            ``"anchor"``. ``None`` (default) infers it from ``anchor_ind``, i.e. the
+            historical behavior. Must match the training config; the loaders read it
+            off the checkpoint's head config (#586).
+        centroid_fallback: Reduce method used when the anchor node is not visible.
 
     """
 
@@ -74,6 +83,8 @@ class CentroidCrop(L.LightningModule):
         max_stride: int = 1,
         use_gt_centroids: bool = False,
         anchor_ind: Optional[int] = None,
+        centroid_method: Optional[str] = None,
+        centroid_fallback: Optional[str] = None,
         **kwargs,
     ):
         """Initialise the model attributes."""
@@ -91,6 +102,12 @@ class CentroidCrop(L.LightningModule):
         self.max_stride = max_stride
         self.use_gt_centroids = use_gt_centroids
         self.anchor_ind = anchor_ind
+        self.centroid_method, self.centroid_fallback = degrade_anchor_if_unresolved(
+            centroid_method
+            or ("anchor" if anchor_ind is not None else "center_of_mass"),
+            centroid_fallback,
+            anchor_ind,
+        )
 
     def _generate_crops(self, inputs, cms: Optional[torch.Tensor] = None):
         """Generate Crops from the predicted centroids."""
@@ -179,7 +196,10 @@ class CentroidCrop(L.LightningModule):
         if self.use_gt_centroids:
             batch = inputs["video_idx"].shape[0]
             centroids = generate_centroids(
-                inputs["instances"], anchor_ind=self.anchor_ind
+                inputs["instances"],
+                anchor_ind=self.anchor_ind,
+                method=self.centroid_method,
+                fallback=self.centroid_fallback,
             )
             centroid_vals = torch.ones(centroids.shape)[..., 0]
             self.refined_peaks_batched = [x[0] for x in centroids]

--- a/sleap_nn/train.py
+++ b/sleap_nn/train.py
@@ -102,6 +102,18 @@ def _run_centroid_split_eval(
     anchor_part = OmegaConf.select(
         config, "model_config.head_configs.centroid.confmaps.anchor_part", default=None
     )
+    # ... and how it is derived, so the metric scores the model against the same
+    # centroid definition it was trained on.
+    centroid_method = OmegaConf.select(
+        config,
+        "model_config.head_configs.centroid.confmaps.centroid_method",
+        default=None,
+    )
+    centroid_fallback = OmegaConf.select(
+        config,
+        "model_config.head_configs.centroid.confmaps.centroid_fallback",
+        default=None,
+    )
     # Pixel match threshold from the eval config if present, else 50.0.
     match_threshold = OmegaConf.select(
         config, "trainer_config.eval.match_threshold", default=None
@@ -115,6 +127,8 @@ def _run_centroid_split_eval(
             predicted_path=pred_path.as_posix(),
             match_method="centroid",
             anchor_part=anchor_part,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
             match_threshold=match_threshold,
             save_metrics=metrics_path.as_posix(),
         )

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -50,7 +50,11 @@ from sleap_nn.config.utils import (
     get_model_type_from_cfg,
 )
 from sleap_nn.training.lightning_modules import LightningModel
-from sleap_nn.config.utils import check_output_strides, check_tiling
+from sleap_nn.config.utils import (
+    check_centroid_methods,
+    check_output_strides,
+    check_tiling,
+)
 from sleap_nn.config_generator.architecture_estimates import (
     compute_backbone_context_margin,
     compute_suggested_tile_size,
@@ -338,6 +342,12 @@ class ModelTrainer:
         total_val_lfs = 0
         self.skeletons = labels[0].skeletons
 
+        # Mask-only labels: derive the centroid annotations a centroid model needs
+        # from the segmentation masks. Must run BEFORE splitting and counting —
+        # such labels have no trainable frame at all until it has (#586 / #674) —
+        # and on the raw lists, so every split inherits the derived centroids.
+        self._apply_centroids_from_masks(labels, val_labels)
+
         # Check if we should count only user-labeled frames
         user_instances_only = OmegaConf.select(
             self.config, "data_config.user_instances_only", default=True
@@ -442,6 +452,29 @@ class ModelTrainer:
         if self.model_type == "single_instance":
             self._validate_single_instance_labels(self.train_labels, "train")
             self._validate_single_instance_labels(self.val_labels, "validation")
+
+    def _apply_centroids_from_masks(self, *label_lists):
+        """Derive user centroids from segmentation masks when configured.
+
+        No-op unless ``data_config.centroids_from_masks`` names a method. Mutates
+        the labels in place, before any split or frame count: a mask-only dataset
+        (no poses, no centroid annotations) has zero trainable frames until this
+        has run, so running it later fails the empty-split guard.
+
+        Args:
+            *label_lists: The raw ``List[sio.Labels]`` inputs (train, val).
+                ``None`` entries are skipped.
+        """
+        method = OmegaConf.select(
+            self.config, "data_config.centroids_from_masks", default=None
+        )
+        if not method:
+            return
+        from sleap_nn.data.instance_centroids import add_centroids_from_masks
+
+        for label_list in label_lists:
+            for labels in label_list or []:
+                add_centroids_from_masks(labels, method=method)
 
     def _validate_nonempty_labels(self, n_labeled_frames: int, split_name: str):
         """Ensure a split has at least one trainable labeled frame.
@@ -1121,6 +1154,9 @@ class ModelTrainer:
 
         # set output stride for backbone from head config and verify max stride
         self.config = check_output_strides(self.config)
+
+        # fail fast on a contradictory / unknown centroid method (#586)
+        self.config = check_centroid_methods(self.config)
 
         # auto-size + validate tiling geometry (no-op unless tiling.enabled)
         self._setup_tiling_config()

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -801,13 +801,30 @@ class ModelTrainer:
         """Setup node, edge and class names in head config."""
         # if edges and part names aren't set in head configs, get it from labels object.
         head_config = self.config.model_config.head_configs[self.model_type]
-        skeleton_node_names = list(self.skeletons[0].node_names)
+        # Mask-only labels carry no skeleton at all (`labels.skeletons == []`), and
+        # a centroid model trained off `data_config.centroids_from_masks` needs
+        # none: its target comes from `UserCentroid` annotations and its head
+        # declares neither part_names nor edges. Indexing `self.skeletons[0]`
+        # unconditionally turned that case into a bare `IndexError` here, before
+        # any of the guards below could speak. Heads that genuinely require a
+        # skeleton now say so by name instead.
+        skeleton = self.skeletons[0] if self.skeletons else None
+        skeleton_node_names = list(skeleton.node_names) if skeleton is not None else []
         for key in head_config:
             if "part_names" in head_config[key].keys():
                 if head_config[key]["part_names"] is None:
+                    if skeleton is None:
+                        message = (
+                            f"model_config.head_configs.{self.model_type}.{key}"
+                            ".part_names is null and the labels carry no skeleton, "
+                            "so the node names cannot be inferred. Provide labels "
+                            "with a skeleton, or set part_names explicitly."
+                        )
+                        logger.error(message)
+                        raise ValueError(message)
                     self.config.model_config.head_configs[self.model_type][key][
                         "part_names"
-                    ] = self.skeletons[0].node_names
+                    ] = skeleton.node_names
                 elif list(head_config[key]["part_names"]) != skeleton_node_names:
                     # GT confidence-map generation always produces one channel
                     # per node in the skeleton (custom_datasets.py's
@@ -857,9 +874,17 @@ class ModelTrainer:
 
             if "edges" in head_config[key].keys():
                 if head_config[key]["edges"] is None:
+                    if skeleton is None:
+                        message = (
+                            f"model_config.head_configs.{self.model_type}.{key}"
+                            ".edges is null and the labels carry no skeleton, so "
+                            "the edges cannot be inferred. Provide labels with a "
+                            "skeleton, or set edges explicitly."
+                        )
+                        logger.error(message)
+                        raise ValueError(message)
                     edges = [
-                        (x.source.name, x.destination.name)
-                        for x in self.skeletons[0].edges
+                        (x.source.name, x.destination.name) for x in skeleton.edges
                     ]
                     self.config.model_config.head_configs[self.model_type][key][
                         "edges"

--- a/tests/assets/generated_configs/centered_instance.yaml
+++ b/tests/assets/generated_configs/centered_instance.yaml
@@ -51,6 +51,8 @@ model_config:
         - A
         - B
         anchor_part: null
+        centroid_method: null
+        centroid_fallback: null
         sigma: 2.5
         output_stride: 2
         loss_weight: 1.0

--- a/tests/assets/generated_configs/centroid.yaml
+++ b/tests/assets/generated_configs/centroid.yaml
@@ -47,6 +47,8 @@ model_config:
     centroid:
       confmaps:
         anchor_part: null
+        centroid_method: null
+        centroid_fallback: null
         sigma: 5.0
         output_stride: 2
     centered_instance: null

--- a/tests/assets/generated_configs/centroid_only.yaml
+++ b/tests/assets/generated_configs/centroid_only.yaml
@@ -47,6 +47,8 @@ model_config:
     centroid:
       confmaps:
         anchor_part: null
+        centroid_method: null
+        centroid_fallback: null
         sigma: 2.5
         output_stride: 2
     centered_instance: null

--- a/tests/assets/generated_configs/multi_class_topdown.yaml
+++ b/tests/assets/generated_configs/multi_class_topdown.yaml
@@ -54,6 +54,8 @@ model_config:
         - A
         - B
         anchor_part: null
+        centroid_method: null
+        centroid_fallback: null
         sigma: 2.5
         output_stride: 2
         loss_weight: 1.0

--- a/tests/data/test_instance_centroids.py
+++ b/tests/data/test_instance_centroids.py
@@ -94,3 +94,288 @@ def test_find_points_mean_ignores_nan():
     means = find_points_mean(points)
     assert torch.allclose(means[0], torch.tensor([2.0, 3.0]))
     assert torch.isnan(means[1]).all()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #586 — centroid methods, and object/tensor-level parity
+# ─────────────────────────────────────────────────────────────────────────
+
+
+import numpy as np
+import pytest
+
+from sleap_nn.data.instance_centroids import (
+    CENTROID_METHODS,
+    REDUCE_METHODS,
+    add_centroids_from_masks,
+    centroid_method_from_config,
+    degrade_anchor_if_unresolved,
+    find_points_geometric_median,
+    reduce_points,
+    resolve_centroid_method,
+)
+
+
+def _rand_instances(n=24, n_nodes=13, seed=0, missing=True):
+    """Random instances with all-or-nothing NaN nodes, as sleap-io writes them."""
+    rng = np.random.default_rng(seed)
+    pts = rng.normal(300.0, 60.0, size=(n, n_nodes, 2))
+    if missing:
+        for i in range(n):
+            k = rng.integers(0, n_nodes - 1)
+            if k:
+                pts[i, rng.choice(n_nodes, size=k, replace=False)] = np.nan
+    return pts
+
+
+def test_default_is_byte_identical_to_the_pre_586_behavior():
+    """`method=None` must reproduce exactly what every existing caller got."""
+    pts = torch.from_numpy(_rand_instances()).to(torch.float32)
+    # No anchor -> mean of visible nodes.
+    assert torch.equal(generate_centroids(pts), find_points_mean(pts))
+    # Anchor -> that node, falling back to the mean when it is missing.
+    with_anchor = generate_centroids(pts, anchor_ind=3)
+    expected = pts[..., 3, :].clone()
+    missing = torch.isnan(expected).any(dim=-1)
+    expected[missing] = find_points_mean(pts[missing])
+    assert torch.equal(with_anchor, expected)
+
+
+@pytest.mark.parametrize("method", REDUCE_METHODS)
+def test_object_and_tensor_levels_agree(method):
+    """The two centroid derivations must not drift (the whole point of #586).
+
+    ``sio.Instance.to_centroid`` (object level, used for annotations) and
+    ``generate_centroids`` (tensor level, used for training targets, crop centers
+    and GT-centroid inference) must give the same answer for the same instance.
+    """
+    pts = _rand_instances(n=32, seed=1)
+    skeleton = sio.Skeleton([f"n{i}" for i in range(pts.shape[1])])
+
+    tensor_level = reduce_points(torch.from_numpy(pts).to(torch.float32), method)
+    for i in range(len(pts)):
+        instance = sio.Instance.from_numpy(pts[i].astype(np.float32), skeleton=skeleton)
+        centroid = instance.to_centroid(method=method)
+        mine = tensor_level[i].numpy()
+        if np.isnan(centroid.x):
+            assert np.isnan(mine).all()
+            continue
+        # float32 accumulation order differs between numpy and torch; the
+        # geometric median is computed in float64 internally and matches exactly.
+        np.testing.assert_allclose(mine, [centroid.x, centroid.y], rtol=0, atol=1e-3)
+
+
+def test_object_and_tensor_levels_agree_for_the_anchor_method():
+    """Anchor + fallback, the one method that combines a node and a reduction."""
+    pts = _rand_instances(n=32, seed=2)
+    skeleton = sio.Skeleton([f"n{i}" for i in range(pts.shape[1])])
+    anchor_ind = 4
+
+    for fallback in REDUCE_METHODS:
+        tensor_level = generate_centroids(
+            torch.from_numpy(pts).to(torch.float32),
+            anchor_ind=anchor_ind,
+            method="anchor",
+            fallback=fallback,
+        )
+        for i in range(len(pts)):
+            instance = sio.Instance.from_numpy(
+                pts[i].astype(np.float32), skeleton=skeleton
+            )
+            centroid = instance.to_centroid(
+                method="anchor", node=anchor_ind, fallback=fallback
+            )
+            mine = tensor_level[i].numpy()
+            if np.isnan(centroid.x):
+                assert np.isnan(mine).all()
+                continue
+            np.testing.assert_allclose(
+                mine, [centroid.x, centroid.y], rtol=0, atol=1e-3
+            )
+
+
+def test_geometric_median_is_robust_to_an_outlying_node():
+    """The reason `geometric_median` is worth having at all."""
+    body = torch.tensor([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]])
+    with_outlier = torch.cat(
+        [body, torch.tensor([[[100.0, 100.0]]])], dim=1
+    )  # a flung-out tail node
+
+    mean_shift = (find_points_mean(with_outlier) - find_points_mean(body)).norm()
+    median_shift = (
+        find_points_geometric_median(with_outlier) - find_points_geometric_median(body)
+    ).norm()
+    assert median_shift < 0.05 * mean_shift
+
+
+def test_geometric_median_edge_cases():
+    """All-NaN, single visible point, and coincident points."""
+    all_nan = torch.full((2, 5, 2), float("nan"))
+    assert torch.isnan(find_points_geometric_median(all_nan)).all()
+
+    one_visible = torch.full((1, 5, 2), float("nan"))
+    one_visible[0, 2] = torch.tensor([7.0, -3.0])
+    torch.testing.assert_close(
+        find_points_geometric_median(one_visible), torch.tensor([[7.0, -3.0]])
+    )
+
+    # Every point identical: the Weiszfeld reweighting would divide by zero.
+    coincident = torch.full((1, 4, 2), 5.0)
+    torch.testing.assert_close(
+        find_points_geometric_median(coincident), torch.tensor([[5.0, 5.0]])
+    )
+
+
+def test_geometric_median_preserves_dtype_and_batch_shape():
+    pts = torch.from_numpy(_rand_instances(n=6)).to(torch.float32)
+    batched = pts.unsqueeze(0).repeat(3, 1, 1, 1)  # (3, 6, 13, 2)
+    out = find_points_geometric_median(batched)
+    assert out.shape == (3, 6, 2)
+    assert out.dtype == torch.float32
+    torch.testing.assert_close(out[0], out[1])
+
+
+def test_geometric_median_is_batch_invariant():
+    """An instance's centroid must not depend on its batch-mates.
+
+    Weiszfeld converges at different rates for different instances. A batch-level
+    stopping rule lets a slow slot keep iterating while its neighbours are done,
+    so the same instance gets a different answer depending on what it was batched
+    with (a real bug caught here: max delta 0.24 px). Convergence is tracked per
+    slot instead.
+    """
+    pts = torch.from_numpy(_rand_instances(n=32, seed=1)).to(torch.float32)
+    batched = find_points_geometric_median(pts)
+    one_at_a_time = torch.stack(
+        [find_points_geometric_median(pts[i : i + 1])[0] for i in range(len(pts))]
+    )
+    torch.testing.assert_close(batched, one_at_a_time, equal_nan=True)
+
+
+def test_resolve_centroid_method_vocabulary():
+    assert resolve_centroid_method() == ("center_of_mass", None)
+    assert resolve_centroid_method(anchor_part="head") == ("anchor", "center_of_mass")
+    assert resolve_centroid_method(
+        anchor_part="head", centroid_fallback="bbox_center"
+    ) == ("anchor", "bbox_center")
+    assert resolve_centroid_method(centroid_method="geometric_median") == (
+        "geometric_median",
+        None,
+    )
+    # anchor_part + a non-anchor method name two different centroids.
+    with pytest.raises(ValueError, match="Contradictory"):
+        resolve_centroid_method(anchor_part="head", centroid_method="bbox_center")
+    # "anchor" needs a node.
+    with pytest.raises(ValueError, match="requires anchor_part"):
+        resolve_centroid_method(centroid_method="anchor")
+    with pytest.raises(ValueError, match="Unknown centroid_method"):
+        resolve_centroid_method(centroid_method="centre_of_mass")
+    # An anchor cannot fall back to another anchor.
+    with pytest.raises(ValueError, match="Unknown centroid_fallback"):
+        resolve_centroid_method(anchor_part="head", centroid_fallback="anchor")
+
+
+def test_centroid_method_from_config_handles_every_config_shape():
+    from omegaconf import OmegaConf
+
+    assert centroid_method_from_config(None) == ("center_of_mass", None)
+    assert centroid_method_from_config({}) == ("center_of_mass", None)
+    # A config written before #586 keeps its historical meaning.
+    assert centroid_method_from_config(
+        OmegaConf.create({"anchor_part": "head", "sigma": 5.0})
+    ) == ("anchor", "center_of_mass")
+    assert centroid_method_from_config({"centroid_method": "bbox_center"}) == (
+        "bbox_center",
+        None,
+    )
+
+
+def test_degrade_anchor_if_unresolved():
+    """An anchor_part absent from the skeleton degrades instead of raising."""
+    assert degrade_anchor_if_unresolved("anchor", "bbox_center", 2) == (
+        "anchor",
+        "bbox_center",
+    )
+    assert degrade_anchor_if_unresolved("anchor", "bbox_center", None) == (
+        "bbox_center",
+        None,
+    )
+    assert degrade_anchor_if_unresolved("anchor", None, None) == (
+        "center_of_mass",
+        None,
+    )
+    assert degrade_anchor_if_unresolved("geometric_median", None, None) == (
+        "geometric_median",
+        None,
+    )
+
+
+def test_generate_centroids_rejects_bad_arguments():
+    pts = torch.from_numpy(_rand_instances(n=2)).to(torch.float32)
+    with pytest.raises(ValueError, match="requires anchor_ind"):
+        generate_centroids(pts, method="anchor")
+    with pytest.raises(ValueError, match="Unknown anchor fallback"):
+        generate_centroids(pts, anchor_ind=0, method="anchor", fallback="anchor")
+    with pytest.raises(ValueError, match="Unknown centroid reduce method"):
+        reduce_points(pts, "median")
+
+
+def test_every_method_is_reachable_through_generate_centroids():
+    pts = torch.from_numpy(_rand_instances(n=4, seed=3)).to(torch.float32)
+    for method in CENTROID_METHODS:
+        kwargs = {"anchor_ind": 0} if method == "anchor" else {}
+        out = generate_centroids(pts, method=method, **kwargs)
+        assert out.shape == (4, 2)
+        assert torch.isfinite(out).all()
+
+
+def test_evaluation_mirror_matches_the_tensor_op():
+    """`compute_gt_centroids` must not drift from `generate_centroids` (#586)."""
+    from sleap_nn.evaluation import compute_gt_centroids
+
+    pts = _rand_instances(n=16, seed=4)
+    for method in REDUCE_METHODS:
+        np.testing.assert_allclose(
+            compute_gt_centroids(pts, method=method),
+            reduce_points(torch.from_numpy(pts), method).numpy(),
+        )
+    np.testing.assert_allclose(
+        compute_gt_centroids(pts, anchor_ind=2),
+        generate_centroids(torch.from_numpy(pts), anchor_ind=2).numpy(),
+    )
+
+
+def test_centroid_source_tag_follows_the_method():
+    """The recorded `sio.Centroid.source` must not contradict the trained target."""
+    from sleap_nn.inference.centroid_convert import centroid_source_for_anchor
+
+    assert centroid_source_for_anchor(None) == "center_of_mass"
+    assert centroid_source_for_anchor(1, ["a", "b"]) == "anchor:b"
+    assert (
+        centroid_source_for_anchor(None, None, "geometric_median") == "geometric_median"
+    )
+    assert centroid_source_for_anchor(None, None, "bbox_center") == "bbox_center"
+    assert centroid_source_for_anchor(1, ["a", "b"], "anchor") == "anchor:b"
+
+
+def test_add_centroids_from_masks(minimal_instance):
+    """Mask-only labels gain the user centroids a centroid model needs (#674)."""
+    labels = sio.load_slp(minimal_instance)
+    lf = labels[0]
+    if not getattr(lf, "masks", None):
+        # Build masks from the poses so this runs on the minimal fixture.
+        labels.get_masks()
+    if not getattr(labels[0], "masks", None):
+        pytest.skip("fixture has no segmentation masks to derive centroids from")
+
+    n_masks = sum(len(f.masks) for f in labels)
+    n_added = add_centroids_from_masks(labels, method="center_of_mass")
+    assert n_added == n_masks
+    assert all(not c.is_predicted for f in labels for c in f.centroids)
+
+    # A second pass must not duplicate: real annotations outrank derived ones.
+    assert add_centroids_from_masks(labels, method="center_of_mass") == 0
+    assert sum(len(f.centroids) for f in labels) == n_masks
+
+    with pytest.raises(ValueError, match="unknown method"):
+        add_centroids_from_masks(labels, method="anchor")

--- a/tests/data/test_instance_centroids.py
+++ b/tests/data/test_instance_centroids.py
@@ -377,5 +377,9 @@ def test_add_centroids_from_masks(minimal_instance):
     assert add_centroids_from_masks(labels, method="center_of_mass") == 0
     assert sum(len(f.centroids) for f in labels) == n_masks
 
-    with pytest.raises(ValueError, match="unknown method"):
+    with pytest.raises(ValueError, match="unsupported method"):
         add_centroids_from_masks(labels, method="anchor")
+    # `geometric_median` is a valid pose method but NOT a mask one -- reject it at
+    # the call rather than letting sleap-io raise deep inside the load.
+    with pytest.raises(ValueError, match="not offered for masks"):
+        add_centroids_from_masks(labels, method="geometric_median")

--- a/tests/data/test_instance_centroids.py
+++ b/tests/data/test_instance_centroids.py
@@ -358,20 +358,63 @@ def test_centroid_source_tag_follows_the_method():
     assert centroid_source_for_anchor(1, ["a", "b"], "anchor") == "anchor:b"
 
 
-def test_add_centroids_from_masks(minimal_instance):
-    """Mask-only labels gain the user centroids a centroid model needs (#674)."""
-    labels = sio.load_slp(minimal_instance)
-    lf = labels[0]
-    if not getattr(lf, "masks", None):
-        # Build masks from the poses so this runs on the minimal fixture.
-        labels.get_masks()
-    if not getattr(labels[0], "masks", None):
-        pytest.skip("fixture has no segmentation masks to derive centroids from")
+def _mask_only_labels(with_skeleton: bool = False, n_frames: int = 2):
+    """Build a mask-only labels object: two square masks per frame, no poses.
 
+    Squares rather than the pose fixture's derived masks, so every expected
+    centroid is known exactly: a filled square's center of mass and its bounding
+    box center coincide at its center, and an L-shape separates them.
+    """
+    video = sio.Video.from_filename("mask_only.mp4")
+    tracks = [sio.Track("a"), sio.Track("b")]
+    frames = []
+    for frame_idx in range(n_frames):
+        masks = []
+        for k, track in enumerate(tracks):
+            arr = np.zeros((40, 40), dtype=bool)
+            arr[4 + 16 * k : 12 + 16 * k, 4 + 16 * k : 12 + 16 * k] = True
+            mask = sio.UserSegmentationMask.from_numpy(arr)
+            mask.track = track
+            masks.append(mask)
+        frames.append(
+            sio.LabeledFrame(
+                video=video, frame_idx=frame_idx, instances=[], masks=masks
+            )
+        )
+    return sio.Labels(
+        labeled_frames=frames,
+        videos=[video],
+        skeletons=[sio.Skeleton(["a"])] if with_skeleton else [],
+        tracks=tracks,
+    )
+
+
+def test_add_centroids_from_masks():
+    """Mask-only labels gain the user centroids a centroid model needs (#586).
+
+    Builds real ``UserSegmentationMask``es: ``Labels.get_masks()`` is a *query* in
+    sleap-io 0.9.2, not a builder, so relying on it left this test skipping and
+    the feature with no exercised coverage.
+    """
+    labels = _mask_only_labels()
     n_masks = sum(len(f.masks) for f in labels)
+    assert n_masks == 4
+
     n_added = add_centroids_from_masks(labels, method="center_of_mass")
     assert n_added == n_masks
+    assert sum(len(f.centroids) for f in labels) == n_masks
     assert all(not c.is_predicted for f in labels for c in f.centroids)
+
+    # Exact values: the two squares span [4, 12) and [20, 28), so their centers
+    # sit at 7.5 and 23.5 on both axes.
+    for frame in labels:
+        xs = sorted(round(float(c.x), 3) for c in frame.centroids)
+        ys = sorted(round(float(c.y), 3) for c in frame.centroids)
+        assert xs == [7.5, 23.5]
+        assert ys == [7.5, 23.5]
+
+    # The mask's track rides along, so identity survives the derivation.
+    assert {c.track.name for f in labels for c in f.centroids} == {"a", "b"}
 
     # A second pass must not duplicate: real annotations outrank derived ones.
     assert add_centroids_from_masks(labels, method="center_of_mass") == 0
@@ -383,3 +426,81 @@ def test_add_centroids_from_masks(minimal_instance):
     # the call rather than letting sleap-io raise deep inside the load.
     with pytest.raises(ValueError, match="not offered for masks"):
         add_centroids_from_masks(labels, method="geometric_median")
+
+
+def test_add_centroids_from_masks_bbox_center_differs_on_an_L_shape():
+    """center_of_mass and bbox_center must not be silently interchangeable."""
+    video = sio.Video.from_filename("l_shape.mp4")
+    arr = np.zeros((40, 40), dtype=bool)
+    arr[10:30, 10:14] = True  # vertical bar
+    arr[26:30, 10:30] = True  # horizontal foot -> mass pulled down-left
+    frame = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[],
+        masks=[sio.UserSegmentationMask.from_numpy(arr)],
+    )
+    labels = sio.Labels(labeled_frames=[frame], videos=[video], skeletons=[])
+
+    assert add_centroids_from_masks(labels, method="center_of_mass") == 1
+    com = (float(labels[0].centroids[0].x), float(labels[0].centroids[0].y))
+
+    labels[0].centroids = []
+    assert add_centroids_from_masks(labels, method="bbox_center") == 1
+    bbox = (float(labels[0].centroids[0].x), float(labels[0].centroids[0].y))
+
+    # The bounding box is symmetric about its own center; the mass is not. Note
+    # the conventions differ by half a pixel: center_of_mass averages pixel
+    # indices (rows 10..29 -> 19.5) while bbox_center measures the half-open
+    # pixel extent (rows [10, 30) -> 20.0).
+    assert bbox == pytest.approx((20.0, 20.0))
+    assert com != pytest.approx(bbox)
+    assert com[1] > bbox[1]  # mass sits below the box center (the foot)
+
+
+def test_add_centroids_from_masks_skips_predicted_masks_and_empty_ones():
+    """Model output is not ground truth, and an all-background mask has no center."""
+    video = sio.Video.from_filename("mixed.mp4")
+    good = np.zeros((20, 20), dtype=bool)
+    good[2:6, 2:6] = True
+    frame = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[],
+        masks=[
+            sio.UserSegmentationMask.from_numpy(good),
+            # An empty user mask: `to_centroid` returns NaN rather than raising.
+            sio.UserSegmentationMask.from_numpy(np.zeros((20, 20), dtype=bool)),
+            # Model output in a ground-truth file.
+            sio.PredictedSegmentationMask.from_numpy(good, score=0.9),
+        ],
+    )
+    labels = sio.Labels(labeled_frames=[frame], videos=[video], skeletons=[])
+
+    assert add_centroids_from_masks(labels, method="center_of_mass") == 1
+    assert len(labels[0].centroids) == 1
+    assert float(labels[0].centroids[0].x) == pytest.approx(3.5)
+
+
+def test_add_centroids_from_masks_overwrite_replaces_derived_centroids():
+    """`overwrite=True` re-derives; the default leaves existing annotations alone."""
+    labels = _mask_only_labels(n_frames=1)
+    assert add_centroids_from_masks(labels, method="center_of_mass") == 2
+
+    # Default: untouched.
+    assert add_centroids_from_masks(labels, method="bbox_center") == 0
+
+    # overwrite: replaced, not appended.
+    assert add_centroids_from_masks(labels, method="bbox_center", overwrite=True) == 2
+    assert len(labels[0].centroids) == 2
+
+
+def test_add_centroids_from_masks_records_its_provenance():
+    """A derived centroid must be distinguishable from a hand-annotated one."""
+    labels = _mask_only_labels(n_frames=1)
+    add_centroids_from_masks(labels, method="center_of_mass")
+    assert {c.source for c in labels[0].centroids} == {"mask:center_of_mass"}
+
+    labels_bbox = _mask_only_labels(n_frames=1)
+    add_centroids_from_masks(labels_bbox, method="bbox_center")
+    assert {c.source for c in labels_bbox[0].centroids} == {"mask:bbox_center"}

--- a/tests/export/test_metadata.py
+++ b/tests/export/test_metadata.py
@@ -103,6 +103,7 @@ class TestExportMetadata:
             "class_names",
             "peak_threshold",
             "anchor_part",
+            "centroid_method",
             "training_config_embedded",
             "training_config_hash",
         }

--- a/tests/inference/test_centroid_only.py
+++ b/tests/inference/test_centroid_only.py
@@ -562,3 +562,70 @@ def test_emit_centroid_with_tracking_raises():
     )
     with pytest.raises(ValueError, match="Tracking"):
         pred_both.predict("anything")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 7. The centroid method/fallback reach the layer the factory builds
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _ckpt_with_centroid_method(tmp_path, method=None, fallback=None, anchor_part=None):
+    """Copy the centroid ckpt and set the centroid knobs in its saved config."""
+    import shutil
+
+    from omegaconf import OmegaConf
+
+    dest = tmp_path / "centroid_ckpt"
+    shutil.copytree(CENTROID_CKPT, dest)
+    cfg_path = dest / "training_config.yaml"
+    cfg = OmegaConf.load(cfg_path)
+    confmaps = cfg.model_config.head_configs.centroid.confmaps
+    if method is not None:
+        confmaps.centroid_method = method
+    if fallback is not None:
+        confmaps.centroid_fallback = fallback
+    confmaps.anchor_part = anchor_part
+    OmegaConf.save(cfg, cfg_path)
+    return dest
+
+
+@pytest.mark.skipif(not CENTROID_CKPT.exists(), reason="centroid ckpt absent")
+@pytest.mark.parametrize("method", ["bbox_center", "geometric_median"])
+def test_centroid_method_reaches_the_predictor_layer(tmp_path, method):
+    """A checkpoint's `centroid_method` must survive into `CentroidLayer`.
+
+    The loaders resolve the method off the head config, but the new-flow builders
+    forwarded only `anchor_ind`, so the layer re-inferred `center_of_mass` from it
+    — and `sio.Centroid.source`, which reads `layer.centroid_method`, then
+    recorded the wrong method for every prediction.
+    """
+    ckpt = _ckpt_with_centroid_method(tmp_path, method=method)
+    predictor = Predictor.from_model_paths([str(ckpt)], device="cpu")
+
+    assert isinstance(predictor.layer, CentroidLayer)
+    assert predictor.layer.centroid_method == method
+    # The `sio.Centroid.source` tag is derived from the same field.
+    assert predictor._packaging_centroid_method() == method
+
+
+@pytest.mark.skipif(not CENTROID_CKPT.exists(), reason="centroid ckpt absent")
+def test_centroid_anchor_and_fallback_reach_the_predictor_layer(tmp_path):
+    """`anchor_part` + `centroid_fallback` must both survive into the layer."""
+    ckpt = _ckpt_with_centroid_method(
+        tmp_path, method="anchor", fallback="bbox_center", anchor_part="A"
+    )
+    predictor = Predictor.from_model_paths([str(ckpt)], device="cpu")
+
+    assert predictor.layer.centroid_method == "anchor"
+    assert predictor.layer.centroid_fallback == "bbox_center"
+    assert predictor.layer.anchor_ind == 0
+
+
+@pytest.mark.skipif(not CENTROID_CKPT.exists(), reason="centroid ckpt absent")
+def test_centroid_method_default_is_unchanged(tmp_path):
+    """With the knobs unset, the layer keeps the historical inference."""
+    ckpt = _ckpt_with_centroid_method(tmp_path)
+    predictor = Predictor.from_model_paths([str(ckpt)], device="cpu")
+
+    assert predictor.layer.centroid_method == "center_of_mass"
+    assert predictor.layer.anchor_ind is None

--- a/tests/test_evaluation_centroid_gt.py
+++ b/tests/test_evaluation_centroid_gt.py
@@ -1,0 +1,217 @@
+"""Centroid evaluation against ground truth that carries no poses.
+
+A centroid model's ground truth need not be poses: it can be ``Centroid``
+annotations, made by hand (#702) or derived from segmentation masks by
+``data_config.centroids_from_masks`` (#586). Such a file has no instances at all,
+so the instance-only frame-pair filter dropped every frame and evaluation died
+with "Empty Frame Pairs" — the metrics could only ever be read off the epoch-end
+callback, never off ``sleap-nn eval``.
+"""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap_nn.data.instance_centroids import add_centroids_from_masks
+from sleap_nn.evaluation import Evaluator, find_frame_pairs, run_evaluation
+
+FNAME = "centroid_gt.mp4"
+# Two squares per frame, spanning [4, 12) and [20, 28) on both axes.
+SQUARE_CENTERS = [(7.5, 7.5), (23.5, 23.5)]
+
+
+def _mask_only_gt(n_frames=3):
+    """Mask-only, skeleton-less ground truth."""
+    video = sio.Video.from_filename(FNAME)
+    frames = []
+    for frame_idx in range(n_frames):
+        masks = []
+        for k in range(2):
+            arr = np.zeros((40, 40), dtype=bool)
+            arr[4 + 16 * k : 12 + 16 * k, 4 + 16 * k : 12 + 16 * k] = True
+            masks.append(sio.UserSegmentationMask.from_numpy(arr))
+        frames.append(
+            sio.LabeledFrame(
+                video=video, frame_idx=frame_idx, instances=[], masks=masks
+            )
+        )
+    return sio.Labels(labeled_frames=frames, videos=[video], skeletons=[])
+
+
+def _centroid_only_gt(n_frames=3):
+    """Hand-annotated ``UserCentroid`` ground truth: no poses, no masks."""
+    video = sio.Video.from_filename(FNAME)
+    frames = []
+    for frame_idx in range(n_frames):
+        frames.append(
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=frame_idx,
+                instances=[],
+                centroids=[sio.UserCentroid(x=x, y=y) for x, y in SQUARE_CENTERS],
+            )
+        )
+    return sio.Labels(labeled_frames=frames, videos=[video], skeletons=[])
+
+
+def _centroid_predictions(n_frames=3, offset=1.0):
+    """Centroid-model output: single-node instances, `offset` px off in x."""
+    video = sio.Video.from_filename(FNAME)
+    skeleton = sio.get_centroid_skeleton()
+    frames = []
+    for frame_idx in range(n_frames):
+        frames.append(
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=frame_idx,
+                instances=[
+                    sio.PredictedInstance.from_numpy(
+                        np.array([[x + offset, y]]),
+                        skeleton=skeleton,
+                        score=0.9,
+                        point_scores=np.ones(1),
+                    )
+                    for x, y in SQUARE_CENTERS
+                ],
+            )
+        )
+    return sio.Labels(labeled_frames=frames, videos=[video], skeletons=[skeleton])
+
+
+def _save(labels, path):
+    sio.save_slp(labels, path.as_posix())
+    return path.as_posix()
+
+
+def test_centroid_eval_on_mask_derived_ground_truth(tmp_path):
+    """Mask-only GT + `centroids_from_masks` is evaluable end to end."""
+    gt = _mask_only_gt()
+    assert add_centroids_from_masks(gt, method="center_of_mass") == 6
+    pred = _centroid_predictions(offset=1.0)
+
+    metrics = run_evaluation(
+        _save(gt, tmp_path / "gt.slp"),
+        _save(pred, tmp_path / "pred.slp"),
+        match_method="centroid",
+    )
+
+    assert metrics is not None
+    # Every prediction matches its own centroid, 1 px away by construction.
+    assert metrics["distance_metrics"]["p50"] == pytest.approx(1.0)
+    assert metrics["detection_metrics"]["precision"] == pytest.approx(1.0)
+    assert metrics["detection_metrics"]["recall"] == pytest.approx(1.0)
+
+
+def test_centroid_eval_on_hand_annotated_centroid_ground_truth(tmp_path):
+    """The same holds for `UserCentroid` annotations with no masks behind them."""
+    metrics = run_evaluation(
+        _save(_centroid_only_gt(), tmp_path / "gt.slp"),
+        _save(_centroid_predictions(offset=2.0), tmp_path / "pred.slp"),
+        match_method="centroid",
+    )
+
+    assert metrics is not None
+    assert metrics["distance_metrics"]["p50"] == pytest.approx(2.0)
+    assert metrics["detection_metrics"]["recall"] == pytest.approx(1.0)
+
+
+def test_centroid_annotations_are_exact_under_every_method(tmp_path):
+    """A one-node wrapper makes the reduce method irrelevant, as it must.
+
+    `anchor_ind` and `centroid_method` index into a POSE skeleton; a centroid
+    annotation is already the answer, so no method may move it.
+    """
+    gt_path = _save(_centroid_only_gt(), tmp_path / "gt.slp")
+    pred_path = _save(_centroid_predictions(offset=1.0), tmp_path / "pred.slp")
+
+    for method in ["center_of_mass", "bbox_center", "geometric_median"]:
+        gt, pred = sio.load_slp(gt_path), sio.load_slp(pred_path)
+        evaluator = Evaluator(
+            gt,
+            pred,
+            match_method="centroid",
+            match_threshold=50.0,
+            centroid_method=method,
+            # A pose anchor index that does not exist on the one-node wrapper:
+            # it must be ignored, not raise.
+            anchor_ind=3,
+        )
+        assert len(evaluator.positive_pairs) == 6
+        assert evaluator.distance_metrics()["p50"] == pytest.approx(1.0)
+
+
+def test_user_instances_still_win_when_a_frame_has_both(tmp_path):
+    """A frame with poses uses them; the centroid path is only a fallback."""
+    video = sio.Video.from_filename(FNAME)
+    skeleton = sio.Skeleton(["A", "B"])
+    # Pose spans x=10..30, so its center of mass is 20 -- far from the
+    # deliberately wrong centroid annotation at x=0.
+    gt = sio.Labels(
+        labeled_frames=[
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    sio.Instance.from_numpy(
+                        np.array([[10.0, 20.0], [30.0, 20.0]]), skeleton=skeleton
+                    )
+                ],
+                centroids=[sio.UserCentroid(x=0.0, y=0.0)],
+            )
+        ],
+        videos=[video],
+        skeletons=[skeleton],
+    )
+    pred_skeleton = sio.get_centroid_skeleton()
+    pred = sio.Labels(
+        labeled_frames=[
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    sio.PredictedInstance.from_numpy(
+                        np.array([[20.0, 20.0]]),
+                        skeleton=pred_skeleton,
+                        score=0.9,
+                        point_scores=np.ones(1),
+                    )
+                ],
+            )
+        ],
+        videos=[video],
+        skeletons=[pred_skeleton],
+    )
+
+    metrics = run_evaluation(
+        _save(gt, tmp_path / "gt.slp"),
+        _save(pred, tmp_path / "pred.slp"),
+        match_method="centroid",
+    )
+
+    # Distance 0 from the pose's own center of mass; had the annotation been
+    # used instead, this would be ~28 px.
+    assert metrics["distance_metrics"]["p50"] == pytest.approx(0.0)
+
+
+def test_frames_with_neither_still_raise(tmp_path):
+    """No poses and no centroids is still an error, not a silent empty pass."""
+    video = sio.Video.from_filename(FNAME)
+    gt = sio.Labels(
+        labeled_frames=[
+            sio.LabeledFrame(video=video, frame_idx=0, instances=[], masks=[])
+        ],
+        videos=[video],
+        skeletons=[],
+    )
+
+    with pytest.raises(Exception, match="Empty Frame Pairs"):
+        Evaluator(gt, _centroid_predictions(n_frames=1), match_method="centroid")
+
+
+def test_find_frame_pairs_keeps_centroid_frames_only_when_asked():
+    """The frame-pair change is opt-in: OKS mode behaves exactly as before."""
+    gt = _centroid_only_gt(n_frames=2)
+    pred = _centroid_predictions(n_frames=2)
+
+    assert find_frame_pairs(gt, pred) == []
+    assert len(find_frame_pairs(gt, pred, keep_user_centroid_frames=True)) == 2

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -1924,3 +1924,138 @@ class TestCsvLogKeysEvalMetrics:
         )
         csv_logger = next(c for c in callbacks if isinstance(c, CSVLoggerCallback))
         assert not any(key.startswith("eval/") for key in csv_logger.keys)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #586 / #674 — centroid methods and mask-derived centroid targets
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _centroid_cfg_from(config, tmp_path, **data_overrides):
+    """A minimal centroid training config off an existing fixture config."""
+    cfg = OmegaConf.create(OmegaConf.to_container(config, resolve=True))
+    cfg.model_config.head_configs.centroid = OmegaConf.create(
+        {"confmaps": {"anchor_part": None, "sigma": 1.5, "output_stride": 2}}
+    )
+    for head in list(cfg.model_config.head_configs.keys()):
+        if head != "centroid":
+            cfg.model_config.head_configs[head] = None
+    cfg.trainer_config.max_epochs = 1
+    cfg.trainer_config.save_ckpt = False
+    cfg.trainer_config.use_wandb = False
+    cfg.trainer_config.ckpt_dir = str(tmp_path)
+    cfg.trainer_config.run_name = "centroid_method_test"
+    for k, v in data_overrides.items():
+        cfg.data_config[k] = v
+    return cfg
+
+
+def test_centroid_method_is_threaded_into_the_dataset(config, tmp_path):
+    """The head config's centroid_method must reach the dataset that builds targets."""
+    from sleap_nn.data.custom_datasets import get_train_val_datasets
+
+    cfg = _centroid_cfg_from(config, tmp_path)
+    cfg.model_config.head_configs.centroid.confmaps.centroid_method = "bbox_center"
+    labels = [sio.load_slp(cfg.data_config.train_labels_path[0])]
+
+    train_ds, _ = get_train_val_datasets(labels, labels, cfg)
+    assert train_ds.centroid_method == "bbox_center"
+    assert train_ds.centroid_fallback is None
+
+
+def _with_skeletons(cfg, labels):
+    """Serialize a skeleton into the config the way ModelTrainer._setup_config does."""
+    import yaml
+    from sleap_io.io.skeleton import SkeletonYAMLEncoder
+
+    skeleton_yaml = yaml.safe_load(SkeletonYAMLEncoder().encode(labels[0].skeletons))
+    cfg.data_config.skeletons = []
+    for name, skl in skeleton_yaml.items():
+        skl["name"] = name
+        cfg.data_config.skeletons.append(skl)
+    return cfg
+
+
+def test_centroid_method_anchor_fallback_is_threaded(config, tmp_path):
+    """anchor_part + centroid_fallback resolve to ('anchor', <fallback>)."""
+    from sleap_nn.data.custom_datasets import get_train_val_datasets
+
+    labels = [sio.load_slp(config.data_config.train_labels_path[0])]
+    node = labels[0].skeletons[0].node_names[0]
+
+    cfg = _with_skeletons(_centroid_cfg_from(config, tmp_path), labels)
+    cfg.model_config.head_configs.centroid.confmaps.anchor_part = node
+    cfg.model_config.head_configs.centroid.confmaps.centroid_fallback = (
+        "geometric_median"
+    )
+    train_ds, _ = get_train_val_datasets(labels, labels, cfg)
+    assert train_ds.centroid_method == "anchor"
+    assert train_ds.centroid_fallback == "geometric_median"
+
+
+def test_unresolvable_anchor_degrades_instead_of_raising(config, tmp_path):
+    """An anchor_part absent from the skeleton falls back rather than crashing.
+
+    The centroid model deliberately tolerates this (the anchor path is only a
+    fallback for frames without user centroids), so the batched op must not raise
+    from inside a dataloader worker.
+    """
+    from sleap_nn.data.custom_datasets import get_train_val_datasets
+
+    labels = [sio.load_slp(config.data_config.train_labels_path[0])]
+    cfg = _with_skeletons(_centroid_cfg_from(config, tmp_path), labels)
+    cfg.model_config.head_configs.centroid.confmaps.anchor_part = "not_a_node"
+    cfg.model_config.head_configs.centroid.confmaps.centroid_fallback = "bbox_center"
+
+    train_ds, _ = get_train_val_datasets(labels, labels, cfg)
+    assert train_ds.centroid_method == "bbox_center"
+    assert train_ds.centroid_fallback is None
+
+
+def test_contradictory_centroid_config_fails_at_setup(config, tmp_path):
+    """anchor_part + a non-anchor method must fail early, naming the head."""
+    cfg = _centroid_cfg_from(config, tmp_path)
+    cfg.model_config.head_configs.centroid.confmaps.anchor_part = "0"
+    cfg.model_config.head_configs.centroid.confmaps.centroid_method = "bbox_center"
+
+    with pytest.raises(ValueError, match=r"head_configs\.centroid\.confmaps"):
+        ModelTrainer.get_model_trainer_from_config(cfg)
+
+
+def test_centroids_from_masks_makes_mask_only_labels_trainable(config, tmp_path):
+    """A mask-only dataset has zero trainable frames until masks are converted.
+
+    This is what #674 existed for; it is now a few lines feeding the existing
+    ``centroid_source="user"`` path.
+    """
+    labels = sio.load_slp(config.data_config.train_labels_path[0])
+    labels.get_masks()  # build masks from the poses
+    if not any(getattr(lf, "masks", None) for lf in labels):
+        pytest.skip("fixture produced no segmentation masks")
+    # Strip the poses: what remains is a mask-only dataset.
+    for lf in labels:
+        lf.instances = []
+    mask_only = tmp_path / "mask_only.slp"
+    sio.save_slp(labels, mask_only.as_posix())
+
+    cfg = _centroid_cfg_from(config, tmp_path)
+    cfg.data_config.train_labels_path = [mask_only.as_posix()]
+    cfg.data_config.val_labels_path = [mask_only.as_posix()]
+
+    # Without the flag: no trainable frame at all.
+    with pytest.raises(ValueError, match="No labeled frames available"):
+        ModelTrainer.get_model_trainer_from_config(cfg)
+
+    # With it: the frames become trainable and carry one centroid per mask.
+    cfg.data_config.centroids_from_masks = "center_of_mass"
+    trainer = ModelTrainer.get_model_trainer_from_config(cfg)
+    n_masks = sum(len(lf.masks) for lf in labels)
+    n_centroids = sum(len(lf.centroids) for lbls in trainer.train_labels for lf in lbls)
+    assert n_centroids == n_masks
+
+
+def test_centroids_from_masks_rejects_an_unknown_method(config, tmp_path):
+    cfg = _centroid_cfg_from(config, tmp_path)
+    cfg.data_config.centroids_from_masks = "anchor"  # a mask has no nodes
+    with pytest.raises(ValueError, match="unknown method"):
+        ModelTrainer.get_model_trainer_from_config(cfg)

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -2057,5 +2057,11 @@ def test_centroids_from_masks_makes_mask_only_labels_trainable(config, tmp_path)
 def test_centroids_from_masks_rejects_an_unknown_method(config, tmp_path):
     cfg = _centroid_cfg_from(config, tmp_path)
     cfg.data_config.centroids_from_masks = "anchor"  # a mask has no nodes
-    with pytest.raises(ValueError, match="unknown method"):
+    with pytest.raises(ValueError, match="unsupported method"):
+        ModelTrainer.get_model_trainer_from_config(cfg)
+
+    # `geometric_median` is valid for POSE-derived centroids but has no mask
+    # equivalent; it must be rejected here, not deep inside sleap-io at load time.
+    cfg.data_config.centroids_from_masks = "geometric_median"
+    with pytest.raises(ValueError, match="not offered for masks"):
         ModelTrainer.get_model_trainer_from_config(cfg)

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -2022,36 +2022,125 @@ def test_contradictory_centroid_config_fails_at_setup(config, tmp_path):
         ModelTrainer.get_model_trainer_from_config(cfg)
 
 
+def _mask_only_labels(config, keep_skeleton: bool = True):
+    """Build mask-only labels in memory: real masks, poses stripped.
+
+    ``Labels.get_masks()`` is a *query* in sleap-io 0.9.2, not a builder, so the
+    earlier version of these tests silently skipped and the feature shipped with
+    no exercised trainer coverage. ``Instance.to_mask`` is the actual builder.
+
+    Kept in memory rather than round-tripped through ``sio.save_slp``: the
+    fixture is an embedded ``.pkg.slp``, and re-saving it thin leaves a video
+    whose shape cannot be resolved — unrelated to what these tests check.
+    """
+    labels = sio.load_slp(config.data_config.train_labels_path[0])
+    for lf in labels:
+        height, width = lf.image.shape[:2]
+        masks = []
+        for inst in lf.instances:
+            # `method="shapes"` (the default) needs a non-zero radius, else it
+            # raises rather than rasterizing an empty geometry. A user instance
+            # yields a `UserSegmentationMask` with metadata propagated.
+            mask = inst.to_mask(
+                height=height, width=width, node_radius=4, edge_radius=2
+            )
+            # The poses are about to be stripped, so drop the back-link too: a
+            # mask-only file has no instance for a mask to point at.
+            mask.instance = None
+            masks.append(mask)
+        lf.masks = masks
+        lf.instances = []
+    assert any(len(lf.masks) for lf in labels), "fixture produced no masks"
+    if not keep_skeleton:
+        labels.skeletons = []
+    return labels
+
+
 def test_centroids_from_masks_makes_mask_only_labels_trainable(config, tmp_path):
     """A mask-only dataset has zero trainable frames until masks are converted.
 
     This is what #674 existed for; it is now a few lines feeding the existing
     ``centroid_source="user"`` path.
     """
-    labels = sio.load_slp(config.data_config.train_labels_path[0])
-    labels.get_masks()  # build masks from the poses
-    if not any(getattr(lf, "masks", None) for lf in labels):
-        pytest.skip("fixture produced no segmentation masks")
-    # Strip the poses: what remains is a mask-only dataset.
-    for lf in labels:
-        lf.instances = []
-    mask_only = tmp_path / "mask_only.slp"
-    sio.save_slp(labels, mask_only.as_posix())
+    labels = _mask_only_labels(config)
+    n_masks = sum(len(lf.masks) for lf in labels)
 
     cfg = _centroid_cfg_from(config, tmp_path)
-    cfg.data_config.train_labels_path = [mask_only.as_posix()]
-    cfg.data_config.val_labels_path = [mask_only.as_posix()]
 
     # Without the flag: no trainable frame at all.
     with pytest.raises(ValueError, match="No labeled frames available"):
-        ModelTrainer.get_model_trainer_from_config(cfg)
+        ModelTrainer.get_model_trainer_from_config(
+            cfg, train_labels=[labels.copy()], val_labels=[labels.copy()]
+        )
 
     # With it: the frames become trainable and carry one centroid per mask.
     cfg.data_config.centroids_from_masks = "center_of_mass"
-    trainer = ModelTrainer.get_model_trainer_from_config(cfg)
-    n_masks = sum(len(lf.masks) for lf in labels)
+    trainer = ModelTrainer.get_model_trainer_from_config(
+        cfg, train_labels=[labels.copy()], val_labels=[labels.copy()]
+    )
     n_centroids = sum(len(lf.centroids) for lbls in trainer.train_labels for lf in lbls)
     assert n_centroids == n_masks
+
+
+def test_centroids_from_masks_works_on_skeleton_less_labels(config, tmp_path):
+    """Truly skeleton-less mask-only labels must reach training.
+
+    ``labels.skeletons == []`` is the real shape of a mask-only file, and
+    ``_setup_head_config`` indexed ``self.skeletons[0]`` unconditionally — so the
+    headline path died with a bare ``IndexError`` before any guard could speak.
+    A centroid head declares neither part_names nor edges, so it needs no
+    skeleton at all.
+    """
+    labels = _mask_only_labels(config, keep_skeleton=False)
+    assert labels.skeletons == [], "the fixture must be genuinely skeleton-less"
+    n_masks = sum(len(lf.masks) for lf in labels)
+
+    cfg = _centroid_cfg_from(config, tmp_path)
+    cfg.data_config.centroids_from_masks = "center_of_mass"
+
+    trainer = ModelTrainer.get_model_trainer_from_config(
+        cfg, train_labels=[labels.copy()], val_labels=[labels.copy()]
+    )
+
+    assert trainer.skeletons == []
+    assert list(trainer.config.data_config.skeletons) == []
+    n_centroids = sum(len(lf.centroids) for lbls in trainer.train_labels for lf in lbls)
+    assert n_centroids == n_masks
+
+
+def test_head_config_without_a_skeleton_names_the_head_it_cannot_fill(config):
+    """A head that genuinely needs a skeleton must say so, not IndexError.
+
+    Called directly: a pose head on skeleton-less labels never gets this far
+    through the factory, because the empty-split guard rejects mask-only data for
+    a pose model first. The guard exists so that a skeleton-less path which DOES
+    reach head setup (as the centroid model now does) fails with a message naming
+    the head and field, instead of a bare ``IndexError`` on ``self.skeletons[0]``.
+    """
+    cfg = OmegaConf.create(OmegaConf.to_container(config, resolve=True))
+    cfg.model_config.head_configs.centered_instance.confmaps.part_names = None
+
+    trainer = ModelTrainer(config=cfg)
+    trainer.model_type = "centered_instance"
+    trainer.skeletons = []
+
+    with pytest.raises(ValueError, match=r"part_names is null and the labels carry"):
+        trainer._setup_head_config()
+
+    # Same for a head that needs edges.
+    cfg_bu = OmegaConf.create(OmegaConf.to_container(config, resolve=True))
+    cfg_bu.model_config.head_configs.centered_instance = None
+    # Only the `pafs` key, so the edges branch is what runs (a `confmaps` key
+    # would hit the part_names check first).
+    cfg_bu.model_config.head_configs.bottomup = OmegaConf.create(
+        {"pafs": {"edges": None, "sigma": 4.0, "output_stride": 4}}
+    )
+    trainer_bu = ModelTrainer(config=cfg_bu)
+    trainer_bu.model_type = "bottomup"
+    trainer_bu.skeletons = []
+
+    with pytest.raises(ValueError, match=r"edges is null and the labels carry"):
+        trainer_bu._setup_head_config()
 
 
 def test_centroids_from_masks_rejects_an_unknown_method(config, tmp_path):


### PR DESCRIPTION
Closes #586.

## The problem

sleap-nn has exactly **one** definition of what a centroid *means* — the mean of an instance's visible nodes, or a named anchor node with that mean as its fallback. `generate_centroids`' own docstring has carried the open question since #530 changed the convention:

> *Pre-#530 this was the bounding-box midpoint. The two modes are tracked for a future revisit in #586 — keep this consistent with the centroid target generated during training.*

Meanwhile `sleap_io` grew `Instance.to_centroid(method=…)` / `SegmentationMask.to_centroid(method=…)` with a four-way vocabulary. This exposes that choice in sleap-nn, using **sleap-io's spelling verbatim** so there is one name for each of these concepts across the ecosystem.

## What you can now set

| `centroid_method` | the centroid is | good for |
|---|---|---|
| `center_of_mass` *(default)* | mean of the visible nodes | most datasets |
| `bbox_center` | midpoint of the visible nodes' bounding box | the pre-#530 convention, now expressible instead of lost |
| `geometric_median` | Weiszfeld median of the visible nodes | **new capability** — robust to a few outlying nodes, so it tracks the body center of an elongated or curled animal where the mean is dragged off by a tail node |
| `anchor` | the `anchor_part` node, falling back to `centroid_fallback` when occluded | a reliable, consistently-visible landmark |

```yaml
model_config:
  head_configs:
    centroid:
      confmaps:
        centroid_method: geometric_median
# or, an anchor with a non-default fallback:
        anchor_part: thorax
        centroid_fallback: bbox_center     # used only when `thorax` is occluded
```

Two knobs — `centroid_method` and `centroid_fallback` — on **every head config that already carries `anchor_part`**: `centroid`, `centered_instance` (and so `multi_class_topdown`), and `centered_instance_segmentation`. `resolve_centroid_method` is the single place that maps the config pair onto sleap-io's `(method, fallback)` argument pair.

## Defaults do not move

`centroid_method: null` (the default) means *"the anchor node when `anchor_part` is set, else `center_of_mass`"* — precisely what every config written before this PR means today. A test asserts the default path is byte-identical to the pre-#586 output, both with and without an anchor.

Setting `anchor_part` **and** a non-anchor `centroid_method` names two different centroids, so it is rejected at setup with a message naming the head — not deep inside a dataloader worker, where the traceback is a multiprocessing wrapper and the run has already spent minutes caching images.

## Threaded everywhere a centroid is derived

These must not drift, and `inference/centroid_convert.py` already documented that they must move "in lockstep":

- all five `generate_centroids` call sites in the datasets (centroid target, top-down crop centers, the segmentation and multi-class variants);
- the GT-centroid inference layers (`CentroidLayer`, `CentroidCrop`) and the four loaders that build them — reading the knobs off the **crop-consuming** model's saved head config, so inference reproduces the training geometry automatically;
- the evaluator, plus `--centroid_method` / `--centroid_fallback` on `sleap-nn eval`, and the post-training centroid eval in `train.py`;
- the export metadata and the recorded `sio.Centroid.source` tag, so an exported `bbox_center` model no longer records its predictions as `center_of_mass`;
- `ConfigGenerator.centroid_method(method, fallback=None)`.

`evaluation.compute_gt_centroids` was a **hand-written numpy mirror** of `generate_centroids`. It now delegates to it. That removes the drift the comment warned about, and means the metric can no longer score a model against a different centroid than the one it was trained to predict.

## Training a centroid model on mask-only labels

A dataset with segmentation masks but no poses has *nothing* for the centroid target to be derived from — zero trainable frames. `data_config.centroids_from_masks` names a method and derives a `UserCentroid` per mask at load time via `sio.SegmentationMask.to_centroid`, after which the existing `centroid_source="user"` path takes over unchanged; nothing downstream knows the centroids came from masks. Frames that already carry user centroids are left alone — a real annotation outranks a derived one.

```yaml
data_config:
  centroids_from_masks: center_of_mass
```

## Two bugs found while doing this

- **`get_train_val_datasets` crashed on skeleton-less labels** for the centroid model — a bare `ConfigIndexError: list index out of range` from indexing `data_config.skeletons[0]`. An absent skeleton just means there is no anchor node to resolve. This is exactly the mask-only case above, so it blocked the feature.
- **The batched geometric median was not batch-invariant.** The stopping rule was the batch's, not each slot's, so a slow-converging instance kept iterating while its neighbours were done — an instance's centroid depended on which other instances shared its batch (measured: **0.24 px**). Convergence is now tracked per slot, which also makes the batched result identical to the per-instance reference. Regression test included.

## Numerics

The Weiszfeld iteration runs in **float64** regardless of input dtype. It reweights by `1 / distance`, and near a Fermat point that sits on one of the input nodes the distances approach zero and float32 loses all relative precision there — measured against the numpy reference on random 13-node instances, float32 drifts up to **0.18 px** while float64 agrees to **~1e-13**. The tensors are a few hundred floats, so the promotion costs nothing measurable, and it is what lets the parity test assert equality rather than a loose tolerance.

One deliberate divergence from sleap-io, documented in the module: sleap-io decides node visibility from the **x-coordinate alone** (`~isnan(pts[:, 0])`); the reductions here count non-NaN **per axis** (`find_points_mean`, #584) or per point (geometric median). The two agree whenever a node's coordinates are NaN together — which is what sleap-io itself writes — and differ only for a half-NaN point, where this module's answer is the better-defined one.

## Tests

25 new tests. The load-bearing one asserts **object-level `to_centroid` and the batched tensor op agree per method** over random instances — the invariant `centroid_convert.py` warns must hold, now checked rather than hoped for. Plus: the default path is byte-identical to pre-#586; every method is reachable end to end; the evaluator mirror matches the tensor op; the contradictory config is rejected naming the head; an unresolvable `anchor_part` degrades rather than raising; and mask-only labels become trainable.

Full suite green on this branch: **1,812 passed** across `data` / `config` / `architectures` / `export` / `inference` / `training` / `tracking` / `evaluation` (the one deselection, `test_loading_pretrained_weights`, is a pre-existing `main` DDP-process-group leak that fails on any multi-GPU machine and is unrelated to this change).

## Measured, not just refactored

`geometric_median` is new capability, so it was measured rather than assumed. Trained on the **mask-only** gerbil set (1,238 frames / 2,257 masks, no poses and no centroid annotations anywhere — so the `centroids_from_masks` path is what makes it trainable at all), UNet, 50 epochs, seed 42, one arm per method, everything else identical:

| `centroid_method` | median dist | avg dist | precision | recall |
|---|---|---|---|---|
| `center_of_mass` | **3.48 px** | 5.19 | 0.868 | 0.962 |
| `bbox_center` | 5.67 px | 6.79 | 0.889 | 0.943 |
| `geometric_median` | *(see comment below)* | | | |

Metrics are read at the last eval epoch at or before the checkpoint the run actually selected, not as a per-metric best across epochs — checkpoint selection is part of the result.

This **reproduces the recorded result** that motivated the mask-derived-centroid work (median ≈3 px, and `center_of_mass` clearly ahead of `bbox_center`) through the new, native derivation path rather than a hand-rolled one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBseNsDJ1wkC44pnQ1vDi
