### PR TITLE
fix(backbones): encoder mode on CNN backbones, offline loading, and frozen BatchNorm

### DIFF
--- a/docs/guides/pretrained-backbones.md
+++ b/docs/guides/pretrained-backbones.md
@@ -112,7 +112,9 @@ A ready-to-edit sample lives at
 - `freeze: true` — the encoder is frozen (feature extraction) and only the
   decoder/head train. Faster, lower memory, and more robust on very small
   datasets. sleap-nn filters frozen parameters out of the optimizer
-  automatically.
+  automatically, and holds the encoder in eval mode for the whole run so a
+  BatchNorm-bearing backbone (ResNet, BiT) does not drift its running statistics —
+  "frozen" covers the statistics, not just the weights.
 
 ### Channels and normalization
 
@@ -141,6 +143,13 @@ is applied **inside the backbone** — the data pipeline still only rescales to
   (`~/.cache/huggingface/hub`) on a networked machine, copy it over, and set
   `HF_HUB_OFFLINE=1`. With `weights: false` the architecture still needs the
   model's `config.json` (tiny), but no checkpoint download.
+
+  sleap-nn resolves the concrete `*Backbone` class from `AutoConfig` rather than
+  going through `AutoBackbone.from_pretrained`, which probes the Hub for the
+  repo's existence before resolving anything and so fails offline even for a
+  fully-cached model. A backbone whose config type is not in `transformers`'
+  backbone mapping (a custom or very new model) falls back to `AutoBackbone` and
+  inherits that limitation.
 
 ## Gotchas
 

--- a/sleap_nn/architectures/pretrained.py
+++ b/sleap_nn/architectures/pretrained.py
@@ -108,6 +108,40 @@ def _resolve_mode(config: Any, mode: str) -> str:
     return "encoder" if is_isotropic else "decoder"
 
 
+def _resolve_backbone_class(config: Any):
+    """Return the concrete ``*Backbone`` class for an HF config.
+
+    ``AutoBackbone.from_pretrained`` performs a Hub existence check before it
+    resolves anything, so it cannot load a cached model under
+    ``HF_HUB_OFFLINE=1``. ``AutoConfig`` has no such check, so resolving the class
+    from an already-loaded config and calling ``from_pretrained`` on it keeps the
+    documented air-gapped path working.
+
+    Args:
+        config: A loaded HuggingFace config object.
+
+    Returns:
+        The mapped ``*Backbone`` class, or :class:`transformers.AutoBackbone` when
+        the config type is not in the backbone mapping (a custom or very new
+        model) — in which case the caller gets the original behavior, including
+        its offline limitation.
+    """
+    from transformers import AutoBackbone
+
+    try:
+        from transformers.models.auto.modeling_auto import (
+            MODEL_FOR_BACKBONE_MAPPING,
+        )
+
+        return MODEL_FOR_BACKBONE_MAPPING[type(config)]
+    except Exception:  # noqa: BLE001 - any lookup failure falls back to Auto
+        logger.debug(
+            f"No backbone mapping for {type(config).__name__}; falling back to "
+            "AutoBackbone (which cannot load offline)."
+        )
+        return AutoBackbone
+
+
 class PretrainedBackbone(nn.Module):
     """Wrap a HuggingFace pretrained backbone as a sleap-nn encoder.
 
@@ -224,18 +258,42 @@ class PretrainedBackbone(nn.Module):
                 idxs = (0, 1, 2, 3)
             backbone_kwargs = dict(out_indices=idxs)
 
+        # BOTH branches configure the backbone the same way: set the options as
+        # ATTRIBUTES on the config, then build from that config. Passing them as
+        # `from_pretrained(**kwargs)` instead — which the weights=True path used to
+        # do — forwards anything the config does not claim to the model's
+        # `__init__`, and Case B's `reshape_hidden_states`/`apply_layernorm` exist
+        # only on the ViT-family classes:
+        #
+        #     ConvNextV2Backbone.__init__() got an unexpected keyword argument
+        #     'reshape_hidden_states'
+        #
+        # That made `mode="encoder"` unusable for every CNN backbone with real
+        # weights, while the weights=False path (already config-based, where an
+        # unclaimed attribute is silently ignored) worked — so the two paths
+        # disagreed, and every test in `tests/architectures/test_pretrained.py`
+        # exercises only the one that works. Configuring both identically removes
+        # the divergence rather than special-casing the symptom.
+        for k, v in backbone_kwargs.items():
+            setattr(hf_config, k, v)
+
         if weights:
-            self.enc = AutoBackbone.from_pretrained(
+            # Resolve the concrete `*Backbone` class from the config instead of
+            # going through `AutoBackbone.from_pretrained`, which probes
+            # `hf_api().repo_exists()` before resolving anything and therefore
+            # raises `OfflineModeIsEnabled` under `HF_HUB_OFFLINE=1` even for a
+            # fully-cached model — breaking the air-gapped workflow the guide
+            # documents. `AutoConfig` is offline-capable, so the class it maps to
+            # is reachable without the network.
+            backbone_cls = _resolve_backbone_class(hf_config)
+            self.enc = backbone_cls.from_pretrained(
                 model_name,
+                config=hf_config,
                 revision=revision,
                 dtype=torch.float32,
-                **backbone_kwargs,
             )
         else:
-            cfg = AutoConfig.from_pretrained(model_name, revision=revision)
-            for k, v in backbone_kwargs.items():
-                setattr(cfg, k, v)
-            self.enc = AutoBackbone.from_config(cfg)
+            self.enc = AutoBackbone.from_config(hf_config)
 
         # Snapshot loaded weights on CPU so they can be re-applied after the
         # LightningModule's xavier init clobbers them (mirrors convnext/swint).
@@ -427,9 +485,32 @@ class PretrainedBackbone(nn.Module):
 
     def freeze_encoder(self) -> None:
         """Freeze the pretrained encoder (feature extraction; decoder/head train)."""
+        self.freeze = True
         self.enc.eval()
         self.enc.requires_grad_(False)
         logger.info(f"Froze pretrained encoder '{self.model_name}'.")
+
+    def train(self, mode: bool = True) -> "PretrainedBackbone":
+        """Set train/eval mode, keeping a FROZEN encoder in eval.
+
+        ``freeze_encoder`` calls ``enc.eval()`` once, but Lightning calls
+        ``model.train()`` at the start of every training epoch and that recurses
+        into every submodule — so without this override the encoder goes back into
+        train mode and its normalization layers keep updating. Weights stay frozen
+        (``requires_grad_(False)``); the running statistics did not, which is not
+        what ``freeze: true`` promises and makes a "frozen" run irreproducible in a
+        way that looks like seed noise.
+
+        Only matters for a backbone with running stats (BatchNorm: ResNet, BiT —
+        measured on ``microsoft/resnet-18``, ``running_mean`` moved 0.63 in a
+        single forward). ConvNeXt / Swin / ViT use LayerNorm and are unaffected,
+        which is why this went unnoticed: the documented default backbone is
+        ConvNeXtV2.
+        """
+        super().train(mode)
+        if getattr(self, "freeze", False):
+            self.enc.eval()
+        return self
 
     # ------------------------------------------------------------------ config
 

--- a/tests/architectures/test_pretrained.py
+++ b/tests/architectures/test_pretrained.py
@@ -1,11 +1,22 @@
 """Tests for external pretrained (HuggingFace) backbones.
 
