### PR TITLE
chore: extend the LF pin beyond *.py

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,37 @@
 # Pin Python source line endings to LF in the repository so a Windows checkout
 # cannot silently re-write a whole file to CRLF and produce a large, spurious diff.
 *.py text eol=lf
+
+# Same policy for the other text formats that tooling REGENERATES and humans
+# then read in diffs -- the config-generator goldens under
+# `tests/assets/generated_configs/` above all. `*.py` alone (added with the
+# `embedding` model type) left those exposed to exactly the problem it fixed:
+# three source files sat CRLF in the index for months, so any PR touching them
+# read as a whole-file rewrite (15,495+/8,665- against 6,912+/82- with
+# `--ignore-cr-at-eol`) and merging them needed `merge.renormalize=true` to
+# dissolve conflicts that were pure line-ending noise.
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.toml text eol=lf
+*.cfg text eol=lf
+
+# Recorded artifacts, not source: these are captured training outputs, some
+# produced on Windows, and their bytes are the point. `model_info` reads them
+# with the csv module, which is newline-agnostic, so normalizing them would
+# rewrite ~400 lines across 7 checkpoint directories for no reader's benefit.
+tests/assets/**/training_log.csv -text
+
+# Binary payloads: never normalize, never diff as text. Git's own heuristic
+# catches most of these, but an HDF5/pickle/npz payload can carry no NUL byte in
+# its first 8 kB and be misdetected as text.
+*.slp binary
+*.h5 binary
+*.npz binary
+*.ckpt binary
+*.pkl binary
+*.pt binary
+*.png binary
+*.jpg binary
+*.mp4 binary


### PR DESCRIPTION
## Why

Review finding 9 on #671 was about diff inflation: three source files had sat CRLF in the index long enough that any PR touching them read as a whole-file rewrite. #671's own diff showed **15,495+/8,665−** against **6,912+/82−** with `--ignore-cr-at-eol`, and merging it needed `merge.renormalize=true` to dissolve conflicts that were pure line-ending noise.

Two thirds of that finding are already resolved:

- **The index is all-LF again** — #671's merge carried the normalized files, so `custom_datasets.py`, `training/utils.py` and `tests/data/test_custom_datasets.py` now have zero CR bytes on main.
- **`.gitattributes` exists** — #671 added it with `*.py text eol=lf`.

What's left is the residual gap: **`*.py` alone leaves the same trap open for every other text format**, and specifically for the ones tooling *regenerates* and humans then read in diffs — the config-generator goldens under `tests/assets/generated_configs/`, which are rewritten whenever the config schema changes (#738 regenerated four of them). Regenerate one on Windows today and it lands CRLF, and the cycle restarts in a different extension.

## What this does

| rule | why |
|---|---|
| `*.yaml *.yml *.json *.md *.toml *.cfg` → `text eol=lf` | the regenerated-and-diffed formats, same treatment `*.py` already gets |
| `*.slp *.h5 *.npz *.ckpt *.pkl *.pt *.png *.jpg *.mp4` → `binary` | git's heuristic catches most, but an HDF5/pickle/npz payload can carry no NUL byte in its first 8 kB and be misdetected as text |
| `tests/assets/**/training_log.csv` → `-text` | recorded artifacts, not source: captured training output, some produced on Windows, whose bytes are the point. Normalizing them would rewrite ~400 lines across 7 checkpoint directories for no reader's benefit — `model_info` parses them with the csv module, which is newline-agnostic |

## No content changes

The index is already all-LF for every governed extension, so **`git add --renormalize .` is a no-op today** — this PR is one file, purely preventive. That's deliberate: doing it now, while nothing needs rewriting, is what keeps it from being a 400-line diff later.

## Test plan

- `tests/test_model_info.py` + `tests/test_config_generator_yaml.py` — 57 passed. Those are the readers of the two fixture families this touches (the frozen CSVs and the normalized YAML goldens).
- Verified the frozen CSVs stay out of the diff, and that a renormalize pass changes no tracked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
