### PR TITLE
feat(eval): identity-persistence metrics for tracking (`sleap-nn eval-tracking`)

### DIFF
--- a/docs/guides/tracking.md
+++ b/docs/guides/tracking.md
@@ -225,6 +225,131 @@ sleap-nn predict -i video.mp4 -m models/ \
 
 ---
 
+## Evaluating Identity Persistence
+
+`sleap-nn eval` scores detection and localization -- whether the animal was found,
+and where. It says nothing about whether a track kept the **right** animal.
+`sleap-nn eval-tracking` scores that:
+
+```bash
+sleap-nn eval-tracking -g ground_truth.slp -p tracked_predictions.slp
+```
+
+Both files must be tracked: the ground truth needs `track` set on the detections
+you want scored, and the prediction needs tracks from `sleap-nn track` or
+`sleap-nn predict -t`. An untracked prediction is skipped with a message rather
+than scored as a failure.
+
+Detections are matched to ground truth within each frame first (OKS for poses,
+mask IoU for segmentation masks), and identity is scored over those matches --
+so a tracker is never penalized for the detector's misses.
+
+| metric | what it measures | better |
+|---|---|---|
+| `id_switches` | Times a ground-truth trajectory changed which predicted track it matched (CLEAR-MOT). A change across a gap counts; the gap itself does not. | lower |
+| `idf1` / `idp` / `idr` | Identity F1 after a global best assignment of predicted identities to ground-truth ones (Ristani et al.). | higher |
+| `mostly_tracked` / `partly_tracked` / `mostly_lost` | Ground-truth trajectories bucketed by how much of them was matched at all. | MT higher |
+| `fragmentations` | Interruptions of a trajectory that later resumes. A trajectory that simply ends is not counted. | lower |
+| `mean_track_purity` | Per predicted track, the share of its matched detections belonging to its dominant ground-truth identity, length-weighted. | higher |
+| `mean_gt_coverage` | Mean share of each ground-truth trajectory's frames that matched. | higher |
+
+The coverage and purity columns are there on purpose: without them a tracker can
+"win" on ID switches by emitting fewer, shorter, more timid tracks. Read them
+together.
+
+Detection counts (`n_gt_dets`, `n_pred_dets`, `n_matched`, `n_pred_untracked`)
+are reported alongside but never folded into the identity scores -- which is why
+MOTA is deliberately absent. MOTA mixes detection false positives and misses
+into one number, so when two trackers are compared over the same detections a
+MOTA delta mostly reports detector noise.
+
+### What carries identity
+
+`--carrier` selects what is matched and scored:
+
+- `pose` -- instances, matched by OKS. The default for pose models.
+- `mask` -- `PredictedSegmentationMask`es, matched by mask IoU, for segmentation
+  models. Scale-aware, so stride-resolution predicted masks and full-resolution
+  ground-truth masks are compared on the same pixel grid.
+- `auto` (default) -- picks `mask` when the prediction carries masks but no
+  instances, else `pose`.
+
+`--match_threshold` is the minimum OKS or IoU for a pair to count as matched
+(default `0.5`), and `--mt_threshold` / `--ml_threshold` are the coverage cuts
+for MT and ML.
+
+!!! note "`--user_labels_only` is OFF here, unlike `sleap-nn eval`"
+    Tracked ground truth usually *is* predicted: the normal workflow predicts
+    poses and then assigns or corrects tracks over them in the GUI. Filtering
+    the ground-truth side by detection type would therefore discard it -- on the
+    re-ID benchmark's own ground-truth sessions, turning the filter on takes
+    2465 scored detections to 0.
+
+    So everything carrying a track on the ground-truth side is scored, and the
+    count of predicted ground-truth detections is reported in `notes`. Pass
+    `--user_labels_only` in the one case it helps: user-labeled ground truth in
+    a file that *also* holds stale predictions from an earlier run, which would
+    otherwise be scored as extra trajectories.
+
+### Score a video clip, not a training split
+
+!!! warning "Identity metrics on a sparse label file are meaningless"
+    An embedded `.pkg.slp` training split renumbers its frames `0..N-1`, so
+    `frame_idx` and `frame_numbers` both read as contiguous while the animal has
+    actually moved across the arena between two "consecutive" frames. Every
+    index-based check passes and the metrics come out looking authoritative.
+
+    `eval-tracking` measures this and warns. The check is exposed directly:
+
+    ```python
+    from sleap_nn.evaluation import motion_diagnostic
+    import sleap_io as sio
+
+    motion_diagnostic(sio.load_slp("labels.slp"), "pose")
+    # continuous video:     {'step_over_size': 0.06, 'is_continuous': True, ...}
+    # sparse training split: {'step_over_size': 8.74, 'is_continuous': False, ...}
+    ```
+
+    `step_over_size` is how far the same animal moves between consecutive frames
+    relative to its own body size. At the high end, consecutive detections of one
+    animal do not even overlap, so geometric association has no signal to work
+    with and any IoU tracker must fail -- for reasons that have nothing to do
+    with the tracker.
+
+### Python API
+
+```python
+import sleap_io as sio
+from sleap_nn.evaluation import identity_metrics
+
+gt = sio.load_slp("ground_truth.slp")
+pred = sio.load_slp("tracked_predictions.slp")
+
+metrics = identity_metrics(gt, pred, "pose")
+print(metrics.summary())
+# IDSW=32  IDF1=0.8491 (P=0.8491 R=0.8491)  MT/PT/ML=5/0/0  Frag=0 ...
+
+metrics.as_dict()["id_switches"]  # 32
+```
+
+Comparing tracker settings is the common case, so there is a table renderer for it:
+
+```python
+from sleap_nn.evaluation import compare_identity_metrics
+
+print(compare_identity_metrics({
+    "fixed_window": identity_metrics(gt, pred_fixed, "pose"),
+    "flow": identity_metrics(gt, pred_flow, "pose"),
+    "kalman": identity_metrics(gt, pred_kalman, "pose"),
+}))
+```
+
+Always compare arms over the **same** detections -- retrack one prediction file
+with different tracker settings rather than re-running inference -- so the
+difference you read is the tracker's and not the detector's.
+
+---
+
 ## Troubleshooting
 
 ??? question "Tracks switch identities"

--- a/sleap_nn/cli.py
+++ b/sleap_nn/cli.py
@@ -3027,6 +3027,88 @@ def info(path):
     print_model_info(path)
 
 
+@cli.command("eval-tracking", context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "--ground_truth_path",
+    "-g",
+    type=str,
+    required=True,
+    help="Path to tracked ground truth labels file (.slp)",
+)
+@click.option(
+    "--predicted_path",
+    "-p",
+    type=str,
+    required=True,
+    help="Path to tracked predicted labels file (.slp)",
+)
+@click.option(
+    "--save_metrics", "-s", type=str, help="Path to save metrics (.json file)"
+)
+@click.option(
+    "--carrier",
+    type=click.Choice(["auto", "pose", "mask"]),
+    default="auto",
+    help=(
+        "What carries identity: 'pose' (instances, matched by OKS), 'mask' "
+        "(segmentation masks, matched by IoU), or 'auto' (mask when the "
+        "prediction has masks but no instances). Default: auto."
+    ),
+)
+@click.option(
+    "--match_threshold",
+    type=float,
+    default=0.5,
+    help=(
+        "Minimum OKS (pose) or mask IoU (mask) for a predicted detection to "
+        "count as matched to a ground-truth one. Default: 0.5."
+    ),
+)
+@click.option(
+    "--mt_threshold",
+    type=float,
+    default=0.8,
+    help="Coverage at or above which a GT trajectory is mostly-tracked (MT).",
+)
+@click.option(
+    "--ml_threshold",
+    type=float,
+    default=0.2,
+    help="Coverage below which a GT trajectory is mostly-lost (ML).",
+)
+@click.option(
+    "--user_labels_only/--no-user_labels_only",
+    default=False,
+    help=(
+        "Drop predicted detections from the GROUND-TRUTH side (default: False, "
+        "unlike `sleap-nn eval`). Tracked ground truth is usually predicted "
+        "poses with tracks assigned afterwards, so filtering by type would "
+        "discard it. Pass this only for user-labeled GT that also carries "
+        "stale predictions from an earlier run."
+    ),
+)
+def eval_tracking(**kwargs):
+    """Evaluate identity persistence of a tracked prediction.
+
+    Scores whether tracks keep the right identity across frames -- ID switches,
+    IDF1, MT/PT/ML, fragmentation and track purity -- against tracked ground
+    truth. Complements `sleap-nn eval`, which scores detection and localization
+    but says nothing about identity.
+
+    Both files must be tracked: ground truth needs `track` set on the detections
+    to score, and the prediction needs tracks from `sleap-nn track` or
+    `sleap-nn predict -t`.
+
+    Examples:
+        sleap-nn eval-tracking -g gt.slp -p tracked.slp
+
+        sleap-nn eval-tracking -g gt.slp -p tracked.slp --carrier mask -s ids.json
+    """
+    from sleap_nn.evaluation import run_identity_evaluation
+
+    run_identity_evaluation(**kwargs)
+
+
 def _register_export_commands():
     """Lazily import and register the export command."""
     from sleap_nn.export.cli import export as export_command

