### PR TITLE
ci: run the pretrained-backbone tests (they have never executed in CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,72 @@ jobs:
           fail_ci_if_error: false
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # The `backbones` extra (external pretrained HuggingFace encoders) is not part
+  # of any other job's sync, so `tests/architectures/test_pretrained.py` — which
+  # opens with `pytest.importorskip("transformers")` — has never executed in CI
+  # on any platform. Three bugs of real size lived behind that (#740: encoder
+  # mode on CNN backbones, the air-gapped load path, frozen BatchNorm), so the
+  # feature shipped with zero automated coverage.
+  #
+  # Kept as its own job rather than a fourth matrix entry, for two reasons: the
+  # extra only needs to be exercised on ONE platform (it is pure-Python
+  # `transformers` over the same torch), and these tests reach huggingface.co —
+  # so a Hub outage reddens this job alone instead of the whole test matrix.
+  pretrained-backbones:
+    name: Tests (pretrained backbones, ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CUDA_VISIBLE_DEVICES: ""
+      USE_CUDA: "0"
+      UV_FROZEN: "1"
+      HF_HUB_DISABLE_TELEMETRY: "1"
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+      # The suite builds backbones with `weights=False`, so it fetches each
+      # model's config.json (~400 KB total) and NO checkpoints. Cached below so
+      # the usual run resolves offline.
+      HF_HOME: ${{ github.workspace }}/.hf-cache
+      # `weights=True` — the path the config-vs-kwargs divergence in #740 lived
+      # in — is opt-in via SLEAP_NN_TEST_HF_WEIGHTS because it downloads real
+      # checkpoints. Flip to "1" to extend this job to that path (the tests it
+      # enables arrive with #740; the variable is inert before then).
+      SLEAP_NN_TEST_HF_WEIGHTS: "0"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: false
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Cache HuggingFace configs
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.hf-cache
+          # Keyed on the test file: it names the models whose configs get
+          # fetched, so the key changes exactly when that set can change.
+          key: hf-configs-${{ hashFiles('tests/architectures/test_pretrained.py') }}
+          restore-keys: hf-configs-
+
+      - name: Install dev dependencies, torch and the backbones extra
+        run: uv sync --no-group gpu --extra torch-cpu --extra backbones
+
+      - name: Assert transformers is importable
+        # Without this the suite would silently `importorskip` back to zero
+        # coverage — the failure mode this job exists to close.
+        run: |
+          uv run --frozen --no-group gpu --extra torch-cpu --extra backbones python -c "
+          import transformers
+          print('transformers', transformers.__version__)
+          "
+
+      - name: Run pretrained backbone tests
+        run: |
+          uv run --frozen --no-group gpu --extra torch-cpu --extra backbones \
+            pytest tests/architectures/test_pretrained.py -v --durations=10


### PR DESCRIPTION
## Why

`tests/architectures/test_pretrained.py` opens with `pytest.importorskip("transformers")`, and no CI job installs the `backbones` extra. **All 18 tests in that file have been skipped on every CI run, on all three platforms, since the feature landed.**

That gap is not theoretical — three bugs of real size were living behind it, all found by hand and all fixed in #740:

- `mode: encoder` raised `TypeError` for every non-ViT backbone with real weights
- the documented `HF_HUB_OFFLINE=1` air-gapped path failed for *every* pretrained backbone
- `freeze: true` did not freeze BatchNorm statistics (`running_mean` moved 0.63 in one forward)

## What

A `pretrained-backbones` job on ubuntu that syncs `--extra backbones` and runs that file.

**Kept out of the test matrix on purpose**, for two reasons:

1. The extra is pure-Python `transformers` over the same torch, so exercising it on one platform is enough.
2. These tests reach huggingface.co. As its own job, a Hub outage reddens *this* job alone instead of the whole test matrix.

There is also an explicit "assert transformers is importable" step, which guards the exact failure mode the job exists to close: a sync that quietly dropped the extra would `importorskip` straight back to zero coverage while still reporting green.

## Measured before writing it

| check | result |
|---|---|
| 18 tests on `main` today, extra installed | **pass**, ~19 s |
| what the network is actually used for | `config.json` only — **392 KB total, no checkpoints** (the suite builds with `weights=False`) |
| warm cache, `HF_HUB_OFFLINE=1` | pass, 9.5 s — so the cache below makes the usual run offline |
| empty cache, `HF_HUB_OFFLINE=1` | **16 of 18 fail** — confirming the dependency is genuine, not incidental |
| `uv sync --frozen --no-group gpu --extra torch-cpu --extra backbones` | resolves against the existing lock; **no `uv.lock` change** |

The HF cache is keyed on the hash of `test_pretrained.py`, since that file names the models whose configs get fetched — the key changes exactly when that set can change.

## The `weights=True` path

#740 gates the checkpoint-downloading tests behind `SLEAP_NN_TEST_HF_WEIGHTS`, off by default, because they pull real weights. This job sets it to `"0"` explicitly, with a comment, so extending coverage to that path — the one where the config-vs-kwargs divergence behind U7 actually lived — is a one-character change once #740 lands. Left as a deliberate decision for review rather than made silently here.

## Test plan

CI on this PR is the test: the new job should appear as **Tests (pretrained backbones, ubuntu)** and run 18 tests instead of skipping them. Locally verified green on `main` with the extra installed, so this should not require #740 to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
