### PR TITLE
fix(backbones): make `embedding` + `pretrained` usable, and expose centroid methods on the re-ID crop

### DIFF
--- a/docs/guides/centroid-only-inference.md
+++ b/docs/guides/centroid-only-inference.md
@@ -198,6 +198,13 @@ and for an anchor with a non-default fallback:
         centroid_fallback: bbox_center      # used only when `thorax` is occluded
 ```
 
+The same two knobs live on **every head that defines a crop or centroid center** —
+`centroid.confmaps`, `centered_instance.confmaps`, `multi_class_topdown.confmaps`,
+`centered_instance_segmentation.segmentation` and `embedding.embedding` — and mean
+the same thing on each. On `embedding.embedding` they set the re-ID crop center for
+**pose** data; a mask-driven embedding dataset crops on the mask's own center of
+mass instead (see `data_config.preprocessing.crop_centering`).
+
 **Defaults are unchanged.** `centroid_method: null` (the default) means "the
 anchor node when `anchor_part` is set, else `center_of_mass`" — exactly the
 behavior of every config written before this knob existed. Setting `anchor_part`

--- a/docs/guides/pretrained-backbones.md
+++ b/docs/guides/pretrained-backbones.md
@@ -40,7 +40,12 @@ a U-Net-style pyramid; they are used encoder-only. A ViT feeding a spatial head
 would need a ViTDet-style Simple Feature Pyramid, which is not yet implemented.
 
 `mode: auto` picks `encoder` for isotropic ViTs and `decoder` for everything
-else.
+else — **except** for the `embedding` (re-ID) model type, where it always
+resolves to `encoder` regardless of family. That head is a lone pooled head that
+reads the encoder bottleneck, so a decoder underneath it would be dead weight:
+on convnextv2-nano, 4.9 M of 20.1 M parameters (24%) receive no gradient, which
+is also a DDP hazard. `mode: decoder` with an `embedding` head is rejected at
+setup for the same reason.
 
 ## Tested model families
 
@@ -125,6 +130,23 @@ the model's `AutoImageProcessor`, or set explicitly via `image_mean`/`image_std`
 is applied **inside the backbone** — the data pipeline still only rescales to
 `[0, 1]`.
 
+!!! note "The `embedding` model type is the exception"
+
+    The re-ID (`embedding`) pipeline per-crop standardizes to ~N(0, 1) before the
+    backbone sees the crop, so it does **not** feed `[0, 1]`. Applying the ImageNet
+    shift on top of that hands the stem mean −1.99 / std 4.43, which trains — badly.
+    Measured on the gerbil re-ID set (DINOv2-with-registers, 3 epochs, seed 0,
+    paired runs): val rank-1 **0.363** with normalization on vs **0.920** with it
+    off. The trainer therefore forces `normalize: false` for `embedding` and logs
+    that it did; set it back to `true` only if you also disable the per-crop
+    standardize.
+
+    For the same reason `embedding` also keeps its own data channels: unlike every
+    other model type it is **not** flipped to `ensure_rgb`, because the 1-channel
+    crop is repeated to 3 in `Model.forward` and grayscale is often a deliberate
+    anti-confound choice (a recording setup mixing color and monochrome cameras
+    makes color an identity cue that will not generalize).
+
 ## Reproducibility, gating, and offline use
 
 - **Pin `revision`.** HuggingFace `main` moves. Set `revision` to a commit sha
@@ -169,3 +191,10 @@ is applied **inside the backbone** — the data pipeline still only rescales to
   exporting transformer backbones.
 - **`dtype`.** `transformers` v5 defaults to `dtype="auto"`, which can silently
   load fp16/bf16. sleap-nn forces `float32` in the backbone factory.
+- **Re-ID (`embedding`) has three trainer-applied overrides.** `mode` resolves to
+  `encoder`, `normalize` is forced off (the pipeline already standardizes each
+  crop), and the data channels are *not* flipped to RGB. Each is logged when it
+  fires; see the notes under
+  [Channels and normalization](#channels-and-normalization). Fine-tuned DINOv2
+  reached val rank-1 0.92 in 3 epochs on the gerbil re-ID set once the
+  normalization override was in place.

--- a/docs/sample_configs/config_embedding_convnext.yaml
+++ b/docs/sample_configs/config_embedding_convnext.yaml
@@ -110,7 +110,16 @@ model_config:
         output_stride: 32  # = backbone max_stride (lone pooled head taps middle_output)
         loss_weight: 1.0
         freeze_backbone: false
+        # Crop centering for POSE data (mask data uses `crop_centering` above).
         anchor_part: null  # pose centering node; null -> mean of visible nodes
+        # How the crop center is reduced from the instance's points, in sleap-io's
+        # vocabulary: center_of_mass (default) | bbox_center | geometric_median |
+        # anchor. null infers it -- "anchor" if anchor_part is set, else
+        # center_of_mass -- so leaving both null is the historical behavior exactly.
+        # Setting anchor_part AND a non-anchor method is rejected at setup; use
+        # centroid_fallback for "anchor, but this when it is occluded".
+        centroid_method: null
+        centroid_fallback: null  # null -> center_of_mass; only used with an anchor
         objective:
           # positives x negatives x loss. scope=global_id needs track_names_are_global=true.
           positives: {scope: global_id, aug_views: 2}

--- a/sleap_nn/config/model_config.py
+++ b/sleap_nn/config/model_config.py
@@ -1337,6 +1337,29 @@ class EmbeddingHeadConfig:
         output_stride: Stride of the pooled feature. Should equal the backbone
             ``max_stride`` so the decoder is empty and the head taps ``middle_output``.
         loss_weight: Scalar loss weight.
+        anchor_part: (str) Node name used to center the re-ID crop. ``None``
+            (default) centers on the mean of each instance's visible nodes.
+        centroid_method: (str) How the crop center is derived from the instance's
+            points, spelled as in ``sio.Instance.to_centroid``:
+            ``"center_of_mass"`` (mean of visible nodes), ``"bbox_center"``
+            (midpoint of the visible nodes' bounding box), ``"geometric_median"``
+            (Weiszfeld median — the least affected by a MISLOCALIZED node; measured
+            on real pose data, one node off by a body length moves it ~1.7x less
+            than the mean and ~5x less than the bbox midpoint. Not more stable
+            than the mean under node dropout), or ``"anchor"``
+            (the ``anchor_part`` node). ``None`` (default) infers it: ``"anchor"``
+            when ``anchor_part`` is set, else ``"center_of_mass"`` — i.e. exactly
+            the historical behavior, so existing configs are unchanged. Setting
+            both ``anchor_part`` and a non-anchor ``centroid_method`` is an error
+            (they name different centroids); use ``centroid_fallback`` for that.
+            Only used in the pose detection mode — a mask-driven embedding dataset
+            crops on the mask's own center of mass. Default is None.
+        centroid_fallback: (str) The reduce method used when ``anchor_part`` is
+            configured but that node is not visible: ``"center_of_mass"``
+            (default), ``"bbox_center"`` or ``"geometric_median"``. Only
+            meaningful for the anchor method. Unlike ``sio``'s ``fallback=None``,
+            sleap-nn always falls back rather than emitting a NaN centroid.
+            Default is None (= ``"center_of_mass"``).
         objective: The pluggable training objective (positives x negatives x loss).
     """
 
@@ -1349,6 +1372,8 @@ class EmbeddingHeadConfig:
     loss_weight: float = 1.0
     freeze_backbone: bool = False
     anchor_part: Optional[str] = None
+    centroid_method: Optional[str] = None
+    centroid_fallback: Optional[str] = None
     objective: Optional[ObjectiveConfig] = None
 
 

--- a/sleap_nn/config/utils.py
+++ b/sleap_nn/config/utils.py
@@ -132,10 +132,54 @@ def check_output_strides(config: OmegaConf) -> OmegaConf:
             "max_stride"
         ]
         config.model_config.head_configs.embedding.embedding.output_stride = max_stride
-        config.model_config.backbone_config[f"{backbone_type}"][
-            "output_stride"
-        ] = max_stride
+        if backbone_type == "pretrained":
+            # The `pretrained` wrapper spells "no decoder" as `mode="encoder"`, not
+            # with strides -- and it treats `output_stride == max_stride` as a user
+            # error ("nothing to decode"). Pinning the stride here, as the native
+            # backbones need, is therefore exactly what made the DEFAULT
+            # `mode: auto` refuse to build for every hierarchical backbone. Say it
+            # in the wrapper's own vocabulary instead and leave its stride alone.
+            _set_pretrained_encoder_mode(config)
+        else:
+            config.model_config.backbone_config[f"{backbone_type}"][
+                "output_stride"
+            ] = max_stride
     return config
+
+
+def _set_pretrained_encoder_mode(config: OmegaConf) -> None:
+    """Put a `pretrained` backbone in encoder-only mode for a pooled-head model.
+
+    Args:
+        config: The full training job config, with `backbone_type == "pretrained"`
+            and a lone pooled head (the `embedding` model type).
+
+    Raises:
+        ValueError: If the config explicitly asks for `mode: decoder`.
+    """
+    pretrained_cfg = config.model_config.backbone_config.pretrained
+    mode = OmegaConf.select(pretrained_cfg, "mode", default="auto")
+    if mode == "decoder":
+        # Not a stride problem, so do not let it surface as one. A pooled head
+        # reads the bottleneck (`Model.forward` routes it to `intermediate_feat`),
+        # so a decoder built underneath it never receives gradient -- measured at
+        # 4.9 M of 20.1 M parameters (24%) on convnextv2-nano, which is dead weight
+        # and a DDP hazard (unused parameters).
+        message = (
+            "model_config.backbone_config.pretrained.mode='decoder' is not valid "
+            "for the `embedding` model type: its lone pooled head reads the "
+            "encoder bottleneck, so the decoder would receive no gradient. Use "
+            "mode='encoder' (or 'auto', which resolves to it here)."
+        )
+        logger.error(message)
+        raise ValueError(message)
+    if mode != "encoder":
+        pretrained_cfg.mode = "encoder"
+        logger.info(
+            "Setting `model_config.backbone_config.pretrained.mode` to 'encoder' "
+            "for the `embedding` model type (its pooled head taps the encoder "
+            "bottleneck; there is nothing for a decoder to do)."
+        )
 
 
 def check_centroid_methods(config: OmegaConf) -> OmegaConf:

--- a/sleap_nn/data/custom_datasets.py
+++ b/sleap_nn/data/custom_datasets.py
@@ -2430,6 +2430,12 @@ class EmbeddingDataset(BaseDataset):
                     if self.anchor_part in names:
                         self.anchor_ind = names.index(self.anchor_part)
                     break
+        # (method, fallback) for the crop center. Resolved after `anchor_ind` so an
+        # `anchor_part` absent from the skeleton degrades to the fallback rather
+        # than raising, matching this dataset's lenient anchor resolution (#586).
+        self.centroid_method, self.centroid_fallback = degrade_anchor_if_unresolved(
+            *centroid_method_from_config(embedding_head_config), self.anchor_ind
+        )
 
         # Detection mode: tracked masks (crop on the mask center-of-mass) vs tracked
         # keypoint instances (crop on the pose centroid, no mask).
@@ -2561,7 +2567,10 @@ class EmbeddingDataset(BaseDataset):
                         torch.float32
                     )  # (n_nodes,2)
                     centroid = generate_centroids(
-                        pts.unsqueeze(0), anchor_ind=self.anchor_ind
+                        pts.unsqueeze(0),
+                        anchor_ind=self.anchor_ind,
+                        method=self.centroid_method,
+                        fallback=self.centroid_fallback,
                     )[
                         0
                     ]  # (x, y) in original image coords

--- a/sleap_nn/export/utils.py
+++ b/sleap_nn/export/utils.py
@@ -276,42 +276,74 @@ def resolve_backbone_type(cfg: DictConfig) -> str:
     return get_backbone_type_from_cfg(cfg)
 
 
+# Sentinel distinguishing "this model type has no centroid head" (-> ``None``)
+# from a present head whose leaf is ``None`` (-> the historical default).
+_NO_HEAD = object()
+
+# Head-config leaf carrying the crop/centroid-center knobs (``anchor_part``,
+# ``centroid_method``, ``centroid_fallback``), per model type. The re-ID head's
+# leaf is ``embedding``, not ``confmaps``.
+_CENTROID_HEAD_LEAVES = {
+    "centroid": ("centroid", "confmaps"),
+    "centered_instance": ("centered_instance", "confmaps"),
+    "embedding": ("embedding", "embedding"),
+}
+
+
+def _centroid_head_leaf(cfg: DictConfig, model_type: str):
+    """Return the head-config leaf carrying the centroid knobs for *model_type*.
+
+    Returns :data:`_NO_HEAD` when the model type has no such head (or the head is
+    absent from the config), so callers can tell that apart from a present head
+    whose leaf resolves to ``None``.
+    """
+    entry = _CENTROID_HEAD_LEAVES.get(model_type)
+    if entry is None:
+        return _NO_HEAD
+    head_name, leaf_name = entry
+    head = getattr(cfg.model_config.head_configs, head_name, None)
+    if head and hasattr(head, leaf_name):
+        return getattr(head, leaf_name)
+    return _NO_HEAD
+
+
 def resolve_anchor_part(cfg: DictConfig, model_type: str) -> Optional[str]:
-    """Resolve anchor_part from config for centroid and centered_instance models.
+    """Resolve anchor_part from config for the model types that center a crop.
 
     Args:
         cfg: The training job configuration.
-        model_type: The model type (e.g., "centroid", "centered_instance").
+        model_type: The model type (e.g., "centroid", "centered_instance",
+            "embedding").
 
     Returns:
-        The anchor part name if configured, None otherwise.
-        Only returns a value for "centroid" and "centered_instance" model types.
+        The anchor part name if configured, None otherwise. Only returns a value
+        for the "centroid", "centered_instance" and "embedding" model types -- the
+        heads that carry the crop/centroid-center knobs (#586). For an
+        ``embedding`` model the consumer of the export has to produce the crops
+        itself, so this is the one piece of geometry it cannot do without.
     """
-    head_configs = cfg.model_config.head_configs
-
-    if model_type == "centroid":
-        head = getattr(head_configs, "centroid", None)
-    elif model_type == "centered_instance":
-        head = getattr(head_configs, "centered_instance", None)
-    else:
+    leaf = _centroid_head_leaf(cfg, model_type)
+    if leaf is _NO_HEAD:
         return None
-
-    if head and hasattr(head, "confmaps"):
-        return getattr(head.confmaps, "anchor_part", None)
-    return None
+    return getattr(leaf, "anchor_part", None)
 
 
 def resolve_centroid_method(cfg: DictConfig, model_type: str) -> Optional[str]:
-    """Resolve the trained centroid method for centroid / centered_instance models.
+    """Resolve the trained centroid method for the model types that center a crop.
 
     Companion to :func:`resolve_anchor_part`. Recorded in the export metadata so a
     consumer of the exported model can tag predicted centroids with the method the
     model was actually trained on (#586) — without it, a ``bbox_center`` model's
     predictions would be recorded as ``center_of_mass``.
 
+    The same applies to an ``embedding`` (re-ID) model, more strongly: its
+    consumer must produce the crops itself, so the crop-center recipe the
+    embedder was trained with is what makes its vectors comparable.
+
     Args:
         cfg: The training job configuration.
-        model_type: The model type (e.g., "centroid", "centered_instance").
+        model_type: The model type (e.g., "centroid", "centered_instance",
+            "embedding").
 
     Returns:
         The resolved method (one of
@@ -320,18 +352,10 @@ def resolve_centroid_method(cfg: DictConfig, model_type: str) -> Optional[str]:
     """
     from sleap_nn.data.instance_centroids import centroid_method_from_config
 
-    head_configs = cfg.model_config.head_configs
-
-    if model_type == "centroid":
-        head = getattr(head_configs, "centroid", None)
-    elif model_type == "centered_instance":
-        head = getattr(head_configs, "centered_instance", None)
-    else:
+    leaf = _centroid_head_leaf(cfg, model_type)
+    if leaf is _NO_HEAD:
         return None
-
-    if head and hasattr(head, "confmaps"):
-        return centroid_method_from_config(head.confmaps)[0]
-    return None
+    return centroid_method_from_config(leaf)[0]
 
 
 def resolve_input_shape(

--- a/sleap_nn/inference/loaders.py
+++ b/sleap_nn/inference/loaders.py
@@ -758,13 +758,28 @@ def _build_topdown_embedding(
     if user_crop_size is None and emb_crop is not None:
         preprocess_config.crop_size = emb_crop
 
-    # anchor_ind is only used by the GT-centroid crop path; the embedding model has
-    # no skeleton anchor, so this only fires when a real anchor_part + skeleton exist.
+    emb_head = emb_config.model_config.head_configs.embedding.embedding
+
+    # anchor_ind is only used by the GT-centroid crop path; the embedding model
+    # usually has no skeleton anchor, so this only fires when a real anchor_part +
+    # skeleton exist. Falling back to the TRAINED anchor (as the seg path does)
+    # matters: `EmbeddingDataset` centers its training crops on it, so honoring only
+    # a CLI override would crop a differently-centered image than the embedder saw.
+    emb_anchor = OmegaConf.select(emb_head, "anchor_part", default=None)
     anchor_ind = None
     if anchor_part is not None and skeletons:
+        # An explicit override names a node: a typo should not be silently ignored.
         anchor_ind = skeletons[0].node_names.index(anchor_part)
+    elif emb_anchor is not None and skeletons:
+        # The trained anchor is resolved leniently, mirroring `EmbeddingDataset`:
+        # embedding labels routinely carry a partial (or no) skeleton, and
+        # `CentroidCrop` degrades an unresolved anchor to the fallback with a warning.
+        names = skeletons[0].node_names
+        anchor_ind = names.index(emb_anchor) if emb_anchor in names else None
 
-    emb_head = emb_config.model_config.head_configs.embedding.embedding
+    # Crop geometry must reproduce what the EMBEDDER was trained with, so the knobs
+    # come off its head config rather than the centroid model's (#586).
+    centroid_method, centroid_fallback = _resolve_centroid_method(emb_head, anchor_part)
     max_stride_emb = emb_config.model_config.backbone_config[emb_backbone_type][
         "max_stride"
     ]
@@ -775,6 +790,8 @@ def _build_topdown_embedding(
             use_gt_centroids=True,
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
             return_crops=True,
         )
     else:
@@ -795,6 +812,8 @@ def _build_topdown_embedding(
             crop_hw=(preprocess_config.crop_size, preprocess_config.crop_size),
             use_gt_centroids=False,
             anchor_ind=anchor_ind,
+            centroid_method=centroid_method,
+            centroid_fallback=centroid_fallback,
         )
 
     emb_ensure_rgb, emb_ensure_grayscale = _resolve_embedding_channels(emb_config)

--- a/sleap_nn/training/model_trainer.py
+++ b/sleap_nn/training/model_trainer.py
@@ -1059,6 +1059,40 @@ class ModelTrainer:
                     / self.config.trainer_config.run_name
                 )
 
+    def _disable_pretrained_normalize_for_embedding(self):
+        """Turn off the pretrained backbone's input normalization for `embedding`.
+
+        `PretrainedBackbone` applies model-specific (ImageNet) mean/std inside its
+        forward, and documents its input contract as ``[0, 1]`` -- which is what
+        every other model type feeds it. The `embedding` model type breaks that
+        contract on purpose: `EmbeddingLightningModule._build_input` per-crop
+        standardizes to ~N(0, 1) before the backbone sees the crop, so applying the
+        ImageNet shift on top of it hands the stem mean -1.99 / std 4.43 instead of
+        the ~N(0, 1) it was pretrained on.
+
+        This is silent -- it trains, it just trains badly. Measured on the gerbil
+        re-ID set (DINOv2-with-registers, 3 epochs, seed 0, paired runs): val rank-1
+        **0.363** with normalization left on vs **0.920** with it off.
+
+        Rather than let the default quietly cost 2.5x rank-1, force it off and say
+        so. Only the pretrained backbone has this knob, so this runs only on that
+        branch of :meth:`_verify_model_input_channels`. Note this is
+        ``backbone_config.pretrained.normalize`` (input normalization), NOT
+        ``head_configs.embedding.embedding.normalize`` (L2-normalizing the output
+        vector), which is unrelated and stays on.
+        """
+        pretrained_cfg = self.config.model_config.backbone_config.pretrained
+        if not OmegaConf.select(pretrained_cfg, "normalize", default=True):
+            return
+        pretrained_cfg.normalize = False
+        logger.info(
+            "Disabling `model_config.backbone_config.pretrained.normalize` for the "
+            "`embedding` model type: the embedding pipeline already per-crop "
+            "standardizes to ~N(0, 1), so the backbone's ImageNet mean/std would "
+            "double-normalize the input (measured cost: 2.5x val rank-1). Set it "
+            "back to `true` only if you also disable the per-crop standardize."
+        )
+
     def _verify_model_input_channels(self):
         """Verify input channels in model_config based on input image and pretrained model weights."""
         # check in channels, verify with img channels / ensure_rgb/ ensure_grayscale
@@ -1123,8 +1157,16 @@ class ModelTrainer:
             if self.config.model_config.backbone_config.pretrained.in_channels != 3:
                 self.config.model_config.backbone_config.pretrained.in_channels = 3
                 logger.info("Updating pretrained backbone in_channels to 3 (RGB stem).")
-            self.config.data_config.preprocessing.ensure_rgb = True
-            self.config.data_config.preprocessing.ensure_grayscale = False
+            if self.model_type == "embedding":
+                # As in the two branches above, the `embedding` model type keeps its
+                # own DATA channels: a 1-channel crop is repeated to 3 in
+                # `Model.forward`, so the stem is fed correctly either way, and
+                # flipping `ensure_rgb` here would silently turn an
+                # explicitly-grayscale re-ID model into an RGB one.
+                self._disable_pretrained_normalize_for_embedding()
+            else:
+                self.config.data_config.preprocessing.ensure_rgb = True
+                self.config.data_config.preprocessing.ensure_grayscale = False
 
         elif (
             self.backbone_type == "unet"

--- a/tests/architectures/test_pretrained.py
+++ b/tests/architectures/test_pretrained.py
@@ -426,3 +426,103 @@ def test_unfrozen_encoder_still_follows_train_and_eval():
     assert bb.enc.training
     bb.eval()
     assert not bb.enc.training
+
+
+# ------------------------------------------------------- embedding (re-ID) x pretrained
+
+
+def _embedding_cfg(model_name, mode="auto", max_stride=32):
+    """A full model config for a lone pooled `embedding` head on `model_name`."""
+    return OmegaConf.create(
+        {
+            "model_config": {
+                "backbone_config": {
+                    "pretrained": _caseA_cfg(
+                        model_name, output_stride=2, max_stride=max_stride, mode=mode
+                    )
+                },
+                "head_configs": {
+                    "single_instance": None,
+                    "centroid": None,
+                    "centered_instance": None,
+                    "bottomup": None,
+                    "multi_class_bottomup": None,
+                    "multi_class_topdown": None,
+                    "embedding": {
+                        "embedding": {
+                            "embedding_dim": 128,
+                            "num_fc_layers": 1,
+                            "num_fc_units": 256,
+                            "pool": "gem",
+                            "normalize": True,
+                            "output_stride": max_stride,
+                            "loss_weight": 1.0,
+                            "freeze_backbone": False,
+                            "anchor_part": None,
+                            "objective": None,
+                        }
+                    },
+                },
+            }
+        }
+    )
+
+
+def _build_embedding_model(model_name, mode="auto"):
+    """Config -> model, through the same `check_output_strides` the trainer runs."""
+    from sleap_nn.config.utils import check_output_strides
+
+    cfg = check_output_strides(_embedding_cfg(model_name, mode=mode))
+    return Model.from_config(
+        backbone_type="pretrained",
+        backbone_config=cfg.model_config.backbone_config.pretrained,
+        head_configs=cfg.model_config.head_configs.embedding,
+        model_type="embedding",
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "facebook/convnextv2-nano-22k-224",
+        "microsoft/resnet-50",
+        "facebook/dinov2-with-registers-small",
+    ],
+)
+def test_embedding_builds_on_the_default_mode(model_name):
+    """`embedding` + `pretrained` must build with `mode: auto` (the default).
+
+    This combination used to be unconfigurable: `check_output_strides` pins the
+    embedding head's stride to `max_stride`, and the pretrained wrapper reads
+    `output_stride == max_stride` as "nothing to decode" and raises. Only an
+    isotropic ViT with an explicit `mode: encoder` got through, so the hierarchical
+    CNN backbones -- the useful ones -- were closed off entirely.
+    """
+    model = _build_embedding_model(model_name)
+    out = model(torch.rand(2, 3, 64, 64))
+    assert out["EmbeddingHead"].shape == (2, 128)
+
+
+def test_embedding_has_no_dead_decoder_parameters():
+    """Every parameter must receive gradient: a decoder here would be dead weight.
+
+    A pooled head reads the encoder bottleneck (`Model.forward` routes it to
+    `intermediate_feat`), so a decoder built underneath it is never touched --
+    measured at 4.9 M of 20.1 M parameters on convnextv2-nano. Unused parameters
+    are also a DDP hazard, which is why the fix is `mode="encoder"` rather than
+    relaxing the stride check.
+    """
+    model = _build_embedding_model("facebook/convnextv2-nano-22k-224")
+    model(torch.rand(2, 3, 64, 64))["EmbeddingHead"].sum().backward()
+    no_grad = [n for n, p in model.named_parameters() if p.grad is None]
+    assert not no_grad, f"{len(no_grad)} parameter tensor(s) received no gradient"
+
+
+def test_embedding_rejects_an_explicit_decoder_mode():
+    """`mode: decoder` under a pooled head fails with a reason, not a stride error."""
+    from sleap_nn.config.utils import check_output_strides
+
+    with pytest.raises(ValueError, match="no gradient"):
+        check_output_strides(
+            _embedding_cfg("facebook/convnextv2-nano-22k-224", mode="decoder")
+        )

--- a/tests/config/test_model_config.py
+++ b/tests/config/test_model_config.py
@@ -259,3 +259,83 @@ def test_get_head_configs_embedding_missing_leaf_raises():
     for bad in ({"embedding": {}}, {"embedding": {"embedding": None}}):
         with pytest.raises(ValueError, match="embedding"):
             get_head_configs(bad)
+
+
+class TestEmbeddingPretrainedEncoderMode:
+    """`embedding` + `pretrained` must be configurable through the DEFAULT path.
+
+    Both features have a notion of "this model has no decoder" and they spell it
+    differently: the embedding model says it with strides (`check_output_strides`
+    pins `backbone.output_stride = max_stride` so the native UNet/ConvNeXt/SwinT
+    decoder comes out empty), while the `pretrained` wrapper says it with
+    `mode="encoder"` and treats `output_stride == max_stride` as a user error
+    ("nothing to decode"). Pinning the stride is therefore what made the default
+    `mode: auto` refuse to build on every hierarchical pretrained backbone.
+    """
+
+    @staticmethod
+    def _cfg(backbone, mode=None, head_output_stride=32, max_stride=32):
+        backbone_cfg = {"max_stride": max_stride, "output_stride": 2}
+        if backbone == "pretrained":
+            backbone_cfg.update(
+                {"model_name": "facebook/convnextv2-nano-22k-224", "mode": mode}
+            )
+        return OmegaConf.create(
+            {
+                "model_config": {
+                    "backbone_config": {backbone: backbone_cfg},
+                    "head_configs": {
+                        "embedding": {
+                            "embedding": {
+                                "embedding_dim": 128,
+                                "output_stride": head_output_stride,
+                            }
+                        }
+                    },
+                }
+            }
+        )
+
+    def test_auto_resolves_to_encoder(self):
+        """The default. Before this, it raised "nothing to decode" at build time."""
+        from sleap_nn.config.utils import check_output_strides
+
+        cfg = check_output_strides(self._cfg("pretrained", mode="auto"))
+        assert cfg.model_config.backbone_config.pretrained.mode == "encoder"
+
+    def test_explicit_encoder_is_left_alone(self):
+        from sleap_nn.config.utils import check_output_strides
+
+        cfg = check_output_strides(self._cfg("pretrained", mode="encoder"))
+        assert cfg.model_config.backbone_config.pretrained.mode == "encoder"
+
+    def test_explicit_decoder_is_rejected_for_a_pooled_head(self):
+        """A decoder under a pooled head gets no gradient; say so, not "strides"."""
+        from sleap_nn.config.utils import check_output_strides
+
+        with pytest.raises(ValueError, match="no gradient"):
+            check_output_strides(self._cfg("pretrained", mode="decoder"))
+
+    def test_pretrained_stride_is_not_pinned_to_max_stride(self):
+        """The pin is the collision; the head still gets max_stride."""
+        from sleap_nn.config.utils import check_output_strides
+
+        cfg = check_output_strides(
+            self._cfg("pretrained", mode="auto", head_output_stride=16, max_stride=32)
+        )
+        head = cfg.model_config.head_configs.embedding.embedding
+        assert head.output_stride == 32
+        assert cfg.model_config.backbone_config.pretrained.output_stride != 32
+
+    def test_native_backbones_still_pin_the_stride(self):
+        """UNet/ConvNeXt/SwinT express "no decoder" with strides; unchanged."""
+        from sleap_nn.config.utils import check_output_strides
+
+        for backbone in ("unet", "convnext", "swint"):
+            cfg = check_output_strides(self._cfg(backbone))
+            assert (
+                cfg.model_config.backbone_config[backbone].output_stride == 32
+            ), backbone
+            assert (
+                cfg.model_config.head_configs.embedding.embedding.output_stride == 32
+            ), backbone

--- a/tests/data/test_embedding_centroid_method.py
+++ b/tests/data/test_embedding_centroid_method.py
@@ -1,0 +1,179 @@
+"""Centroid-method knobs on the `embedding` head (#586, #671 follow-up).
+
+`EmbeddingDataset` centers each re-ID crop on a pose centroid, and until now that
+centroid was always the mean of visible nodes (or the `anchor_part` node). #738
+gave every other head config `centroid_method` / `centroid_fallback` in sleap-io's
+vocabulary; these are the same knobs on the embedding head, plus the parity that
+makes them safe: `centroid_method: null` must reproduce today's crops exactly.
+"""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from omegaconf import OmegaConf
+
+from sleap_nn.config.utils import check_centroid_methods
+from sleap_nn.data.custom_datasets import EmbeddingDataset
+
+# Three nodes; deliberately asymmetric so the three reduce methods disagree:
+#   center_of_mass -> (10 + 0 + 2) / 3 = 4.0 in x
+#   bbox_center    -> (0 + 10) / 2     = 5.0 in x
+#   anchor("a")    -> 10.0 in x
+_SKEL = sio.Skeleton(nodes=["a", "b", "c"], name="s")
+_POINTS = np.array([[10.0, 0.0], [0.0, 0.0], [2.0, 0.0]])
+
+_COM_X = 4.0
+_BBOX_X = 5.0
+_ANCHOR_X = 10.0
+
+
+def _head(**overrides):
+    cfg = {
+        "embedding_dim": 16,
+        "output_stride": 16,
+        "objective": {
+            "positives": {"scope": "tracklet", "aug_views": 2},
+            "negatives": {"sources": ["in_batch"], "restrict_same_video": True},
+        },
+    }
+    cfg.update(overrides)
+    return OmegaConf.create(cfg)
+
+
+def _labels(skeleton=_SKEL, points=_POINTS):
+    video = sio.Video.from_filename("a.mp4")
+    track = sio.Track(name="t0")
+    frame = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[sio.Instance.from_numpy(points, skeleton=skeleton, track=track)],
+    )
+    return sio.Labels(
+        videos=[video],
+        labeled_frames=[frame],
+        skeletons=[skeleton],
+        tracks=[track],
+    )
+
+
+def _dataset(head, labels=None):
+    return EmbeddingDataset(
+        labels=[labels if labels is not None else _labels()],
+        crop_size=16,
+        class_names=[],
+        embedding_head_config=head,
+        max_stride=16,
+        id_scope="tracklet",
+        cache_img=None,
+    )
+
+
+def _crop_center_x(head, labels=None):
+    """The x of the one indexed instance's crop center."""
+    dataset = _dataset(head, labels)
+    assert len(dataset.mask_idx_list) == 1
+    return float(dataset.mask_idx_list[0]["centroid"][0])
+
+
+class TestEmbeddingCentroidMethod:
+    def test_default_is_center_of_mass(self):
+        """`centroid_method: null` with no anchor = the historical mean-of-visible."""
+        head = _head()
+        dataset = _dataset(head)
+        assert (dataset.centroid_method, dataset.centroid_fallback) == (
+            "center_of_mass",
+            None,
+        )
+        assert _crop_center_x(head) == pytest.approx(_COM_X)
+
+    def test_absent_keys_reproduce_the_default(self):
+        """A config written before #586 has neither key and must be unchanged."""
+        head = _head()
+        assert "centroid_method" not in head
+        assert _crop_center_x(head) == pytest.approx(_COM_X)
+
+    @pytest.mark.parametrize(
+        "method,expected_x",
+        [
+            ("center_of_mass", _COM_X),
+            ("bbox_center", _BBOX_X),
+        ],
+    )
+    def test_method_moves_the_crop_center(self, method, expected_x):
+        """The knob is load-bearing: it actually relocates the crop."""
+        assert _crop_center_x(_head(centroid_method=method)) == pytest.approx(
+            expected_x
+        )
+
+    def test_geometric_median_is_accepted_and_differs_from_bbox(self):
+        """The Weiszfeld median resolves and is not the bbox midpoint here."""
+        head = _head(centroid_method="geometric_median")
+        dataset = _dataset(head)
+        assert dataset.centroid_method == "geometric_median"
+        assert _crop_center_x(head) != pytest.approx(_BBOX_X)
+
+    def test_anchor_part_still_wins(self):
+        """The pre-existing `anchor_part` path is unchanged."""
+        head = _head(anchor_part="a")
+        dataset = _dataset(head)
+        assert (dataset.centroid_method, dataset.centroid_fallback) == (
+            "anchor",
+            "center_of_mass",
+        )
+        assert _crop_center_x(head) == pytest.approx(_ANCHOR_X)
+
+    def test_anchor_fallback_is_configurable(self):
+        """`centroid_fallback` rides along with an anchor and is resolved."""
+        dataset = _dataset(_head(anchor_part="a", centroid_fallback="bbox_center"))
+        assert (dataset.centroid_method, dataset.centroid_fallback) == (
+            "anchor",
+            "bbox_center",
+        )
+
+    def test_unresolvable_anchor_degrades_to_the_fallback(self):
+        """An `anchor_part` absent from the skeleton degrades, it does not raise.
+
+        `EmbeddingDataset` resolves `anchor_ind` leniently (embedding labels often
+        carry a partial skeleton), so the method must degrade in step with it --
+        otherwise `generate_centroids` would be asked for an "anchor" with no index.
+        """
+        head = _head(anchor_part="nope", centroid_fallback="bbox_center")
+        dataset = _dataset(head)
+        assert dataset.anchor_ind is None
+        assert (dataset.centroid_method, dataset.centroid_fallback) == (
+            "bbox_center",
+            None,
+        )
+        assert _crop_center_x(head) == pytest.approx(_BBOX_X)
+
+    def test_contradictory_config_is_rejected_naming_the_head(self):
+        """`anchor_part` + a non-anchor method fails at setup, not in a worker."""
+        config = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "embedding": {
+                            "embedding": {
+                                "anchor_part": "a",
+                                "centroid_method": "bbox_center",
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        with pytest.raises(ValueError, match=r"head_configs\.embedding\.embedding"):
+            check_centroid_methods(config)
+
+    def test_unknown_method_is_rejected(self):
+        config = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "embedding": {"embedding": {"centroid_method": "centre"}}
+                    }
+                }
+            }
+        )
+        with pytest.raises(ValueError, match="Unknown centroid_method"):
+            check_centroid_methods(config)

--- a/tests/export/test_cli.py
+++ b/tests/export/test_cli.py
@@ -229,6 +229,17 @@ class TestExportCommand:
         metadata = json.loads((output_dir / "export_metadata.json").read_text())
         assert metadata["model_type"] == "embedding"
         assert metadata["embedding_dim"] == 16
+        # The re-ID crop-center recipe is recorded too (#586 remainder): an ONNX
+        # consumer has to produce the crops itself, so it must know how the
+        # embedder's training crops were centered.
+        from omegaconf import OmegaConf
+
+        from sleap_nn.export.utils import resolve_anchor_part, resolve_centroid_method
+
+        cfg = OmegaConf.load(minimal_embedding_model_dir / "training_config.yaml")
+        assert metadata["anchor_part"] == resolve_anchor_part(cfg, "embedding")
+        assert metadata["centroid_method"] == resolve_centroid_method(cfg, "embedding")
+        assert metadata["centroid_method"] is not None
         assert metadata["normalize"] is True
         assert metadata["backbone_source"] == "scratch"
         assert metadata["normalization"] == "per_crop_standardize"

--- a/tests/export/test_utils.py
+++ b/tests/export/test_utils.py
@@ -826,6 +826,31 @@ class TestResolveAnchorPart:
         anchor = resolve_anchor_part(cfg, "single_instance")
         assert anchor is None
 
+    def test_resolve_anchor_part_embedding(self):
+        """The re-ID head carries the same knob on its `embedding` leaf (#746)."""
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "embedding": {"embedding": {"anchor_part": "thorax"}}
+                    }
+                }
+            }
+        )
+        assert resolve_anchor_part(cfg, "embedding") == "thorax"
+
+    def test_resolve_anchor_part_embedding_none_when_not_set(self):
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_anchor_part
+
+        cfg = OmegaConf.create(
+            {"model_config": {"head_configs": {"embedding": {"embedding": {}}}}}
+        )
+        assert resolve_anchor_part(cfg, "embedding") is None
+
     def test_resolve_anchor_part_none_for_unsupported_model(self):
         """Test that anchor_part returns None for unsupported model types."""
         from omegaconf import OmegaConf
@@ -854,6 +879,77 @@ class TestResolveAnchorPart:
         anchor = resolve_anchor_part(cfg, "centered_instance")
         # anchor_part may be None or a string depending on config
         assert anchor is None or isinstance(anchor, str)
+
+
+class TestResolveCentroidMethod:
+    """Tests for resolve_centroid_method (export metadata, #586 / #746)."""
+
+    @staticmethod
+    def _cfg(head_type, leaf_name, **leaf):
+        from omegaconf import OmegaConf
+
+        return OmegaConf.create(
+            {"model_config": {"head_configs": {head_type: {leaf_name: leaf}}}}
+        )
+
+    @pytest.mark.parametrize(
+        "model_type,leaf_name",
+        [
+            ("centroid", "confmaps"),
+            ("centered_instance", "confmaps"),
+            ("embedding", "embedding"),
+        ],
+    )
+    def test_default_is_center_of_mass(self, model_type, leaf_name):
+        """No knobs set -> the historical default, recorded explicitly."""
+        from sleap_nn.export.utils import resolve_centroid_method
+
+        cfg = self._cfg(model_type, leaf_name)
+        assert resolve_centroid_method(cfg, model_type) == "center_of_mass"
+
+    @pytest.mark.parametrize(
+        "model_type,leaf_name",
+        [
+            ("centroid", "confmaps"),
+            ("centered_instance", "confmaps"),
+            ("embedding", "embedding"),
+        ],
+    )
+    def test_explicit_method_is_recorded(self, model_type, leaf_name):
+        """A `bbox_center` model must not be recorded as `center_of_mass`."""
+        from sleap_nn.export.utils import resolve_centroid_method
+
+        cfg = self._cfg(model_type, leaf_name, centroid_method="bbox_center")
+        assert resolve_centroid_method(cfg, model_type) == "bbox_center"
+
+    def test_embedding_anchor_resolves_to_anchor(self):
+        """anchor_part on the re-ID head -> method 'anchor' (fallback is implied)."""
+        from sleap_nn.export.utils import resolve_centroid_method
+
+        cfg = self._cfg(
+            "embedding",
+            "embedding",
+            anchor_part="thorax",
+            centroid_fallback="bbox_center",
+        )
+        assert resolve_centroid_method(cfg, "embedding") == "anchor"
+
+    @pytest.mark.parametrize("model_type", ["bottomup", "single_instance", "nope"])
+    def test_none_for_model_types_without_a_centroid(self, model_type):
+        from omegaconf import OmegaConf
+        from sleap_nn.export.utils import resolve_centroid_method
+
+        cfg = OmegaConf.create(
+            {
+                "model_config": {
+                    "head_configs": {
+                        "bottomup": {"confmaps": {}, "pafs": {}},
+                        "single_instance": {"confmaps": {}},
+                    }
+                }
+            }
+        )
+        assert resolve_centroid_method(cfg, model_type) is None
 
 
 class TestResolveNodeNamesEdgeCases:

--- a/tests/inference/test_embedding_crop_geometry.py
+++ b/tests/inference/test_embedding_crop_geometry.py
@@ -1,0 +1,141 @@
+"""Crop geometry on the composed centroid + `embedding` inference path (#586).
+
+`_build_topdown_embedding` builds the `CentroidCrop` that feeds the embedder. Its
+crop geometry has to reproduce what the EMBEDDER was trained with -- the vectors
+are only comparable to the training distribution if the crops are centered the
+same way -- so both the anchor and the centroid method come off the embedding
+model's own saved head config, not the centroid model's and not only the CLI.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sleap_io as sio
+import torch
+from omegaconf import OmegaConf
+
+from sleap_nn.inference import loaders as loaders_mod
+from sleap_nn.inference.loaders import _build_topdown_embedding
+
+_SKEL = sio.Skeleton(nodes=["head", "thorax", "abdomen"], name="fly")
+
+
+def _emb_config(**head_overrides):
+    head = {"embedding_dim": 8, "output_stride": 16}
+    head.update(head_overrides)
+    return OmegaConf.create(
+        {
+            "data_config": {
+                "preprocessing": {
+                    "scale": 1.0,
+                    "crop_size": 32,
+                    "ensure_rgb": False,
+                    "ensure_grayscale": True,
+                },
+                "skeletons": [
+                    {
+                        "nodes": [{"name": n} for n in _SKEL.node_names],
+                        "edges": [],
+                        "symmetries": [],
+                        "name": _SKEL.name,
+                    }
+                ],
+            },
+            "model_config": {
+                "backbone_config": {"unet": {"max_stride": 16}},
+                "head_configs": {"embedding": {"embedding": head}},
+            },
+        }
+    )
+
+
+@pytest.fixture
+def stub_embedding_ckpt(monkeypatch):
+    """Return a factory that stubs the checkpoint load with an in-memory config."""
+
+    def _install(emb_config):
+        def fake_load(module_cls, ckpt_path, *, model_type, **kwargs):
+            assert model_type == "embedding"
+            return torch.nn.Identity(), emb_config, "unet"
+
+        monkeypatch.setattr(loaders_mod, "_load_lightning_module", fake_load)
+
+    return _install
+
+
+def _build(emb_config, stub, anchor_part=None):
+    stub(emb_config)
+    assets = _build_topdown_embedding(
+        None,  # no centroid model -> the GT-centroid crop path
+        "unused/ckpt",
+        device="cpu",
+        backbone_ckpt_path=None,
+        head_ckpt_path=None,
+        peak_threshold=0.2,
+        integral_refinement="integral",
+        integral_patch_size=5,
+        max_instances=None,
+        return_confmaps=False,
+        preprocess_config=OmegaConf.create(
+            {"scale": None, "crop_size": None, "ensure_rgb": None, "max_height": None}
+        ),
+        anchor_part=anchor_part,
+    )
+    return assets.inference_model.centroid_crop
+
+
+class TestEmbeddingCropGeometry:
+    def test_default_is_center_of_mass(self, stub_embedding_ckpt):
+        crop = _build(_emb_config(), stub_embedding_ckpt)
+        assert crop.centroid_method == "center_of_mass"
+        assert crop.anchor_ind is None
+
+    def test_method_comes_from_the_embedding_head(self, stub_embedding_ckpt):
+        crop = _build(
+            _emb_config(centroid_method="bbox_center"),
+            stub_embedding_ckpt,
+        )
+        assert crop.centroid_method == "bbox_center"
+
+    def test_fallback_comes_from_the_embedding_head(self, stub_embedding_ckpt):
+        crop = _build(
+            _emb_config(anchor_part="thorax", centroid_fallback="bbox_center"),
+            stub_embedding_ckpt,
+        )
+        assert crop.centroid_method == "anchor"
+        assert crop.centroid_fallback == "bbox_center"
+
+    def test_trained_anchor_is_honored_without_a_cli_override(
+        self, stub_embedding_ckpt
+    ):
+        """The gap this closes: `EmbeddingDataset` centers training crops on the
+        head config's `anchor_part`, so inference must too -- otherwise a model
+        trained on thorax-centered crops is fed mean-of-visible ones."""
+        crop = _build(_emb_config(anchor_part="thorax"), stub_embedding_ckpt)
+        assert crop.anchor_ind == _SKEL.node_names.index("thorax")
+        assert crop.centroid_method == "anchor"
+
+    def test_cli_anchor_overrides_the_trained_one(self, stub_embedding_ckpt):
+        crop = _build(
+            _emb_config(anchor_part="thorax"),
+            stub_embedding_ckpt,
+            anchor_part="abdomen",
+        )
+        assert crop.anchor_ind == _SKEL.node_names.index("abdomen")
+        assert crop.centroid_method == "anchor"
+
+    def test_trained_anchor_absent_from_the_skeleton_degrades(
+        self, stub_embedding_ckpt
+    ):
+        """Embedding labels routinely carry a partial skeleton; degrade, don't raise."""
+        crop = _build(
+            _emb_config(anchor_part="wing", centroid_fallback="bbox_center"),
+            stub_embedding_ckpt,
+        )
+        assert crop.anchor_ind is None
+        assert crop.centroid_method == "bbox_center"
+
+    def test_cli_anchor_not_in_the_skeleton_still_raises(self, stub_embedding_ckpt):
+        """An explicit override names a node by hand: a typo must not pass silently."""
+        with pytest.raises(ValueError):
+            _build(_emb_config(), stub_embedding_ckpt, anchor_part="wing")

--- a/tests/training/test_model_trainer.py
+++ b/tests/training/test_model_trainer.py
@@ -2449,3 +2449,111 @@ class TestMultiClassIdentityClasses:
         cv = trainer.config.model_config.head_configs.multi_class_topdown.class_vectors
         assert cv.classes is not None and len(cv.classes) == 2
         assert not hasattr(cv, "class_uuids")
+
+
+class TestEmbeddingPretrainedBackboneSync:
+    """`pretrained` backbone x `embedding` model type (U8 / U11, #671 follow-up).
+
+    The `pretrained` branch of `_verify_model_input_channels` was the only one of
+    the three 3-channel-stem branches with no `embedding` guard, so it (U11)
+    overrode an explicitly-grayscale re-ID model, and (U8) left the backbone's
+    ImageNet mean/std on top of the embedding pipeline's own per-crop standardize.
+    """
+
+    @staticmethod
+    def _cfg(model_type, *, in_channels=1, normalize=True):
+        head = (
+            {"embedding": {"embedding": {"embedding_dim": 128}}}
+            if model_type == "embedding"
+            else {"centered_instance": {"confmaps": {}}}
+        )
+        return OmegaConf.create(
+            {
+                "data_config": {
+                    "preprocessing": {"ensure_rgb": False, "ensure_grayscale": True}
+                },
+                "model_config": {
+                    "backbone_config": {
+                        "pretrained": {
+                            "model_name": "facebook/dinov2-with-registers-base",
+                            "mode": "encoder",
+                            "in_channels": in_channels,
+                            "normalize": normalize,
+                        }
+                    },
+                    "head_configs": head,
+                },
+            }
+        )
+
+    def _verify(self, model_type, **kwargs):
+        mt = ModelTrainer.__new__(ModelTrainer)
+        mt.config = self._cfg(model_type, **kwargs)
+        mt.backbone_type = "pretrained"
+        mt.model_type = model_type
+        mt.train_labels = [None]  # skip the image-derived channel block
+        mt._verify_model_input_channels()
+        return mt.config
+
+    # ---- U11: the grayscale override ----
+
+    def test_embedding_keeps_explicit_grayscale(self):
+        """U11: an `ensure_grayscale` re-ID model is not silently flipped to RGB."""
+        cfg = self._verify("embedding")
+        # The STEM still goes to 3 channels -- gray is repeated in `Model.forward`.
+        assert cfg.model_config.backbone_config.pretrained.in_channels == 3
+        assert cfg.data_config.preprocessing.ensure_grayscale is True
+        assert cfg.data_config.preprocessing.ensure_rgb is False
+
+    def test_non_embedding_still_flips_to_rgb(self):
+        """The behavior every other model type relies on is unchanged."""
+        cfg = self._verify("centered_instance")
+        assert cfg.model_config.backbone_config.pretrained.in_channels == 3
+        assert cfg.data_config.preprocessing.ensure_rgb is True
+        assert cfg.data_config.preprocessing.ensure_grayscale is False
+
+    # ---- U8: the double-normalization ----
+
+    def test_embedding_disables_pretrained_normalize(self, caplog):
+        """U8: the ImageNet mean/std is turned off, loudly, for `embedding`."""
+        with caplog.at_level("INFO"):
+            cfg = self._verify("embedding")
+        assert cfg.model_config.backbone_config.pretrained.normalize is False
+        assert "double-normalize" in caplog.text
+
+    def test_non_embedding_keeps_pretrained_normalize(self):
+        """Every other model type feeds [0, 1], so it keeps the ImageNet stats."""
+        cfg = self._verify("centered_instance")
+        assert cfg.model_config.backbone_config.pretrained.normalize is True
+
+    def test_already_disabled_normalize_is_not_relogged(self, caplog):
+        """An explicit `normalize: false` is a no-op, not a second log line."""
+        with caplog.at_level("INFO"):
+            cfg = self._verify("embedding", normalize=False)
+        assert cfg.model_config.backbone_config.pretrained.normalize is False
+        assert "double-normalize" not in caplog.text
+
+    def test_missing_normalize_key_defaults_to_on_and_is_disabled(self):
+        """A config written before this knob existed still gets the fix."""
+        mt = ModelTrainer.__new__(ModelTrainer)
+        cfg = self._cfg("embedding")
+        del cfg.model_config.backbone_config.pretrained.normalize
+        mt.config = cfg
+        mt.backbone_type = "pretrained"
+        mt.model_type = "embedding"
+        mt.train_labels = [None]
+        mt._verify_model_input_channels()
+        assert mt.config.model_config.backbone_config.pretrained.normalize is False
+
+    def test_head_normalize_is_untouched(self):
+        """`head_configs...normalize` (L2 on the OUTPUT vector) is a different knob."""
+        mt = ModelTrainer.__new__(ModelTrainer)
+        cfg = self._cfg("embedding")
+        cfg.model_config.head_configs.embedding.embedding.normalize = True
+        mt.config = cfg
+        mt.backbone_type = "pretrained"
+        mt.model_type = "embedding"
+        mt.train_labels = [None]
+        mt._verify_model_input_channels()
+        assert cfg.model_config.head_configs.embedding.embedding.normalize is True
+        assert cfg.model_config.backbone_config.pretrained.normalize is False


### PR DESCRIPTION
The **#671 follow-up**: the pieces of the re-ID work that could not go against `main` before the `embedding` model type existed there. Three of them are `embedding` × `pretrained` defects; the fourth is the centroid-method remainder from #738.

Nothing here changes behavior for any other model type — asserted, not assumed.

## 1. `embedding` + `pretrained` could not be built at all

Both features have a notion of *"this model has no decoder"* and they spell it differently:

| | how it says "no decoder" |
|---|---|
| the `embedding` model | with **strides** — `check_output_strides` pins `backbone.output_stride = max_stride` so the native UNet/ConvNeXt/SwinT decoder comes out empty and the pooled head taps `middle_output` |
| the `pretrained` wrapper | with **`mode="encoder"`**, and it treats `output_stride == max_stride` as a user error |

So the embedding model's own stride convention is what made the pretrained backbone refuse to build — on the **default** `mode: auto`, for every hierarchical family:

```
mode: auto/decoder → ValueError: output_stride=32 is >= the backbone's deepest stride 32;
                     nothing to decode. Lower output_stride.