--- a/sleap_nn/evaluation.py
+++ b/sleap_nn/evaluation.py
@@ -515,6 +515,38 @@ class MatchInstance:
     video_path: str
 
 
+def _video_key(video: Optional[sio.Video]) -> str:
+    """Identify a video by path, with fallbacks for embedded and image-sequence videos.
+
+    Args:
+        video: The video to identify, or ``None``.
+
+    Returns:
+        ``source_filename`` (embedded videos, which carry their original path)
+        else ``filename`` (first entry for image sequences), else a per-object
+        identifier so two distinct videos never collide.
+    """
+    if video is None:
+        return "unknown"
+    video_path = None
+    backend = getattr(video, "backend", None)
+    if backend is not None:
+        # Try source_filename first (for embedded videos with provenance)
+        video_path = getattr(backend, "source_filename", None)
+        if video_path is None:
+            video_path = getattr(backend, "filename", None)
+    # Fallback to video.filename if backend doesn't have it
+    if video_path is None:
+        video_path = getattr(video, "filename", None)
+        # Handle list filenames (image sequences)
+        if isinstance(video_path, list) and video_path:
+            video_path = video_path[0]
+    # Final fallback: use a unique identifier
+    if video_path is None:
+        return f"video_{id(video)}"
+    return str(video_path)
+
+
 def get_instances(labeled_frame: sio.LabeledFrame) -> List[MatchInstance]:
     """Get a list of instances of type MatchInstance from the Labeled Frame.
 
@@ -526,26 +558,7 @@ def get_instances(labeled_frame: sio.LabeledFrame) -> List[MatchInstance]:
     """
     instance_list = []
     frame_idx = labeled_frame.frame_idx
