### PR TITLE
test: stop the CLI tests from re-syncing the project venv to CPU torch

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 from omegaconf import OmegaConf
 import subprocess
+from tests.utils.cli import cpu_only_env, sleap_nn_cli
 from click.testing import CliRunner
 from sleap_nn.legacy_predict import run_inference
 from sleap_nn.cli import (
@@ -949,14 +950,7 @@ def _strip_ansi_codes(text: str) -> str:
 
 def test_main_cli(sample_config, tmp_path):
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "train",
         "--help",
     ]
@@ -964,6 +958,7 @@ def test_main_cli(sample_config, tmp_path):
         cmd,
         capture_output=True,
         text=True,
+        env=cpu_only_env(),
     )
     # Exit code should be 0
     assert result.returncode == 0
@@ -984,14 +979,7 @@ def test_main_cli(sample_config, tmp_path):
     no_color_env = {**os.environ, "NO_COLOR": "1", "FORCE_COLOR": "0"}
 
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "train",
         "--config-dir",
         f"{tmp_path}",
@@ -1002,7 +990,7 @@ def test_main_cli(sample_config, tmp_path):
         cmd,
         capture_output=True,
         text=True,
-        env=no_color_env,
+        env=cpu_only_env(no_color_env),
     )
     # Exit code should be 0
     assert result.returncode == 0
@@ -1022,14 +1010,7 @@ def test_main_cli(sample_config, tmp_path):
     sample_config.trainer_config.max_epochs = 2
     sample_config.data_config.preprocessing.scale = 1.2
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "train",
         "--config-dir",
         f"{tmp_path}",
@@ -1042,7 +1023,7 @@ def test_main_cli(sample_config, tmp_path):
         cmd,
         capture_output=True,
         text=True,
-        env=no_color_env,
+        env=cpu_only_env(no_color_env),
     )
     # Exit code should be 0
     assert result.returncode == 0
@@ -1056,14 +1037,7 @@ def test_main_cli(sample_config, tmp_path):
 
     # Test CLI with '--' to separate config overrides from positional args
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "train",
         "--config-dir",
         f"{tmp_path}",
@@ -1077,7 +1051,7 @@ def test_main_cli(sample_config, tmp_path):
         cmd,
         capture_output=True,
         text=True,