-These tests build backbones with ``weights=False`` (random init from the model
+Most tests build backbones with ``weights=False`` (random init from the model
 config) so they never touch the network — the HF architecture code is exercised
 without downloading checkpoints. They are skipped when ``transformers`` (the
 ``backbones`` optional extra) is not installed, mirroring the ``requires_onnxruntime``
 convention in ``tests/export``.
+
+**That convention hid a bug.** ``weights=True`` and ``weights=False`` used to
+configure the backbone by *different mechanisms* — kwargs to ``from_pretrained``
+vs. attributes on the config — and only the weights=False one tolerated an option
+the model class does not declare. So ``mode="encoder"`` was broken for every CNN
+backbone with real weights while every test here passed. The two paths now share
+one mechanism, and ``TestWeightsTrueParity`` below pins the parity directly. Those
+tests need a cached model (or the network), so they are marked ``hf_weights`` and
+skipped unless ``SLEAP_NN_TEST_HF_WEIGHTS=1``.
 """
+
+import os
 
 import numpy as np
 import pytest
@@ -304,3 +315,114 @@ def test_resolve_mode():
     assert _resolve_mode(_Cfg("convnextv2", ["stem", "s1", "s2"]), "auto") == "decoder"
     assert _resolve_mode(_Cfg("dinov2", None), "auto") == "encoder"
     assert _resolve_mode(_Cfg("resnet", ["stem", "s1", "s2"]), "auto") == "decoder"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# weights=True — the path CI never runs, where the config-vs-kwargs
+# divergence lived. Opt in with SLEAP_NN_TEST_HF_WEIGHTS=1 (needs a cached
+# model or the network).
+# ─────────────────────────────────────────────────────────────────────────
+
+requires_hf_weights = pytest.mark.skipif(
+    os.environ.get("SLEAP_NN_TEST_HF_WEIGHTS") != "1",
+    reason="needs HF weights; set SLEAP_NN_TEST_HF_WEIGHTS=1 to run",
+)
+
+
+class TestWeightsTrueParity:
+    """`weights=True` must accept exactly what `weights=False` accepts."""
+
+    @requires_hf_weights
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "facebook/convnextv2-nano-22k-224",  # CNN: no reshape_hidden_states
+            "facebook/dinov2-with-registers-base",  # ViT: has it
+        ],
+    )
+    @pytest.mark.parametrize("mode", ["auto", "encoder"])
+    def test_builds_with_and_without_weights(self, model_name, mode):
+        """Both weight settings build for both families, in both modes.
+
+        `mode="encoder"` + a CNN + `weights=True` raised
+        `TypeError: ConvNextV2Backbone.__init__() got an unexpected keyword
+        argument 'reshape_hidden_states'` — the Case-B options were forwarded to
+        the model constructor, and only ViT classes declare them.
+        """
+        for weights in (False, True):
+            bb = PretrainedBackbone.from_config(
+                _caseA_cfg(model_name, mode=mode, weights=weights)
+            )
+            out = bb(torch.rand(1, 3, 128, 128))
+            assert "middle_output" in out and "intermediate_feat" in out
+
+    @requires_hf_weights
+    def test_weights_are_actually_loaded_and_snapshotted(self):
+        """weights=True must snapshot real weights for the post-xavier reload."""
+        bb = PretrainedBackbone.from_config(
+            _caseA_cfg("facebook/convnextv2-nano-22k-224", weights=True)
+        )
+        assert bb._pretrained_sd is not None and len(bb._pretrained_sd) > 0
+        live = bb.enc.state_dict()
+        assert all(torch.equal(v, live[k].cpu()) for k, v in bb._pretrained_sd.items())
+
+
+def test_backbone_class_resolves_from_config_not_automodel():
+    """The concrete `*Backbone` class is resolved from the (offline-capable) config.
+
+    `AutoBackbone.from_pretrained` probes `hf_api().repo_exists()` before resolving
+    anything, so it raises `OfflineModeIsEnabled` under `HF_HUB_OFFLINE=1` even for
+    a fully-cached model — breaking the air-gapped workflow the guide documents.
+    Resolving the class off `AutoConfig` (which has no such probe) avoids it.
+    """
+    from transformers import AutoBackbone, AutoConfig
+
+    from sleap_nn.architectures.pretrained import _resolve_backbone_class
+
+    cfg = AutoConfig.from_pretrained("facebook/convnextv2-nano-22k-224")
+    cls = _resolve_backbone_class(cfg)
+    assert cls is not AutoBackbone
+    assert cls.__name__.endswith("Backbone")
+
+    # An unmapped config type falls back to AutoBackbone rather than raising.
+    class _Unmapped:
+        pass
+
+    assert _resolve_backbone_class(_Unmapped()) is AutoBackbone
+
+
+def test_frozen_encoder_stays_in_eval_through_train():
+    """A frozen encoder must not be flipped back to train mode.
+
+    `freeze_encoder()` calls `enc.eval()` once, but Lightning calls `model.train()`
+    at the start of every epoch and that recurses into submodules. Weights stayed
+    frozen; BatchNorm running statistics did not — measured on `microsoft/resnet-18`,
+    `running_mean` moved 0.63 in a single forward, so a "frozen" run was not
+    reproducible.
+    """
+    bb = PretrainedBackbone.from_config(_caseA_cfg("microsoft/resnet-18", freeze=True))
+    bb.freeze_encoder()
+    assert not bb.enc.training
+
+    bb.train()  # what Lightning does at every epoch start
+    assert not bb.enc.training, "frozen encoder was flipped back into train mode"
+
+    bns = [
+        m
+        for m in bb.enc.modules()
+        if isinstance(m, torch.nn.modules.batchnorm._BatchNorm)
+    ]
+    assert bns, "resnet-18 should have BatchNorm layers"
+    before = bns[0].running_mean.clone()
+    with torch.no_grad():
+        bb(torch.rand(2, 3, 128, 128))
+    assert torch.equal(before, bns[0].running_mean), "frozen BN stats drifted"
+
+
+def test_unfrozen_encoder_still_follows_train_and_eval():
+    """The override must not pin an UNfrozen encoder to eval."""
+    bb = PretrainedBackbone.from_config(_caseA_cfg("microsoft/resnet-18", freeze=False))
+    bb.train()
+    assert bb.enc.training
+    bb.eval()
+    assert not bb.enc.training


### PR DESCRIPTION
Three bugs in the external pretrained-backbone path (`backbone_config.pretrained`, added in #680), found by exercising it against a pooled re-ID head — the use case `pretrained.py:25` was written anticipating ("pooled heads: class-vectors / re-ID / embedding") but that nothing had ever tried.

**All three are invisible to the suite as it stands**, for two compounding reasons: CI never installs the `backbones` extra, so `tests/architectures/test_pretrained.py` is skipped wholesale; and every test in that file uses `weights=False`, which turns out to be the path that *works*.

## 1. `mode: encoder` was unusable for every non-ViT backbone with real weights

```python
PretrainedBackbone(model_name="facebook/convnextv2-nano-22k-224", mode="encoder")
TypeError: ConvNextV2Backbone.__init__() got an unexpected keyword argument
           'reshape_hidden_states'
```

| backbone | `weights=False` | `weights=True` (the default) |
|---|---|---|
| `facebook/convnextv2-nano-22k-224` | builds | **TypeError** |
| `facebook/dinov2-with-registers-base` | builds | builds |

Case B's `reshape_hidden_states` / `apply_layernorm` exist only on the ViT-family `*Backbone` classes. The root cause is not the options themselves but that **the two weight paths configured the backbone by different mechanisms**:

- `weights=True` → `AutoBackbone.from_pretrained(**kwargs)`, which forwards anything the config doesn't claim to the model constructor → `TypeError`;
- `weights=False` → `setattr` on the config, where an unclaimed attribute is silently ignored → fine.

So the tested path worked and the shipped path did not. `tests/architectures/test_pretrained.py:178` is literally *"mode='encoder' forces the pooled path even on a hierarchical backbone"* — asserting the behavior of the branch that cannot break.

**Fix:** both paths configure through the config. That removes the divergence rather than special-casing the symptom, so the two can't drift again.

## 2. The documented air-gapped path was broken for every pretrained backbone

The guide says to pre-seed the cache and set `HF_HUB_OFFLINE=1`. With the model fully cached:

| call | offline result |
|---|---|
| `AutoConfig.from_pretrained` | ok |
| `AutoBackbone.from_pretrained` | **`OfflineModeIsEnabled`** |
| `AutoBackbone.from_pretrained(local_files_only=True)` | **`OfflineModeIsEnabled`** |
| `ConvNextV2Backbone.from_pretrained` | ok |

`transformers/models/auto/auto_factory.py:465` calls `hf_api().repo_exists()` before resolving anything, which cannot be satisfied offline. Since `AutoConfig` has no such probe, resolve the concrete `*Backbone` class from the config already loaded and call `from_pretrained` on that. A config type absent from `transformers`' backbone mapping (custom or very new) falls back to `AutoBackbone` and inherits the limitation.

Nothing here is specific to any model type — this is the shipped feature's own documented workflow.

## 3. `freeze: true` did not freeze BatchNorm statistics

`freeze_encoder()` calls `enc.eval()` once, in `__init__`. Lightning calls `model.train()` at the start of every epoch, and that recurses into every submodule:

```
microsoft/resnet-18, freeze=True   →  20 BatchNorm layers
   enc.training at init            :  False
   enc.training after lm.train()   :  True
   running_mean after ONE forward  :  moved, max |Δ| = 0.63
```

Weights were frozen (`requires_grad_(False)` holds); the **normalization statistics were not**. A "frozen feature extractor" whose BN stats drift toward the new dataset isn't what the documentation promises, and it makes frozen runs irreproducible in a way that reads as seed noise. Overriding `train()` keeps a frozen encoder in eval.

Affects the BatchNorm-bearing families (ResNet, BiT — the same ones `config/utils.py:172` already flags as "BatchNorm-bearing" for the tiling guard). ConvNeXt / Swin / ViT use LayerNorm and are unaffected, which is why nobody hit it: the documented default backbone is ConvNeXtV2.

## Tests

- `TestWeightsTrueParity` — pins that `weights=True` accepts exactly what `weights=False` accepts, for a CNN **and** a ViT, in both modes, and that the weights are really loaded and snapshotted for the post-xavier reload. Marked behind `SLEAP_NN_TEST_HF_WEIGHTS=1` since it needs a cached model.
- The class resolution, including the `AutoBackbone` fallback for an unmapped config type.
- The frozen-BN behavior, plus a companion asserting an **un**frozen encoder still follows `train()`/`eval()` — the override must not pin it the other way.

Verified the new tests **fail on the old code and pass on the new** — exactly one failure per bug:

```
FAILED TestWeightsTrueParity::test_builds_with_and_without_weights[encoder-facebook/convnextv2-nano-22k-224]
FAILED test_backbone_class_resolves_from_config_not_automodel
FAILED test_frozen_encoder_stays_in_eval_through_train
3 failed, 23 passed
```

and after the fix, `26 passed` with `SLEAP_NN_TEST_HF_WEIGHTS=1`, `21 passed, 5 skipped` without.

## Note on CI coverage

These tests still skip on CI, because CI does not install the `backbones` extra — the fixes are verified locally. Making the extra part of one CI job would be a separate, worthwhile change; without it, this feature has no automated coverage at all, which is how three bugs of this size survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBseNsDJ1wkC44pnQ1vDi