```

Only an isotropic ViT with an explicit `mode: encoder` got through, i.e. the useful CNN backbones were closed off entirely. Nothing is wrong with either rule in isolation.

**Fix:** for a `pretrained` backbone, `check_output_strides` says it in the wrapper's own vocabulary — set `mode="encoder"`, leave the stride alone. Native backbones are unchanged.

`mode: decoder` under a pooled head is now **rejected with the actual reason** instead of surfacing as a stride error. It is not a stride problem: a pooled head reads the bottleneck (`Model.forward` routes it to `intermediate_feat`), so a decoder underneath receives no gradient.

```
convnextv2-nano  mode=decoder → params(M) {enc: 14.98, dec: 4.90, head: 0.20}
                                no-grad(M) {enc:  0.00, dec: 4.90, head: 0.00}   ← 24% dead
convnextv2-nano  mode=encoder → params(M) {enc: 14.98, dec:  0.0, head: 0.20}   no-grad: none
```

Relaxing the stride check instead would have shipped exactly that state — dead weight, and a DDP hazard (unused parameters).

## 2. The default silently cost 2.5× rank-1

`PretrainedBackbone` applies ImageNet mean/std inside its forward and documents its input contract as `[0, 1]`, which is what every other model type feeds it. The `embedding` pipeline breaks that contract on purpose: `EmbeddingLightningModule._build_input` per-crop standardizes to ~N(0, 1) **before** the backbone sees the crop, so the stem received **mean −1.99 / std 4.43**.

It trains. It just trains badly — which is why no test could see it. Measured on the gerbil re-ID set (DINOv2-with-registers, 3 epochs, seed 0, **paired** runs):

| `pretrained.normalize` | val rank-1 |
|---|---|
| `true` (the default) | **0.363** |
| `false` | **0.920** |

The trainer now forces `normalize: false` for `embedding` and logs that it did.

> Two different knobs share the name. This is `backbone_config.pretrained.normalize` (input normalization). `head_configs.embedding.embedding.normalize` (L2-normalizing the *output vector*) is unrelated and stays on — there is a test pinning that.

An already-trained model is unaffected: it persisted `normalize: true`, inference re-reads the saved config, and train/inference stay consistent.

## 3. An explicit grayscale choice was overridden

`_verify_model_input_channels` has three 3-channel-stem branches. Two already guard on `model_type != "embedding"` — the 1-channel crop is repeated to 3 in `Model.forward`, so the stem is fed correctly either way and flipping `ensure_rgb` would turn an explicitly-grayscale re-ID model into an RGB one. The `pretrained` branch had no such guard, so `ensure_grayscale: true` was persisted as `ensure_rgb: true`.

Not a correctness break, but it overrides an explicit choice the same method preserves two branches earlier, and grayscale can be a deliberate anti-confound measure — a recording setup that mixes a color and a monochrome camera makes color an identity cue that will not generalize.

## 4. Centroid methods on the re-ID crop center

#738 gave `centroid_method` / `centroid_fallback` to every head that defines a crop or centroid center, in sleap-io's vocabulary, but skipped `embedding.embedding` — the model type did not exist on `main` at the time. This is that remainder.

- `EmbeddingHeadConfig` gains both fields. `centroid_method: null` (the default) means *"the anchor node when `anchor_part` is set, else `center_of_mass`"* — the historical behavior exactly, asserted with a parity test.
- `EmbeddingDataset` resolves `(method, fallback)` once, **after** `anchor_ind`, so an `anchor_part` absent from the skeleton degrades to the fallback rather than asking `generate_centroids` for an anchor with no index. That matches this dataset's deliberately lenient anchor resolution — embedding labels routinely carry a partial skeleton.
- `check_centroid_methods` already walks every head generically, so a contradictory `anchor_part` + non-anchor method now fails at setup naming `head_configs.embedding.embedding`, not inside a dataloader worker.

Mask-driven embedding datasets are unaffected — they crop on the mask's own center of mass via `data_config.preprocessing.crop_centering`.

**The inference side of the same seam had a matching gap.** `_build_topdown_embedding` honored only a CLI `--anchor_part` and ignored the one the model was *trained* with, so a model trained on thorax-centered crops was fed mean-of-visible ones at inference. It now falls back to the head config's anchor (as the segmentation path already does) and reads the centroid method off the **embedder's** head config rather than the centroid model's — the crops have to reproduce what the embedder saw for its vectors to be comparable to its training distribution. An explicit CLI override still wins and still raises on a node the skeleton lacks; a trained anchor resolves leniently.

The `geometric_median` docstring follows `main`'s **measured** description (#738's F31 correction: least affected by a *mislocalized* node, *not* more stable than the mean under node dropout), not the pre-correction claim.

## 5. Export metadata records the re-ID crop-center recipe

Found in review. `export/utils.py::resolve_anchor_part` / `resolve_centroid_method` returned `None` for `model_type == "embedding"`, so an exported embedding model's `export_metadata.json` carried `anchor_part: null, centroid_method: null` whatever it was trained with — confirmed live with a thorax-anchored, `bbox_center`-fallback config. #738's reason for recording the method ("so a consumer of the exported model can tag predicted centroids with the method the model was actually trained on") is *stronger* for this head: an ONNX consumer has to produce the crops itself, so the crop-center recipe is what makes its vectors comparable to the training distribution.

Both resolvers now read `head_configs.embedding.embedding` (the leaf is `embedding`, not `confmaps`). The `centroid` / `centered_instance` results are unchanged, including the edge that a present head whose leaf is `null` still yields the historical default rather than `None`.

## Tests

Each defect has at least one test that **fails on the old code and passes on the new**; the remaining tests are unchanged-behavior guards that pass on both (13 of the first 34 do, by design):

| file | n | covers |
|---|---|---|
| `tests/config/test_model_config.py` | 5 | `mode: auto` → `encoder`; `decoder` rejected; the stride is not pinned for `pretrained`; native backbones unchanged |
| `tests/architectures/test_pretrained.py` | 5 | the combination **builds and runs** on ConvNeXtV2 / ResNet-50 / DINOv2-registers through the default path; no parameter goes without gradient |
| `tests/training/test_model_trainer.py` | 7 | `normalize` forced off + logged, not re-logged when already off, absent key handled, head `normalize` untouched; grayscale kept; every other model type unchanged |
| `tests/data/test_embedding_centroid_method.py` | 10 | each method relocates the crop center; the `null` default reproduces today exactly; unresolvable anchor degrades; contradictions rejected |
| `tests/inference/test_embedding_crop_geometry.py` | 7 | method + trained anchor come off the embedding head; CLI override wins; lenient vs. strict anchor resolution |
| `tests/export/test_utils.py` | 12 | `anchor_part` + `centroid_method` resolve off the `embedding` leaf; `centroid` / `centered_instance` unchanged; `None` for model types without a centroid |
| `tests/export/test_cli.py` | +1 | the embedding ONNX export's `export_metadata.json` carries a non-null `centroid_method` matching the resolver |

The build-level tests live in `tests/architectures/test_pretrained.py` so they run in the `backbones`-extra job added by #742 — the job that exists because this file had never executed in CI. The config-level ones need no `transformers` and run in the main matrix (verified with the import blocked).

Full suite: **2694 passed, 154 skipped, 4 xfailed, 0 failed** locally under `CUDA_VISIBLE_DEVICES="" USE_CUDA=0` (what `ci.yml` sets), plus `tests/architectures/test_pretrained.py` green with the `backbones` extra (26 passed, 5 `hf_weights` skipped). `black` / `ruff` / `codespell` clean.

## Docs

`docs/guides/pretrained-backbones.md` gains the three trainer-applied `embedding` overrides — the `[0, 1]` contract sentence now carries the exception that motivated #2, the mode table carries #1, and the gotchas list points at both. `docs/guides/centroid-only-inference.md` names the full set of heads carrying the centroid knobs. The sample config documents the two new fields.

## Follow-up to

#671 (the `embedding` model type) and #740 (U7/U9/U10 of the same pretrained cluster). These four are the items that referenced `model_type == "embedding"` and so had to wait for #671 to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