-        env=no_color_env,
+        env=cpu_only_env(no_color_env),
     )
     assert (
         Path(f"{sample_config.trainer_config.ckpt_dir}")
@@ -1113,14 +1087,7 @@ def test_train_cli_with_video_paths(
 
     # with video paths as list
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "train",
         "--config-dir",
         f"{tmp_path}",
@@ -1129,7 +1096,7 @@ def test_train_cli_with_video_paths(
         "--video-paths",
         f"{small_robot_minimal_video.as_posix()}",
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=cpu_only_env())
     assert result.returncode == 0
 
     assert (
@@ -1149,14 +1116,7 @@ def test_train_cli_with_video_paths(
     video_path = Path(labels.videos[0].filename).as_posix()
 
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "train",
         "--config-dir",
         f"{tmp_path}",
@@ -1166,7 +1126,7 @@ def test_train_cli_with_video_paths(
         f"{video_path}",
         f"{small_robot_minimal_video.as_posix()}",
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=cpu_only_env())
     assert result.returncode == 0
 
     assert (
@@ -1200,14 +1160,7 @@ def test_train_cli_with_prefix_map(
     new_prefix = new_video_path.parent.as_posix()
 
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "train",
         "--config-dir",
         f"{tmp_path}",
@@ -1217,7 +1170,7 @@ def test_train_cli_with_prefix_map(
         f"{old_prefix}",
         f"{new_prefix}",
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=cpu_only_env())
     assert result.returncode == 0, f"stderr: {result.stderr}"
 
     assert (
@@ -1238,14 +1191,7 @@ def test_track_command(
     import subprocess
 
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "track",
         "--model_paths",
         minimal_instance_centroid_ckpt,
@@ -1262,7 +1208,9 @@ def test_track_command(
         "--device",
         "cpu",
     ]
-    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        cmd, check=True, capture_output=True, text=True, env=cpu_only_env()
+    )
     assert Path(f"{tmp_path}/test.slp").exists()
 
     labels = sio.load_slp(f"{tmp_path}/test.slp")
@@ -1281,14 +1229,7 @@ def test_track_command_retrack_only_uses_new_flow(
     # Step 1: produce a tracked .slp via the inference + tracking path.
     pred_slp = f"{tmp_path}/preds.slp"
     inference_cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "predict",
         "--model_paths",
         minimal_instance_centroid_ckpt,
@@ -1305,20 +1246,15 @@ def test_track_command_retrack_only_uses_new_flow(
         "--device",
         "cpu",
     ]
-    subprocess.run(inference_cmd, check=True, capture_output=True, text=True)
+    subprocess.run(
+        inference_cmd, check=True, capture_output=True, text=True, env=cpu_only_env()
+    )
     assert Path(pred_slp).exists()
 
     # Step 2: retrack with NO model_paths (pure tracking-only path).
     retracked_slp = f"{tmp_path}/retracked.slp"
     retrack_cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "predict",
         "--data_path",
         pred_slp,
@@ -1328,7 +1264,9 @@ def test_track_command_retrack_only_uses_new_flow(
         "--output_path",
         retracked_slp,
     ]
-    subprocess.run(retrack_cmd, check=True, capture_output=True, text=True)
+    subprocess.run(
+        retrack_cmd, check=True, capture_output=True, text=True, env=cpu_only_env()
+    )
     assert Path(retracked_slp).exists()
 
     out = sio.load_slp(retracked_slp)
@@ -1346,14 +1284,7 @@ def test_track_command_with_tracking_uses_new_flow(
     import subprocess
 
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "predict",
         "--model_paths",
         minimal_instance_centroid_ckpt,
@@ -1373,7 +1304,7 @@ def test_track_command_with_tracking_uses_new_flow(
         "--device",
         "cpu",
     ]
-    subprocess.run(cmd, check=True, capture_output=True, text=True)
+    subprocess.run(cmd, check=True, capture_output=True, text=True, env=cpu_only_env())
     out = Path(f"{tmp_path}/test_tracked.slp")
     assert out.exists()
 
@@ -1402,14 +1333,7 @@ def test_eval_command(
         device="cpu" if torch.backends.mps.is_available() else "auto",
     )
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "eval",
         "--ground_truth_path",
         minimal_instance.as_posix(),
@@ -1419,5 +1343,7 @@ def test_eval_command(
         f"{tmp_path}/metrics_test.npz",
     ]
     # Run the command and check for errors
-    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        cmd, check=True, capture_output=True, text=True, env=cpu_only_env()
+    )
     assert Path(f"{tmp_path}/metrics_test.npz").exists()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 import copy
 import torch
+from tests.utils.cli import cpu_only_env, sleap_nn_cli
 import warnings
 from sleap_nn.legacy_predict import run_inference
 from sleap_nn.evaluation import (
@@ -762,14 +763,7 @@ def test_evaluator_main(
 
     # Build the command to run sleap-nn eval with the required arguments
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "eval",
         "--ground_truth_path",
         minimal_instance.as_posix(),
@@ -779,7 +773,9 @@ def test_evaluator_main(
         f"{tmp_path}/metrics_test.npz",
     ]
     # Run the command and check for errors
-    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        cmd, check=True, capture_output=True, text=True, env=cpu_only_env()
+    )
     assert Path(f"{tmp_path}/metrics_test.npz").exists()
 
     # Load metrics in SLEAP 1.4 format (single "metrics" key)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -8,6 +8,7 @@ from sleap_nn.legacy_predict import run_inference
 from loguru import logger
 from _pytest.logging import LogCaptureFixture
 import torch
+from tests.utils.cli import cpu_only_env, sleap_nn_cli
 
 
 def test_run_inference_emits_deprecation_warning(
@@ -1318,14 +1319,7 @@ def test_predict_main(
 
     # Single comprehensive test with tracking and cleaning options
     cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--no-group",
-        "gpu",
-        "--extra",
-        "torch-cpu",
-        "sleap-nn",
+        *sleap_nn_cli(),
         "track",
         "--model_paths",
         minimal_instance_centroid_ckpt,
@@ -1348,7 +1342,9 @@ def test_predict_main(
         "--device",
         "cpu" if torch.backends.mps.is_available() else "auto",
     ]
-    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        cmd, check=True, capture_output=True, text=True, env=cpu_only_env()
+    )
     assert Path(f"{tmp_path}/test.slp").exists()
 
     labels = sio.load_slp(f"{tmp_path}/test.slp")

--- a/tests/test_subprocess_hygiene.py
+++ b/tests/test_subprocess_hygiene.py
@@ -1,0 +1,29 @@
+"""No test may spawn ``uv run``: it re-syncs the shared project ``.venv`` as a side effect.
+
+See ``tests/utils/cli.py`` for the history. Tests that need the ``sleap-nn`` CLI in a
+subprocess use ``sleap_nn_cli()`` there, which runs it on ``sys.executable``.
+"""
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent
+UV_ARGV = re.compile(r"""\[\s*["']uv["']\s*,""", re.S)
+
+
+def test_no_test_spawns_uv():
+    """Every test file is free of a subprocess argv that starts with ``uv``."""
+    offenders = []
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        if path.resolve() == Path(__file__).resolve():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for m in UV_ARGV.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            offenders.append(f"{path.relative_to(TESTS_DIR)}:{line}")
+    assert not offenders, (
+        "These tests build a subprocess argv starting with 'uv'. `uv run` syncs the "
+        "project venv before running (it swapped torch+cu130 for torch+cpu under a "
+        "running suite); spawn the CLI with tests.utils.cli.sleap_nn_cli() instead:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/utils/cli.py
+++ b/tests/utils/cli.py
@@ -1,0 +1,38 @@
+"""Spawn the ``sleap-nn`` CLI from a test WITHOUT re-syncing the project environment.
+
+The CLI tests used to shell out to::
+
+    uv run --frozen --no-group gpu --extra torch-cpu sleap-nn ...
+
+``--frozen`` only pins the lockfile; ``uv run`` still **syncs the project's ``.venv``**
+to the requested groups/extras before running. On CI that is a no-op (the job already
+synced with exactly those flags), but on a developer machine whose default ``gpu``
+group installed ``torch+cu130`` it silently uninstalled torch/torchvision and put the
+``+cpu`` wheels in their place -- mid-suite, for every other process sharing the venv.
+It is the "venv keeps flipping to CPU torch" hazard that cost several GPU sessions.
+
+Run the CLI in *this* interpreter's environment instead: ``sleap_nn.cli`` has a
+``__main__`` guard, so ``python -m sleap_nn.cli`` is the console script without ``uv``
+(and without depending on ``uv`` being installed at all).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def sleap_nn_cli(*args: str) -> list[str]:
+    """Command prefix running ``sleap-nn`` on ``sys.executable``: ``[python, -m, sleap_nn.cli, *args]``."""
+    return [sys.executable, "-m", "sleap_nn.cli", *args]
+
+
+def cpu_only_env(base: dict[str, str] | None = None) -> dict[str, str]:
+    """Environment for a CLI subprocess that must stay off the GPU.
+
+    ``--extra torch-cpu`` used to guarantee a CPU-only torch in the child; hiding the
+    devices keeps that intent on a GPU box without touching the installed wheel.
+    """
+    env = dict(os.environ if base is None else base)
+    env["CUDA_VISIBLE_DEVICES"] = ""
+    return env


### PR DESCRIPTION
## Summary

Fourteen CLI tests spawn the console script as `uv run --frozen --no-group gpu --extra torch-cpu sleap-nn ...`. `--frozen` only pins the lockfile; **`uv run` still syncs the project `.venv`** to the requested groups/extras before it runs anything. On CI that is a no-op (the job already synced with exactly those flags). On a developer machine whose default `gpu` group installed `torch+cu130`, the first such test **uninstalls torch/torchvision and installs the `+cpu` wheels** — mid-suite, for every process sharing the venv. Processes that already imported torch keep the mmapped GPU build; anything started afterwards is silently CPU-only.

This PR runs the CLI in the current interpreter instead, and adds a meta-test so the pattern cannot come back.

## Root cause, observed

- Live: during a `pytest tests` run on a 2×A6000 box, `.venv/.../torch-2.9.1+cu130.dist-info` became `torch-2.9.1+cpu.dist-info` at 44% of the run (root `tests/test_*.py`), with `transformers` untouched (so not a bare `uv sync`), no `UV_*` env, hook, or runtime installer anywhere.
- Controlled: running the exact test argv once, `uv run --frozen --no-group gpu --extra torch-cpu sleap-nn --help`, prints `Uninstalled 2 packages / Installed 2 packages` and leaves `torch-2.9.1+cpu` + `torchvision-0.24.1+cpu` in the venv, in 4 s. `uv sync` restores it.
- This is the "venv keeps flipping to CPU torch, cause unknown" hazard recorded three times during the re-ID landing (`scratch/2026-09-02-embedding-reid-landing`, F17/F21), which produced false negatives in GPU/DDP checks.

## Changes Made

- `tests/utils/cli.py` (new): `sleap_nn_cli(*args)` → `[sys.executable, "-m", "sleap_nn.cli", *args]` — the console script without `uv` (`sleap_nn.cli` has a `__main__` guard; rich-click renders the same `sleap-nn train` help, so the existing `"Usage"` / `"sleap.ai"` assertions hold). `cpu_only_env(base=None)` hides CUDA devices from the child, preserving the CPU-only intent the `torch-cpu` extra used to express. No dependency on `uv` being installed.
- `tests/test_cli.py` (12 sites), `tests/test_predict.py`, `tests/test_evaluation.py`: the 8-token prefix → `*sleap_nn_cli(),`; each `subprocess.run` gets `env=cpu_only_env(...)` (wrapping the existing `no_color_env` where one was passed). No assertion changed.
- `tests/test_subprocess_hygiene.py` (new): fails on any argv in `tests/**/*.py` that starts with `"uv"`. It flags all 14 old sites and 0 new ones.

## Testing

- The four touched files under the CI env (`CUDA_VISIBLE_DEVICES="" USE_CUDA=0`): **118 passed**, 2:50; a 3-second poller on the `torch-*.dist-info` name stayed silent for the whole run (the original suite flipped it).
- Full suite, same env, with the fix: **2699 passed / 162 skipped / 4 xfailed** in 6:31 (2698 before, +1 meta-test), and the torch wheel is `+cu130` before and after the run. The same suite without the fix flipped the wheel to `+cpu` at 44%.
- `black --check` and `ruff check` clean.

## Design Decisions

- **`sys.executable -m sleap_nn.cli` rather than `uv run --no-sync sleap-nn`.** Both stop the sync; the former also removes the test suite's hidden dependency on `uv` being on `PATH` and follows the in-repo precedent (`tests/utils/parity_goldens.py` spawns `sys.executable`).
- **Why `cpu_only_env`.** The old flags guaranteed a CPU-only torch in the child. Without it, on a GPU box the child would inherit CUDA and `trainer_accelerator="auto"` would pick the GPUs (a 2-GPU box then hits the DDP-in-pytest hazard). Hiding the devices keeps the old behavior with no wheel swap.
- **Why a meta-test.** The pattern was introduced once (#404) and copied to 14 sites over eight months; a grep-level guard is cheaper than the sessions it cost.

## Related

- `scratch/2026-09-02-embedding-reid-landing/results/p7-repro-2026-09-11.md` (local scratch, not committed) — the reproduction session that found this, finding F48.
- `ci.yml` is unaffected: it syncs with `--no-group gpu --extra torch-cpu` and runs pytest via `uv run --frozen --no-group gpu --extra torch-cpu`, so the children now run in that same env via `sys.executable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