-
-    # Extract video path with fallbacks for embedded videos
-    video = labeled_frame.video
-    video_path = None
-    if video is not None:
-        backend = getattr(video, "backend", None)
-        if backend is not None:
-            # Try source_filename first (for embedded videos with provenance)
-            video_path = getattr(backend, "source_filename", None)
-            if video_path is None:
-                video_path = getattr(backend, "filename", None)
-        # Fallback to video.filename if backend doesn't have it
-        if video_path is None:
-            video_path = getattr(video, "filename", None)
-            # Handle list filenames (image sequences)
-            if isinstance(video_path, list) and video_path:
-                video_path = video_path[0]
-    # Final fallback: use a unique identifier
-    if video_path is None:
-        video_path = f"video_{id(video)}" if video is not None else "unknown"
+    video_path = _video_key(labeled_frame.video)
 
     for instance in labeled_frame.instances:
         match_instance = MatchInstance(
@@ -2529,3 +2542,708 @@ def run_evaluation(
         logger.info(f"Metrics saved successfully to {save_path}")
 
     return metrics
+
+
+# ---------------------------------------------------------------------------
+# Identity-persistence metrics (MOT-style)
+# ---------------------------------------------------------------------------
+# These score a TRACKED prediction against TRACKED ground truth: not "was the
+# animal found" (the detection metrics above) but "did it keep the same identity
+# across frames". Any tracker can use them -- fixed-window/local-queues, optical
+# flow, Kalman, mask-IoU -- since they read only `track` off the detections.
+#
+# Deliberately NOT MOTA: MOTA folds detection FP/FN into the identity score, so
+# when two trackers are compared over a FROZEN detection stage (the usual A/B) a
+# MOTA delta mostly reports detector noise. Detection counts are reported
+# separately in `IdentityMetrics` and never folded into IDF1 or the switch count.
+#
+# Definitions follow the standard multi-object-tracking literature:
+#   - ID switches (IDSW): CLEAR-MOT. Per ground-truth trajectory, a switch each
+#     time the predicted track matched to it differs from the last one it was
+#     matched to. Gaps do not count; a change *across* a gap does.
+#   - IDF1 / IDP / IDR: Ristani et al. Global max-weight assignment between
+#     ground-truth and predicted identities over co-matched detection counts,
+#     then F1 over IDTP / IDFP / IDFN.
+#   - MT/PT/ML + fragmentation: coverage of each ground-truth trajectory, so a
+#     tracker cannot win on switches by emitting fewer, shorter tracks.
+#   - Purity: per predicted track, the share of its matched detections belonging
+#     to its dominant ground-truth identity (length-weighted mean).
+
+IDENTITY_CARRIERS = ("pose", "mask")
+
+
+def _validate_carrier(carrier: str) -> str:
+    """Normalize and validate an identity-metric carrier.
+
+    Args:
+        carrier: ``"pose"`` (instances, matched by OKS) or ``"mask"``
+            (segmentation masks, matched by mask IoU).
+
+    Returns:
+        The validated carrier string.
+
+    Raises:
+        ValueError: If ``carrier`` is not one of ``IDENTITY_CARRIERS``.
+    """
+    if carrier not in IDENTITY_CARRIERS:
+        raise ValueError(
+            f"carrier must be one of {IDENTITY_CARRIERS}, got {carrier!r}. "
+            "Use 'pose' for instances (OKS) or 'mask' for segmentation masks (IoU)."
+        )
+    return carrier
+
+
+def _identity_frame_key(frame: sio.LabeledFrame) -> Tuple[str, int]:
+    """Key a frame by ``(video path, frame index)``.
+
+    Keyed on the video's path rather than its position in ``labels.videos`` so a
+    single-video prediction aligns with the right video of a multi-video
+    ground-truth project -- position would pair it with whatever happens to be
+    first. Matches the video identity `find_frame_pairs` uses for the detection
+    metrics.
+    """
+    return (_video_key(frame.video), frame.frame_idx)
+
+
+def _identity_dets(frame: sio.LabeledFrame, carrier: str) -> List[Any]:
+    """Return a frame's detections for the given carrier, in file order."""
+    if carrier == "mask":
+        return list(getattr(frame, "masks", None) or [])
+    return list(frame.instances)
+
+
+def _is_predicted_detection(det: Any) -> bool:
+    """Return True for model output, on either carrier."""
+    return isinstance(det, (sio.PredictedInstance, sio.PredictedSegmentationMask))
+
+
+def _keeps_identity(det: Any, drop_predicted: bool) -> bool:
+    """Return True if a detection should take part in identity scoring.
+
+    Args:
+        det: An instance or segmentation mask.
+        drop_predicted: Drop model output (the ground-truth side under
+            ``user_labels_only``).
+
+    Returns:
+        True when the detection carries a track and survives the predicted
+        filter. Untracked detections are counted in the totals but never
+        matched -- identity is what is being scored, so a detection without one
+        has no identity to get right.
+    """
+    if getattr(det, "track", None) is None:
+        return False
+    return not (drop_predicted and _is_predicted_detection(det))
+
+
+def _pose_similarity(gt: List[Any], pr: List[Any]) -> np.ndarray:
+    """Compute the ``(n_gt, n_pr)`` OKS matrix between two instance lists.
+
+    Built one predicted instance at a time. OKS is defined per ``(gt, pr)`` pair
+    -- each column depends only on its own prediction and the ground-truth
+    scales -- so the loop is exactly equivalent to the matrix form while also
+    working on repo versions whose ``compute_oks`` only accepted a single
+    prediction (see #739).
+    """
+    if not gt or not pr:
+        return np.zeros((len(gt), len(pr)))
+    pts_gt = np.stack([np.asarray(inst.numpy(), dtype=float)[:, :2] for inst in gt])
+    sim = np.zeros((len(gt), len(pr)))
+    for j, inst in enumerate(pr):
+        pts_pr = np.asarray(inst.numpy(), dtype=float)[None, :, :2]
+        sim[:, j] = np.asarray(compute_oks(pts_gt, pts_pr), dtype=float).reshape(
+            len(gt)
+        )
+    return sim
+
+
+def _mask_similarity(gt: List[np.ndarray], pr: List[np.ndarray]) -> np.ndarray:
+    """Compute the ``(n_gt, n_pr)`` mask-IoU matrix from decoded boolean arrays."""
+    if not len(gt) or not len(pr):
+        return np.zeros((len(gt), len(pr)))
+    # _mask_iou_matrix is (n_pred, n_gt); transpose to (n_gt, n_pr).
+    return np.asarray(_mask_iou_matrix(pr, gt), dtype=float).T
+
+
+def _match_identity_frame(
+    gt: List[Any], pr: List[Any], carrier: str, threshold: float
+) -> List[Tuple[int, int, float]]:
+    """Hungarian-match ground-truth to predicted detections within one frame.
+
+    Args:
+        gt: Ground-truth detections -- instances for ``"pose"``, decoded boolean
+            mask arrays for ``"mask"``.
+        pr: Predicted detections, same convention.
+        carrier: ``"pose"`` or ``"mask"``.
+        threshold: Minimum similarity (OKS or IoU) for a pair to count as matched.
+
+    Returns:
+        List of ``(gt_index, pred_index, similarity)`` for pairs at or above
+        ``threshold``.
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    sim = _pose_similarity(gt, pr) if carrier == "pose" else _mask_similarity(gt, pr)
+    if sim.size == 0:
+        return []
+    rows, cols = linear_sum_assignment(-sim)
+    return [
+        (int(r), int(c), float(sim[r, c]))
+        for r, c in zip(rows, cols)
+        if sim[r, c] >= threshold
+    ]
+
+
+def motion_diagnostic(labels: sio.Labels, carrier: str = "pose") -> Dict[str, Any]:
+    """Judge whether a labels file is continuous video or temporally sparse samples.
+
+    **Identity metrics are meaningless on a sparse set, and nothing in the file
+    says so.** Embedded ``.pkg.slp`` training splits renumber their frames
+    ``0..N-1`` and record ``frame_numbers`` as contiguous, so every index-based
+    contiguity check passes -- while the animal has actually moved across the
+    arena between two "consecutive" frames. Run this before quoting a tracking
+    number on an unfamiliar file.
+
+    The decisive quantity is how far the same animal moves between consecutive
+    frames relative to its own size. Measured on real files, ``step_over_size``
+    lands near ``0.01-0.06`` for genuine video and ``3-9`` for sparse training
+    splits -- and at the high end same-animal consecutive mask IoU is ``0.000``
+    for most pairs, so geometric association has no signal to work with and any
+    IoU tracker must fail.
+
+    Args:
+        labels: Tracked labels to inspect.
+        carrier: ``"pose"`` (instance keypoints) or ``"mask"`` (segmentation
+            masks); decides how a detection's center and size are measured.
+
+    Returns:
+        Dict with ``median_step_px``, ``median_size_px``, ``step_over_size`` and
+        ``is_continuous`` (``step_over_size < 0.5``). When too few tracked
+        detections are present to judge, ``step_over_size`` is NaN,
+        ``is_continuous`` is False and a ``note`` explains why.
+    """
+    carrier = _validate_carrier(carrier)
+    prev: Dict[str, np.ndarray] = {}
+    steps: List[float] = []
+    sizes: List[float] = []
+
+    for frame in sorted(labels, key=lambda lf: lf.frame_idx):
+        items: List[Tuple[str, np.ndarray, float]] = []
+        if carrier == "mask":
+            for arr, det in zip(_frame_masks(frame), _identity_dets(frame, carrier)):
+                if getattr(det, "track", None) is None:
+                    continue
+                ys, xs = np.nonzero(arr)
+                if not len(xs):
+                    continue
+                items.append(
+                    (
+                        det.track.name,
+                        np.array([xs.mean(), ys.mean()]),
+                        # Equivalent-circle diameter of the mask.
+                        2.0 * float(np.sqrt(arr.sum() / np.pi)),
+                    )
+                )
+        else:
+            for det in _identity_dets(frame, carrier):
+                if getattr(det, "track", None) is None:
+                    continue
+                pts = np.asarray(det.numpy(), dtype=float)[:, :2]
+                pts = pts[~np.isnan(pts).any(axis=1)]
+                if not len(pts):
+                    continue
+                items.append(
+                    (det.track.name, pts.mean(axis=0), float(np.ptp(pts, axis=0).max()))
+                )
+
+        for name, center, size in items:
+            sizes.append(size)
+            if name in prev:
+                steps.append(float(np.linalg.norm(center - prev[name])))
+            prev[name] = center
+
+    if not steps or not sizes:
+        return {
+            "median_step_px": float("nan"),
+            "median_size_px": float("nan"),
+            "step_over_size": float("nan"),
+            "is_continuous": False,
+            "note": "not enough tracked detections to judge",
+        }
+
+    median_step = float(np.median(steps))
+    median_size = float(np.median(sizes))
+    if median_size <= 0.0:
+        # A single-node skeleton (a centroid model) or coincident nodes have no
+        # measurable extent, so there is nothing to normalize the step against.
+        # Report "cannot judge" rather than dividing by ~0 and calling every
+        # centroid prediction sparse.
+        return {
+            "median_step_px": round(median_step, 2),
+            "median_size_px": median_size,
+            "step_over_size": float("nan"),
+            "is_continuous": False,
+            "note": (
+                "detections have no measurable extent (single-node skeleton?) -- "
+                "cannot judge continuity"
+            ),
+        }
+    ratio = median_step / median_size
+    return {
+        "median_step_px": round(median_step, 2),
+        "median_size_px": round(median_size, 2),
+        "step_over_size": round(ratio, 3),
+        "is_continuous": bool(ratio < 0.5),
+    }
+
+
+@attrs.define(auto_attribs=True, slots=True)
+class IdentityMetrics:
+    """Identity-persistence metrics for one tracked prediction.
+
+    Attributes:
+        id_switches: CLEAR-MOT ID switches, summed over ground-truth trajectories.
+        idf1: Identity F1 (Ristani et al.).
+        idp: Identity precision.
+        idr: Identity recall.
+        mostly_tracked: Ground-truth trajectories covered at or above
+            ``mt_threshold``.
+        partly_tracked: Ground-truth trajectories between the two coverage cuts.
+        mostly_lost: Ground-truth trajectories covered below ``ml_threshold``.
+        fragmentations: Matched -> unmatched -> matched interruptions of a
+            ground-truth trajectory.
+        mean_gt_coverage: Mean share of each trajectory's frames that matched.
+        mean_track_purity: Length-weighted mean dominant-identity share per
+            predicted track.
+        n_gt_dets: Tracked ground-truth detections compared.
+        n_pred_dets: Predicted detections in the compared frames.
+        n_matched: Ground-truth/predicted pairs matched above threshold.
+        n_frames_compared: Frames present on both sides.
+        n_gt_tracks: Distinct ground-truth track names seen.
+        n_pred_tracks: Distinct predicted track names seen.
+        n_pred_untracked: Predicted detections with no ``track`` set.
+        notes: Human-readable caveats raised while comparing.
+    """
+
+    # Headline.
+    id_switches: int = 0
+    idf1: float = float("nan")
+    idp: float = float("nan")
+    idr: float = float("nan")
+    # Coverage -- guards against winning on switches by tracking less.
+    mostly_tracked: int = 0
+    partly_tracked: int = 0
+    mostly_lost: int = 0
+    fragmentations: int = 0
+    mean_gt_coverage: float = float("nan")
+    # Purity.
+    mean_track_purity: float = float("nan")
+    # Detection accounting, reported separately and never folded into the above.
+    n_gt_dets: int = 0
+    n_pred_dets: int = 0
+    n_matched: int = 0
+    n_frames_compared: int = 0
+    n_gt_tracks: int = 0
+    n_pred_tracks: int = 0
+    n_pred_untracked: int = 0
+    notes: List[str] = attrs.field(factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return the metrics as a plain, JSON-serializable dict."""
+        return attrs.asdict(self)
+
+    def summary(self) -> str:
+        """Return a one-line summary of the headline metrics."""
+        return (
+            f"IDSW={self.id_switches}  IDF1={self.idf1:.4f} "
+            f"(P={self.idp:.4f} R={self.idr:.4f})  "
+            f"MT/PT/ML={self.mostly_tracked}/{self.partly_tracked}/{self.mostly_lost}  "
+            f"Frag={self.fragmentations}  purity={self.mean_track_purity:.4f}  "
+            f"cov={self.mean_gt_coverage:.4f}  "
+            f"[{self.n_matched}/{self.n_gt_dets} GT dets matched, "
+            f"{self.n_pred_dets} pred, {self.n_frames_compared} frames]"
+        )
+
+
+def identity_metrics(
+    gt_labels: sio.Labels,
+    pred_labels: sio.Labels,
+    carrier: str = "pose",
+    *,
+    match_threshold: float = 0.5,
+    mt_threshold: float = 0.8,
+    ml_threshold: float = 0.2,
+    user_labels_only: bool = False,
+) -> IdentityMetrics:
+    """Score a tracked prediction against tracked ground truth.
+
+    Detections are Hungarian-matched to ground truth within each frame (OKS for
+    ``"pose"``, mask IoU for ``"mask"``), then identity is scored over those
+    matches. Detections with no ``track`` set are counted but never matched, on
+    either side.
+
+    Args:
+        gt_labels: Ground truth with ``track`` set on the detections to score.
+        pred_labels: Prediction with ``track`` set by the tracker under test.
+        carrier: ``"pose"`` (instances, OKS) or ``"mask"`` (segmentation masks,
+            IoU) -- which similarity matches detections.
+        match_threshold: Minimum similarity for a ground-truth/predicted pair to
+            count as matched (OKS or IoU, per carrier).
+        mt_threshold: Coverage at or above which a ground-truth trajectory counts
+            as mostly-tracked.
+        ml_threshold: Coverage below which a ground-truth trajectory counts as
+            mostly-lost.
+        user_labels_only: Drop model output (``PredictedInstance`` /
+            ``PredictedSegmentationMask``) from the GROUND-TRUTH side.
+            **Defaults to False, unlike the detection metrics**, because tracked
+            ground truth usually *is* predicted: the standard workflow predicts
+            poses and then assigns or corrects tracks over them, so filtering by
+            type would silently discard the whole ground truth (measured on the
+            re-ID benchmark's GT sessions: 2465 detections to 0). Pass True when
+            the ground truth is user-labeled and the file also carries stale
+            predictions from an earlier run, which would otherwise be scored as
+            extra trajectories. Either way the count is reported in ``notes``,
+            and the prediction side is never filtered.
+
+    Returns:
+        An :class:`IdentityMetrics`. When the two files share no frames, the
+        result is empty and ``notes`` says so rather than raising -- check
+        ``n_frames_compared`` before quoting a number.
+    """
+    from collections import Counter, defaultdict
+    from scipy.optimize import linear_sum_assignment
+
+    carrier = _validate_carrier(carrier)
+    metrics = IdentityMetrics()
+
+    gt_by_key = {_identity_frame_key(lf): lf for lf in gt_labels}
+    pred_by_key = {_identity_frame_key(lf): lf for lf in pred_labels}
+    shared = sorted(set(gt_by_key) & set(pred_by_key))
+    if not shared:
+        # One video on each side but under different paths (a clip re-saved or
+        # copied elsewhere, an embedded package vs its source) is common enough
+        # to be worth rescuing: there is only one possible pairing, so fall back
+        # to frame_idx alone rather than reporting nothing. With several videos
+        # on either side the pairing is ambiguous, so it is left unaligned.
+        if (
+            len({k[0] for k in gt_by_key}) == 1
+            and len({k[0] for k in pred_by_key}) == 1
+        ):
+            gt_by_key = {("", lf.frame_idx): lf for lf in gt_labels}
+            pred_by_key = {("", lf.frame_idx): lf for lf in pred_labels}
+            shared = sorted(set(gt_by_key) & set(pred_by_key))
+            metrics.notes.append(
+                "aligned on frame_idx only (single video on both sides)"
+            )
+        if not shared:
+            metrics.notes.append("no frames in common -- nothing compared")
+            return metrics
+    if len(shared) < len(gt_by_key):
+        metrics.notes.append(
+            f"{len(gt_by_key) - len(shared)} GT frames had no predicted counterpart"
+        )
+
+    # gt track name -> ordered list of (frame position, matched pred name or None)
+    timeline: Dict[str, List[Tuple[int, Optional[str]]]] = defaultdict(list)
+    co_matched: "Counter[Tuple[str, str]]" = Counter()
+    pred_track_dets: "Counter[str]" = Counter()
+    gt_tracks: set = set()
+    pred_tracks: set = set()
+    n_gt_predicted = 0
+
+    for position, key in enumerate(shared):
+        gt_frame, pred_frame = gt_by_key[key], pred_by_key[key]
+        gt_all = _identity_dets(gt_frame, carrier)
+        gt_dets = [d for d in gt_all if _keeps_identity(d, user_labels_only)]
+        pred_all = _identity_dets(pred_frame, carrier)
+        pred_dets = [d for d in pred_all if _keeps_identity(d, False)]
+        n_gt_predicted += sum(1 for d in gt_all if _is_predicted_detection(d))
+
+        metrics.n_gt_dets += len(gt_dets)
+        metrics.n_pred_dets += len(pred_all)
+        metrics.n_pred_untracked += len(pred_all) - len(pred_dets)
+        gt_tracks.update(d.track.name for d in gt_dets)
+        pred_tracks.update(d.track.name for d in pred_dets)
+
+        # For the mask carrier, match on decoded image-grid arrays rather than on
+        # the mask objects: `_frame_masks` is scale-aware, so a stride-res
+        # prediction and a full-res ground-truth mask are compared on a common
+        # pixel grid (the class of bug #693/#694 fixed). It decodes `lf.masks` in
+        # order, so filtering the decoded list by the same tracked-ness
+        # predicate keeps it index-aligned with `gt_dets` / `pred_dets`.
+        if carrier == "mask":
+            match_gt = [
+                arr
+                for arr, det in zip(_frame_masks(gt_frame), gt_all)
+                if _keeps_identity(det, user_labels_only)
+            ]
+            match_pred = [
+                arr
+                for arr, det in zip(_frame_masks(pred_frame), pred_all)
+                if _keeps_identity(det, False)
+            ]
+        else:
+            match_gt, match_pred = gt_dets, pred_dets
+
+        matched_gt: Dict[int, str] = {}
+        for gt_idx, pred_idx, _sim in _match_identity_frame(
+            match_gt, match_pred, carrier, match_threshold
+        ):
+            gt_name = gt_dets[gt_idx].track.name
+            pred_name = pred_dets[pred_idx].track.name
+            matched_gt[gt_idx] = pred_name
+            co_matched[(gt_name, pred_name)] += 1
+            pred_track_dets[pred_name] += 1
+            metrics.n_matched += 1
+
+        for gt_idx, det in enumerate(gt_dets):
+            timeline[det.track.name].append((position, matched_gt.get(gt_idx)))
+
+    metrics.n_frames_compared = len(shared)
+    metrics.n_gt_tracks = len(gt_tracks)
+    metrics.n_pred_tracks = len(pred_tracks)
+    if n_gt_predicted:
+        if user_labels_only:
+            metrics.notes.append(
+                f"{n_gt_predicted} predicted detections were dropped from the "
+                "ground truth (user_labels_only=True)"
+            )
+            if not metrics.n_gt_dets:
+                metrics.notes.append(
+                    "user_labels_only=True left NO ground truth: every tracked "
+                    "detection is model output. Tracked GT is usually predicted "
+                    "poses with tracks assigned afterwards -- pass "
+                    "user_labels_only=False to score it."
+                )
+        else:
+            metrics.notes.append(
+                f"{n_gt_predicted} of the ground-truth detections are model "
+                "output (tracks assigned over predictions); scored as ground "
+                "truth. Pass user_labels_only=True to exclude them."
+            )
+
+    # --- ID switches, coverage and fragmentation, per ground-truth trajectory ---
+    coverages: List[float] = []
+    for entries in timeline.values():
+        entries.sort(key=lambda entry: entry[0])
+        matched = [name for _position, name in entries if name is not None]
+        coverage = len(matched) / len(entries) if entries else 0.0
+        coverages.append(coverage)
+
+        last: Optional[str] = None
+        for _position, name in entries:
+            if name is None:
+                continue
+            if last is not None and name != last:
+                metrics.id_switches += 1
+            last = name
+
+        # Fragmentation: matched -> unmatched -> matched interruptions. Only gaps
+        # that are re-matched later count, so a trajectory that simply ends is
+        # not a fragmentation.
+        matched_seq = [name is not None for _position, name in entries]
+        started = False
+        for i, is_matched in enumerate(matched_seq):
+            if is_matched:
+                started = True
+            elif started and i > 0 and matched_seq[i - 1] and any(matched_seq[i + 1 :]):
+                metrics.fragmentations += 1
+
+        if coverage >= mt_threshold:
+            metrics.mostly_tracked += 1
+        elif coverage < ml_threshold:
+            metrics.mostly_lost += 1
+        else:
+            metrics.partly_tracked += 1
+
+    metrics.mean_gt_coverage = float(np.mean(coverages)) if coverages else float("nan")
+
+    # --- IDF1: global max-weight ground-truth <-> predicted identity assignment ---
+    gt_names = sorted(gt_tracks)
+    pred_names = sorted(pred_tracks)
+    if gt_names and pred_names:
+        weights = np.zeros((len(gt_names), len(pred_names)))
+        gt_index = {name: i for i, name in enumerate(gt_names)}
+        pred_index = {name: i for i, name in enumerate(pred_names)}
+        for (gt_name, pred_name), count in co_matched.items():
+            weights[gt_index[gt_name], pred_index[pred_name]] = count
+        rows, cols = linear_sum_assignment(-weights)
+        idtp = float(weights[rows, cols].sum())
+        idfn = metrics.n_gt_dets - idtp
+        idfp = (metrics.n_pred_dets - metrics.n_pred_untracked) - idtp
+        metrics.idp = idtp / (idtp + idfp) if (idtp + idfp) > 0 else float("nan")
+        metrics.idr = idtp / (idtp + idfn) if (idtp + idfn) > 0 else float("nan")
+        denominator = 2 * idtp + idfp + idfn
+        metrics.idf1 = 2 * idtp / denominator if denominator > 0 else float("nan")
+
+    # --- Track purity, length-weighted over predicted tracks ---
+    by_pred: Dict[str, "Counter[str]"] = defaultdict(Counter)
+    for (gt_name, pred_name), count in co_matched.items():
+        by_pred[pred_name][gt_name] += count
+    if by_pred:
+        total = sum(pred_track_dets[name] for name in by_pred)
+        metrics.mean_track_purity = (
+            float(sum(max(counts.values()) for counts in by_pred.values()) / total)
+            if total
+            else float("nan")
+        )
+
+    return metrics
+
+
+def compare_identity_metrics(arms: Dict[str, IdentityMetrics]) -> str:
+    """Render a Markdown comparison table across tracker arms.
+
+    Args:
+        arms: Mapping of arm name (e.g. ``"geometry"``, ``"fused"``) to its
+            :class:`IdentityMetrics`.
+
+    Returns:
+        A Markdown table, one row per arm, with a footer naming the direction of
+        improvement for each column.
+    """
+    columns = [
+        ("IDSW", "id_switches", "{:d}"),
+        ("IDF1", "idf1", "{:.4f}"),
+        ("purity", "mean_track_purity", "{:.4f}"),
+        ("cov", "mean_gt_coverage", "{:.4f}"),
+        ("MT", "mostly_tracked", "{:d}"),
+        ("ML", "mostly_lost", "{:d}"),
+        ("Frag", "fragmentations", "{:d}"),
+        ("matched", "n_matched", "{:d}"),
+    ]
+    lines = [
+        "| arm | " + " | ".join(label for label, _attr, _fmt in columns) + " |",
+        "|---|" + "|".join("---" for _ in columns) + "|",
+    ]
+    for name, metrics in arms.items():
+        cells = []
+        for _label, attr, fmt in columns:
+            value = getattr(metrics, attr)
+            cells.append(
+                "n/a"
+                if value is None or (isinstance(value, float) and np.isnan(value))
+                else fmt.format(value)
+            )
+        lines.append(f"| {name} | " + " | ".join(cells) + " |")
+    lines.append("")
+    lines.append(
+        "Lower is better: IDSW, ML, Frag. Higher is better: IDF1, purity, cov, MT."
+    )
+    return "\n".join(lines)
+
+
+def run_identity_evaluation(
+    ground_truth_path: str,
+    predicted_path: str,
+    carrier: str = "auto",
+    match_threshold: float = 0.5,
+    mt_threshold: float = 0.8,
+    ml_threshold: float = 0.2,
+    user_labels_only: bool = False,
+    save_metrics: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Evaluate identity persistence of a tracked prediction against tracked GT.
+
+    Args:
+        ground_truth_path: Path to the ground-truth ``.slp`` file, tracked.
+        predicted_path: Path to the predicted ``.slp`` file, tracked.
+        carrier: ``"pose"``, ``"mask"``, or ``"auto"`` -- ``"auto"`` picks
+            ``"mask"`` when the prediction carries segmentation masks but no
+            instances, else ``"pose"``.
+        match_threshold: Minimum OKS (pose) or IoU (mask) for a detection pair to
+            count as matched.
+        mt_threshold: Mostly-tracked coverage cut.
+        ml_threshold: Mostly-lost coverage cut.
+        user_labels_only: Drop model output from the ground-truth side; off by
+            default (see :func:`identity_metrics` for why).
+        save_metrics: Optional ``.json`` path to write the metrics to.
+
+    Returns:
+        Dict with the :class:`IdentityMetrics` fields plus ``carrier``,
+        ``match_threshold`` and ``motion_diagnostic``, or ``None`` if the
+        prediction carries no tracked detections at all (nothing to score).
+    """
+    logger.info("Loading ground truth labels...")
+    gt_labels = sio.load_slp(ground_truth_path)
+    logger.info(
+        f"  Ground truth: {len(gt_labels.videos)} videos, "
+        f"{len(gt_labels.labeled_frames)} frames"
+    )
+
+    logger.info("Loading predicted labels...")
+    pred_labels = sio.load_slp(predicted_path)
+    logger.info(
+        f"  Predictions: {len(pred_labels.videos)} videos, "
+        f"{len(pred_labels.labeled_frames)} frames"
+    )
+
+    if carrier == "auto":
+        has_masks = any(len(getattr(lf, "masks", None) or []) for lf in pred_labels)
+        has_instances = any(len(lf.instances) for lf in pred_labels)
+        carrier = "mask" if (has_masks and not has_instances) else "pose"
+        logger.info(f"Auto-detected carrier: {carrier}.")
+    carrier = _validate_carrier(carrier)
+
+    n_tracked = sum(
+        1
+        for lf in pred_labels
+        for det in _identity_dets(lf, carrier)
+        if getattr(det, "track", None) is not None
+    )
+    if not n_tracked:
+        logger.info(
+            "0 tracked predicted detections: skipping identity metrics. Run "
+            "`sleap-nn track` (or predict with `-t`) first -- these metrics score "
+            "identity, so an untracked prediction has nothing to score."
+        )
+        return None
+
+    # The sparse-split trap: a `.pkg.slp` training split renumbers its frames
+    # contiguously, so it *looks* like video while the animal teleports between
+    # "consecutive" frames. Say so loudly rather than reporting a meaningless
+    # switch count.
+    motion = motion_diagnostic(gt_labels, carrier)
+    if np.isnan(motion["step_over_size"]):
+        logger.info(f"Continuity check inconclusive: {motion.get('note', '')}")
+    elif not motion["is_continuous"]:
+        logger.warning(
+            "Ground truth does not look like continuous video "
+            f"(step/size = {motion['step_over_size']}). Identity metrics on a "
+            "temporally sparse set (e.g. a `.pkg.slp` training split) are not "
+            "meaningful -- score a real video clip instead."
+        )
+
+    metrics = identity_metrics(
+        gt_labels,
+        pred_labels,
+        carrier,
+        match_threshold=match_threshold,
+        mt_threshold=mt_threshold,
+        ml_threshold=ml_threshold,
+        user_labels_only=user_labels_only,
+    )
+
+    logger.info("Identity Evaluation Results:")
+    logger.info(f"  {metrics.summary()}")
+    for note in metrics.notes:
+        logger.warning(f"  note: {note}")
+    if not metrics.n_gt_dets:
+        logger.warning(
+            "No tracked ground-truth detections were scored -- every metric "
+            "above is empty. Check that the ground truth carries tracks."
+        )
+
+    result = metrics.as_dict()
+    result["carrier"] = carrier
+    result["match_threshold"] = match_threshold
+    result["motion_diagnostic"] = motion
+
+    if save_metrics:
+        save_path = Path(save_metrics)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(save_path, "w") as f:
+            json.dump(_metrics_to_json_safe(result), f, indent=2)
+        logger.info(f"Metrics saved successfully to {save_path}")
+
+    return result

--- a/tests/test_evaluation_identity.py
+++ b/tests/test_evaluation_identity.py
@@ -1,0 +1,686 @@
+"""Tests for the MOT-style identity-persistence metrics in ``sleap_nn.evaluation``.
+
+Every case is built so the right answer is known by construction: two
+trajectories far enough apart that detection matching is unambiguous, with
+identity swaps and dropped frames injected at known positions. That way a
+failure points at the metric, not at the matcher.
+"""
+
+import json
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from click.testing import CliRunner
+
+from sleap_nn.evaluation import (
+    IdentityMetrics,
+    compare_identity_metrics,
+    identity_metrics,
+    motion_diagnostic,
+    run_identity_evaluation,
+)
+
+FNAME = "synthetic_identity_video.mp4"
+
+
+def _synthetic_pose(n_frames, swap_at=(), drop=(), step=1.0, body_length=12.0):
+    """Two trajectories; ``swap_at`` swaps predicted identities onward.
+
+    Args:
+        n_frames: Number of frames to generate.
+        swap_at: Frames at which the predicted identity assignment flips.
+        drop: Frames for which the prediction has no detections at all.
+        step: Per-frame displacement, in pixels, of both animals.
+        body_length: Distance between the two nodes. ``0`` yields a single-node
+            (centroid-style) skeleton with no measurable extent.
+
+    Returns:
+        ``(gt_labels, pred_labels)``.
+    """
+    skeleton = sio.Skeleton(["head", "tail"] if body_length else ["head"])
+    video = sio.Video.from_filename(FNAME)
+    swap_at, drop = set(swap_at), set(drop)
+
+    gt_tracks = [sio.Track("g0"), sio.Track("g1")]
+    pred_tracks = [sio.Track("p0"), sio.Track("p1")]
+    gt_frames, pred_frames = [], []
+    flipped = False
+    for frame_idx in range(n_frames):
+        if frame_idx in swap_at:
+            flipped = not flipped
+        points = []
+        for x0, y0 in ((10.0, 10.0), (200.0, 200.0)):
+            nodes = [[x0 + step * frame_idx, y0]]
+            if body_length:
+                nodes.append([x0 + step * frame_idx + body_length, y0])
+            points.append(np.array(nodes))
+        gt_frames.append(
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=frame_idx,
+                instances=[
+                    sio.Instance.from_numpy(
+                        points[k], skeleton=skeleton, track=gt_tracks[k]
+                    )
+                    for k in range(2)
+                ],
+            )
+        )
+        if frame_idx in drop:
+            pred_frames.append(
+                sio.LabeledFrame(video=video, frame_idx=frame_idx, instances=[])
+            )
+            continue
+        pred_frames.append(
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=frame_idx,
+                instances=[
+                    sio.PredictedInstance.from_numpy(
+                        points[k],
+                        skeleton=skeleton,
+                        score=1.0,
+                        point_scores=np.ones(len(points[k])),
+                        tracking_score=1.0,
+                        track=pred_tracks[(k + 1) % 2 if flipped else k],
+                    )
+                    for k in range(2)
+                ],
+            )
+        )
+    return (
+        sio.Labels(
+            labeled_frames=gt_frames,
+            videos=[video],
+            skeletons=[skeleton],
+            tracks=gt_tracks,
+        ),
+        sio.Labels(
+            labeled_frames=pred_frames,
+            videos=[video],
+            skeletons=[skeleton],
+            tracks=pred_tracks,
+        ),
+    )
+
+
+def _square(height, width, cy, cx, half):
+    """Return a boolean mask with a filled square centered at ``(cy, cx)``."""
+    mask = np.zeros((height, width), dtype=bool)
+    mask[cy - half : cy + half, cx - half : cx + half] = True
+    return mask
+
+
+def _synthetic_mask(n_frames, swap_at=()):
+    """Mask-carrier twin of :func:`_synthetic_pose`, one square per animal."""
+    video = sio.Video.from_filename(FNAME)
+    swap_at = set(swap_at)
+    gt_tracks = [sio.Track("g0"), sio.Track("g1")]
+    pred_tracks = [sio.Track("p0"), sio.Track("p1")]
+    gt_frames, pred_frames = [], []
+    flipped = False
+    for frame_idx in range(n_frames):
+        if frame_idx in swap_at:
+            flipped = not flipped
+        squares = [
+            _square(64, 64, 12 + frame_idx, 12, 5),
+            _square(64, 64, 48 + frame_idx, 48, 5),
+        ]
+        gt_masks = []
+        for k in range(2):
+            mask = sio.UserSegmentationMask.from_numpy(squares[k])
+            mask.track = gt_tracks[k]
+            gt_masks.append(mask)
+        gt_frames.append(
+            sio.LabeledFrame(video=video, frame_idx=frame_idx, masks=gt_masks)
+        )
+        pred_frames.append(
+            sio.LabeledFrame(
+                video=video,
+                frame_idx=frame_idx,
+                masks=[
+                    sio.PredictedSegmentationMask.from_numpy(
+                        squares[k],
+                        score=0.9,
+                        track=pred_tracks[(k + 1) % 2 if flipped else k],
+                    )
+                    for k in range(2)
+                ],
+            )
+        )
+    return (
+        sio.Labels(labeled_frames=gt_frames, videos=[video], tracks=gt_tracks),
+        sio.Labels(labeled_frames=pred_frames, videos=[video], tracks=pred_tracks),
+    )
+
+
+# ---------------------------------------------------------------------------
+# identity_metrics: known-by-construction cases
+# ---------------------------------------------------------------------------
+def test_identity_metrics_perfect_tracking():
+    """No swaps, no drops -> zero switches and a perfect IDF1."""
+    gt, pred = _synthetic_pose(100)
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.id_switches == 0
+    assert m.idf1 == pytest.approx(1.0)
+    assert m.idp == pytest.approx(1.0)
+    assert m.idr == pytest.approx(1.0)
+    assert m.mean_track_purity == pytest.approx(1.0)
+    assert m.mean_gt_coverage == pytest.approx(1.0)
+    assert (m.mostly_tracked, m.partly_tracked, m.mostly_lost) == (2, 0, 0)
+    assert m.fragmentations == 0
+    assert m.n_matched == 200
+    assert m.n_gt_dets == 200
+    assert m.n_pred_dets == 200
+    assert m.n_frames_compared == 100
+    assert (m.n_gt_tracks, m.n_pred_tracks) == (2, 2)
+    assert m.notes == []
+
+
+def test_identity_metrics_one_swap_counts_two_switches():
+    """One swap costs a switch on EACH GT trajectory, and halves purity."""
+    gt, pred = _synthetic_pose(100, swap_at=[50])
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.id_switches == 2
+    assert m.mean_track_purity == pytest.approx(0.5)
+    # Coverage is untouched: every GT detection still matched something.
+    assert m.mean_gt_coverage == pytest.approx(1.0)
+    assert m.n_matched == 200
+    # A swap does not create tracks, so IDF1 caps at the half each identity kept.
+    assert m.idf1 == pytest.approx(0.5)
+
+
+def test_identity_metrics_two_swaps_restore_identity():
+    """Swapping back is still two more switches, but purity recovers."""
+    gt, pred = _synthetic_pose(100, swap_at=[30, 60])
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.id_switches == 4
+    assert m.mean_track_purity == pytest.approx(0.7)
+
+
+def test_identity_metrics_gap_is_fragmentation_not_switch():
+    """A dropped run mid-trajectory fragments coverage without a switch."""
+    gt, pred = _synthetic_pose(100, drop=range(40, 50))
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.id_switches == 0
+    assert m.fragmentations == 2  # one per GT trajectory
+    assert m.mean_gt_coverage == pytest.approx(0.9)
+    assert m.n_matched == 180
+    # 180 IDTP, 20 IDFN, 0 IDFP.
+    assert m.idf1 == pytest.approx(2 * 180 / (2 * 180 + 0 + 20))
+    assert m.idp == pytest.approx(1.0)
+    assert m.idr == pytest.approx(0.9)
+
+
+def test_identity_metrics_trailing_gap_is_not_a_fragmentation():
+    """A trajectory that simply ends is lost coverage, not a fragmentation."""
+    gt, pred = _synthetic_pose(100, drop=range(90, 100))
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.fragmentations == 0
+    assert m.mean_gt_coverage == pytest.approx(0.9)
+
+
+def test_identity_metrics_coverage_buckets_mt_pt_ml():
+    """The MT/PT/ML cuts follow per-trajectory coverage, not the mean."""
+    gt, pred = _synthetic_pose(100, drop=range(50, 100))
+    m = identity_metrics(gt, pred, "pose", mt_threshold=0.8, ml_threshold=0.2)
+
+    # Both trajectories sit at 0.5 coverage: partly tracked, neither MT nor ML.
+    assert (m.mostly_tracked, m.partly_tracked, m.mostly_lost) == (0, 2, 0)
+    m_strict = identity_metrics(gt, pred, "pose", mt_threshold=0.4, ml_threshold=0.2)
+    assert (m_strict.mostly_tracked, m_strict.partly_tracked) == (2, 0)
+    m_loose = identity_metrics(gt, pred, "pose", mt_threshold=0.9, ml_threshold=0.6)
+    assert (m_loose.mostly_lost, m_loose.partly_tracked) == (2, 0)
+
+
+def test_identity_metrics_untracked_predictions_are_counted_not_matched():
+    """Untracked predicted detections inflate no metric but are reported."""
+    gt, pred = _synthetic_pose(10)
+    for lf in pred:
+        for inst in lf.instances:
+            inst.track = None
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.n_pred_dets == 20
+    assert m.n_pred_untracked == 20
+    assert m.n_matched == 0
+    assert m.n_pred_tracks == 0
+    assert m.mostly_lost == 2
+    assert np.isnan(m.idf1)
+
+
+def test_identity_metrics_threshold_rejects_far_matches():
+    """Below-threshold similarity leaves the GT detection unmatched."""
+    gt, pred = _synthetic_pose(20)
+    m_loose = identity_metrics(gt, pred, "pose", match_threshold=0.5)
+    m_strict = identity_metrics(gt, pred, "pose", match_threshold=1.5)
+
+    assert m_loose.n_matched == 40
+    assert m_strict.n_matched == 0
+    assert m_strict.mean_gt_coverage == pytest.approx(0.0)
+
+
+def test_identity_metrics_no_frames_in_common_reports_a_note():
+    """Disjoint frame ranges return an empty result with an explanatory note."""
+    gt, _ = _synthetic_pose(10)
+    _, pred = _synthetic_pose(10)
+    for lf in pred:
+        lf.frame_idx += 1000
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.n_frames_compared == 0
+    assert m.n_matched == 0
+    assert any("no frames in common" in note for note in m.notes)
+
+
+def test_identity_metrics_missing_predicted_frames_reports_a_note():
+    """GT frames with no predicted counterpart are flagged, not silently dropped."""
+    gt, pred = _synthetic_pose(10)
+    pred.labeled_frames = pred.labeled_frames[:6]
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.n_frames_compared == 6
+    assert any("no predicted counterpart" in note for note in m.notes)
+
+
+def test_identity_metrics_aligns_a_distinct_video_object_on_the_same_path():
+    """A re-loaded prediction aligns on the video path, with no caveat needed."""
+    gt, pred = _synthetic_pose(10)
+    same_path_video = sio.Video.from_filename(FNAME)
+    for lf in pred:
+        lf.video = same_path_video
+    pred.videos = [same_path_video]
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.n_frames_compared == 10
+    assert m.id_switches == 0
+    assert m.notes == []
+
+
+def test_identity_metrics_falls_back_to_frame_idx_on_a_renamed_clip():
+    """One video per side under different paths: the only pairing is taken."""
+    gt, pred = _synthetic_pose(10)
+    renamed = sio.Video.from_filename("copied_elsewhere.mp4")
+    for lf in pred:
+        lf.video = renamed
+    pred.videos = [renamed]
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.n_frames_compared == 10
+    assert m.id_switches == 0
+    assert any("frame_idx only" in note for note in m.notes)
+
+
+def test_identity_metrics_pairs_a_single_video_prediction_with_a_project():
+    """A prediction on GT's SECOND video must not be paired with its first.
+
+    Keying by position in ``labels.videos`` would compare the prediction against
+    the wrong video's ground truth (or find nothing); keying by path pairs it
+    correctly.
+    """
+    gt, pred = _synthetic_pose(10)
+    # Turn the GT into a two-video project whose labeled frames belong to the
+    # second video, leaving the prediction a single-video run on that same path.
+    decoy = sio.Video.from_filename("some_other_recording.mp4")
+    gt.videos = [decoy, gt.videos[0]]
+    m = identity_metrics(gt, pred, "pose")
+
+    assert m.n_frames_compared == 10
+    assert m.n_matched == 20
+    assert m.id_switches == 0
+    assert m.notes == []
+
+
+def test_identity_metrics_rejects_unknown_carrier():
+    """An unknown carrier fails loudly instead of scoring the wrong thing."""
+    gt, pred = _synthetic_pose(2)
+    with pytest.raises(ValueError, match="carrier must be one of"):
+        identity_metrics(gt, pred, "keypoints")
+
+
+# ---------------------------------------------------------------------------
+# The mask carrier
+# ---------------------------------------------------------------------------
+def test_identity_metrics_mask_carrier_perfect_and_swapped():
+    """Masks carry identity too, scored by IoU instead of OKS."""
+    gt, pred = _synthetic_mask(20)
+    m = identity_metrics(gt, pred, "mask")
+    assert m.n_matched == 40
+    assert m.id_switches == 0
+    assert m.idf1 == pytest.approx(1.0)
+
+    gt, pred = _synthetic_mask(20, swap_at=[10])
+    m_swapped = identity_metrics(gt, pred, "mask")
+    assert m_swapped.id_switches == 2
+    assert m_swapped.mean_track_purity == pytest.approx(0.5)
+
+
+def test_identity_metrics_mask_carrier_ignores_instances():
+    """The mask carrier scores `lf.masks`; poses in the same file are irrelevant."""
+    gt, pred = _synthetic_mask(5)
+    m = identity_metrics(gt, pred, "mask")
+    # The same files have no instances at all, so the pose carrier sees nothing.
+    m_pose = identity_metrics(gt, pred, "pose")
+
+    assert m.n_gt_dets == 10
+    assert m_pose.n_gt_dets == 0
+
+
+# ---------------------------------------------------------------------------
+# motion_diagnostic
+# ---------------------------------------------------------------------------
+def test_motion_diagnostic_flags_continuous_video():
+    """Small per-frame steps relative to body size read as continuous."""
+    gt, _ = _synthetic_pose(50, step=0.5)
+    diagnostic = motion_diagnostic(gt, "pose")
+
+    assert diagnostic["is_continuous"] is True
+    assert diagnostic["step_over_size"] < 0.5
+
+
+def test_motion_diagnostic_flags_sparse_split():
+    """A teleporting animal is reported as not continuous (the .pkg.slp trap)."""
+    gt, _ = _synthetic_pose(50, step=400.0)
+    diagnostic = motion_diagnostic(gt, "pose")
+
+    assert diagnostic["is_continuous"] is False
+    assert diagnostic["step_over_size"] > 0.5
+
+
+def test_motion_diagnostic_single_node_skeleton_cannot_be_judged():
+    """A centroid-style skeleton has no extent, so continuity is inconclusive.
+
+    Reporting it as sparse would fire the "not continuous video" warning on
+    every centroid-model tracking evaluation.
+    """
+    gt, _ = _synthetic_pose(50, step=0.5, body_length=0.0)
+    diagnostic = motion_diagnostic(gt, "pose")
+
+    assert np.isnan(diagnostic["step_over_size"])
+    assert diagnostic["is_continuous"] is False
+    assert "no measurable extent" in diagnostic["note"]
+
+
+def test_motion_diagnostic_without_tracks_says_so():
+    """Untracked labels cannot be judged, and the result says why."""
+    gt, _ = _synthetic_pose(5)
+    for lf in gt:
+        for inst in lf.instances:
+            inst.track = None
+    diagnostic = motion_diagnostic(gt, "pose")
+
+    assert diagnostic["is_continuous"] is False
+    assert np.isnan(diagnostic["step_over_size"])
+    assert "not enough tracked detections" in diagnostic["note"]
+
+
+def test_motion_diagnostic_mask_carrier():
+    """The mask carrier measures step against equivalent-circle diameter."""
+    gt, _ = _synthetic_mask(20)
+    diagnostic = motion_diagnostic(gt, "mask")
+
+    assert diagnostic["is_continuous"] is True
+    assert diagnostic["median_step_px"] == pytest.approx(1.0, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Reporting helpers
+# ---------------------------------------------------------------------------
+def test_compare_identity_metrics_renders_arms_and_nan():
+    """The table carries one row per arm and prints NaN cells as n/a."""
+    gt, pred = _synthetic_pose(20)
+    table = compare_identity_metrics(
+        {
+            "geometry": identity_metrics(gt, pred, "pose"),
+            "empty": IdentityMetrics(),
+        }
+    )
+
+    assert "| geometry |" in table
+    assert "| empty |" in table
+    assert "n/a" in table
+    assert "Lower is better" in table
+
+
+def test_identity_metrics_as_dict_and_summary_are_serializable():
+    """`as_dict` is JSON-safe and `summary` is a single line."""
+    gt, pred = _synthetic_pose(10)
+    m = identity_metrics(gt, pred, "pose")
+
+    payload = m.as_dict()
+    json.dumps(payload)
+    assert payload["id_switches"] == 0
+    assert "IDSW=0" in m.summary()
+    assert "\n" not in m.summary()
+
+
+# ---------------------------------------------------------------------------
+# run_identity_evaluation + the CLI
+# ---------------------------------------------------------------------------
+def test_run_identity_evaluation_round_trip(tmp_path):
+    """The driver loads both files, scores them, and saves JSON."""
+    gt, pred = _synthetic_pose(30, swap_at=[15])
+    gt_path = tmp_path / "gt.slp"
+    pred_path = tmp_path / "pred.slp"
+    gt.save(gt_path.as_posix())
+    pred.save(pred_path.as_posix())
+    out_path = tmp_path / "identity.json"
+
+    result = run_identity_evaluation(
+        gt_path.as_posix(),
+        pred_path.as_posix(),
+        save_metrics=out_path.as_posix(),
+    )
+
+    assert result["carrier"] == "pose"
+    assert result["id_switches"] == 2
+    assert result["match_threshold"] == 0.5
+    assert "step_over_size" in result["motion_diagnostic"]
+    saved = json.loads(out_path.read_text())
+    assert saved["id_switches"] == 2
+
+
+def test_run_identity_evaluation_auto_detects_mask_carrier(tmp_path):
+    """A mask-only prediction selects the mask carrier without being told."""
+    gt, pred = _synthetic_mask(10)
+    gt_path = tmp_path / "gt_mask.slp"
+    pred_path = tmp_path / "pred_mask.slp"
+    gt.save(gt_path.as_posix())
+    pred.save(pred_path.as_posix())
+
+    result = run_identity_evaluation(gt_path.as_posix(), pred_path.as_posix())
+
+    assert result["carrier"] == "mask"
+    assert result["n_matched"] == 20
+
+
+def test_run_identity_evaluation_untracked_prediction_returns_none(tmp_path, caplog):
+    """An untracked prediction is skipped with a pointer at `sleap-nn track`."""
+    gt, pred = _synthetic_pose(10)
+    for lf in pred:
+        for inst in lf.instances:
+            inst.track = None
+    gt_path = tmp_path / "gt.slp"
+    pred_path = tmp_path / "pred_untracked.slp"
+    gt.save(gt_path.as_posix())
+    pred.save(pred_path.as_posix())
+
+    assert run_identity_evaluation(gt_path.as_posix(), pred_path.as_posix()) is None
+
+
+def test_run_identity_evaluation_warns_on_sparse_ground_truth(tmp_path, caplog):
+    """A sparse GT set is called out rather than silently scored."""
+    gt, pred = _synthetic_pose(20, step=400.0)
+    gt_path = tmp_path / "gt_sparse.slp"
+    pred_path = tmp_path / "pred_sparse.slp"
+    gt.save(gt_path.as_posix())
+    pred.save(pred_path.as_posix())
+
+    result = run_identity_evaluation(gt_path.as_posix(), pred_path.as_posix())
+
+    assert result is not None
+    assert result["motion_diagnostic"]["is_continuous"] is False
+
+
+def test_cli_eval_tracking_smoke(tmp_path):
+    """`sleap-nn eval-tracking` wires the options through to the driver."""
+    from sleap_nn.cli import cli
+
+    gt, pred = _synthetic_pose(20, swap_at=[10])
+    gt_path = tmp_path / "gt.slp"
+    pred_path = tmp_path / "pred.slp"
+    gt.save(gt_path.as_posix())
+    pred.save(pred_path.as_posix())
+    out_path = tmp_path / "ids.json"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "eval-tracking",
+            "-g",
+            gt_path.as_posix(),
+            "-p",
+            pred_path.as_posix(),
+            "--carrier",
+            "pose",
+            "--match_threshold",
+            "0.5",
+            "-s",
+            out_path.as_posix(),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(out_path.read_text())["id_switches"] == 2
+
+
+# ---------------------------------------------------------------------------
+# user_labels_only: predictions living in the ground-truth file
+# ---------------------------------------------------------------------------
+def test_identity_metrics_drops_predicted_detections_from_ground_truth():
+    """Predictions carried in a GT project must not be scored as ground truth.
+
+    A proofread project routinely holds both user labels and predictions from an
+    earlier run, and those predictions carry tracks. Counted as ground truth
+    they invent trajectories and inflate every total.
+    """
+    gt, pred = _synthetic_pose(10)
+    # Splice a third, predicted "animal" into the GT file, tracked as its own
+    # identity -- exactly what an earlier tracking run leaves behind.
+    stray_track = sio.Track("stale_prediction")
+    skeleton = gt.skeletons[0]
+    for lf in gt:
+        lf.instances.append(
+            sio.PredictedInstance.from_numpy(
+                np.array([[500.0, 500.0], [512.0, 500.0]]),
+                skeleton=skeleton,
+                score=1.0,
+                point_scores=np.ones(2),
+                tracking_score=1.0,
+                track=stray_track,
+            )
+        )
+
+    kept = identity_metrics(gt, pred, "pose", user_labels_only=True)
+    default = identity_metrics(gt, pred, "pose")
+
+    # Filtered: the two real animals only, and a note saying what happened.
+    assert kept.n_gt_dets == 20
+    assert kept.n_gt_tracks == 2
+    assert kept.idf1 == pytest.approx(1.0)
+    assert any("were dropped" in note for note in kept.notes)
+
+    # Default (off): the phantom third trajectory is scored, dragging IDF1 down
+    # and showing up as mostly-lost -- with a note pointing at the flag.
+    assert default.n_gt_dets == 30
+    assert default.n_gt_tracks == 3
+    assert default.mostly_lost == 1
+    assert default.idf1 < kept.idf1
+    assert any("are model output" in note for note in default.notes)
+
+
+def test_identity_metrics_user_labels_only_can_empty_the_ground_truth():
+    """Predicted GT + the filter = nothing scored, said out loud.
+
+    Tracked ground truth is usually predicted poses with tracks assigned
+    afterwards, which is why the filter is off by default: on the re-ID
+    benchmark's own GT sessions, turning it on takes 2465 detections to 0.
+    """
+    gt, pred = _synthetic_pose(10)
+    # Rebuild the GT side entirely out of predicted instances, keeping tracks.
+    for lf in gt:
+        lf.instances = [
+            sio.PredictedInstance.from_numpy(
+                inst.numpy(),
+                skeleton=gt.skeletons[0],
+                score=1.0,
+                point_scores=np.ones(len(inst.numpy())),
+                tracking_score=1.0,
+                track=inst.track,
+            )
+            for inst in lf.instances
+        ]
+
+    assert identity_metrics(gt, pred, "pose").n_gt_dets == 20
+
+    filtered = identity_metrics(gt, pred, "pose", user_labels_only=True)
+    assert filtered.n_gt_dets == 0
+    assert filtered.n_matched == 0
+    assert any("left NO ground truth" in note for note in filtered.notes)
+
+
+def test_identity_metrics_mask_carrier_drops_predicted_gt_masks():
+    """Same rule on the mask carrier, with the decoded arrays kept in step."""
+    gt, pred = _synthetic_mask(5)
+    stray_track = sio.Track("stale_prediction")
+    for lf in gt:
+        lf.masks.append(
+            sio.PredictedSegmentationMask.from_numpy(
+                _square(64, 64, 32, 32, 4), score=0.9, track=stray_track
+            )
+        )
+
+    kept = identity_metrics(gt, pred, "mask", user_labels_only=True)
+    default = identity_metrics(gt, pred, "mask")
+
+    assert kept.n_gt_dets == 10
+    assert kept.n_gt_tracks == 2
+    assert kept.n_matched == 10
+    assert default.n_gt_dets == 15
+    assert default.n_gt_tracks == 3
+
+
+def test_cli_eval_tracking_user_labels_only_flag(tmp_path):
+    """The CLI can turn the ground-truth filter on."""
+    from sleap_nn.cli import cli
+
+    gt, pred = _synthetic_pose(10)
+    gt_path = tmp_path / "gt.slp"
+    pred_path = tmp_path / "pred.slp"
+    gt.save(gt_path.as_posix())
+    pred.save(pred_path.as_posix())
+    out_path = tmp_path / "ids.json"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "eval-tracking",
+            "-g",
+            gt_path.as_posix(),
+            "-p",
+            pred_path.as_posix(),
+            "--user_labels_only",
+            "-s",
+            out_path.as_posix(),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # The synthetic GT is user-labeled, so the filter keeps all of it.
+    assert json.loads(out_path.read_text())["n_gt_dets"] == 20


### PR DESCRIPTION
## Why

`sleap-nn eval` scores detection and localization. Nothing in the repo scored whether a track kept the **right** animal — the tracking demos report track counts, track lengths, and a single "identity agreement" percentage, which is a smoke test rather than evidence.

So none of the trackers sleap-nn ships — fixed-window, local-queues, optical flow, Kalman, mask-IoU — has ever had an identity number. A tracker whose quality claim has no in-repo metric is a claim nobody can re-check.

## What

Adds the standard multi-object-tracking metrics to `sleap_nn.evaluation`, plus a CLI:

```bash
sleap-nn eval-tracking -g ground_truth.slp -p tracked_predictions.slp
```

| API | what |
|---|---|
| `identity_metrics(gt, pred, carrier)` | ID switches (CLEAR-MOT), IDF1/IDP/IDR (Ristani et al.), MT/PT/ML, fragmentation, track purity, GT coverage |
| `motion_diagnostic(labels, carrier)` | whether a file is continuous video at all |
| `compare_identity_metrics(arms)` | arm-comparison table |
| `run_identity_evaluation(...)` | driver behind `sleap-nn eval-tracking` |

Both carriers are supported: `pose` (instances, OKS) and `mask` (segmentation masks, scale-aware IoU so a stride-res prediction and a full-res GT mask meet on the same pixel grid), with `auto` picking by content.

Detections are matched to GT within each frame first, and identity is scored over those matches — so a tracker is never penalized for the detector's misses. Detection counts are reported alongside but never folded into the identity scores, which is also why **MOTA is deliberately absent**: it mixes detection FP/FN into one number, so over a frozen detection stage (the usual A/B) a MOTA delta mostly reports detector noise.

Coverage and purity are reported next to the switch count on purpose: without them a tracker can "win" on ID switches by emitting fewer, shorter, more timid tracks.

## Three decisions worth reviewer attention

**1. `user_labels_only` defaults to `False` here, unlike `sleap-nn eval`.** Tracked ground truth usually *is* predicted — the normal workflow predicts poses and then assigns or corrects tracks over them — so filtering the GT side by detection type discards the ground truth. I had it defaulting to `True` for consistency with the detection metrics, and measuring it on real GT sessions killed that: **2465 scored detections → 0, IDF1 → NaN**, silently. The predicted-GT count is reported in `notes` either way, and an emptied ground truth now says so loudly instead of returning a table of NaNs. The flag is still there for the case it does help: user-labeled GT in a file that also holds stale predictions from an earlier run.

**2. Frames are keyed by video path, not by position in `labels.videos`.** Position pairs a single-video prediction with whatever video happens to be first in a multi-video GT project. This uses the same video identity `find_frame_pairs` already uses for the detection metrics — factored out as `_video_key` so the embedded-video fallback chain has one copy instead of two (behavior-preserving; `get_instances` now calls it).

**3. A single-node (centroid) skeleton has no measurable extent**, so `motion_diagnostic` reports "cannot judge" rather than dividing by ~0 and calling every centroid-model prediction sparse.

## The sparse-file trap, shipped as a check

An embedded `.pkg.slp` training split renumbers its frames `0..N-1`, so `frame_idx` and `frame_numbers` both read as contiguous while the animal has moved across the arena between two "consecutive" frames. Every index-based contiguity check passes and the metrics come out looking authoritative. `motion_diagnostic` measures per-frame displacement against body size instead:

```
continuous video       step/size 0.01 - 0.06
sparse training split  step/size 3 - 9      <- consecutive detections of one animal
                                               do not even overlap, so no IoU tracker
                                               can work, for reasons unrelated to the tracker
```

`eval-tracking` runs it on the ground truth and warns before reporting anything.

## Validation

**32 new tests**, every case known by construction — two trajectories far enough apart that detection matching is unambiguous, with swaps and gaps injected at known positions, so a failure points at the metric and not the matcher. Covers both carriers, the coverage buckets, untracked predictions, disjoint frame ranges, the renamed-clip and multi-video pairing paths, and both `user_labels_only` directions.

Beyond the unit tests, two checks that the shipped code produces the numbers this metric family was originally measured with:

- **Field-for-field identical** to the prototype across six cases, including a mixed swap+gap case and a 3-frame edge case (17 fields each).
- **Reproduces recorded real-data results exactly** on three benchmark sessions — two pose (2465 dets / 600 frames, and 1079 / 595) and one mask (212 / 71) — all 16-17 fields per session, including the mask carrier's RLE decode path and the motion diagnostic's `8.743` step/size on the known-sparse split.

## Test plan

- [x] `pytest tests/test_evaluation_identity.py` — 32 passed
- [x] `pytest tests/tracking tests/test_evaluation.py tests/test_evaluation_identity.py` — 115 passed
- [x] `pytest tests/test_cli.py tests/cli` — 162 passed (CLI surface unchanged apart from the new command)
- [x] `pytest tests/test_segmentation_eval.py` — passes (`get_instances` refactor is behavior-preserving)
- [x] `black --check`, `ruff check`, `codespell` clean

Based directly on `main`, no dependency on any open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
